### PR TITLE
Add missing dependencies to package.json files

### DIFF
--- a/change/@fluentui-react-native-button-2020-08-10-17-51-26-deps.json
+++ b/change/@fluentui-react-native-button-2020-08-10-17-51-26-deps.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add missing deps",
+  "packageName": "@fluentui-react-native/button",
+  "email": "rezha@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-11T00:51:07.679Z"
+}

--- a/change/@fluentui-react-native-callout-2020-08-10-17-51-26-deps.json
+++ b/change/@fluentui-react-native-callout-2020-08-10-17-51-26-deps.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add missing deps",
+  "packageName": "@fluentui-react-native/callout",
+  "email": "rezha@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-11T00:51:09.167Z"
+}

--- a/change/@fluentui-react-native-checkbox-2020-08-10-17-51-26-deps.json
+++ b/change/@fluentui-react-native-checkbox-2020-08-10-17-51-26-deps.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add missing deps",
+  "packageName": "@fluentui-react-native/checkbox",
+  "email": "rezha@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-11T00:51:10.614Z"
+}

--- a/change/@fluentui-react-native-contextual-menu-2020-08-10-17-51-26-deps.json
+++ b/change/@fluentui-react-native-contextual-menu-2020-08-10-17-51-26-deps.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add missing deps",
+  "packageName": "@fluentui-react-native/contextual-menu",
+  "email": "rezha@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-11T00:51:11.685Z"
+}

--- a/change/@fluentui-react-native-focus-trap-zone-2020-08-10-17-51-26-deps.json
+++ b/change/@fluentui-react-native-focus-trap-zone-2020-08-10-17-51-26-deps.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add missing deps",
+  "packageName": "@fluentui-react-native/focus-trap-zone",
+  "email": "rezha@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-11T00:51:12.798Z"
+}

--- a/change/@fluentui-react-native-link-2020-08-10-17-51-26-deps.json
+++ b/change/@fluentui-react-native-link-2020-08-10-17-51-26-deps.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add missing deps",
+  "packageName": "@fluentui-react-native/link",
+  "email": "rezha@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-11T00:51:13.937Z"
+}

--- a/change/@fluentui-react-native-persona-2020-08-10-17-51-26-deps.json
+++ b/change/@fluentui-react-native-persona-2020-08-10-17-51-26-deps.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add missing deps",
+  "packageName": "@fluentui-react-native/persona",
+  "email": "rezha@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-11T00:51:15.012Z"
+}

--- a/change/@fluentui-react-native-persona-coin-2020-08-10-17-51-26-deps.json
+++ b/change/@fluentui-react-native-persona-coin-2020-08-10-17-51-26-deps.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add missing deps",
+  "packageName": "@fluentui-react-native/persona-coin",
+  "email": "rezha@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-11T00:51:16.024Z"
+}

--- a/change/@fluentui-react-native-pressable-2020-08-10-17-51-26-deps.json
+++ b/change/@fluentui-react-native-pressable-2020-08-10-17-51-26-deps.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add missing deps",
+  "packageName": "@fluentui-react-native/pressable",
+  "email": "rezha@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-11T00:51:17.203Z"
+}

--- a/change/@fluentui-react-native-radio-group-2020-08-10-17-51-26-deps.json
+++ b/change/@fluentui-react-native-radio-group-2020-08-10-17-51-26-deps.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add missing deps",
+  "packageName": "@fluentui-react-native/radio-group",
+  "email": "rezha@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-11T00:51:18.704Z"
+}

--- a/change/@fluentui-react-native-separator-2020-08-10-17-51-26-deps.json
+++ b/change/@fluentui-react-native-separator-2020-08-10-17-51-26-deps.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add missing deps",
+  "packageName": "@fluentui-react-native/separator",
+  "email": "rezha@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-11T00:51:20.197Z"
+}

--- a/change/@fluentui-react-native-stack-2020-08-10-17-51-26-deps.json
+++ b/change/@fluentui-react-native-stack-2020-08-10-17-51-26-deps.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add missing deps",
+  "packageName": "@fluentui-react-native/stack",
+  "email": "rezha@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-11T00:51:21.778Z"
+}

