### PR TITLE
Check for private packages

### DIFF
--- a/scripts/just.config.js
+++ b/scripts/just.config.js
@@ -7,6 +7,11 @@ const path = require('path');
 const srcPath = path.join(process.cwd(), 'src');
 const libPath = path.join(process.cwd(), 'lib');
 
+const checkPublishing = () => {
+  const { checkPublishingTask } = require('./lib/tasks/checkPublishingTask');
+  return checkPublishingTask();
+};
+
 module.exports = function preset() {
   option('production');
 
@@ -22,6 +27,7 @@ module.exports = function preset() {
     }),
   );
 
+  task('depcheck', checkPublishing);
   task('lint', eslintTask({ files: ['src/.'] }));
   task('cleanlib', cleanTask([libPath]));
   task('build', series('cleanlib', parallel('lint', 'ts')));

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -10,6 +10,7 @@
     "build-tools": "just-scripts build",
     "bundlesize": "bundlesize --debug",
     "code-style": "node ./lib/just-scripts.js code-style",
+    "depcheck": "just-scripts depcheck",
     "prettier": "node ./lib/just-scripts.js prettier",
     "verify-api": "echo no api to verify",
     "update-api": "echo no api to update"
@@ -65,7 +66,8 @@
     "webpack-bundle-analyzer": "^3.0.4",
     "webpack-cli": "3.2.3",
     "webpack-dev-server": "3.1.14",
