### PR TITLE
🐛 Fix children crashing the test app

### DIFF
--- a/change/@uifabricshared-foundation-composable-2020-03-24-13-59-55-fixchildren.json
+++ b/change/@uifabricshared-foundation-composable-2020-03-24-13-59-55-fixchildren.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "🐛 Fix children crashing the test app",
+  "packageName": "@uifabricshared/foundation-composable",
+  "email": "email not defined",
+  "commit": "2344c650c213befe98be0bfc0764e11abd1c04e1",
+  "dependentChangeType": "patch",
+  "date": "2020-03-24T20:59:55.206Z"
+}

--- a/packages/framework/foundation-composable/src/Composable.ts
+++ b/packages/framework/foundation-composable/src/Composable.ts
@@ -18,9 +18,6 @@ import { useCompoundPrepare } from './Composable.slots';
 import { renderSlot } from './slots';
 import { ISlotProps, mergeSettings } from '@uifabricshared/foundation-settings';
 
-// just a generic object with children specified as props
-type IWithChildren<T> = T & { children?: React.ReactNode[] };
-
 export function atomicRender<TProps extends object, TState = object>(
   Slots: ISlots<ISlotProps<TProps>>,
   _renderData: IRenderData<ISlotProps<TProps>, TState>,
@@ -96,7 +93,7 @@ export function composable<TType>(
   // create the actual implementation
   const render = (userProps: IProps) => {
     // split out children, they will be excluded from the prop preparation phase
-    const { children, ...props } = userProps as IWithChildren<IProps>;
+    const { children, ...props } = userProps as React.PropsWithChildren<IProps>;
 
     // prepare the props, all the way down the tree, also build the slots
     const { renderData, Slots } = useCompoundPrepare<IProps, IThisSlotProps, IState>(
@@ -105,7 +102,7 @@ export function composable<TType>(
     );
 
     // now do the render, adding the children back in
-    return options.render(Slots, renderData, ...children);
+    return options.render(Slots, renderData, children);
   };
   render.displayName = options.displayName;
 


### PR DESCRIPTION
When upgrading Typescript I broke the test app.

This was because we're incorrectly casting our props in composable.ts to IWithChildren instead of React.PropsWithChildren.   PropsWithChildren correctly describes the type of children on the props as a ReactNode instead of a ReactNode[].  

The crash came from the use of the spread operator in the options.render(Slots, renderData, ...children).  The type checking thought this was valid because of our bad cast to a ReactNode[] array, but it crashed at run time because it wasn't a ReactNode array but could be a single object or undefined if no children.

Older versions of typescript transpiled this in a fashion that just happened to work.
