### PR TITLE
Update to new version of beachball with working prepublish hook

### DIFF
--- a/beachball.config.js
+++ b/beachball.config.js
@@ -1,14 +1,16 @@
+const fs = require('fs');
+const path = require('path');
+
 module.exports = {
   disallowedChangeTypes: ['major'],
   hooks: {
-    prepublish: bumpInfo => {
-      // iterate through the packages that are being published as part of the bump info
-      for (const pkg in bumpInfo.packageInfos) {
-        const packageJson = bumpInfo.packageInfos[pkg];
-        if (packageJson && packageJson.onPublish && typeof packageJson.onPublish === 'object') {
-          Object.assign(packageJson, packageJson.onPublish);
-          delete packageJson.onPublish;
-        }
+    prepublish: packagePath => {
+      const packageJsonPath = path.join(packagePath, 'package.json');
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+      if (packageJson.onPublish) {
+        Object.assign(packageJson, packageJson.onPublish);
+        delete packageJson.onPublish;
+        fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + '\n');
       }
     }
   }

--- a/change/@fluentui-react-native-2020-04-20-10-03-15-prepublish.json
+++ b/change/@fluentui-react-native-2020-04-20-10-03-15-prepublish.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix package publishing (#163)",
+  "packageName": "@fluentui/react-native",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-20T17:03:15.838Z"
+}

--- a/change/@fluentui-react-native-adapters-2020-04-20-10-14-24-prepublish.json
+++ b/change/@fluentui-react-native-adapters-2020-04-20-10-14-24-prepublish.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update beachball hook to use new prepublish strategy",
+  "packageName": "@fluentui-react-native/adapters",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-20T17:14:24.276Z"
+}

--- a/change/@fluentui-react-native-build-tools-2020-04-20-10-14-54-prepublish.json
+++ b/change/@fluentui-react-native-build-tools-2020-04-20-10-14-54-prepublish.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update beachball hook to use new prepublish strategy",
+  "packageName": "@fluentui-react-native/build-tools",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-20T17:14:54.739Z"
+}

--- a/change/@fluentui-react-native-button-2020-04-20-10-09-57-prepublish.json
+++ b/change/@fluentui-react-native-button-2020-04-20-10-09-57-prepublish.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update beachball hook to use new prepublish strategy",
+  "packageName": "@fluentui-react-native/button",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-20T17:09:57.948Z"
+}

--- a/change/@fluentui-react-native-callout-2020-04-20-10-10-11-prepublish.json
+++ b/change/@fluentui-react-native-callout-2020-04-20-10-10-11-prepublish.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update beachball hook to use new prepublish strategy",
+  "packageName": "@fluentui-react-native/callout",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-20T17:10:11.340Z"
+}

--- a/change/@fluentui-react-native-checkbox-2020-04-20-10-10-23-prepublish.json
+++ b/change/@fluentui-react-native-checkbox-2020-04-20-10-10-23-prepublish.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update beachball hook to use new prepublish strategy",
+  "packageName": "@fluentui-react-native/checkbox",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-20T17:10:23.790Z"
+}

--- a/change/@fluentui-react-native-focus-trap-zone-2020-04-20-10-10-47-prepublish.json
+++ b/change/@fluentui-react-native-focus-trap-zone-2020-04-20-10-10-47-prepublish.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update beachball hook to use new prepublish strategy",
+  "packageName": "@fluentui-react-native/focus-trap-zone",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-20T17:10:47.464Z"
+}

--- a/change/@fluentui-react-native-interactive-hooks-2020-04-20-10-15-12-prepublish.json
+++ b/change/@fluentui-react-native-interactive-hooks-2020-04-20-10-15-12-prepublish.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update beachball hook to use new prepublish strategy",
+  "packageName": "@fluentui-react-native/interactive-hooks",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-20T17:15:12.925Z"
+}

--- a/change/@fluentui-react-native-link-2020-04-20-10-11-01-prepublish.json
+++ b/change/@fluentui-react-native-link-2020-04-20-10-11-01-prepublish.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update beachball hook to use new prepublish strategy",
+  "packageName": "@fluentui-react-native/link",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-20T17:11:01.082Z"
+}

