### PR TITLE
Bump versions of rex-win32 and react-native-win32 packages

### DIFF
--- a/experiments/react-native-uifabric/package.json
+++ b/experiments/react-native-uifabric/package.json
@@ -19,8 +19,8 @@
     "verify-api": "just-scripts verify-api-extractor",
     "update-api": "just-scripts update-api-extractor",
     "build:tester": "just-scripts bundle --useMetro --bundleName rnTester",
-    "run-win32": "rex-win32 --bundle RNTester --component RNTesterApp --basePath ./dist",
-    "run-win32-web": "rex-win32 --bundle RNTester --component RNTesterApp --basePath ./dist --useWebDebugger"
+    "run-win32": "rex-win32 --bundle RNTester --component RNTesterApp --windowTitle \"FluentUI Tester\" --basePath ./dist",
+    "run-win32-web": "rex-win32 --bundle RNTester --component RNTesterApp --basePath ./dist --useWebDebugger --windowTitle \"FluentUI Tester\""
   },
   "dependencies": {
     "@uifabricshared/foundation-composable": "0.5.2",
@@ -33,8 +33,8 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@office-iss/react-native-win32": "0.26.2",
-    "@office-iss/rex-win32": "0.0.33",
+    "@office-iss/react-native-win32": "0.27.1",
+    "@office-iss/rex-win32": "0.0.34",
     "@types/prop-types": "15.5.1",
     "@types/react": "16.9.11",
     "@types/react-dom": "16.9.5",
@@ -49,7 +49,7 @@
   "peerDependencies": {
     "react": "^16.0.0",
     "react-native": "^0.59.0",
-    "@office-iss/react-native-win32": "0.26.4"
+    "@office-iss/react-native-win32": "0.27.1"
   },
   "metroBundles": {
     "uifabric": {

--- a/experiments/react-native-uifabric/src/RNTester/TestComponents/PressableTest.tsx
+++ b/experiments/react-native-uifabric/src/RNTester/TestComponents/PressableTest.tsx
@@ -12,14 +12,14 @@ const styles = StyleSheet.create({
     padding: 8,
     margin: 4,
     borderStyle: 'dotted',
-    borderColor: 'red',
+    borderColor: 'red'
   },
   solidBorder: {
     borderWidth: 1,
     padding: 8,
     margin: 4,
     borderStyle: 'solid',
-    borderColor: 'black',
+    borderColor: 'black'
   },
   notfocused: {
     borderWidth: 1,
@@ -72,7 +72,11 @@ export const PressableTest: React.FunctionComponent<{}> = () => {
       </Pressable>
       <Square color="green" />
       <Stack>
-        <ViewWin32 onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave} style={hoverState.hovered ? styles.dottedBorder : styles.solidBorder}>
+        <ViewWin32
+          onMouseEnter={onMouseEnter}
+          onMouseLeave={onMouseLeave}
+          style={hoverState.hovered ? styles.dottedBorder : styles.solidBorder}
+        >
           <Text>{hoverState.hovered ? 'hovered' : 'not hovered'}</Text>
         </ViewWin32>
       </Stack>
@@ -92,17 +96,12 @@ export const PressableTest: React.FunctionComponent<{}> = () => {
 };
 
 /* Pressable that only has focusState */
-const FocusComponent: React.FunctionComponent<IViewWin32Props> = (props: IViewWin32Props) => {
+const FocusComponent: React.FunctionComponent<IViewWin32Props> = () => {
   const [{ onFocus, onBlur }, focusState] = useFocusState();
 
   return (
     <Stack {...{ acceptsKeyboardFocus: false }}>
-      <ViewWin32
-        acceptsKeyboardFocus
-        onFocus={onFocus}
-        onBlur={onBlur}
-        style={focusState.focused ? styles.focused : styles.notfocused}
-      />
+      <ViewWin32 acceptsKeyboardFocus onFocus={onFocus} onBlur={onBlur} style={focusState.focused ? styles.focused : styles.notfocused} />
     </Stack>
   );
 };
@@ -115,7 +114,9 @@ const PressComponent: React.FunctionComponent<IViewWin32Props> = (props: IViewWi
     (e: ReactNative.GestureResponderEvent) => {
       pressProps.onTouchEnd && pressProps.onTouchEnd(e);
       ReactNative.Alert.alert('Alert.', 'Object has been pressed.');
-    }, [pressProps]);
+    },
+    [pressProps]
+  );
 
   return (
     <Stack {...{ acceptsKeyboardFocus: false }}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1184,12 +1184,6 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.4.0":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.3.tgz#0811944f73a6c926bb2ad35e918dcc1bfab279f1"
-  dependencies:
-    regenerator-runtime "^0.13.2"
-
 "@babel/template@^7.0.0", "@babel/template@^7.1.0", "@babel/template@^7.4.0", "@babel/template@^7.4.4", "@babel/template@^7.6.0":
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.6.0.tgz#7f0159c7f5012230dad64cca42ec9bdb5c9536e6"
@@ -2300,11 +2294,12 @@
     once "^1.4.0"
     universal-user-agent "^4.0.0"
 
-"@office-iss/react-native-win32@0.26.2":
-  version "0.26.2"
-  resolved "https://registry.yarnpkg.com/@office-iss/react-native-win32/-/react-native-win32-0.26.2.tgz#0aa48c5688673fabbedd16eb00fd6f6a7c397576"
+"@office-iss/react-native-win32@0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@office-iss/react-native-win32/-/react-native-win32-0.27.1.tgz#4e844e7e3eafd5c78fa8e173c6023b543430745d"
+  integrity sha512-nlsMrW1DhmO1X4lRKu5uiDJ6ObV0K2kK8aBXU3KDILVWmdJSUC8xUKBj9Aqs2g1UptkTGDn9l2UKq7LWgbiRTQ==
   dependencies:
-    "@babel/runtime" "^7.4.0"
+    "@babel/runtime" "^7.0.0"
     "@react-native-community/cli" "^2.6.0"
     abort-controller "^3.0.0"
     art "^0.10.0"
@@ -2325,10 +2320,10 @@
     stacktrace-parser "^0.1.3"
     whatwg-fetch "^3.0.0"
 
-"@office-iss/rex-win32@0.0.33":
-  version "0.0.33"
-  resolved "https://registry.yarnpkg.com/@office-iss/rex-win32/-/rex-win32-0.0.33.tgz#960ed52275c827df58aede4819d39927bdf2ae70"
-  integrity sha512-Eh4orZ3F4P03IJAn509H7rXPcA8/6iXIEJbBTrNdO0RK6gVIRQ/5GVVPg3BA3QrFN7GDJeXOqjN1/9daV4O8ag==
+"@office-iss/rex-win32@0.0.34":
+  version "0.0.34"
+  resolved "https://registry.yarnpkg.com/@office-iss/rex-win32/-/rex-win32-0.0.34.tgz#8c529a7c66a72edbb99b981a5c80662f5959a122"
+  integrity sha512-1G/qJ+gKuKqdZ9uIdfMUJjCq5JsOjUIqd85vXTwsFUn1qyn5dGTSHwYwegFS3UfEeP3GNI619xAnfZmcrQAfYA==
   dependencies:
     command-line-args "^5.0.2"
     command-line-usage "^5.0.5"


### PR DESCRIPTION
Upgrade the versions of these two packages in order to pull in support for the `<Picker>` component. 