### PR TITLE
Add a Slider component and use it in PersonaCoin test page

### DIFF
--- a/experiments/tester/src/RNTester/TestComponents/Common/AlignmentPicker.tsx
+++ b/experiments/tester/src/RNTester/TestComponents/Common/AlignmentPicker.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { undefinedText } from '../PersonaCoin/styles';
+import { IconAlignment } from 'react-native-uifabric';
+import { Picker, StyleProp, ViewStyle } from 'react-native';
+
+
+const alignmentValues: Array<typeof undefinedText | IconAlignment> = [undefinedText, 'start', 'center', 'end'];
+
+interface IAlignmentPickerProps {
+  style?: StyleProp<ViewStyle>;
+  label: string;
+  onSelectionChange: (value: IconAlignment | undefined) => void;
+}
+
+export const AlignmentPicker: React.FunctionComponent<IAlignmentPickerProps> = (props: IAlignmentPickerProps) => {
+  const { label, onSelectionChange, style } = props;
+  return (
+    <Picker
+      style={style}
+      prompt={label}
+      selectedValue={undefinedText}
+      onValueChange={(value, index) => onSelectionChange(index == 0 ? undefined : value)}
+    >
+      {alignmentValues.map((alignment, index) => (
+        <Picker.Item label={alignment} key={index} value={alignment} />
+      ))}
+    </Picker>
+  );
+};

--- a/experiments/tester/src/RNTester/TestComponents/Common/Slider.tsx
+++ b/experiments/tester/src/RNTester/TestComponents/Common/Slider.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ViewProps, StyleSheet, StyleProp, ViewStyle, UIManager, findNodeHandle } from 'react-native';
+import { ViewProps, StyleSheet, StyleProp, ViewStyle, UIManager, Text, findNodeHandle } from 'react-native';
 import { ViewWin32 } from '@office-iss/react-native-win32';
 import { Separator, Pressable, IPressableState } from 'react-native-uifabric';
 
