### PR TITLE
Set Focus props during initial render to avoid shifting other components

### DIFF
--- a/change/@fluentui-react-native-checkbox-2020-07-16-14-01-57-focusBorder-fix.json
+++ b/change/@fluentui-react-native-checkbox-2020-07-16-14-01-57-focusBorder-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Set Focus props during initial render to avoid shifting other components",
+  "packageName": "@fluentui-react-native/checkbox",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-16T21:01:54.651Z"
+}

--- a/change/@fluentui-react-native-link-2020-07-16-14-01-57-focusBorder-fix.json
+++ b/change/@fluentui-react-native-link-2020-07-16-14-01-57-focusBorder-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Set Focus props during initial render to avoid shifting other components",
+  "packageName": "@fluentui-react-native/link",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-16T21:01:57.050Z"
+}

--- a/packages/components/Checkbox/src/Checkbox.settings.ts
+++ b/packages/components/Checkbox/src/Checkbox.settings.ts
@@ -47,6 +47,8 @@ export const settings: IComposeSettings<ICheckboxType> = [
       variant: 'bodyStandard',
       style: {
         marginTop: 1,
+        borderStyle: 'dotted',
+        borderWidth: 1
       }
     },
     _precedence: ['disabled', 'boxAtEnd', 'hovered', 'focused', 'pressed', 'checked'],
@@ -56,12 +58,6 @@ export const settings: IComposeSettings<ICheckboxType> = [
           backgroundColor: 'menuItemBackgroundHovered',
           textBorderColor: 'focusBorder'
         },
-        content: {
-          style: {
-            borderStyle: 'dotted',
-            borderWidth: 1
-          }
-        }
       },
       checked: {
         checkmark: {

--- a/packages/components/Link/src/Link.settings.ts
+++ b/packages/components/Link/src/Link.settings.ts
@@ -7,7 +7,9 @@ export const settings: IComposeSettings<ILinkType> = [
     tokens: {
       variant: 'secondaryStandard',
       color: 'link',
-      borderColor: 'transparent'
+      borderColor: 'transparent',
+      borderStyle: 'dotted',
+      borderWidth: 1,
     },
     root: {
       accessible: true,
@@ -49,8 +51,6 @@ export const settings: IComposeSettings<ILinkType> = [
       },
       focused: {
         tokens: {
-          borderStyle: 'dotted',
-          borderWidth: 1,
           borderColor: 'focusBorder'
         }
       }


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32
- [X] windows
- [ ] android

### Description of changes
Set borderStyle and borderWidth props during initial render instead of on focus. Setting this props on focus shifts the other components in the tree to make room for the border.

### Verification
Tested that tabbing through Link and Checkbox to change focus does not move other components in the tree.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [X] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
