### PR TITLE
Support enter key for calling onClick on Button

### DIFF
--- a/change/@fluentui-react-native-2020-05-26-21-34-00-lehon-keyboardClick.json
+++ b/change/@fluentui-react-native-2020-05-26-21-34-00-lehon-keyboardClick.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Support enter key for calling onClick on Button",
+  "packageName": "@fluentui/react-native",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-27T04:33:57.689Z"
+}

--- a/change/@fluentui-react-native-adapters-2020-05-26-21-34-00-lehon-keyboardClick.json
+++ b/change/@fluentui-react-native-adapters-2020-05-26-21-34-00-lehon-keyboardClick.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Support enter key for calling onClick on Button",
+  "packageName": "@fluentui-react-native/adapters",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-27T04:33:58.656Z"
+}

--- a/change/@fluentui-react-native-button-2020-05-26-21-34-00-lehon-keyboardClick.json
+++ b/change/@fluentui-react-native-button-2020-05-26-21-34-00-lehon-keyboardClick.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Support enter key for calling onClick on Button",
+  "packageName": "@fluentui-react-native/button",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-27T04:33:21.587Z"
+}

--- a/change/@fluentui-react-native-callout-2020-05-26-21-34-00-lehon-keyboardClick.json
+++ b/change/@fluentui-react-native-callout-2020-05-26-21-34-00-lehon-keyboardClick.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Support enter key for calling onClick on Button",
+  "packageName": "@fluentui-react-native/callout",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-27T04:33:30.421Z"
+}

--- a/change/@fluentui-react-native-checkbox-2020-05-26-21-34-00-lehon-keyboardClick.json
+++ b/change/@fluentui-react-native-checkbox-2020-05-26-21-34-00-lehon-keyboardClick.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Support enter key for calling onClick on Button",
+  "packageName": "@fluentui-react-native/checkbox",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-27T04:33:32.027Z"
+}

--- a/change/@fluentui-react-native-focus-trap-zone-2020-05-26-21-34-00-lehon-keyboardClick.json
+++ b/change/@fluentui-react-native-focus-trap-zone-2020-05-26-21-34-00-lehon-keyboardClick.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Support enter key for calling onClick on Button",
+  "packageName": "@fluentui-react-native/focus-trap-zone",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-27T04:33:33.282Z"
+}

--- a/change/@fluentui-react-native-interactive-hooks-2020-05-26-21-34-00-lehon-keyboardClick.json
+++ b/change/@fluentui-react-native-interactive-hooks-2020-05-26-21-34-00-lehon-keyboardClick.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Support enter key for calling onClick on Button",
+  "packageName": "@fluentui-react-native/interactive-hooks",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-27T04:33:59.747Z"
+}

--- a/change/@fluentui-react-native-link-2020-05-26-21-34-00-lehon-keyboardClick.json
+++ b/change/@fluentui-react-native-link-2020-05-26-21-34-00-lehon-keyboardClick.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Support enter key for calling onClick on Button",
+  "packageName": "@fluentui-react-native/link",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-27T04:33:36.873Z"
+}

--- a/change/@fluentui-react-native-persona-2020-05-26-21-34-00-lehon-keyboardClick.json
+++ b/change/@fluentui-react-native-persona-2020-05-26-21-34-00-lehon-keyboardClick.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Support enter key for calling onClick on Button",
+  "packageName": "@fluentui-react-native/persona",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-27T04:33:38.370Z"
+}

--- a/change/@fluentui-react-native-persona-coin-2020-05-26-21-34-00-lehon-keyboardClick.json
+++ b/change/@fluentui-react-native-persona-coin-2020-05-26-21-34-00-lehon-keyboardClick.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Support enter key for calling onClick on Button",
+  "packageName": "@fluentui-react-native/persona-coin",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-27T04:33:41.122Z"
+}

