### PR TITLE
🚀 Deploy utils packages

### DIFF
--- a/change/@fluentui-react-native-adapters-2020-03-17-09-21-54-publishmore.json
+++ b/change/@fluentui-react-native-adapters-2020-03-17-09-21-54-publishmore.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Publish",
+  "packageName": "@fluentui-react-native/adapters",
+  "email": "email not defined",
+  "commit": "a0e097ec7cad3b88bc48215d9b58323057068794",
+  "dependentChangeType": "patch",
+  "date": "2020-03-17T16:21:47.118Z"
+}

--- a/change/@fluentui-react-native-interactive-hooks-2020-03-17-09-21-54-publishmore.json
+++ b/change/@fluentui-react-native-interactive-hooks-2020-03-17-09-21-54-publishmore.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Publish",
+  "packageName": "@fluentui-react-native/interactive-hooks",
+  "email": "email not defined",
+  "commit": "a0e097ec7cad3b88bc48215d9b58323057068794",
+  "dependentChangeType": "patch",
+  "date": "2020-03-17T16:21:51.158Z"
+}

--- a/change/@fluentui-react-native-tokens-2020-03-17-09-21-54-publishmore.json
+++ b/change/@fluentui-react-native-tokens-2020-03-17-09-21-54-publishmore.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Publish",
+  "packageName": "@fluentui-react-native/tokens",
+  "email": "email not defined",
+  "commit": "a0e097ec7cad3b88bc48215d9b58323057068794",
+  "dependentChangeType": "patch",
+  "date": "2020-03-17T16:21:54.342Z"
+}

--- a/packages/utils/adapters/package.json
+++ b/packages/utils/adapters/package.json
@@ -5,7 +5,6 @@
   "main": "lib/index.js",
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
-  "private": true,
   "scripts": {
     "build": "just-scripts build",
     "just": "just-scripts",

--- a/packages/utils/interactive-hooks/package.json
+++ b/packages/utils/interactive-hooks/package.json
@@ -5,7 +5,6 @@
   "main": "lib/index.js",
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
-  "private": true,
   "scripts": {
     "build": "just-scripts build",
     "just": "just-scripts",

--- a/packages/utils/tokens/package.json
+++ b/packages/utils/tokens/package.json
@@ -5,7 +5,6 @@
   "main": "lib/index.js",
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
-  "private": true,
   "scripts": {
     "build": "just-scripts build",
     "just": "just-scripts",


### PR DESCRIPTION
If you try to add @fluentui\react-native as a dependency, the utils packages can't be found on npm because they're not being published.