### PR TITLE
✨ Add Box to ThemeProvider

### DIFF
--- a/apps/playground/App.tsx
+++ b/apps/playground/App.tsx
@@ -25,7 +25,7 @@ const mockThemingModuleHelper = createMockThemingModuleHelper(mockThemingModule,
 const customThemeRegistry = createPlatformThemeRegistry('TaskPane', mockThemingModuleHelper);
 // default theme
 customThemeRegistry.setTheme({});
-customThemeRegistry.setTheme(ThemingModuleHelper.getPlatformThemeDefinition('WhiteColors'), 'PlatformWhiteColors');
+customThemeRegistry.setTheme(mockThemingModuleHelper.getPlatformThemeDefinition('WhiteColors'), 'PlatformWhiteColors');
 
 const getPrimaryButtonStyles = themedStyleSheet((t: ITheme) => {
   return {
@@ -59,7 +59,7 @@ const ThemeSwitcher: React.FunctionComponent = (_p: {}) => {
     emitter.emit('onPlatformDefaultsChanged');
   }, []);
   return (
-    <TouchableOpacity activeOpacity={0.9} onPress={switchTheme}>
+    <TouchableOpacity activeOpacity={0.3} onPress={switchTheme}>
       <ButtonBackground>
         <ButtonText>Switch Theme!</ButtonText>
       </ButtonBackground>
@@ -70,7 +70,7 @@ const ThemeSwitcher: React.FunctionComponent = (_p: {}) => {
 export default function App() {
   return (
     <ThemeProvider registry={customThemeRegistry}>
-      <ThemedPanel style={styles.root}>
+      <View style={styles.root}>
         <View style={styles.container}>
           <ThemedText>Open up App.tsx to start working on your app!</ThemedText>
           <ButtonBackground>
@@ -79,23 +79,17 @@ export default function App() {
           <ThemeSwitcher />
         </View>
         <ThemeProvider theme="PlatformWhiteColors">
-          <ThemedPanel style={styles.container}>
+          <View style={styles.container}>
             <ThemedText>Theme Provider text!</ThemedText>
             <ButtonBackground>
               <ButtonText>Fake Primary Button</ButtonText>
             </ButtonBackground>
-          </ThemedPanel>
+          </View>
         </ThemeProvider>
-      </ThemedPanel>
+      </View>
     </ThemeProvider>
   );
 }
-
-const ThemedPanel: React.FunctionComponent<ViewProps> = (props: ViewProps) => {
-  const { style, ...rest } = props;
-  const theme = useTheme();
-  return <View {...rest} style={[{ backgroundColor: theme.colors.background }, style]} />;
-};
 
 const ThemedText: React.FunctionComponent<TextProps> = (p: TextProps) => {
   const theme = useTheme();

--- a/apps/playground/App.tsx
+++ b/apps/playground/App.tsx
@@ -23,6 +23,10 @@ const mockThemingModule = createMockThemingModule({
 const mockThemingModuleHelper = createMockThemingModuleHelper(mockThemingModule, emitter);
 
 const customThemeRegistry = createPlatformThemeRegistry('TaskPane', mockThemingModuleHelper);
+mockThemingModuleHelper.addListener(() => {
+  customThemeRegistry.updatePlatformDefaults(mockThemingModuleHelper.getPlatformDefaults('TaskPane'));
+});
+
 // default theme
 customThemeRegistry.setTheme({});
 customThemeRegistry.setTheme(mockThemingModuleHelper.getPlatformThemeDefinition('WhiteColors'), 'PlatformWhiteColors');
@@ -99,7 +103,6 @@ const ThemedText: React.FunctionComponent<TextProps> = (p: TextProps) => {
 
 const styles = StyleSheet.create({
   root: {
-    flex: 1,
     alignItems: 'stretch',
     justifyContent: 'space-evenly'
   },

--- a/packages/theming-react-native/package.json
+++ b/packages/theming-react-native/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@uifabricshared/theme-registry": "^0.2.0",
     "@uifabricshared/foundation-settings": "^0.4.0",
+    "@uifabricshared/themed-stylesheet": "0.2.2",
     "@uifabricshared/theming-ramp": "^0.4.2"
   },
   "devDependencies": {

--- a/packages/theming-react-native/src/NativeModule/ThemingModuleHelpers.ts
+++ b/packages/theming-react-native/src/NativeModule/ThemingModuleHelpers.ts
@@ -8,7 +8,6 @@ import {
 } from './ThemingModule.types';
 import { getBaselinePlatformTheme } from '../BaselinePlatformDefaults';
 import { IOfficePalette, paletteFromOfficeColors } from './office';
-import { useFakePalette } from './useFakePalette';
 
 const createColorRamp = ({ values, index = -1 }: Partial<IColorRamp>) => ({
   values,
@@ -45,7 +44,7 @@ function updatePaletteInCache(module: IOfficeThemingModule, cache: PaletteCache,
 }
 
 function translatePalette(module: IOfficeThemingModule, paletteCache: PaletteCache, palette?: string): IPartialPalette {
-  const key = useFakePalette ? 'debug' : palette || 'WhiteColors';
+  const key = palette || 'WhiteColors';
   if (!paletteCache[key]) {
     updatePaletteInCache(module, paletteCache, key);
   }

--- a/packages/theming-react-native/src/ThemeProvider/ThemeProvider.tsx
+++ b/packages/theming-react-native/src/ThemeProvider/ThemeProvider.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react';
+import { withBox } from './withBox';
 import { IThemeProviderProps } from './ThemeProvider.types';
-import { useThemeRegistry, ThemeRegistryContext, ThemeContext } from './ThemeContext';
+import { useThemeRegistry, ThemeRegistryContext, ThemeContext } from '../ThemeContext';
 import { IThemeEventListener } from '@uifabricshared/theme-registry';
-import { getThemeRegistry } from './Global';
+import { getThemeRegistry } from '../Global';
+
+const Box = withBox();
 
 export const ThemeProvider: React.FunctionComponent<IThemeProviderProps> = (props: IThemeProviderProps) => {
   const { registry: registryFromProps, theme: themeName = '', children } = props;
@@ -22,7 +25,11 @@ export const ThemeProvider: React.FunctionComponent<IThemeProviderProps> = (prop
     };
   }, [registryToUse, themeName, setThemeState]);
 
-  const themeProvider = <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>;
+  const themeProvider = (
+    <ThemeContext.Provider value={theme}>
+      <Box>{children}</Box>
+    </ThemeContext.Provider>
+  );
 
   // note `registryFromProps` came from props and it's not the same as `registryToUse`
   return registryFromProps ? (

--- a/packages/theming-react-native/src/ThemeProvider/ThemeProvider.types.ts
+++ b/packages/theming-react-native/src/ThemeProvider/ThemeProvider.types.ts
@@ -1,4 +1,4 @@
-import { ThemeRegistry } from './Theme.types';
+import { ThemeRegistry } from '../Theme.types';
 
 export interface IThemeProviderProps extends React.PropsWithChildren<{}> {
   theme?: string;

--- a/packages/theming-react-native/src/ThemeProvider/index.ts
+++ b/packages/theming-react-native/src/ThemeProvider/index.ts
@@ -1,0 +1,3 @@
+export * from './ThemeProvider';
+export * from './ThemeProvider.types';
+export * from './withBox';

--- a/packages/theming-react-native/src/ThemeProvider/withBox.native.tsx
+++ b/packages/theming-react-native/src/ThemeProvider/withBox.native.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { StyleProp, View } from 'react-native';
+import { ITheme } from '../Theme.types';
+import { themedStyleSheet } from '@uifabricshared/themed-stylesheet';
+import { useTheme } from '../ThemeContext';
+
+const getStyles = themedStyleSheet((t: ITheme) => ({
+  box: {
+    backgroundColor: t.colors.background
+  }
+}));
+
+type IWithBoxProps = { style?: StyleProp<object> };
+export const withBox = (WrappedComponent: React.ComponentType<IWithBoxProps> = View): React.FunctionComponent<IWithBoxProps> => (
+  props: IWithBoxProps
+) => {
+  const { style, ...rest } = props;
+  const theme = useTheme();
+  const boxStyle = getStyles(theme).box;
+  return <WrappedComponent {...rest} style={[style, boxStyle]} />;
+};

--- a/packages/theming-react-native/src/ThemeProvider/withBox.tsx
+++ b/packages/theming-react-native/src/ThemeProvider/withBox.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import { useTheme } from '../ThemeContext';
+import { ITheme } from '../Theme.types';
+
+const getBoxStyle = (theme: ITheme) => ({
+  backgroundColor: theme.colors.background
+});
+
+export const withBox = (WrappedComponent?: React.ComponentType): React.FunctionComponent<any> => (props: any) => {
+  const theme = useTheme();
+  const boxStyle = React.useMemo(() => getBoxStyle(theme), [theme]);
+  return WrappedComponent ? <WrappedComponent {...props} style={boxStyle} /> : <div {...props} style={boxStyle} />;
+};

--- a/packages/theming-react-native/src/index.native.ts
+++ b/packages/theming-react-native/src/index.native.ts
@@ -1,0 +1,2 @@
+export * from './indexcommon';
+export * from '@uifabricshared/themed-stylesheet';

--- a/packages/theming-react-native/src/index.ts
+++ b/packages/theming-react-native/src/index.ts
@@ -1,8 +1,1 @@
-export { addThemeRegistryListener, removeThemeRegistryListener, setTheme, getTheme, augmentPlatformTheme } from './Global';
-export * from './Theme.types';
-export { IThemeLayerProps, ThemeLayer } from './ThemeLayer';
-export * from './platform';
-export * from './ThemeProvider';
-export * from './ThemeProvider.types';
-export * from './ThemeContext';
-export * from './NativeModule';
+export * from './indexcommon';

--- a/packages/theming-react-native/src/indexcommon.ts
+++ b/packages/theming-react-native/src/indexcommon.ts
@@ -1,0 +1,7 @@
+export { addThemeRegistryListener, removeThemeRegistryListener, setTheme, getTheme, augmentPlatformTheme } from './Global';
+export * from './Theme.types';
+export { IThemeLayerProps, ThemeLayer } from './ThemeLayer';
+export * from './platform';
+export * from './ThemeProvider';
+export * from './ThemeContext';
+export * from './NativeModule';


### PR DESCRIPTION
This adds a 'Box' to ThemeProvider, mostly getting it out for review in the unlikely event someone wants to land this.

- The web is doing this too (see link in issue #75) on native it's just useful to have someone automatically set the background for you because that's one thing that might change when theme changes.
- Maybe I should've written the HOC using compose?
- re-exports themed-stylesheet from theming-react-native
- I kept theming-react-native with pure ReactJS support although I don't know if that actually makes sense any more.