--- a/change/@fluentui-react-native-persona-2020-04-20-10-11-10-prepublish.json
+++ b/change/@fluentui-react-native-persona-2020-04-20-10-11-10-prepublish.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update beachball hook to use new prepublish strategy",
+  "packageName": "@fluentui-react-native/persona",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-20T17:11:10.968Z"
+}

--- a/change/@fluentui-react-native-persona-coin-2020-04-20-10-11-21-prepublish.json
+++ b/change/@fluentui-react-native-persona-coin-2020-04-20-10-11-21-prepublish.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update beachball hook to use new prepublish strategy",
+  "packageName": "@fluentui-react-native/persona-coin",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-20T17:11:21.271Z"
+}

--- a/change/@fluentui-react-native-pressable-2020-04-20-10-11-36-prepublish.json
+++ b/change/@fluentui-react-native-pressable-2020-04-20-10-11-36-prepublish.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update beachball hook to use new prepublish strategy",
+  "packageName": "@fluentui-react-native/pressable",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-20T17:11:36.362Z"
+}

--- a/change/@fluentui-react-native-radio-group-2020-04-20-10-12-12-prepublish.json
+++ b/change/@fluentui-react-native-radio-group-2020-04-20-10-12-12-prepublish.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update beachball hook to use new prepublish strategy",
+  "packageName": "@fluentui-react-native/radio-group",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-20T17:12:12.528Z"
+}

--- a/change/@fluentui-react-native-separator-2020-04-20-10-12-37-prepublish.json
+++ b/change/@fluentui-react-native-separator-2020-04-20-10-12-37-prepublish.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update beachball hook to use new prepublish strategy",
+  "packageName": "@fluentui-react-native/separator",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-20T17:12:37.414Z"
+}

--- a/change/@fluentui-react-native-text-2020-04-20-10-12-50-prepublish.json
+++ b/change/@fluentui-react-native-text-2020-04-20-10-12-50-prepublish.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update beachball hook to use new prepublish strategy",
+  "packageName": "@fluentui-react-native/text",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-20T17:12:50.552Z"
+}

--- a/change/@fluentui-react-native-tokens-2020-04-20-10-15-26-prepublish.json
+++ b/change/@fluentui-react-native-tokens-2020-04-20-10-15-26-prepublish.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update beachball hook to use new prepublish strategy",
+  "packageName": "@fluentui-react-native/tokens",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-20T17:15:26.255Z"
+}

--- a/change/@uifabricshared-foundation-composable-2020-04-20-10-17-24-prepublish.json
+++ b/change/@uifabricshared-foundation-composable-2020-04-20-10-17-24-prepublish.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update beachball hook to use new prepublish strategy",
+  "packageName": "@uifabricshared/foundation-composable",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-20T17:17:24.183Z"
+}

--- a/change/@uifabricshared-foundation-compose-2020-04-20-10-17-39-prepublish.json
+++ b/change/@uifabricshared-foundation-compose-2020-04-20-10-17-39-prepublish.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update beachball hook to use new prepublish strategy",
+  "packageName": "@uifabricshared/foundation-compose",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-20T17:17:39.638Z"
+}

--- a/change/@uifabricshared-foundation-settings-2020-04-20-10-17-54-prepublish.json
+++ b/change/@uifabricshared-foundation-settings-2020-04-20-10-17-54-prepublish.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update beachball hook to use new prepublish strategy",
+  "packageName": "@uifabricshared/foundation-settings",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-20T17:17:54.652Z"
+}

--- a/change/@uifabricshared-foundation-tokens-2020-04-20-10-18-09-prepublish.json
+++ b/change/@uifabricshared-foundation-tokens-2020-04-20-10-18-09-prepublish.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update beachball hook to use new prepublish strategy",
+  "packageName": "@uifabricshared/foundation-tokens",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-20T17:18:09.381Z"
+}

--- a/change/@uifabricshared-immutable-merge-2020-04-20-10-18-26-prepublish.json
+++ b/change/@uifabricshared-immutable-merge-2020-04-20-10-18-26-prepublish.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update beachball hook to use new prepublish strategy",
+  "packageName": "@uifabricshared/immutable-merge",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-20T17:18:26.901Z"
+}

