### PR TITLE
🎨 Create host settings in theme object for direct access to native colors

### DIFF
--- a/change/@uifabricshared-theming-react-native-2020-03-05-17-33-52-hostcolors.json
+++ b/change/@uifabricshared-theming-react-native-2020-03-05-17-33-52-hostcolors.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "🎨 Create host settings in theme object for direct access to native colors",
+  "packageName": "@uifabricshared/theming-react-native",
+  "email": "adrum@microsoft.com",
+  "commit": "bd89c1fdc283b80bdfaec69fc43164a845bbc48f",
+  "dependentChangeType": "patch",
+  "date": "2020-03-06T01:33:51.985Z"
+}

--- a/experiments/tester/package.json
+++ b/experiments/tester/package.json
@@ -26,6 +26,7 @@
     "@uifabricshared/immutable-merge": "0.2.3",
     "@uifabricshared/theming-ramp": "0.5.4",
     "@uifabricshared/theming-react-native": "0.3.4",
+    "@uifabricshared/themed-stylesheet": "0.2.6",
     "react-native-uifabric": "0.12.10",
     "tslib": "^1.9.3"
   },

--- a/experiments/tester/src/RNTester/TestComponents/ThemeTest.tsx
+++ b/experiments/tester/src/RNTester/TestComponents/ThemeTest.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react';
 import * as ReactNative from 'react-native';
-import { ThemeProvider, useTheme } from '@uifabricshared/theming-react-native';
+import { getHostSettingsWin32, ThemeProvider, useTheme, IThemeDefinition } from '@uifabricshared/theming-react-native';
+import { themedStyleSheet } from '@uifabricshared/themed-stylesheet';
 import { commonTestStyles } from '../styles';
-import { Button, PrimaryButton, StealthButton, Text } from 'react-native-uifabric';
+import { Button, PrimaryButton, Separator, StealthButton, Text, RadioGroup, RadioButton } from 'react-native-uifabric';
+import { ITheme, IPartialTheme } from '@uifabricshared/theming-ramp';
+import { customRegistry } from '../CustomThemes';
 
 const Panel: React.FunctionComponent = () => {
   const [disabled, setDisabled] = React.useState(false);
@@ -19,13 +22,151 @@ const Panel: React.FunctionComponent = () => {
   );
 };
 
-export const ThemeTest: React.FunctionComponent = () => {
+let brand = 'Office';
+
+const brandColors = {
+  Word: ['#E3ECFA', '#A5B9D1', '#7DA3C6', '#4A78B0', '#3C65A4', '#2B579A', '#124078', '#002050'],
+  Excel: ['#E9F5EE', '#9FCDB3', '#6EB38A', '#4E9668', '#3F8159', '#217346', '#0E5C2F', '#004B1C'],
+  Powerpoint: ['#FCF0ED', '#FDC9B5', '#ED9583', '#E86E58', '#C75033', '#B7472A', '#A92B1A', '#740912'],
+  Outlook: ['#CCE3F5', '#B3D6F2', '#69AFE5', '#2488D8', '#0078D7', '#106EBE', '#1664A7', '#135995']
+};
+
+const fakeBrandTheme: IThemeDefinition = (theme: ITheme): IPartialTheme => {
+  if (brand === 'Office') return {};
+
+  const brandValues = theme.colors.brand.values;
+  const brandedTheme = { colors: {}, host: { palette: {} } };
+  Object.keys(theme.colors).forEach((value: string) => {
+    if (typeof theme.colors[value] === 'string') {
+      const index = brandValues.indexOf(theme.colors[value].toString());
+      if (index !== -1) brandedTheme.colors[value] = brandColors[brand][index];
+    }
+  });
+
+  const hostThemeSettings = getHostSettingsWin32(theme);
+  if (hostThemeSettings === undefined) return brandedTheme;
+
+  Object.keys(hostThemeSettings.palette).forEach((value: string) => {
+    const index = brandValues.indexOf(hostThemeSettings.palette[value].toString());
+    if (index !== -1) brandedTheme.host.palette[value] = brandColors[brand][index];
+  });
+  return brandedTheme;
+};
+
+customRegistry.setTheme(fakeBrandTheme, 'BrandedTheme');
+
+const getThemedStyles = themedStyleSheet((theme: ITheme) => ({
+  swatch: {
+    width: 80,
+    height: 20,
+    marginRight: 5,
+    borderWidth: 2,
+    borderColor: theme.colors.bodyText
+  },
+  extraLargeStandardEmphasis: {
+    color: theme['host'].palette.TextEmphasis,
+    fontSize: theme.typography.sizes.xxLarge,
+    fontWeight: theme.typography.weights.medium,
+    fontFamily: theme.typography.families.primary
+  } as ReactNative.TextStyle,
+  largeStandard: {
+    color: theme.colors.bodyText,
+    fontSize: theme.typography.sizes.large,
+    fontWeight: theme.typography.weights.medium,
+    fontFamily: theme.typography.families.primary,
+    marginBottom: 5
+  } as ReactNative.TextStyle
+}));
+
+const styles = ReactNative.StyleSheet.create({
+  swatchItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginVertical: 5
+  }
+});
+
+const getSwatchColorStyle = (color: string): ReactNative.ViewStyle => {
+  styles[color] = styles[color] || { backgroundColor: color };
+  return styles[color];
+};
+
+type SemanticColorProps = { color: string; name: string };
+const SemanticColor: React.FunctionComponent<SemanticColorProps> = (p: SemanticColorProps) => {
+  const themedStyles = getThemedStyles(useTheme());
+  return (
+    <ReactNative.View style={styles.swatchItem}>
+      <ReactNative.View style={[getSwatchColorStyle(p.color), themedStyles.swatch]} />
+      <Text>{p.name}</Text>
+    </ReactNative.View>
+  );
+};
+
+const SwatchList: React.FunctionComponent = () => {
+  const hostSettings = getHostSettingsWin32(useTheme());
+  const themedStyles = getThemedStyles(useTheme());
+
+  if (hostSettings === undefined) return <Text>Error</Text>;
+
+  const aggregator = React.useCallback(
+    (key: string) => {
+      return { name: key + ' (' + hostSettings.palette[key] + ')', color: hostSettings.palette[key] };
+    },
+    [hostSettings.palette]
+  );
+
+  const flattenArray = React.useCallback(() => {
+    return Object.keys(hostSettings.palette)
+      .sort()
+      .map(aggregator);
+  }, [hostSettings.palette, aggregator]);
+
+  const paletteAsArray = React.useMemo(flattenArray, [flattenArray]);
+  const renderSwatch = React.useCallback(({ item }) => {
+    const { color, name } = item;
+    return <SemanticColor key={name} color={color} name={name} />;
+  }, []);
+  return (
+    <ReactNative.View style={[commonTestStyles.viewStyle, commonTestStyles.stackStyle]}>
+      <Text style={themedStyles.largeStandard}>getHostSettingsWin32(theme: ITheme).palette</Text>
+      <ReactNative.FlatList data={paletteAsArray} renderItem={renderSwatch} />
+    </ReactNative.View>
+  );
+};
+
+const ThemeTestInner: React.FunctionComponent = () => {
+  const themedStyles = getThemedStyles(useTheme());
+  const onAppChange = React.useCallback((app: string) => {
+    brand = app;
+    customRegistry.setTheme(fakeBrandTheme, 'BrandedTheme');
+  }, []);
   return (
     <ReactNative.View>
+      <RadioGroup label="Pick App Colors" onChange={onAppChange} defaultSelectedKey="Office">
+        <RadioButton buttonKey="Office" content="Office" />
+        {Object.keys(brandColors).map((app: string) => (
+          <RadioButton key={app} buttonKey={app} content={app} />
+        ))}
+      </RadioGroup>
+      <Text style={themedStyles.extraLargeStandardEmphasis}>Platform Theme</Text>
+      <Separator />
       <Panel />
+      <Text style={themedStyles.extraLargeStandardEmphasis}>Custom JS Theme</Text>
+      <Separator />
       <ThemeProvider theme="Caterpillar">
         <Panel />
       </ThemeProvider>
+      <Text style={themedStyles.extraLargeStandardEmphasis}>Host-specific Theme Settings</Text>
+      <Separator />
+      <SwatchList />
     </ReactNative.View>
+  );
+};
+
+export const ThemeTest: React.FunctionComponent = () => {
+  return (
+    <ThemeProvider theme="BrandedTheme">
+      <ThemeTestInner />
+    </ThemeProvider>
   );
 };

