### PR TITLE
Remove docs from yarn and lerna workspace

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,10 +1,5 @@
 {
-  "packages": [
-    "apps/*",
-    "docs",
-    "packages/**",
-    "scripts"
-  ],
+  "packages": ["apps/*", "packages/**", "scripts"],
   "useWorkspaces": true,
   "npmClient": "yarn",
   "version": "0.0.0"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   "workspaces": {
     "packages": [
       "apps/*",
-      "docs",
       "packages/**",
       "scripts"
     ],


### PR DESCRIPTION
As the documentation would be moved to a different repo, we no longer need these yarn workspace and lerna package for docs 