--- a/change/@uifabricshared-theme-registry-2020-04-20-10-18-43-prepublish.json
+++ b/change/@uifabricshared-theme-registry-2020-04-20-10-18-43-prepublish.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update beachball hook to use new prepublish strategy",
+  "packageName": "@uifabricshared/theme-registry",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-20T17:18:43.760Z"
+}

--- a/change/@uifabricshared-themed-settings-2020-04-20-10-19-23-prepublish.json
+++ b/change/@uifabricshared-themed-settings-2020-04-20-10-19-23-prepublish.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update beachball hook to use new prepublish strategy",
+  "packageName": "@uifabricshared/themed-settings",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-20T17:19:23.483Z"
+}

--- a/change/@uifabricshared-themed-stylesheet-2020-04-20-10-16-16-prepublish.json
+++ b/change/@uifabricshared-themed-stylesheet-2020-04-20-10-16-16-prepublish.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update beachball hook to use new prepublish strategy",
+  "packageName": "@uifabricshared/themed-stylesheet",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-20T17:16:16.192Z"
+}

--- a/change/@uifabricshared-theming-ramp-2020-04-20-10-19-42-prepublish.json
+++ b/change/@uifabricshared-theming-ramp-2020-04-20-10-19-42-prepublish.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update beachball hook to use new prepublish strategy",
+  "packageName": "@uifabricshared/theming-ramp",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-20T17:19:42.376Z"
+}

--- a/change/@uifabricshared-theming-react-native-2020-04-20-10-16-56-prepublish.json
+++ b/change/@uifabricshared-theming-react-native-2020-04-20-10-16-56-prepublish.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update beachball hook to use new prepublish strategy",
+  "packageName": "@uifabricshared/theming-react-native",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-20T17:16:56.029Z"
+}

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@types/react": "16.8.23",
     "@types/react-dom": "16.8.5",
     "@types/react-native": "^0.60.0",
-    "beachball": "^1.29.1",
+    "beachball": "^1.30.0",
     "lerna": "^3.16.4",
     "react": "16.8.6",
     "react-dom": "16.8.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7592,10 +7592,10 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-beachball@^1.29.1:
-  version "1.29.1"
-  resolved "https://registry.npmjs.org/beachball/-/beachball-1.29.1.tgz#6893ccf7118f9652cfdf9a46b30b4c0a1a212ad0"
-  integrity sha512-xoRLCm1P1s6SdqXQah17WMtUf6B2AjTEU1hfqX2QODK+UhSloikM4Weu9aeJcdFxvryH8PlGTc60dll1rme23g==
+beachball@^1.30.0:
+  version "1.30.0"
+  resolved "https://registry.yarnpkg.com/beachball/-/beachball-1.30.0.tgz#9a0073507e5fce4cff0afc855cf630c8aa8499b7"
+  integrity sha512-5vQmoi8qIiUDyMluncYZH2xFlUGpJ36kV2riJWmpNvM//zi+ybXfEmuil0CWn9s2Vw4KAgARXYRjtUDbNFYnUA==
   dependencies:
     cosmiconfig "^6.0.0"
     fs-extra "^8.0.1"
@@ -7605,6 +7605,7 @@ beachball@^1.29.1:
     minimatch "^3.0.4"
     prompts "~2.1.0"
     semver "^6.1.1"
+    toposort "^2.0.2"
     yargs-parser "^13.1.0"
 
 before-after-hook@^2.0.0:
@@ -27377,6 +27378,11 @@ toposort@^1.0.0:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/toposort/-/toposort-1.0.7.tgz#2e68442d9f64ec720b8cc89e6443ac6caa950029"
   integrity sha1-LmhELZ9k7HILjMieZEOsbKqVACk=
+
+toposort@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
+  integrity sha1-riF2gXXRVZ1IvvNUILL0li8JwzA=
 
 touch@0.0.3:
   version "0.0.3"


### PR DESCRIPTION
This change has three main parts:

### Bump beachball version

This moves to a version of beachball that has an updated prepublish hook.  See https://github.com/microsoft/beachball/pull/326 for the fix and some of the discussion around this.

### Update prepublish implementation

This change uses the implementation that I added as part of the beachball end to end unit tests.  This works per platform and effectively applies anything in an onPublish object within package.json up to the root level.

### Manually added change files

I added change files for the published packages in the repo to make sure republish is triggered.