### PR TITLE
remove node warning

### DIFF
--- a/scripts/use-yarn-please.js
+++ b/scripts/use-yarn-please.js
@@ -41,23 +41,6 @@ if (path.basename(npmPath) !== 'yarn.js') {
   process.exit(1);
 }
 
-checkNodeVersion();
-
-function checkNodeVersion() {
-  const nodeVersion = process.versions.node;
-  if (!nodeVersion) {
-    return;
-  }
-
-  const nodeMajorVersion = nodeVersion.split('.', 1);
-  if (nodeMajorVersion.length > 0 && parseInt(nodeMajorVersion[0]) >= 11) {
-    console.warn(
-      '\x1b[33m%s\x1b[0m',
-      `Your Node version is ${nodeVersion}. If you are seeing some strange build error, try downgrading Node to version 10.x.x.`
-    );
-  }
-}
-
 checkRepositoryLocation();
 
 function checkRepositoryLocation() {


### PR DESCRIPTION
Remove the check for node v10 because we can use v12 now.