### PR TITLE
remove cycle in scripts/package.json

### DIFF
--- a/scripts/package.json
+++ b/scripts/package.json
@@ -41,7 +41,6 @@
     "@typescript-eslint/eslint-plugin": "^2.24.0",
     "@typescript-eslint/parser": "^2.24.0",
     "@uifabric/prettier-rules": "^7.0.3",
-    "@uifabricshared/build-native": "^0.1.1",
     "babel-jest": "^24.9.0",
     "babel-plugin-module-resolver": "^4.0.0",
     "enzyme": "^3.11.0",


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32
- [ ] windows
- [ ] android

### Description of changes

There was a devDependency cycle in scripts/package.json where scripts was effectively referencing itself.  Some tools complained about this, it is unclear what actual issues are coming out of it.

It does appear that we are generating changes for packages even when none exist so beachballs change logic is breaking down. I haven't had time to look more deeply but removing dependency cycles is the first step to fixing that.

### Verification

Just building and bundling

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
