### PR TITLE
Rework CI pipelines to be faster

### DIFF
--- a/.ado/azure-pipelines.yml
+++ b/.ado/azure-pipelines.yml
@@ -123,11 +123,6 @@ jobs:
         workingDirectory: apps/ios
         displayName: "yarn bundle ios"
 
-      - script: |
-          yarn bundle
-        workingDirectory: apps/macos
-        displayName: "yarn bundle macos"
-
       # Select proper XCode version
       - template: templates/apple-xcode-select.yml
 

--- a/.ado/azure-pipelines.yml
+++ b/.ado/azure-pipelines.yml
@@ -5,6 +5,38 @@ variables:
   CI: true
 
 jobs:
+  # Dedicated task to build and bundle JS code, including jest tests, snapshot testing, and linting, because these things can be super
+  # time consuming they don't need to run on every CI pass, instead do a dedicated JS loop to make the platform specific tests start quicker
+  - job: BuildAndBundle
+    displayName: Build, test, and bundle JavaScript
+    pool:
+      vmImage: "ubuntu-latest"
+    timeoutInMinutes: 60 # how long to run the job before automatically cancelling
+    cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
+
+    steps:
+      - checkout: self
+        persistCredentials: true
+
+      - template: templates/setup-repo.yml
+
+      - script: |
+          yarn build
+        displayName: "yarn build"
+
+      - script: |
+          yarn bundle
+        displayName: "yarn bundle"
+
+      - script: |
+          yarn checkchange
+      displayName: "check change"
+
+      - script: |
+          yarn check-for-changed-files
+        displayName: "verify API and Ensure Changed Files"
+
+  # Windows bundling and end to end testing
   - job: WindowsPR
     displayName: Windows PR
     pool:
@@ -18,22 +50,29 @@ jobs:
       - checkout: self
         persistCredentials: true
 
-      - template: templates/setup-repo.yml
+      # yarn and minimal build to get set up
+      - template: templates/setup-repo-min-build.yml
 
-      - script: |
-          yarn checkchange
-        displayName: "check change"
-
-      - script: |
-          yarn check-for-changed-files
-        displayName: "verify API and Ensure Changed Files"
-
+      # bundle windows adn do end to end tests
       - template: templates/e2e-testing-uwp.yml
 
-      - script: |
-          yarn e2etest
-        workingDirectory: apps/win32
-        displayName: "run E2E Win32 tests"
+  # Win32 bundling and end to end testing
+  - job: Win32PR
+    displayName: Win32 PR
+    pool:
+      vmImage: "windows-2019"
+    timeoutInMinutes: : 60
+    cancelTimeoutInMinutes: 5
+
+    steps:
+      - checkout: self
+        persistCredentials: true
+
+      # yarn and minimal build to get set up
+      - template: templates/setup-repo-min-build.yml
+
+      # bundle win32 and do end to end tests
+      - template: templates/e2e-testing-win32.yml
 
   - job: ApplePR
     displayName: Apple PR
@@ -77,7 +116,17 @@ jobs:
           sudo gem install cocoapods
         displayName: "Install Cocoapods Environment"
 
-      - template: templates/setup-repo.yml
+      - template: templates/setup-repo-min-build.yml
+
+      - script: |
+          yarn bundle
+        workingDirectory: apps/ios
+        displayName: "yarn bundle ios"
+
+      - script: |
+          yarn bundle
+        workingDirectory: apps/macos
+        displayName: "yarn bundle macos"
 
       # Select proper XCode version
       - template: templates/apple-xcode-select.yml

--- a/.ado/azure-pipelines.yml
+++ b/.ado/azure-pipelines.yml
@@ -30,7 +30,7 @@ jobs:
 
       - script: |
           yarn checkchange
-      displayName: "check change"
+        displayName: "check change"
 
       - script: |
           yarn check-for-changed-files

--- a/.ado/azure-pipelines.yml
+++ b/.ado/azure-pipelines.yml
@@ -61,7 +61,7 @@ jobs:
     displayName: Win32 PR
     pool:
       vmImage: "windows-2019"
-    timeoutInMinutes: : 60
+    timeoutInMinutes: 60
     cancelTimeoutInMinutes: 5
 
     steps:

--- a/.ado/templates/e2e-testing-uwp.yml
+++ b/.ado/templates/e2e-testing-uwp.yml
@@ -1,4 +1,9 @@
 steps:
+  - script: |
+      yarn bundle
+    workingDirectory: apps\windows
+    displayName: yarn bundle
+
   - task: DownloadSecureFile@1
     name: UwpCertificate
     inputs:

--- a/.ado/templates/e2e-testing-win32.yml
+++ b/.ado/templates/e2e-testing-win32.yml
@@ -1,0 +1,10 @@
+steps:
+  - script: |
+      yarn bundle
+    workingDirectory: apps/win32
+    displayName: "yarn bundle"
+
+  - script: |
+      yarn e2etest
+    workingDirectory: apps/win32
+    displayName: "run E2E Win32 tests"

--- a/.ado/templates/setup-repo-min-build.yml
+++ b/.ado/templates/setup-repo-min-build.yml
@@ -1,0 +1,6 @@
+steps:
+  - template: setup-repo.yml
+
+  - script: |
+      yarn build --min
+    displayName: "yarn build --min"

--- a/.ado/templates/setup-repo.yml
+++ b/.ado/templates/setup-repo.yml
@@ -13,11 +13,3 @@ steps:
   - script: |
       yarn
     displayName: "yarn"
-
-  - script: |
-      yarn build
-    displayName: "yarn build"
-
-  - script: |
-      yarn bundle
-    displayName: "yarn bundle"


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32
- [x] windows
- [ ] android

### Description of changes

Our CI loops are running really slowly right now, currently a big chunk of this time is the process of running yarn install, yarn build, then yarn bundle. In many cases each of these steps is taking 4-6 minutes.  Looking more deeply at this those steps are doing:

- `yarn`: doing the yarn install, not much we can do except for de-dupe dependencies, doing that separately
- `yarn build`: this currently does typescript builds, linting and jest tests
- `yarn bundle`: this currently bundles all platforms, even if they aren't relevant

This PR does the following:

- Create a new PR loop for building and bundling, this will run the full build loop and bundle all platforms and packages.
- Make all other PR loops use yarn build --min which skips jest/linting and is much faster
- Create dedicated win32 and windows loops
- Each of these loops will only bundle the appropriate platform
- Change the apple loops to only bundle macos/ios

This should hopefully yield faster CI turnaround times. Conceivably even more of the building could be skipped but this change is a more conservative start.

### Verification

This change only affects CI loops.