--- a/change/@fluentui-react-native-text-2020-08-10-17-51-26-deps.json
+++ b/change/@fluentui-react-native-text-2020-08-10-17-51-26-deps.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add missing deps",
+  "packageName": "@fluentui-react-native/text",
+  "email": "rezha@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-11T00:51:23.576Z"
+}

--- a/change/@fluentui-react-native-use-slots-2020-08-10-17-51-26-deps.json
+++ b/change/@fluentui-react-native-use-slots-2020-08-10-17-51-26-deps.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add missing deps",
+  "packageName": "@fluentui-react-native/use-slots",
+  "email": "rezha@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-11T00:51:25.984Z"
+}

--- a/packages/components/Button/package.json
+++ b/packages/components/Button/package.json
@@ -27,8 +27,7 @@
     "@fluentui-react-native/text": ">=0.6.2 <1.0.0",
     "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0",
     "@uifabricshared/foundation-composable": ">=0.6.69 <1.0.0",
-    "@uifabricshared/foundation-settings": ">=0.6.1 <1.0.0",
-    "react": "16.11.0"
+    "@uifabricshared/foundation-settings": ">=0.6.1 <1.0.0"
   },
   "devDependencies": {
     "@office-iss/react-native-win32": "0.62.0-preview.3",
@@ -38,6 +37,7 @@
     "react-native": "0.62.2"
   },
   "peerDependencies": {
+    "react": "^16.8.0",
     "react-native": ">=0.60.0"
   },
   "author": "",

--- a/packages/components/Button/package.json
+++ b/packages/components/Button/package.json
@@ -25,7 +25,10 @@
     "@fluentui-react-native/interactive-hooks": ">=0.5.0 <1.0.0",
     "@fluentui-react-native/pressable": ">=0.3.79 <1.0.0",
     "@fluentui-react-native/text": ">=0.6.2 <1.0.0",
-    "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0"
+    "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0",
+    "@uifabricshared/foundation-composable": ">=0.6.69 <1.0.0",
+    "@uifabricshared/foundation-settings": ">=0.6.1 <1.0.0",
+    "react": "16.11.0"
   },
   "devDependencies": {
     "@office-iss/react-native-win32": "0.62.0-preview.3",

--- a/packages/components/Callout/package.json
+++ b/packages/components/Callout/package.json
@@ -23,7 +23,10 @@
     "@uifabricshared/foundation-compose": "^1.6.75",
     "@fluentui-react-native/adapters": ">=0.3.34 <1.0.0",
     "@fluentui-react-native/interactive-hooks": ">=0.5.0 <1.0.0",
-    "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0"
+    "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0",
+    "@uifabricshared/foundation-composable": ">=0.6.69 <1.0.0",
+    "@uifabricshared/foundation-settings": ">=0.6.1 <1.0.0",
+    "react": "16.11.0"
   },
   "devDependencies": {
     "@types/react-native": "^0.62.0",

--- a/packages/components/Callout/package.json
+++ b/packages/components/Callout/package.json
@@ -25,8 +25,7 @@
     "@fluentui-react-native/interactive-hooks": ">=0.5.0 <1.0.0",
     "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0",
     "@uifabricshared/foundation-composable": ">=0.6.69 <1.0.0",
-    "@uifabricshared/foundation-settings": ">=0.6.1 <1.0.0",
-    "react": "16.11.0"
+    "@uifabricshared/foundation-settings": ">=0.6.1 <1.0.0"
   },
   "devDependencies": {
     "@types/react-native": "^0.62.0",
@@ -35,6 +34,7 @@
     "react-native": "0.62.2"
   },
   "peerDependencies": {
+    "react": "^16.8.0",
     "react-native": ">=0.60.0"
   },
   "author": "",

--- a/packages/components/Checkbox/package.json
+++ b/packages/components/Checkbox/package.json
@@ -27,8 +27,7 @@
     "@fluentui-react-native/text": ">=0.6.2 <1.0.0",
     "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0",
     "@uifabricshared/foundation-composable": ">=0.6.69 <1.0.0",
