### PR TITLE
Switch components from using symbols to WeakMaps for caching

### DIFF
--- a/change/@uifabricshared-foundation-compose-2020-03-10-14-36-08-weak-map.json
+++ b/change/@uifabricshared-foundation-compose-2020-03-10-14-36-08-weak-map.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "switch symbol based caching to use WeakMaps",
+  "packageName": "@uifabricshared/foundation-compose",
+  "email": "jasonmo@microsoft.com",
+  "commit": "7ccb806b6df0520ad775ef0f7eae8786ced67315",
+  "dependentChangeType": "patch",
+  "date": "2020-03-10T21:36:03.405Z"
+}

--- a/change/@uifabricshared-themed-stylesheet-2020-03-10-14-36-08-weak-map.json
+++ b/change/@uifabricshared-themed-stylesheet-2020-03-10-14-36-08-weak-map.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "switch symbol based caching to use WeakMaps",
+  "packageName": "@uifabricshared/themed-stylesheet",
+  "email": "jasonmo@microsoft.com",
+  "commit": "7ccb806b6df0520ad775ef0f7eae8786ced67315",
+  "dependentChangeType": "patch",
+  "date": "2020-03-10T21:36:08.063Z"
+}

--- a/packages/framework/foundation-compose/src/useStyling.ts
+++ b/packages/framework/foundation-compose/src/useStyling.ts
@@ -24,12 +24,7 @@ function _buildGetComponentCache(): IGetComponentCache {
   const nullTheme = {} as ITheme;
   return (theme: ITheme) => {
     theme = theme || nullTheme;
-    let cacheEntry = weakMap.get(theme);
-    if (!cacheEntry) {
-      cacheEntry = {};
-      weakMap.set(theme, cacheEntry);
-    }
-    return cacheEntry;
+    return weakMap.get(theme) || weakMap.set(theme, {}).get(theme);
   };
 }
 

--- a/packages/framework/foundation-compose/src/useStyling.ts
+++ b/packages/framework/foundation-compose/src/useStyling.ts
@@ -13,15 +13,24 @@ export function getOptionsFromObj<TComponent>(obj: any): TComponent | undefined 
   return ((objType === 'object' || objType === 'function') && (obj as IWithComposable<object, TComponent>).__composable) || undefined;
 }
 
-/**
- * Get the cache for the given component from the theme, creating it if necessary
- *
- * @param component - component to get the cache for, the component object itself will store the unique symbol for its lookups
- * @param theme - theme where the cache will be stored
- */
-function _getComponentCache(cacheKey: symbol, theme: ITheme): { [key: string]: ISlotProps } {
-  theme[cacheKey] = theme[cacheKey] || {};
-  return theme[cacheKey];
+interface ICacheEntry {
+  [key: string]: ISlotProps;
+}
+
+type IGetComponentCache = (theme: ITheme) => ICacheEntry;
+
+function _buildGetComponentCache(): IGetComponentCache {
+  const weakMap = new WeakMap<ITheme, ICacheEntry>();
+  const nullTheme = {} as ITheme;
+  return (theme: ITheme) => {
+    theme = theme || nullTheme;
+    let cacheEntry = weakMap.get(theme);
+    if (!cacheEntry) {
+      cacheEntry = {};
+      weakMap.set(theme, cacheEntry);
+    }
+    return cacheEntry;
+  };
 }
 
 function _getSettingsFromTheme(theme: ITheme, name: string): IComponentSettings {
@@ -43,25 +52,17 @@ function _getHasToken<TProps, TSlotProps extends ISlotProps, TTokens extends obj
   };
 }
 
-function _nameFromSettings<TSlotProps extends ISlotProps, TTokens extends object>(
-  styleSettings: IStylingSettings<TSlotProps, TTokens>
-): string | undefined {
-  const settings = styleSettings.settings;
-  const names: string[] = settings.filter(v => typeof v === 'string').map(v => v as string);
-  return names && names.length > 0 ? names.join('-') : undefined;
-}
-
 function useStylingCore<TProps, TSlotProps extends ISlotProps, TTokens extends object>(
   props: TProps,
   options: IStylingSettings<TSlotProps, TTokens>,
   baseKey: string,
-  tokenCacheKey: symbol,
+  getComponentCache: IGetComponentCache,
   lookupOverride?: IOverrideLookup
 ): IWithTokens<TSlotProps, TTokens> {
   // get the theme value from the context (or the default theme if it is not set)
   const theme = React.useContext(ThemeContext) || getTheme();
   // get the cache for this component from the theme
-  const cache = _getComponentCache(tokenCacheKey, theme);
+  const cache = getComponentCache(theme);
 
   // resolve the array of settings for these options
   lookupOverride = lookupOverride || props;
@@ -101,12 +102,8 @@ export function initializeStyling<
   const { styles, slots } = options;
   options.resolvedTokens = buildComponentTokens<TSlotProps, TTokens, ITheme>(styles, _getHasToken(slots));
 
-  // ensure we have a name to use for caching.  Try to pull something identifiable to help with debugging
-  name = name || _nameFromSettings(options) || 'anonymous';
-  const tokenCacheKey = Symbol(name);
-
   // create a useStyling implementation for this component type (per type, not per instance)
   return (props: TProps, lookupOverride?: IOverrideLookup) => {
-    return useStylingCore<TProps, TSlotProps, TTokens>(props, options, name, tokenCacheKey, lookupOverride);
+    return useStylingCore<TProps, TSlotProps, TTokens>(props, options, name, _buildGetComponentCache(), lookupOverride);
   };
 }