--- a/change/@fluentui-react-native-pressable-2020-05-26-21-34-00-lehon-keyboardClick.json
+++ b/change/@fluentui-react-native-pressable-2020-05-26-21-34-00-lehon-keyboardClick.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Support enter key for calling onClick on Button",
+  "packageName": "@fluentui-react-native/pressable",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-27T04:33:42.328Z"
+}

--- a/change/@fluentui-react-native-radio-group-2020-05-26-21-34-00-lehon-keyboardClick.json
+++ b/change/@fluentui-react-native-radio-group-2020-05-26-21-34-00-lehon-keyboardClick.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Support enter key for calling onClick on Button",
+  "packageName": "@fluentui-react-native/radio-group",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-27T04:33:43.448Z"
+}

--- a/change/@fluentui-react-native-separator-2020-05-26-21-34-00-lehon-keyboardClick.json
+++ b/change/@fluentui-react-native-separator-2020-05-26-21-34-00-lehon-keyboardClick.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Support enter key for calling onClick on Button",
+  "packageName": "@fluentui-react-native/separator",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-27T04:33:44.472Z"
+}

--- a/change/@fluentui-react-native-text-2020-05-26-21-34-00-lehon-keyboardClick.json
+++ b/change/@fluentui-react-native-text-2020-05-26-21-34-00-lehon-keyboardClick.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Support enter key for calling onClick on Button",
+  "packageName": "@fluentui-react-native/text",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-27T04:33:45.519Z"
+}

--- a/change/@fluentui-react-native-tokens-2020-05-26-21-34-00-lehon-keyboardClick.json
+++ b/change/@fluentui-react-native-tokens-2020-05-26-21-34-00-lehon-keyboardClick.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Support enter key for calling onClick on Button",
+  "packageName": "@fluentui-react-native/tokens",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-27T04:34:00.592Z"
+}

--- a/change/@uifabricshared-foundation-composable-2020-05-26-21-34-00-lehon-keyboardClick.json
+++ b/change/@uifabricshared-foundation-composable-2020-05-26-21-34-00-lehon-keyboardClick.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Support enter key for calling onClick on Button",
+  "packageName": "@uifabricshared/foundation-composable",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-27T04:33:46.427Z"
+}

--- a/change/@uifabricshared-foundation-compose-2020-05-26-21-34-00-lehon-keyboardClick.json
+++ b/change/@uifabricshared-foundation-compose-2020-05-26-21-34-00-lehon-keyboardClick.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Support enter key for calling onClick on Button",
+  "packageName": "@uifabricshared/foundation-compose",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-27T04:33:47.522Z"
+}

--- a/change/@uifabricshared-foundation-settings-2020-05-26-21-34-00-lehon-keyboardClick.json
+++ b/change/@uifabricshared-foundation-settings-2020-05-26-21-34-00-lehon-keyboardClick.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Support enter key for calling onClick on Button",
+  "packageName": "@uifabricshared/foundation-settings",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-27T04:33:48.698Z"
+}

--- a/change/@uifabricshared-foundation-tokens-2020-05-26-21-34-00-lehon-keyboardClick.json
+++ b/change/@uifabricshared-foundation-tokens-2020-05-26-21-34-00-lehon-keyboardClick.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Support enter key for calling onClick on Button",
+  "packageName": "@uifabricshared/foundation-tokens",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-27T04:33:49.636Z"
+}

--- a/change/@uifabricshared-immutable-merge-2020-05-26-21-34-00-lehon-keyboardClick.json
+++ b/change/@uifabricshared-immutable-merge-2020-05-26-21-34-00-lehon-keyboardClick.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Support enter key for calling onClick on Button",
+  "packageName": "@uifabricshared/immutable-merge",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-27T04:33:50.555Z"
+}

--- a/change/@uifabricshared-theme-registry-2020-05-26-21-34-00-lehon-keyboardClick.json
+++ b/change/@uifabricshared-theme-registry-2020-05-26-21-34-00-lehon-keyboardClick.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Support enter key for calling onClick on Button",
+  "packageName": "@uifabricshared/theme-registry",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-27T04:33:51.636Z"
+}