-    "@uifabricshared/foundation-settings": ">=0.6.1 <1.0.0",
-    "react": "16.11.0"
+    "@uifabricshared/foundation-settings": ">=0.6.1 <1.0.0"
   },
   "devDependencies": {
     "@office-iss/react-native-win32": "0.62.0-preview.3",
@@ -38,6 +37,7 @@
     "react-native": "0.62.2"
   },
   "peerDependencies": {
+    "react": "^16.8.0",
     "react-native": ">=0.60.0"
   },
   "author": "",

--- a/packages/components/Checkbox/package.json
+++ b/packages/components/Checkbox/package.json
@@ -25,7 +25,10 @@
     "@fluentui-react-native/interactive-hooks": ">=0.5.0 <1.0.0",
     "@fluentui-react-native/pressable": ">=0.3.79 <1.0.0",
     "@fluentui-react-native/text": ">=0.6.2 <1.0.0",
-    "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0"
+    "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0",
+    "@uifabricshared/foundation-composable": ">=0.6.69 <1.0.0",
+    "@uifabricshared/foundation-settings": ">=0.6.1 <1.0.0",
+    "react": "16.11.0"
   },
   "devDependencies": {
     "@office-iss/react-native-win32": "0.62.0-preview.3",

--- a/packages/components/ContextualMenu/package.json
+++ b/packages/components/ContextualMenu/package.json
@@ -27,8 +27,7 @@
     "@fluentui-react-native/text": ">=0.6.2 <1.0.0",
     "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0",
     "@uifabricshared/foundation-composable": ">=0.6.69 <1.0.0",
-    "@uifabricshared/foundation-settings": ">=0.6.1 <1.0.0",
-    "react": "16.11.0"
+    "@uifabricshared/foundation-settings": ">=0.6.1 <1.0.0"
   },
   "devDependencies": {
     "@fluentui-react-native/pressable": ">=0.3.79 <1.0.0",
@@ -38,6 +37,7 @@
     "react-native": "0.62.2"
   },
   "peerDependencies": {
+    "react": "^16.8.0",
     "react-native": ">=0.60.0"
   },
   "author": "",

--- a/packages/components/ContextualMenu/package.json
+++ b/packages/components/ContextualMenu/package.json
@@ -25,7 +25,10 @@
     "@fluentui-react-native/callout": ">=0.11.3 <1.0.0",
     "@fluentui-react-native/interactive-hooks": ">=0.5.0 <1.0.0",
     "@fluentui-react-native/text": ">=0.6.2 <1.0.0",
-    "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0"
+    "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0",
+    "@uifabricshared/foundation-composable": ">=0.6.69 <1.0.0",
+    "@uifabricshared/foundation-settings": ">=0.6.1 <1.0.0",
+    "react": "16.11.0"
   },
   "devDependencies": {
     "@fluentui-react-native/pressable": ">=0.3.79 <1.0.0",

--- a/packages/components/FocusTrapZone/package.json
+++ b/packages/components/FocusTrapZone/package.json
@@ -23,7 +23,10 @@
     "@uifabricshared/foundation-compose": "^1.6.75",
     "@fluentui-react-native/adapters": ">=0.3.34 <1.0.0",
     "@fluentui-react-native/interactive-hooks": ">=0.5.0 <1.0.0",
-    "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0"
+    "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0",
+    "@uifabricshared/foundation-composable": ">=0.6.69 <1.0.0",
+    "@uifabricshared/foundation-settings": ">=0.6.1 <1.0.0",
+    "react": "16.11.0"
   },
   "devDependencies": {
     "@types/react-native": "^0.62.0",

--- a/packages/components/FocusTrapZone/package.json
+++ b/packages/components/FocusTrapZone/package.json
@@ -25,8 +25,7 @@
     "@fluentui-react-native/interactive-hooks": ">=0.5.0 <1.0.0",
     "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0",
     "@uifabricshared/foundation-composable": ">=0.6.69 <1.0.0",
-    "@uifabricshared/foundation-settings": ">=0.6.1 <1.0.0",
-    "react": "16.11.0"
+    "@uifabricshared/foundation-settings": ">=0.6.1 <1.0.0"
   },
   "devDependencies": {
     "@types/react-native": "^0.62.0",
@@ -35,6 +34,7 @@
     "react-native": "0.62.2"
   },
   "peerDependencies": {
+    "react": "^16.8.0",
     "react-native": ">=0.60.0"
   },
   "author": "",

