### PR TITLE
Add iPad support to the FluentUITester-iOS target

### DIFF
--- a/apps/ios/src/Common.xcconfig
+++ b/apps/ios/src/Common.xcconfig
@@ -27,6 +27,8 @@ GCC_WARN_UNUSED_VARIABLE = YES
 SWIFT_TREAT_WARNINGS_AS_ERRORS = YES
 LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks
 
+TARGETED_DEVICE_FAMILY = "1,2"
+
 INFOPLIST_FILE = FluentUITester/Info.plist
 
 // Versions

--- a/apps/ios/src/FluentUITester.xcodeproj/project.pbxproj
+++ b/apps/ios/src/FluentUITester.xcodeproj/project.pbxproj
@@ -285,7 +285,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9F3A29F4244F657400A401D2 /* Debug.xcconfig */;
 			buildSettings = {
-				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -293,7 +292,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9F3A29F5244F658400A401D2 /* Release.xcconfig */;
 			buildSettings = {
-				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};

--- a/apps/ios/src/FluentUITester.xcodeproj/project.pbxproj
+++ b/apps/ios/src/FluentUITester.xcodeproj/project.pbxproj
@@ -285,6 +285,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9F3A29F4244F657400A401D2 /* Debug.xcconfig */;
 			buildSettings = {
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -292,6 +293,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9F3A29F5244F658400A401D2 /* Release.xcconfig */;
 			buildSettings = {
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32
- [ ] windows
- [ ] android

### Description of changes

I noticed that the FluentUITester-ios test app didn't use the full iPad screen in simulator, and rendered as an iPhone app.
Click the checkbox in the test app target so it renders for iPad.

### Verification

Opened test app in iPad. It is now using the full screen.

![Screen Shot 2020-07-09 at 12 47 03 PM](https://user-images.githubusercontent.com/6722175/87083993-56211600-c1e2-11ea-9692-8d680e84dd15.png)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
