### PR TITLE
Fix issue with slot implementations unnecessarily calling createSlotRenderInfo multiple times

### DIFF
--- a/change/@fluentui-react-native-use-slots-2020-08-07-14-08-41-slot-issue.json
+++ b/change/@fluentui-react-native-use-slots-2020-08-07-14-08-41-slot-issue.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Remove unnecessary calls to slot data factories",
+  "packageName": "@fluentui-react-native/use-slots",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-07T21:08:39.235Z"
+}

--- a/change/@uifabricshared-foundation-composable-2020-08-07-14-08-41-slot-issue.json
+++ b/change/@uifabricshared-foundation-composable-2020-08-07-14-08-41-slot-issue.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Remove unnecessary calls to slot data factories",
+  "packageName": "@uifabricshared/foundation-composable",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-07T21:08:41.048Z"
+}

--- a/packages/experimental/use-slots/src/buildUseSlots.ts
+++ b/packages/experimental/use-slots/src/buildUseSlots.ts
@@ -64,7 +64,7 @@ export function buildUseSlots<TSlotProps>(options: UseSlotOptions<TSlotProps>): 
   const { slots, filters, useStyling } = options;
   return (...args: any[]) => {
     // build up a set of slots closures and store them in props
-    const [state] = React.useState(buildSlotFunctions<TSlotProps>(slots, filters));
+    const state = React.useMemo(() => buildSlotFunctions<TSlotProps>(slots, filters), []);
 
     // get the baseline slot props to render with the slots
     const slotProps: TSlotProps = typeof useStyling === 'function' ? (useStyling as Function)(...args) : ((useStyling || {}) as TSlotProps);

--- a/packages/framework/foundation-composable/src/Composable.slots.ts
+++ b/packages/framework/foundation-composable/src/Composable.slots.ts
@@ -113,7 +113,7 @@ export function useCompoundPrepare<TProps, TSlotProps extends ISlotProps, TState
 ): { renderData: IRenderData<TSlotProps, TState>; Slots: ISlots<TSlotProps> } {
   // create the slot render info (which may be a tree) and store it into state once.  Note that this will also create any
   // needed closures for the slots to ensure they don't get recreated over the lifetime of the component
-  const [renderInfo] = React.useState(createSlotRenderInfo<TProps, TSlotProps, TState>(composable));
+  const renderInfo = React.useMemo(() => createSlotRenderInfo<TProps, TSlotProps, TState>(composable), []);
 
   // process the props of the tree using the created/retrieved renderInfo
   return useUpdateRenderData<TProps, TSlotProps, TState>(props, renderInfo);


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32
- [x] windows
- [x] android

### Description of changes

This addresses Issue #363 by changing away from useState to useMemo for caching. 

These routines are attempting to create a set of closures with data references for the slots. This ensures that the slot functions maintain the same reference across render passes. This was working but the way the code was implemented it was calling the factory functions every time, even if they weren't needed.

- I switched it to useMemo from useState as we don't actually need the additional layering of useState. I could also have used useRef but this just internally calls useMemo.
- This issue appears in both the standard and experimental versions of the framework so I fixed it in both.

### Verification

Automated tests plus manual validation that things still work. We definitely need some automated perf tests that can catch things like this.

This will not cause any visual changes.

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