--- a/packages/components/Link/package.json
+++ b/packages/components/Link/package.json
@@ -24,7 +24,10 @@
     "@fluentui-react-native/adapters": ">=0.3.34 <1.0.0",
     "@fluentui-react-native/interactive-hooks": ">=0.5.0 <1.0.0",
     "@fluentui-react-native/text": ">=0.6.2 <1.0.0",
-    "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0"
+    "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0",
+    "@uifabricshared/foundation-composable": ">=0.6.69 <1.0.0",
+    "@uifabricshared/foundation-settings": ">=0.6.1 <1.0.0",
+    "react": "16.11.0"
   },
   "devDependencies": {
     "@types/react-native": "^0.62.0",

--- a/packages/components/Link/package.json
+++ b/packages/components/Link/package.json
@@ -26,8 +26,7 @@
     "@fluentui-react-native/text": ">=0.6.2 <1.0.0",
     "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0",
     "@uifabricshared/foundation-composable": ">=0.6.69 <1.0.0",
-    "@uifabricshared/foundation-settings": ">=0.6.1 <1.0.0",
-    "react": "16.11.0"
+    "@uifabricshared/foundation-settings": ">=0.6.1 <1.0.0"
   },
   "devDependencies": {
     "@types/react-native": "^0.62.0",
@@ -36,6 +35,7 @@
     "react-native": "0.62.2"
   },
   "peerDependencies": {
+    "react": "^16.8.0",
     "react-native": ">=0.60.0"
   },
   "author": "",

--- a/packages/components/Persona/package.json
+++ b/packages/components/Persona/package.json
@@ -23,7 +23,12 @@
     "@uifabricshared/foundation-compose": "^1.6.75",
     "@fluentui-react-native/adapters": ">=0.3.34 <1.0.0",
     "@fluentui-react-native/persona-coin": ">=0.3.78 <1.0.0",
-    "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0"
+    "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0",
+    "@uifabricshared/foundation-composable": ">=0.6.69 <1.0.0",
+    "@uifabricshared/foundation-settings": ">=0.6.1 <1.0.0",
+    "@uifabricshared/foundation-tokens": ">=0.7.0 <1.0.0",
+    "@uifabricshared/theming-ramp": ">=0.10.1 <1.0.0",
+    "react": "16.11.0"
   },
   "devDependencies": {
     "@types/react-native": "^0.62.0",

--- a/packages/components/Persona/package.json
+++ b/packages/components/Persona/package.json
@@ -27,8 +27,7 @@
     "@uifabricshared/foundation-composable": ">=0.6.69 <1.0.0",
     "@uifabricshared/foundation-settings": ">=0.6.1 <1.0.0",
     "@uifabricshared/foundation-tokens": ">=0.7.0 <1.0.0",
-    "@uifabricshared/theming-ramp": ">=0.10.1 <1.0.0",
-    "react": "16.11.0"
+    "@uifabricshared/theming-ramp": ">=0.10.1 <1.0.0"
   },
   "devDependencies": {
     "@types/react-native": "^0.62.0",
@@ -37,6 +36,7 @@
     "react-native": "0.62.2"
   },
   "peerDependencies": {
+    "react": "^16.8.0",
     "react-native": ">=0.60.0"
   },
   "author": "",

--- a/packages/components/PersonaCoin/package.json
+++ b/packages/components/PersonaCoin/package.json
@@ -22,7 +22,12 @@
   "dependencies": {
     "@uifabricshared/foundation-compose": "^1.6.75",
     "@fluentui-react-native/adapters": ">=0.3.34 <1.0.0",
-    "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0"
+    "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0",
+    "@uifabricshared/foundation-composable": ">=0.6.69 <1.0.0",
+    "@uifabricshared/foundation-settings": ">=0.6.1 <1.0.0",
+    "@uifabricshared/foundation-tokens": ">=0.7.0 <1.0.0",
+    "@uifabricshared/theming-ramp": ">=0.10.1 <1.0.0",
+    "react": "16.11.0"
   },
   "devDependencies": {
     "@office-iss/react-native-win32": "0.62.0-preview.3",

--- a/packages/components/PersonaCoin/package.json
+++ b/packages/components/PersonaCoin/package.json
@@ -26,8 +26,7 @@
     "@uifabricshared/foundation-composable": ">=0.6.69 <1.0.0",
     "@uifabricshared/foundation-settings": ">=0.6.1 <1.0.0",
     "@uifabricshared/foundation-tokens": ">=0.7.0 <1.0.0",
-    "@uifabricshared/theming-ramp": ">=0.10.1 <1.0.0",
-    "react": "16.11.0"
+    "@uifabricshared/theming-ramp": ">=0.10.1 <1.0.0"
   },
   "devDependencies": {
     "@office-iss/react-native-win32": "0.62.0-preview.3",
@@ -37,6 +36,7 @@
     "react-native": "0.62.2"
   },
   "peerDependencies": {
+    "react": "^16.8.0",
     "react-native": ">=0.60.0"
   },
   "author": "",

