### PR TITLE
Enable yarn build and yarn bundle for iOS

### DIFF
--- a/.ado/azure-pipelines.yml
+++ b/.ado/azure-pipelines.yml
@@ -61,7 +61,7 @@ jobs:
           relative_directory: "ios"
           xcode_sdx: "ios"
           xcode_configuration: "Debug"
-          xcode_workspacePath: "apps/apple/FluentUITester/ios/FluentUITester.xcworkspace"
+          xcode_workspacePath: "apps/ios/src/FluentUITester.xcworkspace"
           xcode_scheme: "FluentUITester"
           xcode_actions: "build"
           xcode_useXcpretty: true
@@ -70,7 +70,7 @@ jobs:
           relative_directory: "macos"
           xcode_sdx: "macosx"
           xcode_configuration: "Debug"
-          xcode_workspacePath: "apps/apple/FluentUITester/macos/FluentUITester.xcworkspace"
+          xcode_workspacePath: "apps/macos/src/FluentUITester.xcworkspace"
           xcode_scheme: "FluentUITester-macOS"
           xcode_actions: "build"
           xcode_useXcpretty: true

--- a/.ado/templates/apple-xcode-build.yml
+++ b/.ado/templates/apple-xcode-build.yml
@@ -12,9 +12,8 @@ parameters:
 steps:
   # Install any pods necessary for the project
   - bash: |
-      echo "Running: cd apps/$platform_directory/src && pod install" &&
-      cd apps/$platform_directory/src &&
-      pod install
+      echo "pod install --project-directory=apps/$platform_directory/src"
+      pod install --project-directory=apps/$platform_directory/src
     env:
       platform_directory: ${{ parameters.relative_directory }}
     displayName: "pod install"

--- a/apps/ios/.eslintrc.js
+++ b/apps/ios/.eslintrc.js
@@ -1,4 +1,3 @@
 module.exports = {
-  root: true,
-  extends: '@react-native-community',
+  extends: ['@uifabricshared/eslint-config-rules']
 };

--- a/apps/ios/app.json
+++ b/apps/ios/app.json
@@ -1,4 +1,4 @@
 {
-  "name": "FluentUITester",
-  "displayName": "FluentUITester"
+  "name": "FluentTester",
+  "displayName": "FluentTester"
 }

--- a/apps/ios/package.json
+++ b/apps/ios/package.json
@@ -1,12 +1,19 @@
 {
-  "name": "FluentUITester-ios",
+  "name": "FluentTester-ios",
   "version": "0.0.1",
   "private": true,
+  "main": "src/index.tsx",
+  "module": "src/index.tsx",
+  "typings": "lib/index.d.ts",
   "scripts": {
-    "ios": "react-native run-ios",
+    "build": "fluentui-scripts build",
+    "just": "fluentui-scripts",
+    "clean": "fluentui-scripts clean",
+    "code-style": "fluentui-scripts code-style",
+    "lint": "fluentui-scripts eslint",
     "start": "react-native start",
-    "test": "jest",
-    "lint": "eslint ."
+    "bundle": "fluentui-scripts metro --cli",
+    "bundle-dev": "fluentui-scripts metro --dev --cli"
   },
   "dependencies": {
     "@fluentui-react-native/tester": "^0.0.1",

--- a/apps/ios/src/FluentUITester/AppDelegate.m
+++ b/apps/ios/src/FluentUITester/AppDelegate.m
@@ -33,7 +33,7 @@ static void InitializeFlipper(UIApplication *application) {
 
   RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
   RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
-                                                   moduleName:@"FluentUITester"
+                                                   moduleName:@"FluentTester"
                                             initialProperties:nil];
 
   rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];

--- a/apps/ios/src/index.tsx
+++ b/apps/ios/src/index.tsx
@@ -13,6 +13,6 @@ const FluentTester: React.FunctionComponent<IFabricTesterProps> = props => {
   );
 };
 
-AppRegistry.registerComponent('FluentUITester', () => FluentTester);
+AppRegistry.registerComponent('FluentTester', () => FluentTester);
 
 export default FluentTester;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3510,6 +3510,20 @@
   resolved "https://registry.yarnpkg.com/@uifabric/prettier-rules/-/prettier-rules-7.0.4.tgz#03082a6cc4b586104738a24892c56e0f1d3df1b6"
   integrity sha512-PK60wLAjPrG2l93r1l/VY2BmnC1la0oxIXYBuln5DOAFJcSXMea9RxoNjuqhhqZGZo6aLjO7lW070MeVOvkABQ==
 
