### PR TITLE
Publish @fluentui-react-native/tester

### DIFF
--- a/apps/fluent-tester/package.json
+++ b/apps/fluent-tester/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@fluentui-react-native/tester",
   "version": "0.0.1",
-  "private": true,
   "main": "src/index.ts",
   "module": "src/index.ts",
   "typings": "lib/index.d.ts",
@@ -17,7 +16,7 @@
     "lint": "fluentui-scripts eslint",
     "start": "fluentui-scripts metro --server",
     "test": "fluentui-scripts jest",
-    "bundle": "fluentui-scripts bundle"
+    "bundle": "fluentui-scripts metro --platform win32 --cli"
   },
   "dependencies": {
     "@fluentui/react-native": ">=0.15.76 <1.0.0",

--- a/change/@fluentui-react-native-tester-2020-07-30-15-01-13-publishTester.json
+++ b/change/@fluentui-react-native-tester-2020-07-30-15-01-13-publishTester.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Make @fluentui-react-native/tester public and bundle win32 tester",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-30T22:01:13.223Z"
+}

--- a/change/@fluentui-react-native-text-2020-04-21-14-56-48-master.json
+++ b/change/@fluentui-react-native-text-2020-04-21-14-56-48-master.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "packageName": "@fluentui-react-native/text",
-  "email": "krsiler@microsoft.com",
-  "dependentChangeType": "patch",
-  "date": "2020-04-21T21:56:48.231Z"
-}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32
- [ ] windows
- [ ] android

### Description of changes

This change publishes the @fluentui-react-native/tester package and bundles the win32 tester so that it can be used in other packages for testing purposes.

### Verification


| Old | New | Effect |
| --- | --- | --- |
| yarn bundle | yarn bundle | previously, this command did nothing but now it bundles the tester for win32 |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
