### PR TITLE
Edit Link and Checkbox Settings for narrator accessibility

### DIFF
--- a/change/@fluentui-react-native-checkbox-2020-07-15-23-24-51-link-ally.json
+++ b/change/@fluentui-react-native-checkbox-2020-07-15-23-24-51-link-ally.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add text borderColor as a token for Link and Checkbox to allow theming",
+  "packageName": "@fluentui-react-native/checkbox",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-16T06:24:43.461Z"
+}

--- a/change/@fluentui-react-native-link-2020-07-15-23-24-51-link-ally.json
+++ b/change/@fluentui-react-native-link-2020-07-15-23-24-51-link-ally.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add text borderColor as a token for Link and Checkbox to allow theming",
+  "packageName": "@fluentui-react-native/link",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-16T06:24:51.460Z"
+}

--- a/packages/components/Checkbox/src/Checkbox.settings.ts
+++ b/packages/components/Checkbox/src/Checkbox.settings.ts
@@ -8,7 +8,8 @@ export const settings: IComposeSettings<ICheckboxType> = [
     tokens: {
       borderColor: 'menuItemText',
       color: 'menuItemText',
-      backgroundColor: 'menuBackground'
+      backgroundColor: 'menuBackground',
+      textBorderColor: 'transparent'
     },
     root: {
       accessible: true,
@@ -46,20 +47,19 @@ export const settings: IComposeSettings<ICheckboxType> = [
       variant: 'bodyStandard',
       style: {
         marginTop: 1,
-        borderStyle: 'dashed',
-        borderColor: 'transparent',
-        borderWidth: 1
       }
     },
     _precedence: ['disabled', 'boxAtEnd', 'hovered', 'focused', 'pressed', 'checked'],
     _overrides: {
       focused: {
         tokens: {
-          backgroundColor: 'menuItemBackgroundHovered'
+          backgroundColor: 'menuItemBackgroundHovered',
+          textBorderColor: 'focusBorder'
         },
         content: {
           style: {
-            borderColor: 'rgba(128, 128, 128, 1)'
+            borderStyle: 'dotted',
+            borderWidth: 1
           }
         }
       },

--- a/packages/components/Checkbox/src/Checkbox.tsx
+++ b/packages/components/Checkbox/src/Checkbox.tsx
@@ -87,11 +87,11 @@ export const Checkbox = compose<ICheckboxType>({
   render: (Slots: ISlots<ICheckboxSlotProps>, renderData: ICheckboxRenderData, ...children: React.ReactNode[]) => {
     return (
       <Slots.root>
-        {renderData ?.state.boxAtEnd && <Slots.content />}
+        {renderData?.state.boxAtEnd && <Slots.content />}
         <Slots.checkbox>
           <Slots.checkmark />
         </Slots.checkbox>
-        {!renderData ?.state.boxAtEnd && <Slots.content />}
+        {!renderData?.state.boxAtEnd && <Slots.content />}
         {children}
       </Slots.root>
     );

--- a/packages/components/Checkbox/src/Checkbox.tsx
+++ b/packages/components/Checkbox/src/Checkbox.tsx
@@ -87,11 +87,11 @@ export const Checkbox = compose<ICheckboxType>({
   render: (Slots: ISlots<ICheckboxSlotProps>, renderData: ICheckboxRenderData, ...children: React.ReactNode[]) => {
     return (
       <Slots.root>
-        {renderData?.state.boxAtEnd && <Slots.content />}
+        {renderData ?.state.boxAtEnd && <Slots.content />}
         <Slots.checkbox>
           <Slots.checkmark />
         </Slots.checkbox>
-        {!renderData?.state.boxAtEnd && <Slots.content />}
+        {!renderData ?.state.boxAtEnd && <Slots.content />}
         {children}
       </Slots.root>
     );
@@ -121,7 +121,13 @@ export const Checkbox = compose<ICheckboxType>({
         { source: 'checkmarkVisibility', target: 'opacity' }
       ]
     ],
-    content: [foregroundColorTokens, textTokens]
+    content: [
+      foregroundColorTokens,
+      textTokens,
+      [
+        { source: 'textBorderColor', lookup: getPaletteFromTheme, target: 'borderColor' }
+      ]
+    ]
   }
 });
 

--- a/packages/components/Checkbox/src/Checkbox.types.ts
+++ b/packages/components/Checkbox/src/Checkbox.types.ts
@@ -77,6 +77,7 @@ export interface ICheckboxTokens extends ITextTokens, IForegroundColorTokens, IB
   checkboxBorderColor?: string;
   checkmarkColor?: string;
   checkmarkVisibility?: number;
+  textBorderColor?: string;
 }
 
 export interface ICheckboxSlotProps {

--- a/packages/components/Link/src/Link.settings.ts
+++ b/packages/components/Link/src/Link.settings.ts
@@ -10,7 +10,9 @@ export const settings: IComposeSettings<ILinkType> = [
       color: 'link'
     },
     root: {
+      accessible: true,
       acceptsKeyboardFocus: true,
+      accessibilityRole: 'link',
       style: {
         margin: 0,
         textDecorationLine: 'underline',

--- a/packages/components/Link/src/Link.settings.ts
+++ b/packages/components/Link/src/Link.settings.ts
@@ -1,13 +1,13 @@
-import { linkName, ILinkType } from './Link.types';
 import { IComposeSettings } from '@uifabricshared/foundation-compose';
-// import { IViewWin32Props } from '@office-iss/react-native-win32';
+import { linkName, ILinkType } from './Link.types';
 import { IViewProps } from '@fluentui-react-native/adapters';
 
 export const settings: IComposeSettings<ILinkType> = [
   {
     tokens: {
       variant: 'secondaryStandard',
-      color: 'link'
+      color: 'link',
+      borderColor: 'transparent'
     },
     root: {
       accessible: true,
@@ -23,9 +23,6 @@ export const settings: IComposeSettings<ILinkType> = [
     content: {
       style: {
         textDecorationLine: 'underline',
-        borderStyle: 'dotted',
-        borderColor: 'transparent',
-        borderWidth: 1
       }
     },
     _precedence: ['visited', 'hovered', 'focused', 'pressed', 'disabled'],
@@ -51,10 +48,10 @@ export const settings: IComposeSettings<ILinkType> = [
         }
       },
       focused: {
-        content: {
-          style: {
-            borderColor: 'rgba(128, 128, 128, 1)',
-          }
+        tokens: {
+          borderStyle: 'dotted',
+          borderWidth: 1,
+          borderColor: 'focusBorder'
         }
       }
     }

--- a/packages/components/Link/src/Link.tsx
+++ b/packages/components/Link/src/Link.tsx
@@ -6,7 +6,7 @@ import { Text } from '@fluentui-react-native/text';
 import { compose, IUseComposeStyling } from '@uifabricshared/foundation-compose';
 import { ILinkProps, ILinkSlotProps, ILinkState, ILinkRenderData, IWithLinkOptions, linkName, ILinkType } from './Link.types';
 import { settings } from './Link.settings';
-import { foregroundColorTokens, textTokens } from '@fluentui-react-native/tokens';
+import { foregroundColorTokens, textTokens, borderTokens } from '@fluentui-react-native/tokens';
 import { useAsPressable, useViewCommandFocus } from '@fluentui-react-native/interactive-hooks';
 import { mergeSettings } from '@uifabricshared/foundation-settings';
 import { ISlots, withSlots } from '@uifabricshared/foundation-composable';
@@ -96,7 +96,7 @@ export const Link = compose<ILinkType>({
   },
   styles: {
     root: [],
-    content: [foregroundColorTokens, textTokens]
+    content: [foregroundColorTokens, textTokens, borderTokens]
   }
 });
 

--- a/packages/components/Link/src/Link.types.ts
+++ b/packages/components/Link/src/Link.types.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { IRenderData } from '@uifabricshared/foundation-composable';
-import { IForegroundColorTokens, ITextTokens } from '@fluentui-react-native/tokens';
+import { IForegroundColorTokens, ITextTokens, IBorderTokens } from '@fluentui-react-native/tokens';
 import { ITextProps } from '@fluentui-react-native/text';
 import { IFocusable, IPressableState, IWithPressableOptions } from '@fluentui-react-native/interactive-hooks';
 import { IViewWin32Props } from '@office-iss/react-native-win32';
@@ -11,7 +11,7 @@ export const linkName = 'RNFLink';
  * Properties for fabric native Link
  */
 
-export type ILinkTokens = IForegroundColorTokens & ITextTokens;
+export type ILinkTokens = IForegroundColorTokens & ITextTokens & IBorderTokens;
 
 /**
  * Because style state updates are coming from the touchable and will cause a child render the link doesn't use


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32
- [X] windows
- [ ] android

### Description of changes

1. Checkbox.settings
    - Set textBorderColor to 'focusBorder' color, and borderStyle to 'dotted' on focus
2. Checkbox
    - Map textBorderColor token to borderColor prop on Content slot (type Text)
3. Checkbox.types
    - Add textBorderColor as a new token
4. Link.settings
    - Set borderColor to 'focusBorder' and borderStyle to 'dotted' on focus
    - Set accessible to true by default, and accessibilityRole to 'link' for narrator to read it as a hyperlink
5. Link
    - Add borderTokens to Content slot (type Text)
6. Link.types
    - Add borderTokens to LinkTokens
### Verification
 Before:
Light focus border with hard coded rbga(128, 128, 128, 1) value as borderColor
![Screenshot (2)](https://user-images.githubusercontent.com/12578599/87706239-04cdd500-c754-11ea-822c-ce9f0a0ee254.png)
![99701e3c-95d8-46e5-8520-55d42bbb473d](https://user-images.githubusercontent.com/12578599/87706292-1fa04980-c754-11ea-979f-6e4d18dd8f47.png)

After:
Dotted focus border with theme aware 'focusBorder' color value
Colorful Theme:
![Capture2](https://user-images.githubusercontent.com/12578599/87706128-db14ae00-c753-11ea-9ca2-f62acceb30aa.PNG)

Dark Theme:
![Capture](https://user-images.githubusercontent.com/12578599/87706146-e49e1600-c753-11ea-82a7-f0ad1dbfb9a1.PNG)




### Pull request checklist

This PR has considered (when applicable):
- [X] Automated Tests
- [ ] Documentation and examples
- [X] Keyboard Accessibility
- [X] Voiceover
- [ ] Internationalization and Right-to-left Layouts
