### PR TITLE
Add iOS CI to run our test app

### DIFF
--- a/.ado/templates/apple-xcode-build.yml
+++ b/.ado/templates/apple-xcode-build.yml
@@ -19,8 +19,8 @@ steps:
     displayName: "pod install"
 
   - bash: |
-      echo "cd apps/$platform_directory && yarn ios"
-      cd apps/$platform_directory && yarn ios
+      echo "cd apps/$platform_directory && yarn $platform_directory"
+      cd apps/$platform_directory && yarn $platform_directory
     env:
       platform_directory: ${{ parameters.relative_directory }}
-    displayName: "yarn ios"
+    displayName: "yarn ios/macos"

--- a/.ado/templates/apple-xcode-build.yml
+++ b/.ado/templates/apple-xcode-build.yml
@@ -17,3 +17,10 @@ steps:
     env:
       platform_directory: ${{ parameters.relative_directory }}
     displayName: "pod install"
+
+  - bash: |
+      echo "cd apps/$platform_directory && yarn ios"
+      cd apps/$platform_directory && yarn ios
+    env:
+      platform_directory: ${{ parameters.relative_directory }}
+    displayName: "yarn ios"

--- a/apps/macos/package.json
+++ b/apps/macos/package.json
@@ -11,7 +11,8 @@
     "clean": "fluentui-scripts clean",
     "code-style": "fluentui-scripts code-style",
     "lint": "fluentui-scripts eslint",
-    "start:macos": "node ../../node_modules/react-native-macos/local-cli/cli.js start --use-react-native-macos"
+    "start:macos": "node ../../node_modules/react-native-macos/local-cli/cli.js start --use-react-native-macos",
+    "macos": "fluentui-scripts"
   },
   "dependencies": {
     "@fluentui-react-native/tester": "^0.0.1",


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32
- [ ] windows
- [ ] android

### Description of changes

Now we have `run ios` support, we can update our CI to use it. 

### Verification

Ran `yarn ios` locally from `apps/platformDir` and verified the packager was launched and the test app ran.

Will also validate in the actual ADO CI loop that this command is executing/succeeding.

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