--- a/packages/components/Pressable/package.json
+++ b/packages/components/Pressable/package.json
@@ -24,8 +24,7 @@
     "@fluentui-react-native/adapters": ">=0.3.34 <1.0.0",
     "@fluentui-react-native/interactive-hooks": ">=0.5.0 <1.0.0",
     "@uifabricshared/foundation-composable": ">=0.6.69 <1.0.0",
-    "@uifabricshared/foundation-settings": ">=0.6.1 <1.0.0",
-    "react": "16.11.0"
+    "@uifabricshared/foundation-settings": ">=0.6.1 <1.0.0"
   },
   "devDependencies": {
     "@types/react-native": "^0.62.0",
@@ -34,6 +33,7 @@
     "react-native": "0.62.2"
   },
   "peerDependencies": {
+    "react": "^16.8.0",
     "react-native": ">=0.60.0"
   },
   "author": "",

--- a/packages/components/Pressable/package.json
+++ b/packages/components/Pressable/package.json
@@ -22,7 +22,10 @@
   "dependencies": {
     "@uifabricshared/foundation-compose": "^1.6.75",
     "@fluentui-react-native/adapters": ">=0.3.34 <1.0.0",
-    "@fluentui-react-native/interactive-hooks": ">=0.5.0 <1.0.0"
+    "@fluentui-react-native/interactive-hooks": ">=0.5.0 <1.0.0",
+    "@uifabricshared/foundation-composable": ">=0.6.69 <1.0.0",
+    "@uifabricshared/foundation-settings": ">=0.6.1 <1.0.0",
+    "react": "16.11.0"
   },
   "devDependencies": {
     "@types/react-native": "^0.62.0",

--- a/packages/components/RadioGroup/package.json
+++ b/packages/components/RadioGroup/package.json
@@ -22,9 +22,13 @@
   "dependencies": {
     "@uifabricshared/foundation-compose": "^1.6.75",
     "@fluentui-react-native/adapters": ">=0.3.34 <1.0.0",
+    "@fluentui-react-native/interactive-hooks": ">=0.5.0 <1.0.0",
     "@fluentui-react-native/pressable": ">=0.3.79 <1.0.0",
     "@fluentui-react-native/text": ">=0.6.2 <1.0.0",
-    "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0"
+    "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0",
+    "@uifabricshared/foundation-composable": ">=0.6.69 <1.0.0",
+    "@uifabricshared/foundation-settings": ">=0.6.1 <1.0.0",
+    "react": "16.11.0"
   },
   "devDependencies": {
     "@office-iss/react-native-win32": "0.62.0-preview.3",

--- a/packages/components/RadioGroup/package.json
+++ b/packages/components/RadioGroup/package.json
@@ -27,8 +27,7 @@
     "@fluentui-react-native/text": ">=0.6.2 <1.0.0",
     "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0",
     "@uifabricshared/foundation-composable": ">=0.6.69 <1.0.0",
-    "@uifabricshared/foundation-settings": ">=0.6.1 <1.0.0",
-    "react": "16.11.0"
+    "@uifabricshared/foundation-settings": ">=0.6.1 <1.0.0"
   },
   "devDependencies": {
     "@office-iss/react-native-win32": "0.62.0-preview.3",
@@ -38,6 +37,7 @@
     "react-native": "0.62.2"
   },
   "peerDependencies": {
+    "react": "^16.8.0",
     "react-native": ">=0.60.0"
   },
   "author": "",

--- a/packages/components/Separator/package.json
+++ b/packages/components/Separator/package.json
@@ -24,8 +24,7 @@
     "@fluentui-react-native/adapters": ">=0.3.34 <1.0.0",
     "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0",
     "@uifabricshared/foundation-tokens": ">=0.7.0 <1.0.0",
-    "@uifabricshared/theming-ramp": ">=0.10.1 <1.0.0",
-    "react": "16.11.0"
+    "@uifabricshared/theming-ramp": ">=0.10.1 <1.0.0"
   },
   "devDependencies": {
     "@office-iss/react-native-win32": "0.62.0-preview.3",
@@ -35,6 +34,7 @@
     "react-native": "0.62.2"
   },
   "peerDependencies": {
+    "react": "^16.8.0",
     "react-native": ">=0.60.0"
   },
   "author": "",

