### PR TITLE
Add setInitialFocus prop

### DIFF
--- a/apps/fluent-tester/src/RNTester/TestComponents/Callout/CalloutTest.tsx
+++ b/apps/fluent-tester/src/RNTester/TestComponents/Callout/CalloutTest.tsx
@@ -81,6 +81,7 @@ export const CalloutTest: React.FunctionComponent<{}> = () => {
           onDismiss={onDismissStandardCallout}
           onShow={onShowStandardCallout}
           accessibilityLabel="Standard Callout"
+          setInitialFocus
         >
           <View style={{ height: 200, width: 400 }}>
             <Button content="click to change anchor" onClick={toggleCalloutRef} />

--- a/change/@fluentui-react-native-callout-2020-06-04-12-32-21-callout-initialfocus.json
+++ b/change/@fluentui-react-native-callout-2020-06-04-12-32-21-callout-initialfocus.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add setInitialFocus prop",
+  "packageName": "@fluentui-react-native/callout",
+  "email": "ppatboyd@outlook.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-04T19:32:21.042Z"
+}

--- a/packages/components/Callout/src/Callout.types.ts
+++ b/packages/components/Callout/src/Callout.types.ts
@@ -98,6 +98,13 @@ export interface ICalloutProps extends ICalloutTokens {
   onShow?: () => void;
 
   /**
+   * If true then the callout will attempt to focus the first focusable element that it contains.
+   * If it doesn't find an element, no focus will be set and the method will return false.
+   * This means that it's the contents responsibility to either set focus or have focusable items.
+   */
+  setInitialFocus?: boolean;
+
+  /**
    * Target node the callout uses for relative positioning; the anchor of the callout.
    */
   target?: React.RefObject<React.Component>;

--- a/packages/components/Callout/src/Callout.types.ts
+++ b/packages/components/Callout/src/Callout.types.ts
@@ -99,8 +99,8 @@ export interface ICalloutProps extends ICalloutTokens {
 
   /**
    * If true then the callout will attempt to focus the first focusable element that it contains.
-   * If it doesn't find an element, no focus will be set and the method will return false.
-   * This means that it's the contents responsibility to either set focus or have focusable items.
+   * If it doesn't find an element, no focus will be set. This means that it's the contents responsibility
+   * to either set focus or have focusable items.
    */
   setInitialFocus?: boolean;
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32
- [ ] windows
- [ ] android

### Description of changes

Add setInitialFocus property to the Callout component.  By default, the Callout does not take focus.  with setInitialFocus=true, the Callout attempts to set focus on the first focusable content inside the Callout.

### Verification

Manual verification

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [x] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
