### PR TITLE
Only allow menu container to focus on mount

### DIFF
--- a/change/@fluentui-react-native-2020-08-26-12-01-32-fixMountFocus.json
+++ b/change/@fluentui-react-native-2020-08-26-12-01-32-fixMountFocus.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "only allow menu container to focus on mount",
+  "packageName": "@fluentui/react-native",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-26T19:01:31.005Z"
+}

--- a/change/@fluentui-react-native-button-2020-08-26-12-01-32-fixMountFocus.json
+++ b/change/@fluentui-react-native-button-2020-08-26-12-01-32-fixMountFocus.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "only allow menu container to focus on mount",
+  "packageName": "@fluentui-react-native/button",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-26T19:00:36.931Z"
+}

--- a/change/@fluentui-react-native-callout-2020-08-26-12-01-32-fixMountFocus.json
+++ b/change/@fluentui-react-native-callout-2020-08-26-12-01-32-fixMountFocus.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "only allow menu container to focus on mount",
+  "packageName": "@fluentui-react-native/callout",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-26T19:00:41.346Z"
+}

--- a/change/@fluentui-react-native-checkbox-2020-08-26-12-01-32-fixMountFocus.json
+++ b/change/@fluentui-react-native-checkbox-2020-08-26-12-01-32-fixMountFocus.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "only allow menu container to focus on mount",
+  "packageName": "@fluentui-react-native/checkbox",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-26T19:00:44.819Z"
+}

--- a/change/@fluentui-react-native-component-cache-2020-08-26-12-01-32-fixMountFocus.json
+++ b/change/@fluentui-react-native-component-cache-2020-08-26-12-01-32-fixMountFocus.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "only allow menu container to focus on mount",
+  "packageName": "@fluentui-react-native/component-cache",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-26T19:01:17.341Z"
+}

--- a/change/@fluentui-react-native-composition-2020-08-26-12-01-32-fixMountFocus.json
+++ b/change/@fluentui-react-native-composition-2020-08-26-12-01-32-fixMountFocus.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "only allow menu container to focus on mount",
+  "packageName": "@fluentui-react-native/composition",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-26T19:01:11.995Z"
+}

--- a/change/@fluentui-react-native-contextual-menu-2020-08-26-12-01-32-fixMountFocus.json
+++ b/change/@fluentui-react-native-contextual-menu-2020-08-26-12-01-32-fixMountFocus.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "only allow menu container to focus on mount",
+  "packageName": "@fluentui-react-native/contextual-menu",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-26T19:00:49.876Z"
+}

--- a/change/@fluentui-react-native-focus-trap-zone-2020-08-26-12-01-32-fixMountFocus.json
+++ b/change/@fluentui-react-native-focus-trap-zone-2020-08-26-12-01-32-fixMountFocus.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "only allow menu container to focus on mount",
+  "packageName": "@fluentui-react-native/focus-trap-zone",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-26T19:00:52.502Z"
+}

--- a/change/@fluentui-react-native-framework-2020-08-26-12-01-32-fixMountFocus.json
+++ b/change/@fluentui-react-native-framework-2020-08-26-12-01-32-fixMountFocus.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "only allow menu container to focus on mount",
+  "packageName": "@fluentui-react-native/framework",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-26T19:01:13.492Z"
+}

--- a/change/@fluentui-react-native-link-2020-08-26-12-01-32-fixMountFocus.json
+++ b/change/@fluentui-react-native-link-2020-08-26-12-01-32-fixMountFocus.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "only allow menu container to focus on mount",
+  "packageName": "@fluentui-react-native/link",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-26T19:00:56.271Z"
+}

--- a/change/@fluentui-react-native-merge-props-2020-08-26-12-01-32-fixMountFocus.json
+++ b/change/@fluentui-react-native-merge-props-2020-08-26-12-01-32-fixMountFocus.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "only allow menu container to focus on mount",
+  "packageName": "@fluentui-react-native/merge-props",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-26T19:01:25.060Z"
+}

--- a/change/@fluentui-react-native-persona-2020-08-26-12-01-32-fixMountFocus.json
+++ b/change/@fluentui-react-native-persona-2020-08-26-12-01-32-fixMountFocus.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "only allow menu container to focus on mount",
+  "packageName": "@fluentui-react-native/persona",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-26T19:00:58.384Z"
+}

