### PR TITLE
Fix Link issues on UWP

### DIFF
--- a/change/@fluentui-react-native-link-2020-04-21-13-35-43-lehon-fixlinkbug.json
+++ b/change/@fluentui-react-native-link-2020-04-21-13-35-43-lehon-fixlinkbug.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fix Link issues on UWP",
+  "packageName": "@fluentui-react-native/link",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-21T20:35:43.226Z"
+}

--- a/packages/components/Link/src/Link.settings.ts
+++ b/packages/components/Link/src/Link.settings.ts
@@ -15,6 +15,11 @@ export const settings: IComposeSettings<ILinkType> = [
         textDecorationLine: 'underline'
       } as IViewProps['style']
     },
+    content: {
+      style: {
+        textDecorationLine: 'underline'
+      }
+    },
     _precedence: ['visited', 'hovered', 'pressed', 'disabled'],
     _overrides: {
       disabled: {

--- a/packages/components/Link/src/Link.tsx
+++ b/packages/components/Link/src/Link.tsx
@@ -77,8 +77,10 @@ export const Link = compose<ILinkType>({
         {children}
       </Slots.root>
     ) : (
-      <Slots.content {...(renderData.slotProps!.root as any)} />
-    );
+        <Slots.root>
+          {content && <Slots.content />}
+        </Slots.root>
+      );
   },
   slots: {
     root: ReactNative.View,


### PR DESCRIPTION
Issues fixed:

Win32
- not clickable when it is not wrapping another component
UWP
- onHover and onClick do not show any visual change
- Clicking on Link component opens the same page twice on browser