--- a/packages/components/Separator/package.json
+++ b/packages/components/Separator/package.json
@@ -22,7 +22,10 @@
   "dependencies": {
     "@uifabricshared/foundation-compose": "^1.6.75",
     "@fluentui-react-native/adapters": ">=0.3.34 <1.0.0",
-    "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0"
+    "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0",
+    "@uifabricshared/foundation-tokens": ">=0.7.0 <1.0.0",
+    "@uifabricshared/theming-ramp": ">=0.10.1 <1.0.0",
+    "react": "16.11.0"
   },
   "devDependencies": {
     "@office-iss/react-native-win32": "0.62.0-preview.3",

--- a/packages/components/Stack/package.json
+++ b/packages/components/Stack/package.json
@@ -22,7 +22,12 @@
   "dependencies": {
     "@uifabricshared/foundation-compose": "^1.6.75",
     "@fluentui-react-native/adapters": ">=0.3.34 <1.0.0",
-    "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0"
+    "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0",
+    "@uifabricshared/foundation-composable": ">=0.6.69 <1.0.0",
+    "@uifabricshared/foundation-settings": ">=0.6.1 <1.0.0",
+    "@uifabricshared/foundation-tokens": ">=0.7.0 <1.0.0",
+    "@uifabricshared/theming-ramp": ">=0.10.1 <1.0.0",
+    "react": "16.11.0"
   },
   "devDependencies": {
     "@types/react-native": "^0.62.0",

--- a/packages/components/Stack/package.json
+++ b/packages/components/Stack/package.json
@@ -26,8 +26,7 @@
     "@uifabricshared/foundation-composable": ">=0.6.69 <1.0.0",
     "@uifabricshared/foundation-settings": ">=0.6.1 <1.0.0",
     "@uifabricshared/foundation-tokens": ">=0.7.0 <1.0.0",
-    "@uifabricshared/theming-ramp": ">=0.10.1 <1.0.0",
-    "react": "16.11.0"
+    "@uifabricshared/theming-ramp": ">=0.10.1 <1.0.0"
   },
   "devDependencies": {
     "@types/react-native": "^0.62.0",
@@ -37,6 +36,7 @@
     "react-native": "0.62.2"
   },
   "peerDependencies": {
+    "react": "^16.8.0",
     "react-native": ">=0.60.0"
   },
   "author": "",

--- a/packages/components/text/package.json
+++ b/packages/components/text/package.json
@@ -22,8 +22,7 @@
   "dependencies": {
     "@uifabricshared/foundation-compose": "^1.6.75",
     "@fluentui-react-native/adapters": ">=0.3.34 <1.0.0",
-    "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0",
-    "react": "16.11.0"
+    "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0"
   },
   "devDependencies": {
     "@types/react-native": "^0.62.0",

--- a/packages/components/text/package.json
+++ b/packages/components/text/package.json
@@ -22,7 +22,8 @@
   "dependencies": {
     "@uifabricshared/foundation-compose": "^1.6.75",
     "@fluentui-react-native/adapters": ">=0.3.34 <1.0.0",
-    "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0"
+    "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0",
+    "react": "16.11.0"
   },
   "devDependencies": {
     "@types/react-native": "^0.62.0",

--- a/packages/experimental/Button/package.json
+++ b/packages/experimental/Button/package.json
@@ -25,8 +25,7 @@
     "@fluentui-react-native/experimental-framework": "0.2.4",
     "@fluentui-react-native/interactive-hooks": ">=0.5.0 <1.0.0",
     "@fluentui-react-native/experimental-text": ">=0.1.0 <1.0.0",
-    "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0",
-    "react": "16.11.0"
+    "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0"
   },
   "devDependencies": {
     "@office-iss/react-native-win32": "0.62.0-preview.3",

--- a/packages/experimental/Button/package.json
+++ b/packages/experimental/Button/package.json
@@ -25,7 +25,8 @@
     "@fluentui-react-native/experimental-framework": "0.2.4",
     "@fluentui-react-native/interactive-hooks": ">=0.5.0 <1.0.0",
     "@fluentui-react-native/experimental-text": ">=0.1.0 <1.0.0",
-    "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0"
+    "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0",
+    "react": "16.11.0"
   },
   "devDependencies": {
     "@office-iss/react-native-win32": "0.62.0-preview.3",

--- a/packages/experimental/Stack/package.json
+++ b/packages/experimental/Stack/package.json
@@ -23,7 +23,9 @@
   "dependencies": {
     "@fluentui-react-native/adapters": ">=0.3.34 <1.0.0",
     "@fluentui-react-native/experimental-framework": "0.2.4",
-    "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0"
+    "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0",
+    "@uifabricshared/theming-ramp": ">=0.10.1 <1.0.0",
+    "react": "16.11.0"
   },
   "devDependencies": {
     "@types/react-native": "^0.62.0",

--- a/packages/experimental/Stack/package.json
+++ b/packages/experimental/Stack/package.json
@@ -24,8 +24,7 @@
     "@fluentui-react-native/adapters": ">=0.3.34 <1.0.0",
     "@fluentui-react-native/experimental-framework": "0.2.4",
     "@fluentui-react-native/tokens": ">=0.5.2 <1.0.0",
-    "@uifabricshared/theming-ramp": ">=0.10.1 <1.0.0",
-    "react": "16.11.0"
+    "@uifabricshared/theming-ramp": ">=0.10.1 <1.0.0"
   },
   "devDependencies": {
     "@types/react-native": "^0.62.0",

--- a/packages/experimental/use-slots/package.json
+++ b/packages/experimental/use-slots/package.json
@@ -34,8 +34,7 @@
     "@fluentui-react-native/memo-cache": ">=0.2.10 <1.0.0",
     "@fluentui-react-native/use-styling": ">=0.2.1 <1.0.0",
     "@uifabricshared/foundation-settings": ">=0.6.1 <1.0.0",
-    "@uifabricshared/immutable-merge": ">=0.5.67 <1.0.0",
-    "react": "16.11.0"
+    "@uifabricshared/immutable-merge": ">=0.5.67 <1.0.0"
   },
   "devDependencies": {
     "@types/jest": "^19.2.2",

--- a/packages/experimental/use-slots/package.json
+++ b/packages/experimental/use-slots/package.json
@@ -33,7 +33,9 @@
   "dependencies": {
     "@fluentui-react-native/memo-cache": ">=0.2.10 <1.0.0",
     "@fluentui-react-native/use-styling": ">=0.2.1 <1.0.0",
-    "@uifabricshared/immutable-merge": ">=0.5.67 <1.0.0"
+    "@uifabricshared/foundation-settings": ">=0.6.1 <1.0.0",
+    "@uifabricshared/immutable-merge": ">=0.5.67 <1.0.0",
+    "react": "16.11.0"
   },
   "devDependencies": {
     "@types/jest": "^19.2.2",


### PR DESCRIPTION
There are phantom dependencies that are used but not declared in package.json. For example, `@uifabricshared/foundation-settings` is used in [`Button`](https://github.com/microsoft/fluentui-react-native/blob/master/packages/components/Button/src/Button.tsx#L11) but not showing up in its [package.json](https://github.com/microsoft/fluentui-react-native/blob/master/packages/components/Button/package.json).

A run of:
`lerna exec --stream --no-bail -- depcheck ./ --ignores="eslint" --ignore-patterns="*eslint*,*.d.ts,*.test.*"`
under repo root reveals a few dozens of those phantom dependencies. This PR fixes some of them.