--- a/change/@fluentui-react-native-persona-coin-2020-08-26-12-01-32-fixMountFocus.json
+++ b/change/@fluentui-react-native-persona-coin-2020-08-26-12-01-32-fixMountFocus.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "only allow menu container to focus on mount",
+  "packageName": "@fluentui-react-native/persona-coin",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-26T19:01:00.573Z"
+}

--- a/change/@fluentui-react-native-pressable-2020-08-26-12-01-32-fixMountFocus.json
+++ b/change/@fluentui-react-native-pressable-2020-08-26-12-01-32-fixMountFocus.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "only allow menu container to focus on mount",
+  "packageName": "@fluentui-react-native/pressable",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-26T19:01:02.609Z"
+}

--- a/change/@fluentui-react-native-radio-group-2020-08-26-12-01-32-fixMountFocus.json
+++ b/change/@fluentui-react-native-radio-group-2020-08-26-12-01-32-fixMountFocus.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "only allow menu container to focus on mount",
+  "packageName": "@fluentui-react-native/radio-group",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-26T19:01:04.327Z"
+}

--- a/change/@fluentui-react-native-separator-2020-08-26-12-01-32-fixMountFocus.json
+++ b/change/@fluentui-react-native-separator-2020-08-26-12-01-32-fixMountFocus.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "only allow menu container to focus on mount",
+  "packageName": "@fluentui-react-native/separator",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-26T19:01:06.098Z"
+}

--- a/change/@fluentui-react-native-stack-2020-08-26-12-01-32-fixMountFocus.json
+++ b/change/@fluentui-react-native-stack-2020-08-26-12-01-32-fixMountFocus.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "only allow menu container to focus on mount",
+  "packageName": "@fluentui-react-native/stack",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-26T19:01:08.206Z"
+}

--- a/change/@fluentui-react-native-tester-2020-08-26-12-01-32-fixMountFocus.json
+++ b/change/@fluentui-react-native-tester-2020-08-26-12-01-32-fixMountFocus.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "only allow menu container to focus on mount",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-26T19:00:27.836Z"
+}

--- a/change/@fluentui-react-native-tester-win32-2020-08-26-12-01-32-fixMountFocus.json
+++ b/change/@fluentui-react-native-tester-win32-2020-08-26-12-01-32-fixMountFocus.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "only allow menu container to focus on mount",
+  "packageName": "@fluentui-react-native/tester-win32",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-26T19:00:33.672Z"
+}

--- a/change/@fluentui-react-native-text-2020-08-26-12-01-32-fixMountFocus.json
+++ b/change/@fluentui-react-native-text-2020-08-26-12-01-32-fixMountFocus.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "only allow menu container to focus on mount",
+  "packageName": "@fluentui-react-native/text",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-26T19:01:10.077Z"
+}

--- a/change/@fluentui-react-native-tokens-2020-08-26-12-01-32-fixMountFocus.json
+++ b/change/@fluentui-react-native-tokens-2020-08-26-12-01-32-fixMountFocus.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "only allow menu container to focus on mount",
+  "packageName": "@fluentui-react-native/tokens",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-26T19:01:32.548Z"
+}

--- a/change/@fluentui-react-native-use-slots-2020-08-26-12-01-32-fixMountFocus.json
+++ b/change/@fluentui-react-native-use-slots-2020-08-26-12-01-32-fixMountFocus.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "only allow menu container to focus on mount",
+  "packageName": "@fluentui-react-native/use-slots",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-26T19:01:15.160Z"
+}

--- a/change/@uifabricshared-foundation-composable-2020-08-26-12-01-32-fixMountFocus.json
+++ b/change/@uifabricshared-foundation-composable-2020-08-26-12-01-32-fixMountFocus.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "only allow menu container to focus on mount",
+  "packageName": "@uifabricshared/foundation-composable",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-26T19:01:18.751Z"
+}

--- a/change/@uifabricshared-foundation-compose-2020-08-26-12-01-32-fixMountFocus.json
+++ b/change/@uifabricshared-foundation-compose-2020-08-26-12-01-32-fixMountFocus.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "only allow menu container to focus on mount",
+  "packageName": "@uifabricshared/foundation-compose",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-26T19:01:20.349Z"
+}

--- a/change/@uifabricshared-foundation-settings-2020-08-26-12-01-32-fixMountFocus.json
+++ b/change/@uifabricshared-foundation-settings-2020-08-26-12-01-32-fixMountFocus.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "only allow menu container to focus on mount",
+  "packageName": "@uifabricshared/foundation-settings",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-26T19:01:21.737Z"
+}

