### PR TITLE
Fix crash bug in Persona Test page

### DIFF
--- a/experiments/tester/src/RNTester/TestComponents/Persona/StandardUsage.tsx
+++ b/experiments/tester/src/RNTester/TestComponents/Persona/StandardUsage.tsx
@@ -56,8 +56,8 @@ export const StandardUsage: React.FunctionComponent<{}> = () => {
         <Picker
           prompt="Size"
           style={styles.header}
-          selectedValue={imageSize !== undefined ? imageSize : undefinedText}
-          onValueChange={size => setImageSize(size)}
+          selectedValue={imageSize || undefinedText}
+          onValueChange={size => setImageSize(size === undefinedText ? undefined : size)}
         >
           {allSizes.map((size, index) => (
             <Picker.Item label={size} key={index} value={size} />


### PR DESCRIPTION
On the Persona Test page, if I select the image size as `(undefined)`, the test app crashes. This will fix it. 