### PR TITLE
⚗ Jazz up theme test page a little

### DIFF
--- a/change/@uifabricshared-theming-ramp-2020-03-06-16-07-18-hostcolorpr.json
+++ b/change/@uifabricshared-theming-ramp-2020-03-06-16-07-18-hostcolorpr.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "👌 Code review comment from Jason",
+  "packageName": "@uifabricshared/theming-ramp",
+  "email": "adrum@microsoft.com",
+  "commit": "a91c6c46970dd8273f5a08115cab2941b0c6fbf7",
+  "dependentChangeType": "patch",
+  "date": "2020-03-07T00:07:18.865Z"
+}

--- a/change/@uifabricshared-theming-react-native-2020-03-09-16-44-18-hostcolorpr.json
+++ b/change/@uifabricshared-theming-react-native-2020-03-09-16-44-18-hostcolorpr.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Add host to theme object typing",
+  "packageName": "@uifabricshared/theming-react-native",
+  "email": "adrum@microsoft.com",
+  "commit": "f5dfe0411c65df116b53d874d369d28eab555152",
+  "dependentChangeType": "patch",
+  "date": "2020-03-09T23:44:18.945Z"
+}

--- a/experiments/tester/src/RNTester/CustomThemes.ts
+++ b/experiments/tester/src/RNTester/CustomThemes.ts
@@ -37,7 +37,5 @@ const caterpillarTheme: IPartialTheme = {
 export const customRegistry: ThemeRegistry = createPlatformThemeRegistry('TaskPane');
 
 export function registerThemes(): void {
-  customRegistry.setTheme({});
-
   customRegistry.setTheme(caterpillarTheme, 'Caterpillar');
 }

--- a/experiments/tester/src/RNTester/TestComponents/ThemeTest.tsx
+++ b/experiments/tester/src/RNTester/TestComponents/ThemeTest.tsx
@@ -18,7 +18,9 @@ const brandColors = {
 
 // This IProcessTheme takes the parent theme and shims in the brand colors selected in the RadioGroup
 const fakeBrandTheme: IThemeDefinition = (theme: ITheme): IPartialTheme => {
-  if (brand === 'Office') return {};
+  if (brand === 'Office') {
+    return {};
+  }
 
   const brandValues = theme.colors.brand.values;
   const brandedTheme = { colors: {}, host: { palette: {} } };
@@ -163,12 +165,6 @@ const ThemeTestInner: React.FunctionComponent = () => {
   }, []);
 
   const [theme, setTheme] = React.useState('Default');
-  const onThemeChange = React.useCallback(
-    (theme: string) => {
-      setTheme(theme);
-    },
-    [theme, setTheme]
-  );
   return (
     <ReactNative.View>
       <Text style={themedStyles.extraLargeStandardEmphasis}>Configure Theme</Text>
@@ -181,7 +177,7 @@ const ThemeTestInner: React.FunctionComponent = () => {
           ))}
         </RadioGroup>
         <Separator vertical />
-        <RadioGroup label="Pick Theme" onChange={onThemeChange} defaultSelectedKey="Default">
+        <RadioGroup label="Pick Theme" onChange={setTheme} defaultSelectedKey="Default">
           <RadioButton buttonKey="Default" content="Default (GrayB / TaskPane)" />
           <RadioButton buttonKey="Caterpillar" content="Caterpillar (Custom JS Theme)" />
           <RadioButton buttonKey="WhiteColors" content="WhiteColors (Platform Theme)" />

--- a/experiments/tester/src/RNTester/TestComponents/ThemeTest.tsx
+++ b/experiments/tester/src/RNTester/TestComponents/ThemeTest.tsx
@@ -48,35 +48,38 @@ customRegistry.setTheme(ThemingModuleHelper.getPlatformThemeDefinition('WhiteCol
 // this applies the shim to the white colors theme
 customRegistry.setTheme(fakeBrandTheme, 'WhiteColors', 'RealWhiteColors');
 
-const getThemedStyles = themedStyleSheet((theme: ITheme) => ({
-  swatch: {
-    width: 80,
-    height: 20,
-    marginRight: 5,
-    borderWidth: 2,
-    borderColor: theme.colors.bodyText
-  },
-  extraLargeStandardEmphasis: {
-    color: theme['host'].palette.TextEmphasis,
-    fontSize: theme.typography.sizes.xxLarge,
-    fontWeight: theme.typography.weights.medium,
-    fontFamily: theme.typography.families.primary
-  } as ReactNative.TextStyle,
-  largeStandard: {
-    color: theme.colors.bodyText,
-    fontSize: theme.typography.sizes.large,
-    fontWeight: theme.typography.weights.medium,
-    fontFamily: theme.typography.families.primary,
-    marginBottom: 5
-  } as ReactNative.TextStyle,
-  stackStyle: {
-    borderWidth: 2,
-    borderColor: theme.colors.focusBorder,
-    padding: 12,
-    margin: 8,
-    backgroundColor: theme.colors.background
-  }
-}));
+const getThemedStyles = themedStyleSheet((theme: ITheme) => {
+  const hostSettings = getHostSettingsWin32(theme);
+  return {
+    swatch: {
+      width: 80,
+      height: 20,
+      marginRight: 5,
+      borderWidth: 2,
+      borderColor: theme.colors.bodyText
+    },
+    extraLargeStandardEmphasis: {
+      color: hostSettings ? hostSettings.palette.TextEmphasis : theme.colors.bodyText,
+      fontSize: theme.typography.sizes.xxLarge,
+      fontWeight: theme.typography.weights.medium,
+      fontFamily: theme.typography.families.primary
+    } as ReactNative.TextStyle,
+    largeStandard: {
+      color: theme.colors.bodyText,
+      fontSize: theme.typography.sizes.large,
+      fontWeight: theme.typography.weights.medium,
+      fontFamily: theme.typography.families.primary,
+      marginBottom: 5
+    } as ReactNative.TextStyle,
+    stackStyle: {
+      borderWidth: 2,
+      borderColor: theme.colors.focusBorder,
+      padding: 12,
+      margin: 8,
+      backgroundColor: theme.colors.background
+    }
+  };
+});
 
 const styles = ReactNative.StyleSheet.create({
   swatchItem: {

--- a/packages/framework/theming-ramp/src/Theme.test.ts
+++ b/packages/framework/theming-ramp/src/Theme.test.ts
@@ -26,7 +26,8 @@ const theme: ITheme = {
         fontFamily: 'primary'
       }
     }
-  }
+  },
+  host: {}
 };
 
 const partialTheme: IPartialTheme = {

--- a/packages/framework/theming-ramp/src/Theme.types.ts
+++ b/packages/framework/theming-ramp/src/Theme.types.ts
@@ -18,6 +18,7 @@ export interface ITheme {
   typography: ITypography;
   components: IComponentSettingsCollection;
   spacing: ISpacing;
+  host: object; // platform specific host settings
 }
 
 /**
@@ -30,4 +31,5 @@ export interface IPartialTheme {
   typography?: IPartialTypography;
   components?: IComponentSettingsCollection;
   spacing?: ISpacing;
+  host?: object;
 }

--- a/packages/framework/theming-react-native/src/BaselinePlatformDefaults.ts
+++ b/packages/framework/theming-react-native/src/BaselinePlatformDefaults.ts
@@ -41,6 +41,7 @@ export function getBaselinePlatformTheme(): ITheme {
     colors: getStockWebPalette(),
     typography: _defaultTypography(),
     spacing: defaultSpacing(),
-    components: {}
+    components: {},
+    host: {}
   };
 }

--- a/packages/framework/theming-react-native/src/NativeModule/getHostSettings.ts
+++ b/packages/framework/theming-react-native/src/NativeModule/getHostSettings.ts
@@ -2,8 +2,8 @@ import { ITheme } from '../Theme.types';
 import { IHostSettingsWin32 } from './ThemingModule.types';
 
 export function getHostSettingsWin32(theme: ITheme): IHostSettingsWin32 | undefined {
-  if (theme['host'] && theme['host'].palette) {
-    return theme['host'];
+  if (theme['host'] && (theme['host'] as Partial<IHostSettingsWin32>).palette) {
+    return theme['host'] as IHostSettingsWin32;
   }
   return undefined;
 }


### PR DESCRIPTION
- adds `host` to `ITheme`
- makes the Theme test page more configurable (I used radiobutton, not Picker.  sorry Luan! I would have but I don't think I have the tenant changes yet).

Now it looks like this:

![image](https://user-images.githubusercontent.com/7664112/76131931-4049dd00-5fc5-11ea-91a1-4c29477ac547.png)