--- a/change/@uifabricshared-foundation-tokens-2020-08-26-12-01-32-fixMountFocus.json
+++ b/change/@uifabricshared-foundation-tokens-2020-08-26-12-01-32-fixMountFocus.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "only allow menu container to focus on mount",
+  "packageName": "@uifabricshared/foundation-tokens",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-26T19:01:23.059Z"
+}

--- a/change/@uifabricshared-themed-settings-2020-08-26-12-01-32-fixMountFocus.json
+++ b/change/@uifabricshared-themed-settings-2020-08-26-12-01-32-fixMountFocus.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "only allow menu container to focus on mount",
+  "packageName": "@uifabricshared/themed-settings",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-26T19:01:26.497Z"
+}

--- a/change/@uifabricshared-theming-ramp-2020-08-26-12-01-32-fixMountFocus.json
+++ b/change/@uifabricshared-theming-ramp-2020-08-26-12-01-32-fixMountFocus.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "only allow menu container to focus on mount",
+  "packageName": "@uifabricshared/theming-ramp",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-26T19:01:27.749Z"
+}

--- a/change/@uifabricshared-theming-react-native-2020-08-26-12-01-32-fixMountFocus.json
+++ b/change/@uifabricshared-theming-react-native-2020-08-26-12-01-32-fixMountFocus.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "only allow menu container to focus on mount",
+  "packageName": "@uifabricshared/theming-react-native",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-26T19:01:29.032Z"
+}

