### PR TITLE
Just makes the JS code more resilient to avoid RedBoxing on macos

### DIFF
--- a/change/@uifabricshared-theming-react-native-2020-04-09-11-38-21-fixmactheming.json
+++ b/change/@uifabricshared-theming-react-native-2020-04-09-11-38-21-fixmactheming.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "🐛 Make ThemingModule not crash on Mac",
+  "packageName": "@uifabricshared/theming-react-native",
+  "email": "email not defined",
+  "dependentChangeType": "patch",
+  "date": "2020-04-09T18:38:21.231Z"
+}

--- a/packages/framework/theming-react-native/src/NativeModule/ThemingModule.native.ts
+++ b/packages/framework/theming-react-native/src/NativeModule/ThemingModule.native.ts
@@ -24,4 +24,7 @@ const getThemingModule = () => {
     : themingModule;
 };
 
-export const ThemingModuleHelper = createThemingModuleHelper(getThemingModule(), new NativeEventEmitter(NativeModules.Theming));
+export const ThemingModuleHelper = createThemingModuleHelper(
+  getThemingModule(),
+  NativeModules && NativeModules.Theming && new NativeEventEmitter(NativeModules.Theming)
+);


### PR DESCRIPTION
This should pass in `undefined` for the second argument of ThemingModuleHelpers.ts createThemingModuleHelper which should be handled gracefully on macos.