### PR TITLE
Support shouldFocusOnMount and shouldFocusOnContainer props

### DIFF
--- a/apps/fluent-tester/src/RNTester/TestComponents/ContextualMenu/ContextualMenuTest.tsx
+++ b/apps/fluent-tester/src/RNTester/TestComponents/ContextualMenu/ContextualMenuTest.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { Text, View } from 'react-native';
-import { Button, ContextualMenu, ContextualMenuItem } from '@fluentui/react-native';
+import { Text, View, Switch } from 'react-native';
+import { Button, ContextualMenu, ContextualMenuItem, Separator } from '@fluentui/react-native';
 import { CONTEXTUALMENU_TESTPAGE } from './consts';
 import { Test, TestSection, PlatformStatus } from '../Test';
 
@@ -9,8 +9,13 @@ const contextualMenu: React.FunctionComponent<{}> = () => {
 
   const [showContextualMenu, setShowContextualMenu] = React.useState(false);
   const [isContextualMenuVisible, setIsContextualMenuVisible] = React.useState(false);
-
   const [lastMenuItemClicked, setLastMenuItemClicked] = React.useState(null);
+
+  const [focusOnMount, setShouldFocusOnMount] = React.useState(true);
+  const toggleFocusOnMount = React.useCallback((value) => setShouldFocusOnMount(value), [setShouldFocusOnMount]);
+
+  const [focusOnContainer, setShouldFocusOnContainer] = React.useState(false);
+  const toggleFocusOnContainer = React.useCallback((value) => setShouldFocusOnContainer(value), [setShouldFocusOnContainer]);
 
   const toggleShowContextualMenu = React.useCallback(() => {
     setShowContextualMenu(!showContextualMenu);
@@ -35,21 +40,39 @@ const contextualMenu: React.FunctionComponent<{}> = () => {
 
   return (
     <View>
-      <View style={{ flexDirection: 'column', paddingVertical: 5 }}>
-        <Text>
-          <Text>Menu Visibility: </Text>
-          {isContextualMenuVisible ? <Text style={{ color: 'green' }}>Visible</Text> : <Text style={{ color: 'red' }}>Not Visible</Text>}
-        </Text>
-        <Text>
-          <Text>Last Menu Item Clicked: </Text>
-          {lastMenuItemClicked > 0 ? (
-            <Text style={{ color: 'blue' }}>{lastMenuItemClicked}</Text>
-          ) : (
-            <Text style={{ color: 'blue' }}>none</Text>
-          )}
-        </Text>
-        <Button content="Press for ContextualMenu" onClick={toggleShowContextualMenu} componentRef={stdBtnRef} />
+      <View style={{ flexDirection: 'row', paddingVertical: 5 }}>
+
+        <View style={{ flexDirection: 'column', paddingHorizontal: 5 }}>
+          <View style={{ flexDirection: 'row' }}>
+            <Text>Should Focus on Mount</Text>
+            <Switch value={focusOnMount} onValueChange={toggleFocusOnMount} />
+          </View>
+
+          <View style={{ flexDirection: 'row' }}>
+            <Text>Should Focus on Container</Text>
+            <Switch value={focusOnContainer} onValueChange={toggleFocusOnContainer} />
+          </View>
+        </View>
+
+        <Separator vertical />
+
+        <View style={{ flexDirection: 'column', paddingHorizontal: 5 }}>
+          <Text>
+            <Text>Menu Visibility: </Text>
+            {isContextualMenuVisible ? <Text style={{ color: 'green' }}>Visible</Text> : <Text style={{ color: 'red' }}>Not Visible</Text>}
+          </Text>
+          <Text>
+            <Text>Last Menu Item Clicked: </Text>
+            {lastMenuItemClicked > 0 ? (
+              <Text style={{ color: 'blue' }}>{lastMenuItemClicked}</Text>
+            ) : (
+                <Text style={{ color: 'blue' }}>none</Text>
+              )}
+          </Text>
+          <Button content="Press for ContextualMenu" onClick={toggleShowContextualMenu} componentRef={stdBtnRef} />
+        </View>
       </View>
+
       {showContextualMenu && (
         <ContextualMenu
           target={stdBtnRef}
@@ -57,9 +80,11 @@ const contextualMenu: React.FunctionComponent<{}> = () => {
           onShow={onShowContextualMenu}
           accessibilityLabel="Standard ContextualMenu"
           onItemClick={onItemClick}
-          setShowMenu={setShowContextualMenu}
+          setShowMenu={toggleShowContextualMenu}
+          shouldFocusOnMount={focusOnMount}
+          shouldFocusOnContainer={focusOnContainer}
         >
-          <ContextualMenuItem text="MenuItem 1" itemKey="1" accessibilityLabel="First Menu Item" />
+          <ContextualMenuItem text="MenuItem 1" itemKey="1" />
           <ContextualMenuItem text="MenuItem 2" itemKey="2" />
           <ContextualMenuItem text="Disabled Menu Item" itemKey="3" disabled />
           <ContextualMenuItem text="MenuItem 4" itemKey="4" />
@@ -68,7 +93,7 @@ const contextualMenu: React.FunctionComponent<{}> = () => {
       )}
     </View>
   );
-};
+}
 
 const contextualMenuSections: TestSection[] = [
   {
@@ -90,5 +115,5 @@ export const ContextualMenuTest: React.FunctionComponent<{}> = () => {
   const description =
     'ContextualMenus are lists of commands that are based on the context of selection, mouse hover or keyboard focus. They are one of the most effective and highly used command surfaces, and can be used in a variety of places.\n\nThere are variants that originate from a command bar, or from cursor or focus. Those that come from CommandBars use a beak that is horizontally centered on the button. Ones that come from right click and menu button do not have a beak, but appear to the right and below the cursor. ContextualMenus can have submenus from commands, show selection checks, and icons.\n\nOrganize commands in groups divided by rules. This helps users remember command locations, or find less used commands based on proximity to others. One should also group sets of mutually exclusive or multiple selectable options. Use icons sparingly, for high value commands, and don’t mix icons with selection checks, as it makes parsing commands difficult. Avoid submenus of submenus as they can be difficult to invoke or remember.';
 
-  return <Test name="Checkbox Test" description={description} sections={contextualMenuSections} status={status}></Test>;
+  return <Test name="ContextualMenu Test" description={description} sections={contextualMenuSections} status={status}></Test>;
 };

--- a/change/@fluentui-react-native-contextual-menu-2020-08-20-10-43-20-contextual-menu.json
+++ b/change/@fluentui-react-native-contextual-menu-2020-08-20-10-43-20-contextual-menu.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "support shouldFocusOnMount and shouldFocusOnContainer props",
+  "packageName": "@fluentui-react-native/contextual-menu",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-20T17:43:20.652Z"
+}

--- a/change/@fluentui-react-native-tester-2020-08-20-10-43-20-contextual-menu.json
+++ b/change/@fluentui-react-native-tester-2020-08-20-10-43-20-contextual-menu.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "support shouldFocusOnMount and shouldFocusOnContainer props",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-20T17:43:13.138Z"
+}

--- a/packages/components/ContextualMenu/src/ContextualMenu.settings.ts
+++ b/packages/components/ContextualMenu/src/ContextualMenu.settings.ts
@@ -13,7 +13,7 @@ export const settings: IComposeSettings<ContextualMenuType> = [
       minPadding: 0
     },
     root: {
-      accessibilityRole: 'menu'
+      accessibilityRole: 'menu',
     }
   },
   contextualMenuName

--- a/packages/components/ContextualMenu/src/ContextualMenu.settings.ts
+++ b/packages/components/ContextualMenu/src/ContextualMenu.settings.ts
@@ -13,7 +13,7 @@ export const settings: IComposeSettings<ContextualMenuType> = [
       minPadding: 0
     },
     root: {
-      accessibilityRole: 'menu',
+      accessibilityRole: 'menu'
     }
   },
   contextualMenuName

--- a/packages/components/ContextualMenu/src/ContextualMenu.tsx
+++ b/packages/components/ContextualMenu/src/ContextualMenu.tsx
@@ -1,5 +1,6 @@
 /** @jsx withSlots */
 import * as React from 'react';
+import { View } from 'react-native';
 import {
   contextualMenuName,
   ContextualMenuProps,
@@ -30,7 +31,12 @@ export const CMContext = React.createContext<ContextualMenuContext>({
 export const ContextualMenu = compose<ContextualMenuType>({
   displayName: contextualMenuName,
   usePrepareProps: (userProps: ContextualMenuProps, useStyling: IUseComposeStyling<ContextualMenuType>) => {
-    const { setShowMenu, ...rest } = userProps;
+    const {
+      setShowMenu,
+      shouldFocusOnMount = true,
+      shouldFocusOnContainer = false,
+      ...rest
+    } = userProps;
 
     // This hook updates the Selected Button and calls the customer's onClick function. This gets called after a button is pressed.
     const data = useSelectedKey(null, userProps.onItemClick);
@@ -52,24 +58,32 @@ export const ContextualMenu = compose<ContextualMenuType>({
 
     const slotProps = mergeSettings<ContextualMenuSlotProps>(styleProps, {
       root: {
-        ...rest
+        ...rest,
+        setInitialFocus: shouldFocusOnMount
+      },
+      container: {
+        accessible: shouldFocusOnContainer,
+        ... { acceptsKeyboardFocus: shouldFocusOnContainer },
       }
+
     });
 
     return { slotProps, state };
   },
   settings: settings,
   slots: {
-    root: Callout
+    root: Callout,
+    container: View
   },
   styles: {
-    root: [backgroundColorTokens, borderTokens]
+    root: [backgroundColorTokens, borderTokens],
+    container: []
   },
   render: (Slots: ISlots<ContextualMenuSlotProps>, renderData: ContextualMenuRenderData, ...children: React.ReactNode[]) => {
     if (renderData.state == undefined) {
       return null;
     }
-    return <CMContext.Provider value={renderData.state.context}><Slots.root>{children}</Slots.root></CMContext.Provider>;
+    return <CMContext.Provider value={renderData.state.context}><Slots.root><Slots.container>{children}</Slots.container></Slots.root></CMContext.Provider>;
   }
 });
 

--- a/packages/components/ContextualMenu/src/ContextualMenu.tsx
+++ b/packages/components/ContextualMenu/src/ContextualMenu.tsx
@@ -63,7 +63,7 @@ export const ContextualMenu = compose<ContextualMenuType>({
       },
       container: {
         accessible: shouldFocusOnContainer,
-        ... { acceptsKeyboardFocus: shouldFocusOnContainer },
+        acceptsKeyboardFocus: shouldFocusOnContainer,
       }
 
     });

--- a/packages/components/ContextualMenu/src/ContextualMenu.types.ts
+++ b/packages/components/ContextualMenu/src/ContextualMenu.types.ts
@@ -48,7 +48,7 @@ export interface ContextualMenuProps extends Omit<ICalloutProps, 'setInitialFocu
 
 export type ContextualMenuSlotProps = {
   root: ContextualMenuProps;
-  container: ViewProps
+  container: ViewProps;
 };
 
 export type ContextualMenuRenderData = IRenderData<ContextualMenuSlotProps, ContextualMenuState>;

--- a/packages/components/ContextualMenu/src/ContextualMenu.types.ts
+++ b/packages/components/ContextualMenu/src/ContextualMenu.types.ts
@@ -1,4 +1,5 @@
 import { ICalloutProps, ICalloutTokens } from '@fluentui-react-native/callout';
+import { ViewProps } from 'react-native';
 import { IRenderData } from '@uifabricshared/foundation-composable';
 
 export const contextualMenuName = 'ContextualMenu';
@@ -39,11 +40,15 @@ export interface ContextualMenuProps extends Omit<ICalloutProps, 'setInitialFocu
    ** Callback for when menu item is clicked
    */
   onItemClick?: (key: string) => void;
+  /*
+   ** Callback to toggle showContextualMenu to false and close menu on item click
+   */
   setShowMenu?: (showMenu: boolean) => void;
 }
 
 export type ContextualMenuSlotProps = {
   root: ContextualMenuProps;
+  container: ViewProps
 };
 
 export type ContextualMenuRenderData = IRenderData<ContextualMenuSlotProps, ContextualMenuState>;

--- a/packages/components/ContextualMenu/src/ContextualMenuItem.settings.ts
+++ b/packages/components/ContextualMenu/src/ContextualMenuItem.settings.ts
@@ -11,6 +11,7 @@ export const settings: IComposeSettings<ContextualMenuItemType> = [
     root: {
       accessible: true,
       accessibilityRole: 'menuitem',
+      ...{ acceptsKeyboardFocus: true },
       style: {
         display: 'flex',
         alignItems: 'flex-start',
@@ -60,7 +61,8 @@ export const settings: IComposeSettings<ContextualMenuItemType> = [
       focused: {
         tokens: {
           borderColor: 'buttonBorderFocused',
-          color: 'buttonTextHovered'
+          color: 'buttonTextHovered',
+          backgroundColor: 'buttonBackgroundHovered'
         }
       }
     }

--- a/packages/components/ContextualMenu/src/ContextualMenuItem.settings.ts
+++ b/packages/components/ContextualMenu/src/ContextualMenuItem.settings.ts
@@ -11,6 +11,7 @@ export const settings: IComposeSettings<ContextualMenuItemType> = [
     root: {
       accessible: true,
       accessibilityRole: 'menuitem',
+      // Since ViewProps does not support this prop, force the prop against type checking
       ...{ acceptsKeyboardFocus: true },
       style: {
         display: 'flex',

--- a/packages/components/ContextualMenu/src/__tests__/__snapshots__/ContextualMenu.test.win32.tsx.snap
+++ b/packages/components/ContextualMenu/src/__tests__/__snapshots__/ContextualMenu.test.win32.tsx.snap
@@ -6,6 +6,7 @@ exports[`ContextualMenu default props 1`] = `
   backgroundColor="bodyStandoutBackground"
   borderColor="bodyFrameBackground"
   borderWidth={1}
+  setInitialFocus={true}
   style={
     Object {
       "backgroundColor": "#faf9f8",
@@ -13,5 +14,10 @@ exports[`ContextualMenu default props 1`] = `
       "borderWidth": 1,
     }
   }
-/>
+>
+  <View
+    acceptsKeyboardFocus={false}
+    accessible={false}
+  />
+</RCTCallout>
 `;


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32
- [X] windows
- [ ] android

### Description of changes

- Add a container slot to ContextualMenu to support initial focus on container
- shouldFocusOnMount maps to Callout slot's setInitialFocus, with default value true and initial focus on first menu item
- shouldFocusOnContainer overrides initial focus from first menu item to container

### Verification
shouldfocusOnMount and shouldFocusOnContainer toggle switches were added on RNTester to observe initial focus behavior on button click that will launch the menu.

Focus events were tested with Narrator to check that appropriate container or first menu item was focused on mount, and narrator only recognized the container when shouldFocusOnContainer was set. 

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [x] Keyboard Accessibility
- [x] Voiceover
- [ ] Internationalization and Right-to-left Layouts