--- a/packages/components/ContextualMenu/src/ContextualMenu.settings.ts
+++ b/packages/components/ContextualMenu/src/ContextualMenu.settings.ts
@@ -4,9 +4,9 @@ import { IComposeSettings } from '@uifabricshared/foundation-compose';
 export const settings: IComposeSettings<ContextualMenuType> = [
   {
     tokens: {
-      backgroundColor: 'bodyStandoutBackground',
+      backgroundColor: 'menuBackground',
       beakWidth: 20,
-      borderColor: 'bodyFrameBackground',
+      borderColor: 'buttonBorder',
       borderWidth: 1,
       directionalHint: 'bottonLeftEdge',
       gapSpace: 0,
@@ -14,6 +14,11 @@ export const settings: IComposeSettings<ContextualMenuType> = [
     },
     root: {
       accessibilityRole: 'menu'
+    },
+    container: {
+      style: {
+        padding: 1
+      }
     }
   },
   contextualMenuName

--- a/packages/components/ContextualMenu/src/ContextualMenu.tsx
+++ b/packages/components/ContextualMenu/src/ContextualMenu.tsx
@@ -46,6 +46,11 @@ export const ContextualMenu = compose<ContextualMenuType>({
         setShowMenu(false);
       }, [setShowMenu]);
 
+    const [containerFocus, setContainerFocus] = React.useState(true);
+    const toggleContainerFocus = React.useCallback(() => {
+      setContainerFocus(false);
+    }, [setContainerFocus]);
+
     const state: ContextualMenuState = {
       context: {
         selectedKey: data.selectedKey,
@@ -63,7 +68,8 @@ export const ContextualMenu = compose<ContextualMenuType>({
       },
       container: {
         accessible: shouldFocusOnContainer,
-        acceptsKeyboardFocus: shouldFocusOnContainer,
+        acceptsKeyboardFocus: shouldFocusOnContainer && containerFocus,
+        onBlur: toggleContainerFocus
       }
 
     });

--- a/packages/components/ContextualMenu/src/ContextualMenuItem.settings.ts
+++ b/packages/components/ContextualMenu/src/ContextualMenuItem.settings.ts
@@ -4,9 +4,10 @@ import { IComposeSettings } from '@uifabricshared/foundation-compose';
 export const settings: IComposeSettings<ContextualMenuItemType> = [
   {
     tokens: {
-      backgroundColor: 'buttonBackground',
-      color: 'buttonText',
-      borderColor: 'buttonBorder'
+      backgroundColor: 'menuBackground',
+      color: 'menuItemText',
+      borderColor: 'transparent',
+      borderWidth: 1
     },
     root: {
       accessible: true,
@@ -40,30 +41,33 @@ export const settings: IComposeSettings<ContextualMenuItemType> = [
     _overrides: {
       disabled: {
         tokens: {
-          backgroundColor: 'buttonBackgroundDisabled',
-          color: 'buttonTextDisabled',
-          borderColor: 'buttonBorderDisabled'
+          backgroundColor: 'menuBackground',
+          color: 'disabledText',
         }
       },
       hovered: {
         tokens: {
-          backgroundColor: 'buttonBackgroundHovered',
-          color: 'buttonTextHovered',
-          borderColor: 'buttonBorderHovered'
+          backgroundColor: 'menuItemBackgroundHovered',
+          color: 'menuItemTextHovered',
         }
       },
       pressed: {
         tokens: {
-          backgroundColor: 'buttonBackgroundPressed',
-          color: 'buttonTextPressed',
-          borderColor: 'buttonBorderPressed'
+          backgroundColor: 'menuItemBackgroundHovered',
+          color: 'menuItemTextHovered',
         }
       },
       focused: {
         tokens: {
-          borderColor: 'buttonBorderFocused',
-          color: 'buttonTextHovered',
-          backgroundColor: 'buttonBackgroundHovered'
+          color: 'menuItemTextHovered',
+          backgroundColor: 'menuItemBackgroundHovered'
+        },
+        _overrides: {
+          disabled: {
+            tokens: {
+              borderColor: 'focusBorder'
+            }
+          }
         }
       }
     }

--- a/packages/components/ContextualMenu/src/ContextualMenuItem.tsx
+++ b/packages/components/ContextualMenu/src/ContextualMenuItem.tsx
@@ -15,6 +15,7 @@ export const ContextualMenuItem = compose<ContextualMenuItemType>({
   displayName: contextualMenuItemName,
   usePrepareProps: (userProps: ContextualMenuItemProps, useStyling: IUseComposeStyling<ContextualMenuItemType>) => {
     const {
+      disabled,
       itemKey,
       icon,
       text,
@@ -29,15 +30,17 @@ export const ContextualMenuItem = compose<ContextualMenuItemType>({
 
     const onItemClick = React.useCallback(
       e => {
-        context?.onDismissMenu();
-        if (onClick) {
-          onClick();
+        if (!disabled) {
+          context ?.onDismissMenu();
+          if (onClick) {
+            onClick();
+          }
+          else {
+            context.onItemClick && context.onItemClick(itemKey);
+          }
+          e.stopPropagation();
         }
-        else {
-          context.onItemClick && context.onItemClick(itemKey);
-        }
-        e.stopPropagation();
-      }, [context, itemKey, onClick]
+      }, [context, disabled, itemKey, onClick]
     );
 
     const onKeyUp = React.useCallback(

--- a/packages/components/ContextualMenu/src/__tests__/__snapshots__/ContextualMenu.test.win32.tsx.snap
+++ b/packages/components/ContextualMenu/src/__tests__/__snapshots__/ContextualMenu.test.win32.tsx.snap
@@ -3,14 +3,14 @@
 exports[`ContextualMenu default props 1`] = `
 <RCTCallout
   accessibilityRole="menu"
-  backgroundColor="bodyStandoutBackground"
-  borderColor="bodyFrameBackground"
+  backgroundColor="menuBackground"
+  borderColor="buttonBorder"
   borderWidth={1}
   setInitialFocus={true}
   style={
     Object {
-      "backgroundColor": "#faf9f8",
-      "borderColor": "#ffffff",
+      "backgroundColor": "#ffffff",
+      "borderColor": "#8a8886",
       "borderWidth": 1,
     }
   }
@@ -18,6 +18,12 @@ exports[`ContextualMenu default props 1`] = `
   <View
     acceptsKeyboardFocus={false}
     accessible={false}
+    onBlur={[Function]}
+    style={
+      Object {
+        "padding": 1,
+      }
+    }
   />
 </RCTCallout>
 `;


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32
- [x] windows
- [ ] android

### Description of changes

ContextualMenu: allow keyboardFocus for container on mount. Container should not get focus when keyboard focus loops through items
ContextualMenu.settings: change background color to menuBackground
ContextualMenuItem.settings: change hover, focus, pressed styling to menu specific colors

### Verification

RNTester ContextualMenu component has a toggle for shouldFocusOnMount. When this is set, initial focus will be set on the container. After this focus, container will not get focus when keyboard focusing through menu items.

### Pull request checklist

This PR has considered (when applicable):
- [X] Automated Tests
- [X] Documentation and examples
- [X] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