-    "webpack-notifier": "^1.6.0"
+    "webpack-notifier": "^1.6.0",
+    "workspace-tools": "^0.9.3"
   },
   "bundlesize": [
     {

--- a/scripts/src/justPreset.ts
+++ b/scripts/src/justPreset.ts
@@ -16,6 +16,7 @@ const { verifyApiExtractor, updateApiExtractor } = require('./tasks/api-extracto
 const checkForModifiedFiles = require('./tasks/check-for-modified-files');
 
 import { metroTask } from '@fluentui-react-native/build-tools';
+import { checkPublishingTask } from './tasks/checkPublishingTask';
 
 export function preset() {
   // this add s a resolve path for the build tooling deps like TS from the scripts folder
@@ -82,7 +83,9 @@ export function preset() {
 
   task('build', series('clean', 'copy', 'ts'));
 
-  task('depcheck', depcheckTask);
+  task('depcheck-files', depcheckTask);
+  task('check-publishing', checkPublishingTask);
+  task('depcheck', parallel('depcheck-files', 'check-publishing'));
 
   task('no-op', () => {});
 }

--- a/scripts/src/justPreset.ts
+++ b/scripts/src/justPreset.ts
@@ -16,7 +16,6 @@ const { verifyApiExtractor, updateApiExtractor } = require('./tasks/api-extracto
 const checkForModifiedFiles = require('./tasks/check-for-modified-files');
 
 import { metroTask } from '@fluentui-react-native/build-tools';
-import { checkPublishingTask } from './tasks/checkPublishingTask';
 
 export function preset() {
   // this add s a resolve path for the build tooling deps like TS from the scripts folder
@@ -83,9 +82,7 @@ export function preset() {
 
   task('build', series('clean', 'copy', 'ts'));
 
-  task('depcheck-files', depcheckTask);
-  task('check-publishing', checkPublishingTask);
-  task('depcheck', parallel('depcheck-files', 'check-publishing'));
+  task('depcheck', depcheckTask);
 
   task('no-op', () => {});
 }

--- a/scripts/src/tasks/checkPublishingTask.ts
+++ b/scripts/src/tasks/checkPublishingTask.ts
@@ -1,22 +1,46 @@
-import { TaskFunction } from 'just-task';
+import { TaskFunction, logger } from 'just-task';
+import { getPackageInfos, findGitRoot } from 'workspace-tools';
+
+export type DependencyType = 'dependencies' | 'devDependencies' | 'peerDependencies';
 
 export interface CheckPublishingOptions {
   /**
-   * By default this will only check dependencies, to check devDependencies as well set this to true
+   * An array of fields to check for private internal dependencies, by default this is just dependencies
    */
-  devDependencies?: boolean;
-
-  /**
-   * Opt in to checking peer dependencies as well
-   */
-  peerDependencies?: boolean;
+  dependencyTypes?: DependencyType[];
 }
 
+/**
+ * Task to check the matrix of packages for publishing errors. In particular this checks for published packages that
+ * have a dependency on a private package
+ *
+ * @param options - options for configuring the task
+ */
 export function checkPublishingTask(options: CheckPublishingOptions = {}): TaskFunction {
+  const dependencyTypes = options.dependencyTypes || ['dependencies'];
   return function(done: (error?: Error) => void) {
-    // get package JSON for the caller based on process.cwd
-    // enumerate deps to check
-    // require package.json for each
-    // check for private bit
+    const packageInfos = getPackageInfos(findGitRoot(process.cwd()));
+    logger.info('Starting scan for publishing errors');
+    try {
+      Object.keys(packageInfos).forEach(pkg => {
+        if (!packageInfos[pkg].private) {
+          logger.verbose(`Scanning published package ${pkg} for private dependenies`);
+          dependencyTypes.forEach(dependencyType => {
+            const deps = packageInfos[pkg][dependencyType];
+            Object.keys(deps || {}).forEach(dep => {
+              if (packageInfos[dep] && packageInfos[dep].private) {
+                const errorMsg = `${pkg} has a ${dependencyType} on private package ${dep}`;
+                logger.error(errorMsg);
+                throw errorMsg;
+              }
+            });
+          });
+        }
+      });
+    } catch (err) {
+      done(err);
+    }
+    logger.info('No publishing errors found');
+    done();
   };
 }

--- a/scripts/src/tasks/checkPublishingTask.ts
+++ b/scripts/src/tasks/checkPublishingTask.ts
@@ -1,0 +1,22 @@
+import { TaskFunction } from 'just-task';
+
+export interface CheckPublishingOptions {
+  /**
+   * By default this will only check dependencies, to check devDependencies as well set this to true
+   */
+  devDependencies?: boolean;
+
+  /**
+   * Opt in to checking peer dependencies as well
+   */
+  peerDependencies?: boolean;
+}
+
+export function checkPublishingTask(options: CheckPublishingOptions = {}): TaskFunction {
+  return function(done: (error?: Error) => void) {
+    // get package JSON for the caller based on process.cwd
+    // enumerate deps to check
+    // require package.json for each
+    // check for private bit
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -17253,6 +17253,24 @@ workspace-tools@^0.9.0:
     multimatch "^4.0.0"
     read-yaml-file "^2.0.0"
 
+workspace-tools@^0.9.3:
+  version "0.9.3"
+  resolved "https://registry.npmjs.org/workspace-tools/-/workspace-tools-0.9.3.tgz#96f3b6c4acf579d2ddd2a5ece7ef1e799ab0b44b"
+  integrity sha512-73K1r42Uzp/mVcHRA+Nh7iG56Bv+e675SoxlNfl1Nko9m5O2DjHSnLzna2MLwNGr0JE8GX/sQUJkg8NSRtw/Sg==
+  dependencies:
+    "@pnpm/lockfile-file" "^3.0.7"
+    "@pnpm/logger" "^3.2.2"
+    "@yarnpkg/lockfile" "^1.1.0"
+    find-up "^4.1.0"
+    find-yarn-workspace-root "^1.2.1"
+    fs-extra "^9.0.0"
+    git-url-parse "^11.1.2"
+    globby "^11.0.0"
+    jju "^1.4.0"
+    matcher "^3.0.0"
+    multimatch "^4.0.0"
+    read-yaml-file "^2.0.0"
+
 wrap-ansi@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32
- [ ] windows
- [ ] android

### Description of changes

This adds a task to scripts that will check for dependency tree violations that might break publishing.

- In particular we have broken partners by having published packages inadvertently depend on private packages
- This will now run as the depcheck for the scripts package (scanning everything)
- As such it is integrated into our CI loops and will block any PRs that have this error

Note that lage will attempt to cache this incorrectly locally, if you are trying to resolve an error of this sort you will likely need to run `yarn depcheck --no-cache` to force it to run.

### Verification

- I tested this locally by running through builds and the depcheck command. 
- I then changed various packages to be marked as private and made sure the check caught them

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