--- a/change/@uifabricshared-themed-settings-2020-05-26-21-34-00-lehon-keyboardClick.json
+++ b/change/@uifabricshared-themed-settings-2020-05-26-21-34-00-lehon-keyboardClick.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Support enter key for calling onClick on Button",
+  "packageName": "@uifabricshared/themed-settings",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-27T04:33:52.590Z"
+}

--- a/change/@uifabricshared-themed-stylesheet-2020-05-26-21-34-00-lehon-keyboardClick.json
+++ b/change/@uifabricshared-themed-stylesheet-2020-05-26-21-34-00-lehon-keyboardClick.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Support enter key for calling onClick on Button",
+  "packageName": "@uifabricshared/themed-stylesheet",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-27T04:33:53.812Z"
+}

--- a/change/@uifabricshared-theming-ramp-2020-05-26-21-34-00-lehon-keyboardClick.json
+++ b/change/@uifabricshared-theming-ramp-2020-05-26-21-34-00-lehon-keyboardClick.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Support enter key for calling onClick on Button",
+  "packageName": "@uifabricshared/theming-ramp",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-27T04:33:55.130Z"
+}

--- a/change/@uifabricshared-theming-react-native-2020-05-26-21-34-00-lehon-keyboardClick.json
+++ b/change/@uifabricshared-theming-react-native-2020-05-26-21-34-00-lehon-keyboardClick.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Support enter key for calling onClick on Button",
+  "packageName": "@uifabricshared/theming-react-native",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-27T04:33:56.667Z"
+}

--- a/packages/components/Button/src/Button.tsx
+++ b/packages/components/Button/src/Button.tsx
@@ -27,7 +27,7 @@ export const Button = compose<IButtonType>({
     const pressable = useAsPressable({ ...rest, onPress: onClick });
     const onKeyDown = React.useCallback(
       e => {
-        if (onClick && e.nativeEvent.key === 'Enter') {
+        if (onClick && (e.nativeEvent.key === 'Enter' || e.nativeEvent.key === ' ')) {
           onClick();
           e.stopPropagation()
         }

--- a/packages/components/Button/src/Button.tsx
+++ b/packages/components/Button/src/Button.tsx
@@ -29,6 +29,7 @@ export const Button = compose<IButtonType>({
       e => {
         if (onClick && e.nativeEvent.key === 'Enter') {
           onClick();
+          e.stopPropagation()
         }
       },
       [onClick]

--- a/packages/components/Button/src/Button.tsx
+++ b/packages/components/Button/src/Button.tsx
@@ -25,6 +25,14 @@ export const Button = compose<IButtonType>({
     } = userProps;
     // attach the pressable state handlers
     const pressable = useAsPressable({ ...rest, onPress: onClick });
+    const onKeyDown = React.useCallback(
+      e => {
+        if (onClick && e.nativeEvent.key === 'Enter') {
+          onClick();
+        }
+      },
+      [onClick]
+    );
     // set up state
     const state: IButtonState = {
       info: {
@@ -45,7 +53,8 @@ export const Button = compose<IButtonType>({
         ...pressable.props,
         ref: buttonRef,
         onAccessibilityTap: onAccessibilityTap,
-        accessibilityLabel: accessibilityLabel
+        accessibilityLabel: accessibilityLabel,
+        onKeyDown: onKeyDown
       },
       content: { children: content },
       icon: { source: icon }

--- a/packages/components/Button/src/__snapshots__/Button.test.tsx.snap
+++ b/packages/components/Button/src/__snapshots__/Button.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`Button default 1`] = `
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
+  onKeyDown={[Function]}
   onResponderGrant={[Function]}
   onResponderMove={[Function]}
   onResponderRelease={[Function]}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32
- [ ] windows
- [ ] android

### Description of changes

onKeyDown recognizes the enter key press to call the onClick event for Button.

### Verification

Manually tested with Buttons recognizing an enter key press when focus and calling onClick event.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [X] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
