### PR TITLE
typo in documentation

### DIFF
--- a/change/@uifabricshared-foundation-compose-2020-04-30-11-13-37-ejlayne-patch-2.json
+++ b/change/@uifabricshared-foundation-compose-2020-04-30-11-13-37-ejlayne-patch-2.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "typo fix",
+  "packageName": "@uifabricshared/foundation-compose",
+  "email": "chrishog@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-30T18:13:37.200Z"
+}

--- a/packages/framework/foundation-compose/README.md
+++ b/packages/framework/foundation-compose/README.md
@@ -14,7 +14,7 @@ This infrastructure builds upon a number of key concepts.
 
 ### Component Settings
 
-Settings are collections of props and styles for the parts of a component. They allow for inheritance and the ability to specify overrides for certain states. See the documentation of the [theme-settings](../theme-settings/README.md) package for a more detailed description.
+Settings are collections of props and styles for the parts of a component. They allow for inheritance and the ability to specify overrides for certain states. See the documentation of the [themed-settings](../themed-settings/README.md) package for a more detailed description.
 
 ### Tokens
 


### PR DESCRIPTION
updated typo in documentation to correctly point to /themed-settings/README.md