+"@uifabricshared/themed-stylesheet@0.3.29":
+  version "0.3.29"
+  resolved "https://registry.yarnpkg.com/@uifabricshared/themed-stylesheet/-/themed-stylesheet-0.3.29.tgz#19d41328e714589d77fe2ce05c143fc27fc15cf3"
+  integrity sha512-kFXv0EVFUJ0Ekkuhfiy/7WiuUpTNZyYNP+TOSfGqVl1lhjEyn2FY5goPvHCxdWYINovHGL+QAwxedN43Yp1N5w==
+
+"@uifabricshared/theming-react-native@0.7.28":
+  version "0.7.28"
+  resolved "https://registry.yarnpkg.com/@uifabricshared/theming-react-native/-/theming-react-native-0.7.28.tgz#3dee7ce9f852dbbdb36ee10653e612bbaabaf03b"
+  integrity sha512-25wGC1UQOYp2VqyPD5I/V3H9Mzlx3/3gAEQ4J1Uw1xoXxp0YaNaxVjBU9UygmOM3LooyBdmcwrPuIDOkhC+GrA==
+  dependencies:
+    "@uifabricshared/foundation-settings" "^0.5.28"
+    "@uifabricshared/theme-registry" "^0.3.28"
+    "@uifabricshared/theming-ramp" "^0.9.27"
+
 "@wdio/appium-service@^5.0.0":
   version "5.18.2"
   resolved "https://registry.yarnpkg.com/@wdio/appium-service/-/appium-service-5.18.2.tgz#e6461c939393c3edbb027e69780f0fd2dadff6a4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3510,20 +3510,6 @@
   resolved "https://registry.yarnpkg.com/@uifabric/prettier-rules/-/prettier-rules-7.0.4.tgz#03082a6cc4b586104738a24892c56e0f1d3df1b6"
   integrity sha512-PK60wLAjPrG2l93r1l/VY2BmnC1la0oxIXYBuln5DOAFJcSXMea9RxoNjuqhhqZGZo6aLjO7lW070MeVOvkABQ==
 
-"@uifabricshared/themed-stylesheet@0.3.29":
-  version "0.3.29"
-  resolved "https://registry.yarnpkg.com/@uifabricshared/themed-stylesheet/-/themed-stylesheet-0.3.29.tgz#19d41328e714589d77fe2ce05c143fc27fc15cf3"
-  integrity sha512-kFXv0EVFUJ0Ekkuhfiy/7WiuUpTNZyYNP+TOSfGqVl1lhjEyn2FY5goPvHCxdWYINovHGL+QAwxedN43Yp1N5w==
-
-"@uifabricshared/theming-react-native@0.7.28":
-  version "0.7.28"
-  resolved "https://registry.yarnpkg.com/@uifabricshared/theming-react-native/-/theming-react-native-0.7.28.tgz#3dee7ce9f852dbbdb36ee10653e612bbaabaf03b"
-  integrity sha512-25wGC1UQOYp2VqyPD5I/V3H9Mzlx3/3gAEQ4J1Uw1xoXxp0YaNaxVjBU9UygmOM3LooyBdmcwrPuIDOkhC+GrA==
-  dependencies:
-    "@uifabricshared/foundation-settings" "^0.5.28"
-    "@uifabricshared/theme-registry" "^0.3.28"
-    "@uifabricshared/theming-ramp" "^0.9.27"
-
 "@wdio/appium-service@^5.0.0":
   version "5.18.2"
   resolved "https://registry.yarnpkg.com/@wdio/appium-service/-/appium-service-5.18.2.tgz#e6461c939393c3edbb027e69780f0fd2dadff6a4"


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32
- [ ] windows
- [ ] android

### Description of changes

Yarn bundle has not been enabled for iOS yet. Let's copy over the bundle command from the win32 test app package.json (along with a few others) to enable this. Specifically:
- `build`
- `clean`
- `lint` (We needed to update the eslint config file to match the win32 test app)
- `just`
- `codestyle`
- `bundle`
- `bundle-dev`

Let's also remove the following commands, as they fail in our current test app:
- `ios` (Renaming the ios/ subdirectory to src/ means react-native run-ios no longer works)
- `test` (There is not a jest.config file in the ios test app, so I don't think we run any actual tests)

While here, let's update some of the Apple PR yml file to remove paths that no longer exist, and simplify some commands.

Also, for some extra parity with the win32/windows test app, let's rename our test app from "Fluent**UI**Tester-ios" to "FluentTester-ios"

### Verification

`yarn && yarn build` at root runs as expected

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
