### PR TITLE
Replace import * from react-native with specific imports

### DIFF
--- a/apps/fluent-tester/src/RNTester/TestComponents/Link/LinkTest.tsx
+++ b/apps/fluent-tester/src/RNTester/TestComponents/Link/LinkTest.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as ReactNative from 'react-native';
+import { Alert } from 'react-native';
 import { Link } from '@fluentui/react-native';
 import { Stack } from '@fluentui-react-native/stack';
 import { Square } from '../Common/Square';
@@ -7,7 +7,7 @@ import { stackStyle } from '../Common/styles';
 
 export const LinkTest: React.FunctionComponent<{}> = () => {
   const doPress = (): void => {
-    ReactNative.Alert.alert('Alert.', 'You have been alerted.');
+    Alert.alert('Alert.', 'You have been alerted.');
   };
   return (
     <Stack style={stackStyle}>

--- a/apps/fluent-tester/src/RNTester/TestComponents/Pressable/PressableTest.tsx
+++ b/apps/fluent-tester/src/RNTester/TestComponents/Pressable/PressableTest.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
-import * as ReactNative from 'react-native';
 import { Text, Pressable, IPressableState } from '@fluentui/react-native';
 import { Stack } from '@fluentui-react-native/stack';
 import { useHoverState, useFocusState, usePressState } from '@fluentui/react-native';
 import { Square } from '../Common/Square';
-import { StyleSheet, View, ViewProps } from 'react-native';
+import { Alert, GestureResponderEvent, StyleSheet, View, ViewProps, ViewState } from 'react-native';
 
 const styles = StyleSheet.create({
   dottedBorder: {
@@ -12,21 +11,21 @@ const styles = StyleSheet.create({
     padding: 8,
     margin: 4,
     borderStyle: 'dotted',
-    borderColor: 'red'
+    borderColor: 'red',
   },
   solidBorder: {
     borderWidth: 1,
     padding: 8,
     margin: 4,
     borderStyle: 'solid',
-    borderColor: 'black'
+    borderColor: 'black',
   },
   notfocused: {
     borderWidth: 1,
     padding: 8,
     margin: 4,
     borderColor: '#ababab',
-    borderStyle: 'solid'
+    borderStyle: 'solid',
   },
   focused: {
     borderWidth: 1,
@@ -34,7 +33,7 @@ const styles = StyleSheet.create({
     margin: 4,
     borderStyle: 'solid',
     borderColor: 'black',
-    backgroundColor: 'lightblue'
+    backgroundColor: 'lightblue',
   },
   notPressed: {
     borderWidth: 1,
@@ -43,7 +42,7 @@ const styles = StyleSheet.create({
     width: 30,
     height: 30,
     borderColor: '#ababab',
-    borderStyle: 'solid'
+    borderStyle: 'solid',
   },
   pressed: {
     borderWidth: 1,
@@ -53,11 +52,11 @@ const styles = StyleSheet.create({
     height: 30,
     borderStyle: 'dashed',
     borderColor: 'black',
-    backgroundColor: 'lightgreen'
-  }
+    backgroundColor: 'lightgreen',
+  },
 });
 
-function renderStyle(state: IPressableState): ReactNative.ViewStyle {
+function renderStyle(state: IPressableState): ViewStyle {
   return (state.pressed && { opacity: 0.5 }) || {};
 }
 
@@ -107,9 +106,9 @@ const PressComponent: React.FunctionComponent<ViewProps> = (props: ViewProps) =>
   const [pressProps, pressState] = usePressState(props);
 
   const onTouchEnd = React.useCallback(
-    (e: ReactNative.GestureResponderEvent) => {
+    (e: GestureResponderEvent) => {
       pressProps.onTouchEnd && pressProps.onTouchEnd(e);
-      ReactNative.Alert.alert('Alert.', 'Object has been pressed.');
+      Alert.alert('Alert.', 'Object has been pressed.');
     },
     [pressProps]
   );

--- a/apps/fluent-tester/src/RNTester/TestComponents/Pressable/PressableTest.tsx
+++ b/apps/fluent-tester/src/RNTester/TestComponents/Pressable/PressableTest.tsx
@@ -3,7 +3,7 @@ import { Text, Pressable, IPressableState } from '@fluentui/react-native';
 import { Stack } from '@fluentui-react-native/stack';
 import { useHoverState, useFocusState, usePressState } from '@fluentui/react-native';
 import { Square } from '../Common/Square';
-import { Alert, GestureResponderEvent, StyleSheet, View, ViewProps, ViewState } from 'react-native';
+import { Alert, GestureResponderEvent, StyleSheet, View, ViewProps, ViewStyle } from 'react-native';
 
 const styles = StyleSheet.create({
   dottedBorder: {

--- a/apps/fluent-tester/src/RNTester/TestComponents/Theme/ThemeTest.tsx
+++ b/apps/fluent-tester/src/RNTester/TestComponents/Theme/ThemeTest.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as ReactNative from 'react-native';
+import { FlatList, View, ViewStyle, TextStyle, StyleSheet } from 'react-native';
 import { getHostSettingsWin32, ThemeProvider, useTheme, IThemeDefinition, ThemingModuleHelper } from '@uifabricshared/theming-react-native';
 import { themedStyleSheet } from '@uifabricshared/themed-stylesheet';
 import { commonTestStyles } from '../Common/styles';
@@ -13,7 +13,7 @@ const brandColors = {
   Word: ['#E3ECFA', '#A5B9D1', '#7DA3C6', '#4A78B0', '#3C65A4', '#2B579A', '#124078', '#002050'],
   Excel: ['#E9F5EE', '#9FCDB3', '#6EB38A', '#4E9668', '#3F8159', '#217346', '#0E5C2F', '#004B1C'],
   Powerpoint: ['#FCF0ED', '#FDC9B5', '#ED9583', '#E86E58', '#C75033', '#B7472A', '#A92B1A', '#740912'],
-  Outlook: ['#CCE3F5', '#B3D6F2', '#69AFE5', '#2488D8', '#0078D7', '#106EBE', '#1664A7', '#135995']
+  Outlook: ['#CCE3F5', '#B3D6F2', '#69AFE5', '#2488D8', '#0078D7', '#106EBE', '#1664A7', '#135995'],
 };
 
 // This IProcessTheme takes the parent theme and shims in the brand colors selected in the RadioGroup
@@ -56,41 +56,41 @@ const getThemedStyles = themedStyleSheet((theme: ITheme) => {
       height: 20,
       marginRight: 5,
       borderWidth: 2,
-      borderColor: theme.colors.bodyText
+      borderColor: theme.colors.bodyText,
     },
     extraLargeStandardEmphasis: {
       color: hostSettings ? hostSettings.palette.TextEmphasis : theme.colors.bodyText,
       fontSize: theme.typography.sizes.header,
       fontWeight: theme.typography.weights.regular,
-      fontFamily: theme.typography.families.primary
-    } as ReactNative.TextStyle,
+      fontFamily: theme.typography.families.primary,
+    } as TextStyle,
     largeStandard: {
       color: theme.colors.bodyText,
       fontSize: theme.typography.sizes.body,
       fontWeight: theme.typography.weights.regular,
       fontFamily: theme.typography.families.primary,
-      marginBottom: 5
-    } as ReactNative.TextStyle,
+      marginBottom: 5,
+    } as TextStyle,
     stackStyle: {
       borderWidth: 2,
       borderColor: theme.colors.focusBorder,
       padding: 12,
       margin: 8,
-      backgroundColor: theme.colors.background
-    }
+      backgroundColor: theme.colors.background,
+    },
   };
 });
 
-const styles = ReactNative.StyleSheet.create({
+const styles = StyleSheet.create({
   swatchItem: {
     flexDirection: 'row',
     alignItems: 'center',
-    marginVertical: 5
+    marginVertical: 5,
   },
   pickerContainer: {
     flexDirection: 'row',
-    justifyContent: 'space-evenly'
-  }
+    justifyContent: 'space-evenly',
+  },
 });
 
 const Panel: React.FunctionComponent = () => {
@@ -98,17 +98,17 @@ const Panel: React.FunctionComponent = () => {
   const onClick = React.useCallback(() => setDisabled(!disabled), [disabled, setDisabled]);
   const themedStyles = getThemedStyles(useTheme());
   return (
-    <ReactNative.View style={[commonTestStyles.view, themedStyles.stackStyle]}>
+    <View style={[commonTestStyles.view, themedStyles.stackStyle]}>
       <PrimaryButton onClick={onClick} content="Primary Button" disabled={disabled} />
       <Button onClick={onClick} content="Default Button" disabled={disabled} />
       <StealthButton onClick={onClick} content="Stealth Button" disabled={disabled} />
       <Text>This is a text element</Text>
       <Button onClick={onClick} content="This button has longer text" disabled={disabled} />
-    </ReactNative.View>
+    </View>
   );
 };
 
-const getSwatchColorStyle = (color: string): ReactNative.ViewStyle => {
+const getSwatchColorStyle = (color: string): ViewStyle => {
   styles[color] = styles[color] || { backgroundColor: color };
   return styles[color];
 };
@@ -117,10 +117,10 @@ type SemanticColorProps = { color: string; name: string };
 const SemanticColor: React.FunctionComponent<SemanticColorProps> = (p: SemanticColorProps) => {
   const themedStyles = getThemedStyles(useTheme());
   return (
-    <ReactNative.View style={styles.swatchItem}>
-      <ReactNative.View style={[getSwatchColorStyle(p.color), themedStyles.swatch]} />
+    <View style={styles.swatchItem}>
+      <View style={[getSwatchColorStyle(p.color), themedStyles.swatch]} />
       <Text>{p.name}</Text>
-    </ReactNative.View>
+    </View>
   );
 };
 
@@ -138,9 +138,7 @@ const SwatchList: React.FunctionComponent = () => {
   );
 
   const flattenArray = React.useCallback(() => {
-    return Object.keys(hostSettings.palette)
-      .sort()
-      .map(aggregator);
+    return Object.keys(hostSettings.palette).sort().map(aggregator);
   }, [hostSettings.palette, aggregator]);
 
   const paletteAsArray = React.useMemo(flattenArray, [flattenArray]);
@@ -149,12 +147,12 @@ const SwatchList: React.FunctionComponent = () => {
     return <SemanticColor key={name} color={color} name={name} />;
   }, []);
   return (
-    <ReactNative.View style={[commonTestStyles.view]}>
+    <View style={[commonTestStyles.view]}>
       <Text style={themedStyles.largeStandard}>getHostSettingsWin32(theme: ITheme).palette</Text>
-      <ReactNative.View style={themedStyles.stackStyle}>
-        <ReactNative.FlatList data={paletteAsArray} renderItem={renderSwatch} />
-      </ReactNative.View>
-    </ReactNative.View>
+      <View style={themedStyles.stackStyle}>
+        <FlatList data={paletteAsArray} renderItem={renderSwatch} />
+      </View>
+    </View>
   );
 };
 
@@ -169,10 +167,10 @@ const ThemeTestInner: React.FunctionComponent = () => {
 
   const [theme, setTheme] = React.useState('Default');
   return (
-    <ReactNative.View>
+    <View>
       <Text style={themedStyles.extraLargeStandardEmphasis}>Configure Theme</Text>
       <Separator />
-      <ReactNative.View style={styles.pickerContainer}>
+      <View style={styles.pickerContainer}>
         <RadioGroup label="Pick App Colors" onChange={onAppChange} defaultSelectedKey="Office">
           <RadioButton buttonKey="Office" content="Office" />
           {Object.keys(brandColors).map((app: string) => (
@@ -185,7 +183,7 @@ const ThemeTestInner: React.FunctionComponent = () => {
           <RadioButton buttonKey="Caterpillar" content="Caterpillar (Custom JS Theme)" />
           <RadioButton buttonKey="WhiteColors" content="WhiteColors (Platform Theme)" />
         </RadioGroup>
-      </ReactNative.View>
+      </View>
       <Text style={themedStyles.extraLargeStandardEmphasis}>{theme + ' Theme'}</Text>
       <Separator />
       <ThemeProvider theme={theme}>
@@ -194,7 +192,7 @@ const ThemeTestInner: React.FunctionComponent = () => {
       <Text style={themedStyles.extraLargeStandardEmphasis}>Host-specific Theme Settings</Text>
       <Separator />
       <SwatchList />
-    </ReactNative.View>
+    </View>
   );
 };
 

--- a/apps/fluent-tester/src/RNTester/styles.ts
+++ b/apps/fluent-tester/src/RNTester/styles.ts
@@ -1,24 +1,24 @@
-import * as ReactNative from 'react-native';
+import { StyleSheet } from 'react-native';
 
-export const commonTestStyles = ReactNative.StyleSheet.create({
+export const commonTestStyles = StyleSheet.create({
   viewStyle: {
     minHeight: 200,
-    justifyContent: 'space-between'
+    justifyContent: 'space-between',
   },
   stackStyle: {
     borderWidth: 2,
     borderColor: '#bdbdbd',
     padding: 12,
-    margin: 8
+    margin: 8,
   },
   separatorStackStyle: {
     height: 200,
     flexDirection: 'row',
-    justifyContent: 'space-evenly'
-  }
+    justifyContent: 'space-evenly',
+  },
 });
 
-export const fabricTesterStyles = ReactNative.StyleSheet.create({
+export const fabricTesterStyles = StyleSheet.create({
   root: {
     flex: 1,
     flexGrow: 1,
@@ -27,35 +27,35 @@ export const fabricTesterStyles = ReactNative.StyleSheet.create({
     minWidth: 300,
     justifyContent: 'flex-start',
     alignItems: 'stretch',
-    padding: 4
+    padding: 4,
   },
 
   testHeader: {
     marginBottom: 8,
     fontSize: 14,
-    fontWeight: 'bold'
+    fontWeight: 'bold',
   },
 
   testList: {
-    width: 160
+    width: 160,
   },
 
   testListContainerStyle: {
     flexDirection: 'column',
-    alignItems: 'stretch'
+    alignItems: 'stretch',
   },
 
   testListItem: {
-    width: 150
+    width: 150,
   },
 
   separator: {
     marginHorizontal: 8,
-    width: 2
+    width: 2,
   },
 
   noTest: {
     alignSelf: 'center',
-    fontSize: 14
-  }
+    fontSize: 14,
+  },
 });

--- a/apps/playground/components/tokens/BorderTokens.ts
+++ b/apps/playground/components/tokens/BorderTokens.ts
@@ -1,4 +1,4 @@
-import * as ReactNative from 'react-native';
+import { ViewStyle } from 'react-native';
 import { IOperationSet } from '@uifabricshared/foundation-tokens';
 import { ITheme } from '@uifabricshared/theming-ramp';
 import { getPaletteFromTheme } from './ColorTokens';
@@ -7,12 +7,12 @@ export interface IBorderTokens {
   borderColor?: string;
   borderWidth?: number | string;
   borderRadius?: number | string;
-  borderStyle?: ReactNative.ViewStyle['borderStyle'];
+  borderStyle?: ViewStyle['borderStyle'];
 }
 
 export const borderTokens: IOperationSet<IBorderTokens, ITheme> = [
   { source: 'borderColor', lookup: getPaletteFromTheme },
   { source: 'borderWidth' },
   { source: 'borderRadius' },
-  { source: 'borderStyle' }
+  { source: 'borderStyle' },
 ];

--- a/change/@fluentui-react-native-callout-2020-04-24-09-12-14-nostarrn.json
+++ b/change/@fluentui-react-native-callout-2020-04-24-09-12-14-nostarrn.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Dont import * from react-native",
+  "packageName": "@fluentui-react-native/callout",
+  "email": "acoates@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-24T16:12:10.742Z"
+}

--- a/change/@fluentui-react-native-link-2020-04-24-09-12-14-nostarrn.json
+++ b/change/@fluentui-react-native-link-2020-04-24-09-12-14-nostarrn.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Dont import * from react-native",
+  "packageName": "@fluentui-react-native/link",
+  "email": "acoates@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-24T16:12:12.021Z"
+}

--- a/change/@fluentui-react-native-tokens-2020-04-24-09-12-14-nostarrn.json
+++ b/change/@fluentui-react-native-tokens-2020-04-24-09-12-14-nostarrn.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Dont import * from react-native",
+  "packageName": "@fluentui-react-native/tokens",
+  "email": "acoates@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-24T16:12:14.460Z"
+}

--- a/change/@uifabricshared-theming-react-native-2020-04-24-09-12-14-nostarrn.json
+++ b/change/@uifabricshared-theming-react-native-2020-04-24-09-12-14-nostarrn.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Dont import * from react-native",
+  "packageName": "@uifabricshared/theming-react-native",
+  "email": "acoates@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-24T16:12:13.070Z"
+}

--- a/packages/components/Callout/src/Callout.types.ts
+++ b/packages/components/Callout/src/Callout.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as ReactNative from 'react-native';
+import { ScreenRect } from 'react-native';
 import { IRenderData } from '@uifabricshared/foundation-composable';
 import { IBackgroundColorTokens, IBorderTokens } from '@fluentui-react-native/tokens';
 import { IFocusable } from '@fluentui-react-native/interactive-hooks';
@@ -27,7 +27,7 @@ export type DirectionalHint =
   | 'bottomRightEdge';
 
 export interface ICalloutTokens extends IBackgroundColorTokens, IBorderTokens {
-  anchorRect?: ReactNative.ScreenRect;
+  anchorRect?: ScreenRect;
   beakWidth?: number;
   directionalHint?: DirectionalHint;
   gapSpace?: number;

--- a/packages/components/Link/src/Link.tsx
+++ b/packages/components/Link/src/Link.tsx
@@ -1,6 +1,7 @@
 /** @jsx withSlots */
 import * as React from 'react';
-import * as ReactNative from 'react-native';
+
+import { Linking, Text, View } from 'react-native';
 import { compose, IUseComposeStyling } from '@uifabricshared/foundation-compose';
 import { ILinkProps, ILinkSlotProps, ILinkState, ILinkRenderData, IWithLinkOptions, linkName, ILinkType } from './Link.types';
 import { settings } from './Link.settings';
@@ -19,10 +20,10 @@ export function useAsLink(userProps: IWithLinkOptions<IViewProps>): ILinkHooks {
 
   const [linkState, setLinkState] = React.useState({ visited: false });
   const linkOnPress = React.useCallback(
-    e => {
+    (e) => {
       setLinkState({ visited: true });
       if (url) {
-        ReactNative.Linking.openURL(url as string);
+        Linking.openURL(url as string);
       } else if (onPress) {
         onPress(e);
       }
@@ -34,12 +35,12 @@ export function useAsLink(userProps: IWithLinkOptions<IViewProps>): ILinkHooks {
 
   const newState = {
     ...pressable.state,
-    ...linkState
+    ...linkState,
   };
 
   const newProps = {
     ...userProps,
-    ...pressable.props
+    ...pressable.props,
   };
 
   return [newProps, newState];
@@ -63,7 +64,7 @@ export const Link = compose<ILinkType>({
     // create the merged slot props
     const slotProps = mergeSettings<ILinkSlotProps>(styleProps, {
       root: { ...linkProps, ref: linkRef },
-      content: { children: content }
+      content: { children: content },
     });
 
     return { slotProps, state: { ...linkState, ...info } };
@@ -77,19 +78,17 @@ export const Link = compose<ILinkType>({
         {children}
       </Slots.root>
     ) : (
-        <Slots.root>
-          {content && <Slots.content />}
-        </Slots.root>
-      );
+      <Slots.root>{content && <Slots.content />}</Slots.root>
+    );
   },
   slots: {
-    root: ReactNative.View,
-    content: ReactNative.Text
+    root: View,
+    content: Text,
   },
   styles: {
     root: [],
-    content: [foregroundColorTokens, textTokens]
-  }
+    content: [foregroundColorTokens, textTokens],
+  },
 });
 
 export default Link;

--- a/packages/components/Link/src/__tests__/Link.test.win32.tsx
+++ b/packages/components/Link/src/__tests__/Link.test.win32.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as ReactNative from 'react-native';
+import { View } from 'react-native';
 import { Link } from '..';
 import * as renderer from 'react-test-renderer';
 
@@ -12,7 +12,7 @@ it('Link with child', () => {
   const tree = renderer
     .create(
       <Link content="Link with child" url="https://www.bing.com">
-        <ReactNative.View />
+        <View />
       </Link>
     )
     .toJSON();

--- a/packages/framework/theming-react-native/README.md
+++ b/packages/framework/theming-react-native/README.md
@@ -124,13 +124,13 @@ export const getThemedStyles = themedStyleSheet((t: ITheme) => {
     style1: {
       backgroundColor: t.colors.background,
       borderStyle: 'solid',
-      borderWidth: 1
+      borderWidth: 1,
     },
     style2: {
       backgroundColor: t.colors.primaryButtonBackground,
       borderStyle: 'solid',
-      borderWidth: 1
-    }
+      borderWidth: 1,
+    },
   };
 });
 ```
@@ -141,11 +141,11 @@ export const getThemedStyles = themedStyleSheet((t: ITheme) => {
 // MyAppImpl.tsx
 
 import * as React from 'react';
-import * as ReactNative from 'react-native';
+import { Text, ViewProps } from 'react-native';
 import { useTheme } from '@uifabricshared/theming-react-native';
 import { getThemedStyles } from './styles';
 
-export const ThemedView: React.FunctionComponent<ReactNative.ViewProps> = (p: ReactNative.ViewProps) => {
+export const ThemedView: React.FunctionComponent<ViewProps> = (p: ViewProps) => {
   const { userStyle, ...rest } = p;
   const theme = useTheme();
   const styles = getThemedStyles(theme);
@@ -155,7 +155,7 @@ export const ThemedView: React.FunctionComponent<ReactNative.ViewProps> = (p: Re
 export const MyAppImpl = () => {
   return (
     <ThemedView>
-      <ReactNative.Text>Hello, World!</ReactNative.Text>
+      <Text>Hello, World!</Text>
     </ThemedView>
   );
 };

--- a/packages/utils/tokens/src/border-tokens.ts
+++ b/packages/utils/tokens/src/border-tokens.ts
@@ -1,4 +1,4 @@
-import * as ReactNative from 'react-native';
+import { ViewStyle } from 'react-native';
 import { IOperationSet } from '@uifabricshared/foundation-tokens';
 import { ITheme } from '@uifabricshared/theming-ramp';
 import { getPaletteFromTheme } from './color-tokens';
@@ -7,12 +7,12 @@ export interface IBorderTokens {
   borderColor?: string;
   borderWidth?: number | string;
   borderRadius?: number | string;
-  borderStyle?: ReactNative.ViewStyle['borderStyle'];
+  borderStyle?: ViewStyle['borderStyle'];
 }
 
 export const borderTokens: IOperationSet<IBorderTokens, ITheme> = [
   { source: 'borderColor', lookup: getPaletteFromTheme },
   { source: 'borderWidth' },
   { source: 'borderRadius' },
-  { source: 'borderStyle' }
+  { source: 'borderStyle' },
 ];


### PR DESCRIPTION
`import * as ReactNative from 'react-native'` is getting transpiled to the following in the published package:

```js
var __importStar = (this && this.__importStar) || function (mod) {
    if (mod && mod.__esModule) return mod;
    var result = {};
    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
    result["default"] = mod;
    return result;
};
var ReactNative = __importStar(require("react-native"));
```

This code has the side effect of hitting all the getters of the root properties of react-native.  React-native is setup with the idea that most of these getters will only be hit if the app is actually using them.  This causes performance issues, not to mention causes all the deprecation yellow boxes for all of RN to show up.