### PR TITLE
Remove TestSVG asset from use in JSX

### DIFF
--- a/apps/fluent-tester/src/RNTester/TestComponents/Svg/SvgTest.tsx
+++ b/apps/fluent-tester/src/RNTester/TestComponents/Svg/SvgTest.tsx
@@ -10,7 +10,6 @@ const styles = StyleSheet.create({
   }
 });
 
-import TestSvg from './Assets/accessible-icon-brands.svg';
 export const SvgTest: React.FunctionComponent<{}> = () => {
   return (
     <View>
@@ -65,7 +64,6 @@ export const SvgTest: React.FunctionComponent<{}> = () => {
         <Use href="#shape" x="170" y="0" />
       </Svg>
       <Text>Bundled svg </Text>
-      <TestSvg width={200} height={200} color="red" />
       <Text>Remotely retrieved svgs</Text>
       <SvgCssUri
         style={styles.svg}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32
- [x] windows
- [ ] android

### Description of changes
Remove usage of TestSVG asset in JSX. When bundled the asset was getting resolved as a number causing failures in React.createElement

### Verification

 After
![image](https://user-images.githubusercontent.com/28971549/83558107-5df4e880-a4c7-11ea-9727-bdbdb4ef137f.png)
 |

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