@@ -16,15 +16,19 @@ interface ISliderProps extends ViewProps {
 
 const styles = StyleSheet.create({
   root: {
+    flexDirection: 'row',
+    alignItems: 'center'
+  },
+  slider: {
     minWidth: thumbSize * 2,
     flexDirection: 'row',
     alignItems: 'center',
     alignContent: 'stretch',
-    height: thumbSize
+    height: thumbSize,
+    width: 200
   },
   track: {
-    flexGrow: 1,
-    flexShrink: 1
+    flexGrow: 1
   },
   thumb: {
     width: thumbSize,
@@ -34,28 +38,37 @@ const styles = StyleSheet.create({
     borderColor: '#7A7574',
     backgroundColor: '#FFFFFF',
     position: 'absolute'
+  },
+  label: {
+    margin: 8,
+    fontSize: 12
   }
 });
 
 const Track = Separator.customize({ tokens: { separatorWidth: 4 } });
 
 function onThumbRenderStyle(state: IPressableState, thumbLocation: number): StyleProp<ViewStyle> {
-  return { 
+  return {
     ...styles.thumb,
-    borderColor: state.pressed ? 'black' : (state.hovered ? 'red' : '#7A7574'),
+    borderColor: state.pressed ? 'black' : state.hovered ? 'red' : '#7A7574',
     marginLeft: thumbLocation
   };
 }
 
 function calculateNewValue(thumbLocation: number, trackLength: number, minimum: number, maximum: number): [number, number] {
-  const newValue = minimum + (thumbLocation / trackLength * (maximum - minimum));
-  const intValue = Math.min(maximum, Math.floor(newValue + 0.3));   // snap to nearest integer value
-  const newThumbLocation = trackLength * (intValue - minimum) / (maximum - minimum);
+  const newValue = minimum + (thumbLocation / trackLength) * (maximum - minimum);
+  const intValue = Math.min(maximum, Math.floor(newValue + 0.3)); // snap to nearest integer value
+  const newThumbLocation = (trackLength * (intValue - minimum)) / (maximum - minimum);
   return [intValue, newThumbLocation];
 }
 
-function calculateNewThumbLocation(currentThumbLocation: number, startTouchPosition: number, currentTouchPosition: number, trackLength: number): number {
-  let newLocation = currentThumbLocation + currentTouchPosition - startTouchPosition;
+function calculateNewThumbLocation(
+  startTouchThumbLocation: number,
+  startTouchPosition: number,
+  currentTouchPosition: number,
+  trackLength: number
+): number {
+  let newLocation = startTouchThumbLocation + currentTouchPosition - startTouchPosition;
   newLocation = Math.max(0, newLocation);
   newLocation = Math.min(newLocation, trackLength);
   return newLocation;
@@ -85,57 +98,80 @@ export const Slider: React.FunctionComponent<ISliderProps> = (props: ISliderProp
   const { style: userStyle, onChange } = props;
 
   const [thumbLocation, setThumbLocation] = React.useState<number>(0);
-  
+
   const startTouchPosition = React.useRef<number>(-1);
   const startTouchThumbLocation = React.useRef<number>(-1);
   const trackLength = React.useRef<number>(-1);
+  const currentValue = React.useRef<number>(initialValue);
 
   const ref = React.useRef<ViewWin32>(null);
 
-  React.useEffect(()=> {
+  React.useEffect(() => {
     const parent = findNodeHandle(ref.current);
     if (parent) {
       UIManager.measure(parent, (x, y, width) => {
-        // the track length is the entire view width subtracted by the thumb size.
+        if (width <= 0) {
+          return;
+        }
+
+        // track length is the entire view width subtracted by the thumb size.
         trackLength.current = Math.max(0, width - thumbSize);
-        
-        const initialThumbLocation = trackLength.current * (initialValue! - minimum!) / (maximum! - minimum!);
+
+        const initialThumbLocation = (trackLength.current * (initialValue! - minimum!)) / (maximum! - minimum!);
         setThumbLocation(initialThumbLocation);
       });
     }
   }, [ref.current, initialValue, maximum, minimum]);
 
   return (
-    <ViewWin32 ref={ref} {...props} style={[userStyle, styles.root]}>
-      <Track style={styles.track} />
-      <Pressable
-        renderStyle={state => onThumbRenderStyle(state, thumbLocation)}
-        onStartShouldSetResponder={() => trackLength.current > 0}
-        onResponderStart={e => {
-          startTouchPosition.current = e.nativeEvent.pageX;
-          startTouchThumbLocation.current = thumbLocation;
-        }}
-        onResponderMove={e => {
-          if (startTouchPosition.current !== -1 && trackLength.current > 0) {
-            const newThumLocation = calculateNewThumbLocation(startTouchThumbLocation.current, startTouchPosition.current, e.nativeEvent.pageX, trackLength.current);
-            setThumbLocation(newThumLocation);
-          }
-        }}
-        onResponderEnd={() => {
-          startTouchPosition.current = -1;
-          startTouchThumbLocation.current = -1;
-        }}
-        onResponderRelease={() => {
-          if (trackLength.current <= 0) {
-            return;
-          }
-          const [newValue, newThumbLocation] = calculateNewValue(thumbLocation, trackLength.current, minimum || defaultMinimumValue, maximum || defaultMaximumValue);
-          setThumbLocation(newThumbLocation);
-          if (onChange) {
-            onChange(newValue);
-          }
-        }}
-      />
+    <ViewWin32 style={[userStyle, styles.root]}>
+      <ViewWin32 ref={ref} {...props} style={styles.slider}>
+        <Track style={styles.track} />
+        {trackLength.current > 0 && (
+          <Pressable
+            renderStyle={state => onThumbRenderStyle(state, thumbLocation)}
+            onStartShouldSetResponder={() => trackLength.current > 0}
+            onResponderStart={e => {
+              startTouchPosition.current = e.nativeEvent.pageX;
+              startTouchThumbLocation.current = thumbLocation;
+            }}
+            onResponderMove={e => {
+              if (startTouchPosition.current !== -1 && trackLength.current > 0) {
+                const newThumbLocation = calculateNewThumbLocation(
+                  startTouchThumbLocation.current,
+                  startTouchPosition.current,
+                  e.nativeEvent.pageX,
+                  trackLength.current
+                );
+                console.log(newThumbLocation);
+                setThumbLocation(newThumbLocation);
+              }
+            }}
+            onResponderEnd={() => {
+              startTouchPosition.current = -1;
+              startTouchThumbLocation.current = -1;
+            }}
+            onResponderRelease={() => {
+              if (trackLength.current <= 0) {
+                return;
+              }
+              const [newValue, newThumbLocation] = calculateNewValue(
+                thumbLocation,
+                trackLength.current,
+                minimum || defaultMinimumValue,
+                maximum || defaultMaximumValue
+              );
+              setThumbLocation(newThumbLocation);
+              if (onChange) {
+                currentValue.current = newValue;
+                onChange(newValue);
+              }
+            }}
+          />
+        )}
+      </ViewWin32>
+
+      <Text style={styles.label}>{currentValue.current}</Text>
     </ViewWin32>
   );
 };

--- a/experiments/tester/src/RNTester/TestComponents/Common/Slider.tsx
+++ b/experiments/tester/src/RNTester/TestComponents/Common/Slider.tsx
@@ -1,0 +1,141 @@
+import * as React from 'react';
+import { ViewProps, StyleSheet, StyleProp, ViewStyle, UIManager, findNodeHandle } from 'react-native';
+import { ViewWin32 } from '@office-iss/react-native-win32';
+import { Separator, Pressable, IPressableState } from 'react-native-uifabric';
+
+const thumbSize = 20;
+const defaultMaximumValue = 100;
+const defaultMinimumValue = 1;
+
+interface ISliderProps extends ViewProps {
+  minimum?: number;
+  maximum?: number;
+  initialValue?: number;
+  onChange?: (value: number) => void;
+}
+
+const styles = StyleSheet.create({
+  root: {
+    minWidth: thumbSize * 2,
+    flexDirection: 'row',
+    alignItems: 'center',
+    alignContent: 'stretch',
+    height: thumbSize
+  },
+  track: {
+    flexGrow: 1,
+    flexShrink: 1
+  },
+  thumb: {
+    width: thumbSize,
+    height: thumbSize,
+    borderRadius: thumbSize,
+    borderWidth: 2,
+    borderColor: '#7A7574',
+    backgroundColor: '#FFFFFF',
+    position: 'absolute'
+  }
+});
+
+const Track = Separator.customize({ tokens: { separatorWidth: 4 } });
+
+function onThumbRenderStyle(state: IPressableState, thumbLocation: number): StyleProp<ViewStyle> {
+  return { 
+    ...styles.thumb,
+    borderColor: state.pressed ? 'black' : (state.hovered ? 'red' : '#7A7574'),
+    marginLeft: thumbLocation
+  };
+}
+
+function calculateNewValue(thumbLocation: number, trackLength: number, minimum: number, maximum: number): [number, number] {
+  const newValue = minimum + (thumbLocation / trackLength * (maximum - minimum));
+  const intValue = Math.min(maximum, Math.floor(newValue + 0.3));   // snap to nearest integer value
+  const newThumbLocation = trackLength * (intValue - minimum) / (maximum - minimum);
+  return [intValue, newThumbLocation];
+}
+
+function calculateNewThumbLocation(currentThumbLocation: number, startTouchPosition: number, currentTouchPosition: number, trackLength: number): number {
+  let newLocation = currentThumbLocation + currentTouchPosition - startTouchPosition;
+  newLocation = Math.max(0, newLocation);
+  newLocation = Math.min(newLocation, trackLength);
+  return newLocation;
+}
+
+function verifyProps(initialValue: number, minimum: number, maximum: number) {
+  if (minimum >= maximum) {
+    throw new Error(`'minimum' must not be greater than or equal 'maximum'.`);
+  }
+
+  if (initialValue < minimum) {
+    throw new Error(`'initialValue' must not be less than 'minimum'.`);
+  }
+
+  if (initialValue > maximum) {
+    throw new Error(`'initialValue' must not be greater than 'maximum'.`);
+  }
+}
+
+export const Slider: React.FunctionComponent<ISliderProps> = (props: ISliderProps) => {
+  let { minimum, maximum, initialValue } = props;
+  minimum = minimum || defaultMinimumValue;
+  maximum = maximum || defaultMaximumValue;
+  initialValue = initialValue || minimum;
+  verifyProps(initialValue, minimum, maximum);
+
+  const { style: userStyle, onChange } = props;
+
+  const [thumbLocation, setThumbLocation] = React.useState<number>(0);
+  
+  const startTouchPosition = React.useRef<number>(-1);
+  const startTouchThumbLocation = React.useRef<number>(-1);
+  const trackLength = React.useRef<number>(-1);
+
+  const ref = React.useRef<ViewWin32>(null);
+
+  React.useEffect(()=> {
+    const parent = findNodeHandle(ref.current);
+    if (parent) {
+      UIManager.measure(parent, (x, y, width) => {
+        // the track length is the entire view width subtracted by the thumb size.
+        trackLength.current = Math.max(0, width - thumbSize);
+        
+        const initialThumbLocation = trackLength.current * (initialValue! - minimum!) / (maximum! - minimum!);
+        setThumbLocation(initialThumbLocation);
+      });
+    }
+  }, [ref.current, initialValue, maximum, minimum]);
+
+  return (
+    <ViewWin32 ref={ref} {...props} style={[userStyle, styles.root]}>
+      <Track style={styles.track} />
+      <Pressable
+        renderStyle={state => onThumbRenderStyle(state, thumbLocation)}
+        onStartShouldSetResponder={() => trackLength.current > 0}
+        onResponderStart={e => {
+          startTouchPosition.current = e.nativeEvent.pageX;
+          startTouchThumbLocation.current = thumbLocation;
+        }}
+        onResponderMove={e => {
+          if (startTouchPosition.current !== -1 && trackLength.current > 0) {
+            const newThumLocation = calculateNewThumbLocation(startTouchThumbLocation.current, startTouchPosition.current, e.nativeEvent.pageX, trackLength.current);
+            setThumbLocation(newThumLocation);
+          }
+        }}
+        onResponderEnd={() => {
+          startTouchPosition.current = -1;
+          startTouchThumbLocation.current = -1;
+        }}
+        onResponderRelease={() => {
+          if (trackLength.current <= 0) {
+            return;
+          }
+          const [newValue, newThumbLocation] = calculateNewValue(thumbLocation, trackLength.current, minimum || defaultMinimumValue, maximum || defaultMaximumValue);
+          setThumbLocation(newThumbLocation);
+          if (onChange) {
+            onChange(newValue);
+          }
+        }}
+      />
+    </ViewWin32>
+  );
+};

--- a/experiments/tester/src/RNTester/TestComponents/Common/Slider.tsx
+++ b/experiments/tester/src/RNTester/TestComponents/Common/Slider.tsx
@@ -55,23 +55,23 @@ function onThumbRenderStyle(state: IPressableState, thumbLocation: number): Styl
   };
 }
 
-function calculateNewValue(thumbLocation: number, trackLength: number, minimum: number, maximum: number): [number, number] {
-  const newValue = minimum + (thumbLocation / trackLength) * (maximum - minimum);
-  const intValue = Math.min(maximum, Math.floor(newValue + 0.3)); // snap to nearest integer value
-  const newThumbLocation = (trackLength * (intValue - minimum)) / (maximum - minimum);
-  return [intValue, newThumbLocation];
-}
-
-function calculateNewThumbLocation(
+function calculateThumbLocationAndValue(
   startTouchThumbLocation: number,
   startTouchPosition: number,
   currentTouchPosition: number,
-  trackLength: number
-): number {
-  let newLocation = startTouchThumbLocation + currentTouchPosition - startTouchPosition;
-  newLocation = Math.max(0, newLocation);
-  newLocation = Math.min(newLocation, trackLength);
-  return newLocation;
+  trackLength: number,
+  minimum: number,
+  maximum: number
+): [number, number] {
+  let newThumbLocation = startTouchThumbLocation + currentTouchPosition - startTouchPosition;
+  newThumbLocation = Math.max(0, newThumbLocation);
+  newThumbLocation = Math.min(newThumbLocation, trackLength);
+
+  const newValue = minimum + (newThumbLocation / trackLength) * (maximum - minimum);
+  const intValue = Math.min(maximum, Math.floor(newValue + 0.3)); // snap to nearest integer value
+  newThumbLocation = (trackLength * (intValue - minimum)) / (maximum - minimum);
+
+  return [newThumbLocation, intValue];
 }
 
 function verifyProps(initialValue: number, minimum: number, maximum: number) {
@@ -102,7 +102,7 @@ export const Slider: React.FunctionComponent<ISliderProps> = (props: ISliderProp
   const startTouchPosition = React.useRef<number>(-1);
   const startTouchThumbLocation = React.useRef<number>(-1);
   const trackLength = React.useRef<number>(-1);
-  const currentValue = React.useRef<number>(initialValue);
+  const sliderValue = React.useRef<number>(initialValue);
 
   const ref = React.useRef<ViewWin32>(null);
 
@@ -137,13 +137,16 @@ export const Slider: React.FunctionComponent<ISliderProps> = (props: ISliderProp
             }}
             onResponderMove={e => {
               if (startTouchPosition.current !== -1 && trackLength.current > 0) {
-                const newThumbLocation = calculateNewThumbLocation(
+                const [newThumbLocation, newValue] = calculateThumbLocationAndValue(
                   startTouchThumbLocation.current,
                   startTouchPosition.current,
                   e.nativeEvent.pageX,
-                  trackLength.current
+                  trackLength.current,
+                  minimum || defaultMinimumValue,
+                  maximum || defaultMaximumValue
                 );
-                console.log(newThumbLocation);
+
+                sliderValue.current = newValue;
                 setThumbLocation(newThumbLocation);
               }
             }}
@@ -152,26 +155,15 @@ export const Slider: React.FunctionComponent<ISliderProps> = (props: ISliderProp
               startTouchThumbLocation.current = -1;
             }}
             onResponderRelease={() => {
-              if (trackLength.current <= 0) {
-                return;
-              }
-              const [newValue, newThumbLocation] = calculateNewValue(
-                thumbLocation,
-                trackLength.current,
-                minimum || defaultMinimumValue,
-                maximum || defaultMaximumValue
-              );
-              setThumbLocation(newThumbLocation);
               if (onChange) {
-                currentValue.current = newValue;
-                onChange(newValue);
+                onChange(sliderValue.current);
               }
             }}
           />
         )}
       </ViewWin32>
 
-      <Text style={styles.label}>{currentValue.current}</Text>
+      <Text style={styles.label}>{sliderValue.current}</Text>
     </ViewWin32>
   );
 };

--- a/experiments/tester/src/RNTester/TestComponents/PersonaCoin/CustomizeUsage.tsx
+++ b/experiments/tester/src/RNTester/TestComponents/PersonaCoin/CustomizeUsage.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { PersonaCoin, IconAlignment, IPersonaCoinTokens } from 'react-native-uifabric';
 import { Switch, View, Text, Picker, TextInput } from 'react-native';
+import { Slider } from '../Common/Slider';
 import { styles, steveBallmerPhotoUrl, undefinedText } from './styles';
 import { useTheme } from '@uifabricshared/theming-react-native';
 
@@ -27,50 +28,13 @@ const AlignmentPicker: React.FunctionComponent<IAlignmentPickerProps> = (props: 
   );
 };
 
-interface INumericInputProps {
-  label: string;
-  maximum?: number;
-  onSubmit: (value: number | undefined) => void;
-}
-
-const NumericInput: React.FunctionComponent<INumericInputProps> = (props: INumericInputProps) => {
-  const { label, onSubmit, maximum } = props;
-
-  const theme = useTheme();
-  const textBoxBorderStyle = {
-    borderColor: theme.colors.inputBorder,
-    width: 100
-  };
-
-  return (
-    <TextInput
-      placeholder={label}
-      style={[styles.textBox, textBoxBorderStyle]}
-      blurOnSubmit={true}
-      onSubmitEditing={e => {
-        const stringValue = e.nativeEvent.text;
-        let numericValue = stringValue ? parseInt(stringValue) : NaN;
-        if (isNaN(numericValue)) {
-          onSubmit(undefined);
-        } else {
-          numericValue = Math.max(0, numericValue);
-          if (maximum) {
-            numericValue = Math.min(numericValue, maximum);
-          }
-          onSubmit(numericValue);
-        }
-      }}
-    />
-  );
-};
-
 export const CustomizeUsage: React.FunctionComponent<{}> = () => {
   const [showImage, setShowImage] = React.useState(true);
   const [coinColor, setCoinColor] = React.useState<string>();
   const [textColor, setTextColor] = React.useState<string>();
-  const [physicalSize, setPhysicalCoinSize] = React.useState<number>();
-  const [iconSize, setIconSize] = React.useState<number>();
-  const [initialsSize, setInitialsFontSize] = React.useState<number>();
+  const [physicalSize, setPhysicalSize] = React.useState<number>(80);
+  const [iconSize, setIconSize] = React.useState<number>(24);
+  const [initialsSize, setInitialsSize] = React.useState<number>(14);
   const [horizontalAlignment, setHorizontalAlignment] = React.useState<IconAlignment>();
   const [verticalAlignment, setVerticalAlignment] = React.useState<IconAlignment>();
 
@@ -135,11 +99,14 @@ export const CustomizeUsage: React.FunctionComponent<{}> = () => {
 
         <AlignmentPicker label="Vertical icon alignment" onSelectionChange={setVerticalAlignment} />
 
-        <NumericInput label="Coin size" maximum={200} onSubmit={setPhysicalCoinSize} />
+        <Text>Coin size</Text>
+        <Slider minimum={8} maximum={200} initialValue={80} style={styles.slider} onChange={setPhysicalSize} />
 
-        <NumericInput label="Icon size" maximum={100} onSubmit={setIconSize} />
+        <Text>Icon size</Text>
+        <Slider minimum={8} maximum={100} initialValue={24} style={styles.slider} onChange={setIconSize} />
 
-        <NumericInput label="Font size" maximum={50} onSubmit={setInitialsFontSize} />
+        <Text>Font size</Text>
+        <Slider minimum={5} maximum={50} initialValue={14} style={styles.slider} onChange={setInitialsSize} />
       </View>
 
       {/* component under test */}

--- a/experiments/tester/src/RNTester/TestComponents/PersonaCoin/CustomizeUsage.tsx
+++ b/experiments/tester/src/RNTester/TestComponents/PersonaCoin/CustomizeUsage.tsx
@@ -1,32 +1,10 @@
 import * as React from 'react';
 import { PersonaCoin, IconAlignment, IPersonaCoinTokens } from 'react-native-uifabric';
-import { Switch, View, Text, Picker, TextInput } from 'react-native';
+import { Switch, View, Text, TextInput } from 'react-native';
 import { Slider } from '../Common/Slider';
-import { styles, steveBallmerPhotoUrl, undefinedText } from './styles';
+import { styles, steveBallmerPhotoUrl } from './styles';
 import { useTheme } from '@uifabricshared/theming-react-native';
-
-const alignmentValues: Array<typeof undefinedText | IconAlignment> = [undefinedText, 'start', 'center', 'end'];
-
-interface IAlignmentPickerProps {
-  label: string;
-  onSelectionChange: (value: IconAlignment | undefined) => void;
-}
-
-const AlignmentPicker: React.FunctionComponent<IAlignmentPickerProps> = (props: IAlignmentPickerProps) => {
-  const { label, onSelectionChange } = props;
-  return (
-    <Picker
-      prompt={label}
-      style={styles.header}
-      selectedValue={undefinedText}
-      onValueChange={(value, index) => onSelectionChange(index == 0 ? undefined : value)}
-    >
-      {alignmentValues.map((alignment, index) => (
-        <Picker.Item label={alignment} key={index} value={alignment} />
-      ))}
-    </Picker>
-  );
-};
+import { AlignmentPicker } from '../Common/AlignmentPicker';
 
 export const CustomizeUsage: React.FunctionComponent<{}> = () => {
   const [showImage, setShowImage] = React.useState(true);
@@ -95,9 +73,8 @@ export const CustomizeUsage: React.FunctionComponent<{}> = () => {
           }}
         />
 
-        <AlignmentPicker label="Horizontal icon alignment" onSelectionChange={setHorizontalAlignment} />
-
-        <AlignmentPicker label="Vertical icon alignment" onSelectionChange={setVerticalAlignment} />
+        <AlignmentPicker style={styles.header} label="Horizontal icon alignment" onSelectionChange={setHorizontalAlignment} />
+        <AlignmentPicker style={styles.header} label="Vertical icon alignment" onSelectionChange={setVerticalAlignment} />
 
         <Text>Coin size</Text>
         <Slider minimum={8} maximum={200} initialValue={80} style={styles.slider} onChange={setPhysicalSize} />

--- a/experiments/tester/src/RNTester/TestComponents/PersonaCoin/styles.ts
+++ b/experiments/tester/src/RNTester/TestComponents/PersonaCoin/styles.ts
@@ -34,8 +34,7 @@ export const styles = StyleSheet.create({
     marginBottom: 8
   },
   slider: {
-    width: 200,
-    marginVertical: 8
+    marginVertical: 6
   }
 });
 

--- a/experiments/tester/src/RNTester/TestComponents/PersonaCoin/styles.ts
+++ b/experiments/tester/src/RNTester/TestComponents/PersonaCoin/styles.ts
@@ -14,7 +14,7 @@ export const styles = StyleSheet.create({
     alignItems: 'center'
   },
   header: {
-    marginTop: 12,
+    marginVertical: 6,
     fontSize: 12
   },
   section: {

--- a/experiments/tester/src/RNTester/TestComponents/PersonaCoin/styles.ts
+++ b/experiments/tester/src/RNTester/TestComponents/PersonaCoin/styles.ts
@@ -32,6 +32,10 @@ export const styles = StyleSheet.create({
     fontSize: 12,
     width: 150,
     marginBottom: 8
+  },
+  slider: {
+    width: 200,
+    marginVertical: 8
   }
 });
 


### PR DESCRIPTION
- Wrote a simple Slider component. I'm putting it under `tester/components/common` for sharing among test pages. If we decide to make it a full fledged FluentUI component, we can move it to `react-native-uifabric` package. 

- Use it on the PersonaCoin test page. 
- Also move the `AlignmentPicker` helper component to the `common` folder.