### PR TITLE
Fix Immutable-merge for arrays

### DIFF
--- a/packages/immutable-merge/README.md
+++ b/packages/immutable-merge/README.md
@@ -28,9 +28,9 @@ The array of objects or undefined values (internally treated as anything falsy) 
 
 The key and options parameters are provided as conveniences in the case that a single handler needs to differentiate different branches or know how deep it is in the tree. In many cases these can be ignored.
 
-## immutableMerge
+## immutableMergeCore
 
-    export function immutableMerge(
+    export function immutableMergeCore(
       options: IMergeOptions, ...objs: (object | undefined)[]
     ): object | undefined {
 
@@ -45,11 +45,38 @@ The routine works as described above with one notable behavior. Unlike `Object.a
       bar: undefined
     };
 
-    const objIM = immutableMerge({}, obj1, obj2);
+    const objIM = immutableMergeCore({}, obj1, obj2);
     // objIM.hasOwnProperty('bar') will return false
 
     const objAssign = Object.assign({}, obj1, obj2);
     // objAssign.hasOwnProperty('bar') will return true but objAssign['bar'] will be undefined
+
+## immutableMerge
+
+    export function immutableMerge<T extends object>(
+      ...objs: (T | undefined)[]
+    ): T | undefined
+
+This convenience function wraps the common use case of recursively merging multiple objects together. Internally this calls `immutableMergeCore` in a fully recursive mode.
+
+## processImmutable
+
+    export function processImmutable<T extends object>(
+      processors: IMergeOptions['recurse'], ...objs: (T | undefined)[]
+    ): T | undefined
+
+This convenience function runs the merge routine as a processor for one or more objects. An example use case might be to turn all style entries into a css class name if it is not already a css class name. This should have the following behavior:
+
+- Every style value in the object should be processed
+- The object should remain unchanged if nothing changed
+- If a style gets updated the object should be mimally mutated
+
+The usage would be as follows. Given a processor called `myStyleProcessor`:
+
+    let complexObject: IMyObjtype = getObjectFromSomewhere();
+    complexObject = processImmutable({ style: myStyleProcessor }, complexObject);
+
+While the primary use case is for a single object this allows merging to happen at the same time if so desired.
 
 ## Things to Explore
 

--- a/packages/immutable-merge/src/Merge.test.ts
+++ b/packages/immutable-merge/src/Merge.test.ts
@@ -1,4 +1,4 @@
-import { IMergeOptions, immutableMerge } from './Merge';
+import { IMergeOptions, immutableMergeCore } from './Merge';
 
 interface IFakeStyle {
   s1?: string;
@@ -150,49 +150,49 @@ const changeMeHandler = (_options: IMergeOptions, ...objs: (object | undefined)[
 
 describe('Immutable merge unit tests', () => {
   test('merge one', () => {
-    const merged = immutableMerge(mergeOptions, sett1, undefined);
+    const merged = immutableMergeCore(mergeOptions, sett1, undefined);
     expect(merged).toBe(sett1);
   });
 
   test('merge with empty object', () => {
-    const merged = immutableMerge(mergeOptions, sett1, {});
+    const merged = immutableMergeCore(mergeOptions, sett1, {});
     expect(merged).toBe(sett1);
-    const merged2 = immutableMerge(mergeOptions, {}, sett2);
+    const merged2 = immutableMergeCore(mergeOptions, {}, sett2);
     expect(merged2).toBe(sett2);
   });
 
   test('merge sett1 and sett2', () => {
-    const merged = immutableMerge(mergeOptions, sett1, sett2) as IFakeSettings;
+    const merged = immutableMergeCore(mergeOptions, sett1, sett2) as IFakeSettings;
     expect(merged).toEqual(sett1plus2);
     expect(merged!.root.style).toBe(sett1.root.style);
     expect(merged!.fakeSlot!.style).toBe(sett2.fakeSlot!.style);
   });
 
   test('merge sett1 and sett3', () => {
-    const merged = immutableMerge(mergeOptions, sett1, sett3) as IFakeSettings;
+    const merged = immutableMergeCore(mergeOptions, sett1, sett3) as IFakeSettings;
     expect(merged).toEqual(sett1plus3);
     expect(merged!.fakeSlot).toBe(sett1.fakeSlot);
   });
 
   test('merge three', () => {
-    const merged = immutableMerge(mergeOptions, sett1, sett2, sett3);
+    const merged = immutableMergeCore(mergeOptions, sett1, sett2, sett3);
     expect(merged).toEqual(sett1plus2plus3);
   });
 
   test('deepMerge', () => {
-    const merged = immutableMerge({ depth: -1 }, deep1, deep2) as IDeepObj;
+    const merged = immutableMergeCore({ depth: -1 }, deep1, deep2) as IDeepObj;
     expect(merged).toEqual(deepMerged);
     expect(merged.b.c.d).toBe(deep1.b.c.d);
     expect(merged.a.b).not.toBe(deep2.a.b);
   });
 
   test('singleProcessNoChange', () => {
-    const merged = immutableMerge({ depth: -1, processSingles: true }, singleToChange);
+    const merged = immutableMergeCore({ depth: -1, processSingles: true }, singleToChange);
     expect(merged).toBe(singleToChange);
   });
 
   test('single process with change', () => {
-    const merged = immutableMerge({ depth: -1, processSingles: true, recurse: { changeMe: changeMeHandler } }, singleToChange);
+    const merged = immutableMergeCore({ depth: -1, processSingles: true, recurse: { changeMe: changeMeHandler } }, singleToChange);
     expect(merged).toEqual(singleWithChanges);
     expect(merged).not.toBe(singleToChange);
     /* tslint:disable-next-line no-any */
@@ -210,7 +210,7 @@ describe('Immutable merge unit tests', () => {
   };
 
   test('arrays overwrite each other', () => {
-    const merged = immutableMerge({ depth: -1 }, withArray1, withArray2);
+    const merged = immutableMergeCore({ depth: -1 }, withArray1, withArray2);
     expect(merged).toEqual(withArray2);
     expect(merged).not.toBe(withArray2);
   });
@@ -226,9 +226,9 @@ describe('Immutable merge unit tests', () => {
   };
 
   test('last writer wins for objects and non-objects', () => {
-    const merged = immutableMerge({ depth: -1 }, withObj, withNonObj);
+    const merged = immutableMergeCore({ depth: -1 }, withObj, withNonObj);
     expect(merged).toEqual(withNonObj);
-    const merged2 = immutableMerge({ depth: -1 }, withNonObj, withObj);
+    const merged2 = immutableMergeCore({ depth: -1 }, withNonObj, withObj);
     expect(merged2).toEqual(withObj);
   });
 
@@ -240,7 +240,7 @@ describe('Immutable merge unit tests', () => {
   };
 
   test('arrays can merge with handler', () => {
-    const merged = immutableMerge({ depth: -1, recurse: { subArray: arrayMerger } }, withArray1, withArray2);
+    const merged = immutableMergeCore({ depth: -1, recurse: { subArray: arrayMerger } }, withArray1, withArray2);
     expect(merged).toEqual({
       baseArray: [4, 5, 6],
       sub: { subArray: ['a', 'b', 'c', 'd', 'e', 'f'] }

--- a/packages/theme-registry/src/Registry.test.ts
+++ b/packages/theme-registry/src/Registry.test.ts
@@ -139,7 +139,7 @@ const _platformDefaultsMergedWithProcessor: IFakeTheme = {
 };
 
 function fakeThemeResolver(parent: IFakeTheme, partial?: Partial<IFakeTheme>): IFakeTheme {
-  let newTheme = immutableMerge({ depth: -1 }, parent, partial) as IFakeTheme;
+  let newTheme = immutableMerge(parent, partial) as IFakeTheme;
   if (newTheme === parent) {
     newTheme = { ...newTheme };
   }

--- a/packages/theme-settings/src/Settings.ts
+++ b/packages/theme-settings/src/Settings.ts
@@ -1,4 +1,4 @@
-import { IMergeOptions, immutableMerge } from '@uifabric/immutable-merge';
+import { IMergeOptions, immutableMergeCore } from '@uifabric/immutable-merge';
 import { IComponentSettingsCollection, IComponentSettings, ISlotProps, IOverrideLookup } from './Settings.types';
 import { mergeAndFinalizeStyles } from './Styles';
 import { IFinalizeStyle, IStyleProp } from './Styles.types';
@@ -50,7 +50,7 @@ const _mergePropsOptions: IMergeOptions = {
  * @param settings - settings to merge together
  */
 export function mergeSettings<TSettings extends IComponentSettings = IComponentSettings>(...settings: (object | undefined)[]): TSettings {
-  return immutableMerge(_mergeSettingsOptions, ...settings) as TSettings;
+  return immutableMergeCore(_mergeSettingsOptions, ...settings) as TSettings;
 }
 
 /**
@@ -58,7 +58,7 @@ export function mergeSettings<TSettings extends IComponentSettings = IComponentS
  * @param props - props to merge together
  */
 export function mergeProps<TProps extends object>(...props: (object | undefined)[]): TProps {
-  return immutableMerge(_mergePropsOptions, ...props) as TProps;
+  return immutableMergeCore(_mergePropsOptions, ...props) as TProps;
 }
 
 /**
@@ -82,7 +82,7 @@ export function mergeAndFinalizeSettings<TSettings extends IComponentSettings = 
       }
     }
   };
-  return immutableMerge(mergeOptions, ...settings) as TSettings;
+  return immutableMergeCore(mergeOptions, ...settings) as TSettings;
 }
 
 /**
@@ -92,7 +92,7 @@ export function mergeAndFinalizeSettings<TSettings extends IComponentSettings = 
 export function mergeSettingsCollection<TCollection extends IComponentSettingsCollection = IComponentSettingsCollection>(
   ...collections: object[]
 ): TCollection {
-  return immutableMerge(_mergeCollectionOptions, ...collections) as TCollection;
+  return immutableMergeCore(_mergeCollectionOptions, ...collections) as TCollection;
 }
 
 /**

--- a/packages/theme-settings/src/Styles.ts
+++ b/packages/theme-settings/src/Styles.ts
@@ -31,7 +31,6 @@ export function flattenStyle(style: IStyleProp<object>): object {
 export function mergeAndFinalizeStyles(finalizer: IFinalizeStyle | undefined, ...styles: IStyleProp<object>[]): object | undefined {
   // baseline merge and flatten the objects
   let merged = immutableMerge(
-    {},
     ...styles.map((styleProp: IStyleProp<object>) => {
       return flattenStyle(styleProp);
     })
@@ -41,7 +40,7 @@ export function mergeAndFinalizeStyles(finalizer: IFinalizeStyle | undefined, ..
   if (finalizer && merged) {
     const updated = finalizer(merged);
     if (updated && Object.keys(updated).length > 0) {
-      merged = immutableMerge({}, merged, updated);
+      merged = immutableMerge(merged, updated);
     }
   }
 

--- a/packages/theming/src/Theme.ts
+++ b/packages/theming/src/Theme.ts
@@ -1,6 +1,6 @@
 import { ITheme, IPartialTheme } from './Theme.types';
 import { mergeSettingsCollection } from '@uifabric/theme-settings';
-import { IMergeOptions, immutableMerge } from '@uifabric/immutable-merge';
+import { IMergeOptions, immutableMergeCore } from '@uifabric/immutable-merge';
 
 function _settingsHandler(_options: IMergeOptions, ...objs: (object | undefined)[]): object | undefined {
   return mergeSettingsCollection(...objs);
@@ -18,7 +18,7 @@ const _themeMergeOptions: IMergeOptions = {
  * in any missing values.
  */
 export function resolvePartialTheme(theme: ITheme, partialTheme?: IPartialTheme): ITheme {
-  let newTheme = immutableMerge(_themeMergeOptions, theme, partialTheme) as ITheme;
+  let newTheme = immutableMergeCore(_themeMergeOptions, theme, partialTheme) as ITheme;
   if (newTheme === theme) {
     newTheme = { ...newTheme };
   }


### PR DESCRIPTION
This fixes the immutable merge code to handle arrays correctly for standard handling (which means arrays overwrite) while still allowing them to be processed by custom handlers.

This change addresses Issue #9 

Custom handlers now don't have array values filtered by type.  This allows merging of arbitrary values with the same keys.

The signature of the handler is now aligned with immutableMerge itself as no one was using the key parameter so it was just dead weight.