### PR TITLE
Fix iOS test app rendering into the notch

### DIFF
--- a/apps/ios/src/index.tsx
+++ b/apps/ios/src/index.tsx
@@ -1,15 +1,17 @@
 'use strict';
 
 import * as React from 'react';
-import { AppRegistry } from 'react-native';
+import { AppRegistry, SafeAreaView } from 'react-native';
 import { ThemeProvider } from '@uifabricshared/theming-react-native';
 import { FabricTester, IFabricTesterProps, customRegistry } from '@fluentui-react-native/tester';
 
 const FluentTester: React.FunctionComponent<IFabricTesterProps> = props => {
   return (
-    <ThemeProvider registry={customRegistry}>
-      <FabricTester {...props} />
-    </ThemeProvider>
+    <SafeAreaView>
+      <ThemeProvider registry={customRegistry}>
+        <FabricTester {...props} />
+      </ThemeProvider>
+    </SafeAreaView>
   );
 };
 


### PR DESCRIPTION
### Platforms Impacted

- [x] iOS
- [ ] macOS
- [ ] win32
- [ ] windows
- [ ] android

### Description of changes

The iOS test app was rendering under the notch. Adding `SafeAreaView` prevents it from doing that.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-06-23 at 19 52 18](https://user-images.githubusercontent.com/4123478/85443856-09a6cb00-b592-11ea-93bf-6b308a989e5e.png) | ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-06-23 at 20 42 05](https://user-images.githubusercontent.com/4123478/85443897-14616000-b592-11ea-9cf7-af6f4ac41008.png) |

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [x] Documentation and examples
- [x] Keyboard Accessibility
- [x] Voiceover
- [x] Internationalization and Right-to-left Layouts
