### PR TITLE
Better clarify prerequisites in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you have an existing React Native project, it's easy to begin using FluentUI 
 
 ### Prerequisites
 
-- [Standard React Native dependencies](https://reactnative.dev/docs/environment-setup)
+- [Standard React Native dependencies](https://microsoft.github.io/react-native-windows/docs/rnw-dependencies#manual-setup)
 - [Node.js](https://nodejs.org/en/download/)
 
 ### Create New React Native project (if needed)


### PR DESCRIPTION
Simply changing a link in the Prerequisites section that navigates you directly to Development dependencies.

### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32
- [ ] windows
- [ ] android

### Description of changes

Clarifying development dependencies in README. The new link I provided navigates the user **directly** to the needed dependencies. 

### Verification


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [X] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
