### PR TITLE
Add native component cache

### DIFF
--- a/change/@fluentui-react-native-callout-2020-08-25-12-44-17-native-component-cache.json
+++ b/change/@fluentui-react-native-callout-2020-08-25-12-44-17-native-component-cache.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "add native component cache for consolidating requireNativeComponent calls",
+  "packageName": "@fluentui-react-native/callout",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-25T19:44:10.040Z"
+}

--- a/change/@fluentui-react-native-component-cache-2020-08-25-12-44-17-native-component-cache.json
+++ b/change/@fluentui-react-native-component-cache-2020-08-25-12-44-17-native-component-cache.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "add native component cache for consolidating requireNativeComponent calls",
+  "packageName": "@fluentui-react-native/component-cache",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-25T19:44:17.969Z"
+}

--- a/change/@fluentui-react-native-focus-trap-zone-2020-08-25-12-44-17-native-component-cache.json
+++ b/change/@fluentui-react-native-focus-trap-zone-2020-08-25-12-44-17-native-component-cache.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "add native component cache for consolidating requireNativeComponent calls",
+  "packageName": "@fluentui-react-native/focus-trap-zone",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-25T19:44:14.270Z"
+}

--- a/packages/components/Callout/package.json
+++ b/packages/components/Callout/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@uifabricshared/foundation-compose": "^1.6.80",
+    "@fluentui-react-native/component-cache": "^1.0.0",
     "@fluentui-react-native/interactive-hooks": ">=0.5.1 <1.0.0",
     "@fluentui-react-native/tokens": ">=0.5.6 <1.0.0",
     "@uifabricshared/foundation-composable": ">=0.6.73 <1.0.0",

--- a/packages/components/Callout/src/Callout.tsx
+++ b/packages/components/Callout/src/Callout.tsx
@@ -3,11 +3,12 @@ import { backgroundColorTokens, borderTokens } from '@fluentui-react-native/toke
 import { compose, IUseComposeStyling } from '@uifabricshared/foundation-compose';
 import { mergeSettings } from '@uifabricshared/foundation-settings';
 import * as React from 'react';
-import { findNodeHandle, requireNativeComponent } from 'react-native';
+import { findNodeHandle } from 'react-native';
 import { settings } from './Callout.settings';
 import { calloutName, ICalloutProps, ICalloutSlotProps, ICalloutType } from './Callout.types';
+import { ensureNativeComponent } from '@fluentui-react-native/component-cache';
 
-const RCTCallout = requireNativeComponent('RCTCallout');
+const RCTCallout = ensureNativeComponent('RCTCallout');
 
 export const Callout = compose<ICalloutType>({
   displayName: calloutName,

--- a/packages/components/FocusTrapZone/src/FocusTrapZone.ts
+++ b/packages/components/FocusTrapZone/src/FocusTrapZone.ts
@@ -1,10 +1,10 @@
 import { IFocusTrapZoneProps, IFocusTrapZoneSlotProps, IFocusTrapZoneType } from './FocusTrapZone.types';
-import { requireNativeComponent } from 'react-native';
 import { IUseStyling, composable } from '@uifabricshared/foundation-composable';
 import { mergeSettings } from '@uifabricshared/foundation-settings';
 import { useViewCommandFocus } from '@fluentui-react-native/interactive-hooks';
+import { ensureNativeComponent } from '@fluentui-react-native/component-cache';
 
-const RCTFocusTrapZone = requireNativeComponent('RCTFocusTrapZone');
+const RCTFocusTrapZone = ensureNativeComponent('RCTFocusTrapZone');
 
 export function filterOutComponentRef(propName: string): boolean {
   return propName !== 'componentRef';
@@ -14,10 +14,10 @@ export const FocusTrapZone = composable<IFocusTrapZoneType>({
   usePrepareProps: (userProps: IFocusTrapZoneProps, useStyling: IUseStyling<IFocusTrapZoneType>) => {
     const ftzRef = useViewCommandFocus(userProps.componentRef);
     return {
-      slotProps: mergeSettings<IFocusTrapZoneSlotProps>(useStyling(userProps), { root: { ...userProps, ref: ftzRef } })
+      slotProps: mergeSettings<IFocusTrapZoneSlotProps>(useStyling(userProps), { root: { ...userProps, ref: ftzRef } }),
     };
   },
   slots: {
-    root: { slotType: RCTFocusTrapZone, filter: filterOutComponentRef }
-  }
+    root: { slotType: RCTFocusTrapZone, filter: filterOutComponentRef },
+  },
 });

--- a/packages/framework/component-cache/.eslintignore
+++ b/packages/framework/component-cache/.eslintignore
@@ -1,0 +1,1 @@
+# As this package grows it's likely we'll want to voluntarily ignore some packages

--- a/packages/framework/component-cache/.eslintrc.js
+++ b/packages/framework/component-cache/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  extends: [
+    "@uifabricshared/eslint-config-rules"
+  ]
+}

--- a/packages/framework/component-cache/.npmignore
+++ b/packages/framework/component-cache/.npmignore
@@ -1,0 +1,14 @@
+src
+node_modules
+.gitignore
+.gitattributes
+.editorconfig
+config.js
+jest.config.js
+.eslintrc.js
+.eslintignore
+tsconfig.json
+jsconfig.json
+webpack.config.js
+webpack.serve.config.js
+*.build.log

--- a/packages/framework/component-cache/README.md
+++ b/packages/framework/component-cache/README.md
@@ -1,0 +1,3 @@
+# @fluentui-react-native/component-cache
+
+This is a simple wrapper to ensure that `requireNativeComponent` doesn't get called multiple times and that multiple consuming controls can reference the same HostComponent. It is designed to be very rarely changed, this helps insulate against multiple versions of a component in the same bundle making rNC calls.

--- a/packages/framework/component-cache/api-extractor.json
+++ b/packages/framework/component-cache/api-extractor.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@uifabricshared/build-native/api-extractor.json"
+}

