### PR TITLE
Make react peer dependency more flexible

### DIFF
--- a/change/@fluentui-react-native-2020-08-07-14-29-36-react-peer-dep.json
+++ b/change/@fluentui-react-native-2020-08-07-14-29-36-react-peer-dep.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update react peer dep to be more flexible",
+  "packageName": "@fluentui/react-native",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-07T21:29:34.400Z"
+}

--- a/change/@fluentui-react-native-experimental-framework-2020-08-07-14-29-36-react-peer-dep.json
+++ b/change/@fluentui-react-native-experimental-framework-2020-08-07-14-29-36-react-peer-dep.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update react peer dep to be more flexible",
+  "packageName": "@fluentui-react-native/experimental-framework",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-07T21:29:30.500Z"
+}

--- a/change/@fluentui-react-native-interactive-hooks-2020-08-07-14-29-36-react-peer-dep.json
+++ b/change/@fluentui-react-native-interactive-hooks-2020-08-07-14-29-36-react-peer-dep.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update react peer dep to be more flexible",
+  "packageName": "@fluentui-react-native/interactive-hooks",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-07T21:29:36.080Z"
+}

--- a/change/@uifabricshared-theming-ramp-2020-08-07-14-29-36-react-peer-dep.json
+++ b/change/@uifabricshared-theming-ramp-2020-08-07-14-29-36-react-peer-dep.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update react peer dep to be more flexible",
+  "packageName": "@uifabricshared/theming-ramp",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-07T21:29:31.850Z"
+}

--- a/change/@uifabricshared-theming-react-native-2020-08-07-14-29-36-react-peer-dep.json
+++ b/change/@uifabricshared-theming-react-native-2020-08-07-14-29-36-react-peer-dep.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update react peer dep to be more flexible",
+  "packageName": "@uifabricshared/theming-react-native",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-07T21:29:33.200Z"
+}

--- a/packages/experimental/experimental-framework/package.json
+++ b/packages/experimental/experimental-framework/package.json
@@ -46,7 +46,7 @@
     "react-native-web": "0.12.3"
   },
   "peerDependencies": {
-    "react": "16.11.0",
+    "react": "^16.8.0",
     "react-native": ">=0.60.0"
   },
   "author": "",

--- a/packages/framework/theming-ramp/package.json
+++ b/packages/framework/theming-ramp/package.json
@@ -42,6 +42,6 @@
     "@uifabricshared/eslint-config-rules": "^0.1.1"
   },
   "peerDependencies": {
-    "react": "16.11.0"
+    "react": "^16.8.0"
   }
 }

--- a/packages/framework/theming-react-native/package.json
+++ b/packages/framework/theming-react-native/package.json
@@ -40,6 +40,6 @@
     "@uifabricshared/eslint-config-rules": "^0.1.1"
   },
   "peerDependencies": {
-    "react": "16.11.0"
+    "react": "^16.8.0"
   }
 }

--- a/packages/libraries/core/package.json
+++ b/packages/libraries/core/package.json
@@ -57,7 +57,7 @@
     "react-native": "0.62.2"
   },
   "peerDependencies": {
-    "react": "16.11.0",
+    "react": "^16.8.0",
     "react-native": ">=0.60.0"
   },
   "author": "",

--- a/packages/libraries/framework/package.json
+++ b/packages/libraries/framework/package.json
@@ -47,7 +47,7 @@
     "react-native-web": "0.12.3"
   },
   "peerDependencies": {
-    "react": "16.11.0",
+    "react": "^16.8.0",
     "react-native": ">=0.60.0"
   },
   "author": "",

--- a/packages/utils/interactive-hooks/package.json
+++ b/packages/utils/interactive-hooks/package.json
@@ -32,7 +32,7 @@
     "react-native": "0.62.2"
   },
   "peerDependencies": {
-    "react": "16.11.0",
+    "react": "^16.8.0",
     "react-native": ">=0.60.0"
   },
   "author": "",


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32
- [x] windows
- [x] android

### Description of changes

Our current declared peer dependency is pinned to a specific version of react. 

- This is problematic because it means a warning will almost always be triggered in real world usage
- It is also problematic because with our react-native peer dependency set to >= 0.60.0, some versions of RN will have react peer deps of 16.8.x, whereas our pinned version was 16.11.x based

### Verification

Automated tests, this is not a runtime change.

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
