### PR TITLE
Fix direct debugger

### DIFF
--- a/experiments/tester/README.md
+++ b/experiments/tester/README.md
@@ -22,7 +22,30 @@
     yarn run-win32
 ```
 
-## Debug `RNTester` app
+## Debug `RNTester` app with direct debugging
+
+1. Follow the same step #1 as above.
+2. Follow the same step #2 as above.
+
+3. Build the RNTester bundle with dev option. This will ensure source map is included in the bundle.
+
+```
+    yarn bundle-dev
+```
+
+4. Launch the RNTester app:
+
+```
+    yarn run-win32
+```
+
+5. Inside ReactTest, open the debug option menu and select the checkbox `Use Direct Debugger`
+
+6. In VS Code, open the debug pane and select `Debug Fabric Tester` option from the "Run And Debug" dropdown.
+
+7. At this time, VS Code will attach to the JS runtime and you can start debugging.
+
+## Debug `RNTester` app with web debugging
 
 1. Follow the same step #1 as above.
 2. Follow the same step #2 as above.

--- a/experiments/tester/package.json
+++ b/experiments/tester/package.json
@@ -13,6 +13,7 @@
     "code-style": "just-scripts code-style",
     "lint": "just-scripts eslint",
     "bundle": "just-scripts bundle --useMetro --bundleName rnTester",
+    "bundle-dev": "just-scripts bundle --useMetro --bundleName rnTester.dev",
     "start": "react-native start --projectRoot ./src",
     "run-win32": "rex-win32 --bundle RNTester --component RNTesterApp --windowTitle \"FluentUI Tester\" --basePath ./dist --pluginProps",
     "run-win32-web": "rex-win32 --bundle RNTester --component RNTesterApp --basePath ./dist --useWebDebugger --windowTitle \"FluentUI Tester\" --useLiveReload --pluginProps"
@@ -50,6 +51,11 @@
     "rnTester": {
       "entry": "./src/RNTester.ts",
       "output": "./dist/RNTester.bundle"
+    },
+    "rnTester.dev": {
+      "entry": "./src/RNTester.ts",
+      "output": "./dist/RNTester.bundle",
+      "dev": true
     }
   },
   "author": "",

--- a/scripts/tasks/metro-pack.js
+++ b/scripts/tasks/metro-pack.js
@@ -36,12 +36,15 @@ exports.metroPackTask = function(bundleName) {
     justTask.logger.info(`Entry file ${entryFile}.`);
     justTask.logger.info(`Output file ${outputBundlePath}.`);
 
+    const dev = (options && options.dev) || false;
+
     await Metro.runBuild(config, {
       platform: (options && options.platform) || 'win32',
       entry: entryFile,
-      minify: (options && options.minify) || true,
+      minify: !dev,
       out: outputBundlePath,
-      optimize: true
+      optimize: !dev,
+      sourceMap: dev
     });
 
     // if the output file's extension is not '.js', metro appends the '.js' to it (how rude!)


### PR DESCRIPTION
This change will make direct debugger work with the Fabric Tester app. Also updated the README file to include instructions on how to do direct debugging.  