### PR TITLE
Fixing Win32 README Incorrect Info

### DIFF
--- a/apps/win32/README.md
+++ b/apps/win32/README.md
@@ -11,10 +11,10 @@
 
 1. Make sure you have followed the Getting Started instructions [here](../../README.md) to install packages and build the entire repository.
 
-2. Then go into `apps\fluent-tester` folder:
+2. Then go into `apps\win32` folder:
 
 ```
-    cd apps\fluent-tester
+    cd apps\win32
 ```
 
 3. Build the FluentUI Tester bundle:


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32
- [X] windows
- [ ] android

### Description of changes

The README had a typo, telling the user to be in apps/fluent-tester instead of apps/win32

### Verification

Manual

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