--- a/packages/framework/component-cache/babel.config.js
+++ b/packages/framework/component-cache/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = require('@uifabricshared/build-native/babel.config');

--- a/packages/framework/component-cache/just.config.js
+++ b/packages/framework/component-cache/just.config.js
@@ -1,0 +1,3 @@
+const { preset } = require('@uifabricshared/build-native');
+
+preset();

--- a/packages/framework/component-cache/package.json
+++ b/packages/framework/component-cache/package.json
@@ -1,7 +1,11 @@
 {
-  "name": "@fluentui-react-native/focus-trap-zone",
-  "version": "0.4.9",
-  "description": "A cross-platform FocusTrapZone component using the Fluent Design System",
+  "name": "@fluentui-react-native/component-cache",
+  "version": "1.0.0",
+  "description": "Simple caching package to avoid duplicate requireNativeComponent calls",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/ui-fabric-react-native"
+  },
   "main": "src/index.ts",
   "module": "src/index.ts",
   "typings": "lib/index.d.ts",
@@ -11,32 +15,31 @@
   },
   "scripts": {
     "build": "fluentui-scripts build",
-    "depcheck": "fluentui-scripts depcheck",
+    "bundle": "fluentui-scripts bundle",
     "just": "fluentui-scripts",
     "clean": "fluentui-scripts clean",
+    "code-style": "fluentui-scripts code-style",
+    "depcheck": "fluentui-scripts depcheck",
     "lint": "fluentui-scripts eslint",
+    "start": "fluentui-scripts dev",
+    "start-test": "fluentui-scripts jest-watch",
     "test": "fluentui-scripts jest",
     "update-snapshots": "fluentui-scripts jest -u",
     "verify-api": "fluentui-scripts verify-api-extractor",
     "update-api": "fluentui-scripts update-api-extractor"
   },
-  "dependencies": {
-    "@fluentui-react-native/adapters": ">=0.3.35 <1.0.0",
-    "@fluentui-react-native/component-cache": "^1.0.0",
-    "@fluentui-react-native/interactive-hooks": ">=0.5.1 <1.0.0",
-    "@uifabricshared/foundation-composable": ">=0.6.73 <1.0.0",
-    "@uifabricshared/foundation-settings": ">=0.7.0 <1.0.0"
-  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
   "devDependencies": {
-    "@types/react-native": "^0.62.0",
+    "@types/jest": "^19.2.2",
+    "@types/node": "^10.3.5",
     "@uifabricshared/build-native": "^0.1.1",
     "@uifabricshared/eslint-config-rules": "^0.1.1",
-    "react-native": "0.62.2"
+    "react": "16.11.0",
+    "react-native": "^0.62.2"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
     "react-native": ">=0.60.0"
-  },
-  "author": "",
-  "license": "MIT"
+  }
 }

--- a/packages/framework/component-cache/src/ensureNativeComponent.ts
+++ b/packages/framework/component-cache/src/ensureNativeComponent.ts
@@ -1,0 +1,11 @@
+import { requireNativeComponent, HostComponent } from 'react-native';
+
+const cache: { [key: string]: HostComponent<any> } = {};
+
+/**
+ * Get a native component of the given name, requiring it if necessary
+ * @param name - name of the component to retrieve from the cache
+ */
+export function ensureNativeComponent<T>(name: string): HostComponent<T> {
+  return cache[name] || requireNativeComponent(name);
+}

--- a/packages/framework/component-cache/src/ensureNativeComponent.web.ts
+++ b/packages/framework/component-cache/src/ensureNativeComponent.web.ts
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+/**
+ * Get a native component of the given name, requiring it if necessary
+ * @param name - name of the component to retrieve from the cache
+ */
+export function ensureNativeComponent<T>(name: string): React.FunctionComponent<T> {
+  return () => {
+    throw `requireNativeComponent(${name}) isn't supported on web`;
+  };
+}

--- a/packages/framework/component-cache/src/index.ts
+++ b/packages/framework/component-cache/src/index.ts
@@ -1,0 +1,1 @@
+export * from './ensureNativeComponent';

--- a/packages/framework/component-cache/tsconfig.json
+++ b/packages/framework/component-cache/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "lib"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32
- [x] windows
- [ ] android

### Description of changes

This is a more scoped version of the change I submitted earlier. It does the following:

- Creates `@fluentui-react-native/component-cache` package. This creates a common place to cache references to native components obtained via `requireNativeComponent`
- This also reroutes these calls on web to return a component that will throw an exception when used. This unblocks the web tester, addressing Issue #410 and Issue #228 
- Switches callout and focus trap zone to use the new cache

### Verification

Ran the web tester, the win32 tester, builds and automated tests

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