--- a/experiments/tester/src/RNTester/styles.ts
+++ b/experiments/tester/src/RNTester/styles.ts
@@ -20,6 +20,8 @@ export const commonTestStyles = ReactNative.StyleSheet.create({
 
 export const fabricTesterStyles = ReactNative.StyleSheet.create({
   root: {
+    flex: 1,
+    flexGrow: 1,
     flexDirection: 'row',
     minHeight: 550,
     minWidth: 300,

--- a/packages/framework/theming-react-native/src/NativeModule/ThemingModule.types.ts
+++ b/packages/framework/theming-react-native/src/NativeModule/ThemingModule.types.ts
@@ -41,3 +41,7 @@ export interface IThemingModuleHelper {
   getPlatformThemeDefinition: (themeId?: string) => IPlatformThemeDefinition;
   addListener: (listener: PlatformDefaultsChangedCallback) => void; // TODO: Should probably be able to remove
 }
+
+export type IHostSettingsWin32 = {
+  palette: IOfficePalette;
+};

--- a/packages/framework/theming-react-native/src/NativeModule/getHostSettings.ts
+++ b/packages/framework/theming-react-native/src/NativeModule/getHostSettings.ts
@@ -1,0 +1,9 @@
+import { ITheme } from '../Theme.types';
+import { IHostSettingsWin32 } from './ThemingModule.types';
+
+export function getHostSettingsWin32(theme: ITheme): IHostSettingsWin32 | undefined {
+  if (theme['host'] && theme['host'].palette) {
+    return theme['host'];
+  }
+  return undefined;
+}

--- a/packages/framework/theming-react-native/src/NativeModule/index.ts
+++ b/packages/framework/theming-react-native/src/NativeModule/index.ts
@@ -1,3 +1,4 @@
 export * from './ThemingModule';
 export * from './ThemingModule.types';
 export * from './MockThemingModule';
+export * from './getHostSettings';


### PR DESCRIPTION
this adds `getHostSettingsWin32(theme: ITheme)` to `theming-react-native`.  This allows the theme object to carry platform & host specific settings for clients who really need it under 

```
const theme: ITheme = {
    colors: // ...
    typography: //...
    components: //...
    host: IHostSettingsWin32 (or whatever platform)
}

type IHostSettingsWin32 = {
    palette: IOfficePalette;
}
```

The `getHostSettingsWin32` is just a way to extract the value in a strongly typed fashion (`IHostSettingsWin32` unless invoked on a theme without the win32 host settings)

These means customers are fully unblocked with direct access to the semantically named native colors at the discussions around the fluentui token sets continues to evolve.  I also spruces up the fluentui testpage for theming:

![image](https://user-images.githubusercontent.com/7664112/76036843-22637600-5efa-11ea-94b0-9ca8e9e0913c.png)