--- a/packages/framework/themed-stylesheet/src/StyleSheet.ts
+++ b/packages/framework/themed-stylesheet/src/StyleSheet.ts
@@ -13,12 +13,7 @@ function getCacheEntry<TStyles extends INamedStyles<TStyles>, TTheme extends obj
   map: WeakMap<TTheme, IWithStyle<TStyles>>,
   theme: TTheme
 ): IWithStyle<TStyles> {
-  let cache = map.get(theme);
-  if (!cache) {
-    cache = {};
-    map.set(theme, cache);
-  }
-  return cache;
+  return map.get(theme) || map.set(theme, {}).get(theme);
 }
 
 /**

--- a/packages/framework/themed-stylesheet/src/StyleSheet.ts
+++ b/packages/framework/themed-stylesheet/src/StyleSheet.ts
@@ -1,19 +1,25 @@
 import { ViewStyle, TextStyle, ImageStyle, StyleSheet } from 'react-native';
 
-/**
- * Style sheets will be cached in the theme itself under a unique symbol value.  Note that the requirement
- * here is that if theme values (such as colors) change, a new theme object will be created.
- *
- * This uses a symbol to avoid conflicts.  This also ensures that when the theme is copied via assign or spread
- * the cache values don't come with it.
- */
-const _keyForSheetsInTheme = Symbol('StyleSheets');
+type IWithStyle<TStyles extends INamedStyles<TStyles>> = {
+  styles?: INamedStyles<TStyles>;
+};
 
 /**
- * If a user has a system where there may or may not be a theme then this is a fallback cache to create
- * style sheets and cache them for the no-theme case
+ * Retrieve or create/set a cache value corresponding to this theme
+ * @param map - WeakMap to use for value lookups
+ * @param theme - theme to use as the key into the map
  */
-const _cacheForNoTheme = {};
+function getCacheEntry<TStyles extends INamedStyles<TStyles>, TTheme extends object>(
+  map: WeakMap<TTheme, IWithStyle<TStyles>>,
+  theme: TTheme
+): IWithStyle<TStyles> {
+  let cache = map.get(theme);
+  if (!cache) {
+    cache = {};
+    map.set(theme, cache);
+  }
+  return cache;
+}
 
 /**
  * Signature for inputs and outputs for StyleSheet.create.  This is a collection of named styles which can
@@ -49,13 +55,14 @@ export type INamedStyles<T> = { [P in keyof T]: ViewStyle | TextStyle | ImageSty
  *
  * @param generator - a function which will get run once per theme to create a cached style sheet.
  */
-export function themedStyleSheet<TStyles extends INamedStyles<TStyles>, TTheme>(
+export function themedStyleSheet<TStyles extends INamedStyles<TStyles>, TTheme extends object>(
   generator: (theme: TTheme) => INamedStyles<TStyles>
 ): (theme: TTheme) => INamedStyles<TStyles> {
-  const _keyForThisSheet = Symbol();
+  const noTheme = {} as TTheme;
+  const themeMap = new WeakMap<TTheme, object>();
   return (theme: TTheme) => {
-    const cache = theme ? (theme[_keyForSheetsInTheme] = theme[_keyForSheetsInTheme] || {}) : _cacheForNoTheme;
-    cache[_keyForThisSheet] = cache[_keyForThisSheet] || StyleSheet.create(generator(theme));
-    return cache[_keyForThisSheet];
+    const cache = getCacheEntry<TStyles, TTheme>(themeMap, theme || noTheme);
+    cache.styles = cache.styles || StyleSheet.create(generator(theme));
+    return cache.styles;
   };
 }


### PR DESCRIPTION
This addresses Issue #117 by switching away from using symbols for caching.  This addresses two issues with the previous approach:

- When compiled using some ES6 settings, symbols throw an error when iterated (such as when using { ...object })
- When transpiled for ES5 they are no longer unique causing cached theme settings to bleed from parent themes to sub-themes.

This adjusts the usage in compose as well as that in themed-stylesheet and should work equally well in both ES5 and ES6