### PR TITLE
Set backgroundColor on focus

### DIFF
--- a/change/@fluentui-react-native-button-2020-07-17-16-25-38-focus-contrast.json
+++ b/change/@fluentui-react-native-button-2020-07-17-16-25-38-focus-contrast.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "set backgroundColor on focus",
+  "packageName": "@fluentui-react-native/button",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-17T23:25:38.708Z"
+}

--- a/packages/components/Button/src/Button.settings.ts
+++ b/packages/components/Button/src/Button.settings.ts
@@ -58,7 +58,8 @@ export const settings: IComposeSettings<IButtonType> = [
       focused: {
         tokens: {
           borderColor: 'buttonBorderFocused',
-          color: 'buttonTextHovered'
+          color: 'buttonTextHovered',
+          backgroundColor: 'buttonBackgroundHovered'
         }
       }
     }


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32
- [X] windows
- [ ] android

### Description of changes

Set backgroundColor to focus state on Button 

### Verification

In high contrast mode, since there wasn't a backgroundColor specified for focus, the text color was not showing up against the default backgroundColor. The change was verified by testing button focus on high contrast mode.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [X] Documentation and examples
- [X] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
