### PR TITLE
Add iconStrokeWidth and iconStrokeColor to PersonaCoin

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-  "editor.formatOnSave": true,
   "editor.detectIndentation": false,
   "editor.trimAutoWhitespace": true,
   "editor.insertSpaces": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "editor.formatOnSave": true,
   "editor.detectIndentation": false,
   "editor.trimAutoWhitespace": true,
   "editor.insertSpaces": true,

--- a/apps/fluent-tester/src/RNTester/TestComponents/PersonaCoin/CustomizeUsage.tsx
+++ b/apps/fluent-tester/src/RNTester/TestComponents/PersonaCoin/CustomizeUsage.tsx
@@ -14,7 +14,7 @@ export const CustomizeUsage: React.FunctionComponent<{}> = () => {
   const [physicalSize, setPhysicalSize] = React.useState<number>(80);
   const [iconSize, setIconSize] = React.useState<number>(24);
   const [iconStrokeWidth, setIconStrokeWidth] = React.useState<number>(2);
-  const [iconStrokeColor, setIconStrokeColor] = React.useState<string>('white');
+  const [iconStrokeColor, setIconStrokeColor] = React.useState<string>(undefined);
   const [initialsSize, setInitialsSize] = React.useState<number>(14);
   const [horizontalAlignment, setHorizontalAlignment] = React.useState<IconAlignment>();
   const [verticalAlignment, setVerticalAlignment] = React.useState<IconAlignment>();

--- a/apps/fluent-tester/src/RNTester/TestComponents/PersonaCoin/CustomizeUsage.tsx
+++ b/apps/fluent-tester/src/RNTester/TestComponents/PersonaCoin/CustomizeUsage.tsx
@@ -13,6 +13,8 @@ export const CustomizeUsage: React.FunctionComponent<{}> = () => {
   const [textColor, setTextColor] = React.useState<string>();
   const [physicalSize, setPhysicalSize] = React.useState<number>(80);
   const [iconSize, setIconSize] = React.useState<number>(24);
+  const [iconStrokeWidth, setIconStrokeWidth] = React.useState<number>(2);
+  const [iconStrokeColor, setIconStrokeColor] = React.useState<string>('white');
   const [initialsSize, setInitialsSize] = React.useState<number>(14);
   const [horizontalAlignment, setHorizontalAlignment] = React.useState<IconAlignment>();
   const [verticalAlignment, setVerticalAlignment] = React.useState<IconAlignment>();
@@ -37,6 +39,12 @@ export const CustomizeUsage: React.FunctionComponent<{}> = () => {
   }
   if (iconSize) {
     tokens.iconSize = iconSize;
+  }
+  if (iconStrokeWidth) {
+    tokens.iconStrokeWidth = iconStrokeWidth;
+  }
+  if (iconStrokeColor) {
+    tokens.iconStrokeColor = iconStrokeColor;
   }
   if (initialsSize) {
     tokens.initialsSize = initialsSize;
@@ -74,6 +82,15 @@ export const CustomizeUsage: React.FunctionComponent<{}> = () => {
           }}
         />
 
+        <TextInput
+          style={[commonStyles.textBox, textBoxBorderStyle]}
+          placeholder="Icon stroke color"
+          blurOnSubmit={true}
+          onSubmitEditing={(e) => {
+            setIconStrokeColor(e.nativeEvent.text);
+          }}
+        />
+
         <AlignmentPicker style={commonStyles.header} label="Horizontal icon alignment" onSelectionChange={setHorizontalAlignment} />
         <AlignmentPicker style={commonStyles.header} label="Vertical icon alignment" onSelectionChange={setVerticalAlignment} />
 
@@ -82,6 +99,9 @@ export const CustomizeUsage: React.FunctionComponent<{}> = () => {
 
         <Text>Icon size</Text>
         <Slider minimum={8} maximum={100} initialValue={24} style={commonStyles.slider} onChange={setIconSize} />
+
+        <Text>Icon stroke width</Text>
+        <Slider minimum={0} maximum={8} initialValue={2} style={commonStyles.slider} onChange={setIconStrokeWidth} />
 
         <Text>Font size</Text>
         <Slider minimum={5} maximum={50} initialValue={14} style={commonStyles.slider} onChange={setInitialsSize} />

--- a/change/@fluentui-react-native-persona-coin-2020-08-30-19-12-19-tomun-persona-coin-stroke.json
+++ b/change/@fluentui-react-native-persona-coin-2020-08-30-19-12-19-tomun-persona-coin-stroke.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Implement iconSizeStrokeWidth and iconSizeStrokeColor tokens for PersonaCoin",
+  "packageName": "@fluentui-react-native/persona-coin",
+  "email": "tomun@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-30T17:12:19.604Z"
+}

--- a/change/@fluentui-react-native-tester-2020-08-30-19-12-19-tomun-persona-coin-stroke.json
+++ b/change/@fluentui-react-native-tester-2020-08-30-19-12-19-tomun-persona-coin-stroke.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Implement iconSizeStrokeWidth and iconSizeStrokeColor tokens for PersonaCoin",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "tomun@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-30T17:12:12.694Z"
+}

--- a/packages/components/PersonaCoin/src/PersonaCoin.helpers.ts
+++ b/packages/components/PersonaCoin/src/PersonaCoin.helpers.ts
@@ -39,19 +39,20 @@ export function getPresenceIconSource(presence: PersonaPresence, isOutOfOffice: 
 export type PersonaSizeConfig = {
   physicalSize: number;
   iconSize: number;
+  iconStrokeWidth: number;
   initialsSize: number;
 };
 
-const sizeTable: { [P in PersonaSize]: PersonaSizeConfig } = {
-  size8: { physicalSize: 8, iconSize: 0, initialsSize: 4 },
-  size24: { physicalSize: 24, iconSize: 8, initialsSize: 10 },
-  size32: { physicalSize: 32, iconSize: 8, initialsSize: 12 },
-  size40: { physicalSize: 40, iconSize: 12, initialsSize: 14 },
-  size48: { physicalSize: 48, iconSize: 12, initialsSize: 16 },
-  size56: { physicalSize: 56, iconSize: 16, initialsSize: 18 },
-  size72: { physicalSize: 72, iconSize: 20, initialsSize: 20 },
-  size100: { physicalSize: 100, iconSize: 28, initialsSize: 36 },
-  size120: { physicalSize: 120, iconSize: 32, initialsSize: 40 }
+const sizeTable: {[P in PersonaSize]: PersonaSizeConfig} = {
+  size8: {physicalSize: 8, iconSize: 0, iconStrokeWidth: 0, initialsSize: 4},
+  size24: {physicalSize: 24, iconSize: 8, iconStrokeWidth: 2, initialsSize: 10},
+  size32: {physicalSize: 32, iconSize: 8, iconStrokeWidth: 2, initialsSize: 12},
+  size40: {physicalSize: 40, iconSize: 12, iconStrokeWidth: 2, initialsSize: 14},
+  size48: {physicalSize: 48, iconSize: 12, iconStrokeWidth: 2, initialsSize: 16},
+  size56: {physicalSize: 56, iconSize: 16, iconStrokeWidth: 3, initialsSize: 18},
+  size72: {physicalSize: 72, iconSize: 20, iconStrokeWidth: 3, initialsSize: 20},
+  size100: {physicalSize: 100, iconSize: 28, iconStrokeWidth: 4, initialsSize: 36},
+  size120: {physicalSize: 120, iconSize: 32, iconStrokeWidth: 4, initialsSize: 40}
 };
 
 export function getSizeConfig(size: PersonaSize): PersonaSizeConfig {
@@ -86,16 +87,22 @@ export function convertCoinColor(coinColor: PersonaCoinColor): string {
 }
 
 export function calculateEffectiveSizes(tokens: IPersonaCoinTokens): PersonaSizeConfig {
-  const { size, coinSize, iconSize, initialsSize } = tokens;
+  const { size, coinSize, iconSize, iconStrokeWidth, initialsSize } = tokens;
 
   if (size) {
     return sizeTable[size];
   } else {
-    const { physicalSize: defaultPhysicalSize, iconSize: defaultIconSize, initialsSize: defaultInitialsSize } = sizeTable['size40'];
+    const {
+      physicalSize: defaultPhysicalSize,
+      iconSize: defaultIconSize,
+      iconStrokeWidth: defaultIconStrokeWidth,
+      initialsSize: defaultInitialsSize
+    } = sizeTable['size40'];
 
     return {
       physicalSize: coinSize || defaultPhysicalSize,
       iconSize: iconSize || defaultIconSize,
+      iconStrokeWidth: iconStrokeWidth || defaultIconStrokeWidth,
       initialsSize: initialsSize || defaultInitialsSize
     };
   }

--- a/packages/components/PersonaCoin/src/PersonaCoin.helpers.ts
+++ b/packages/components/PersonaCoin/src/PersonaCoin.helpers.ts
@@ -44,15 +44,15 @@ export type PersonaSizeConfig = {
 };
 
 const sizeTable: {[P in PersonaSize]: PersonaSizeConfig} = {
-  size8: {physicalSize: 8, iconSize: 0, iconStrokeWidth: 0, initialsSize: 4},
-  size24: {physicalSize: 24, iconSize: 8, iconStrokeWidth: 2, initialsSize: 10},
-  size32: {physicalSize: 32, iconSize: 8, iconStrokeWidth: 2, initialsSize: 12},
-  size40: {physicalSize: 40, iconSize: 12, iconStrokeWidth: 2, initialsSize: 14},
-  size48: {physicalSize: 48, iconSize: 12, iconStrokeWidth: 2, initialsSize: 16},
-  size56: {physicalSize: 56, iconSize: 16, iconStrokeWidth: 3, initialsSize: 18},
-  size72: {physicalSize: 72, iconSize: 20, iconStrokeWidth: 3, initialsSize: 20},
-  size100: {physicalSize: 100, iconSize: 28, iconStrokeWidth: 4, initialsSize: 36},
-  size120: {physicalSize: 120, iconSize: 32, iconStrokeWidth: 4, initialsSize: 40}
+  size8: { physicalSize: 8, iconSize: 0, iconStrokeWidth: 0, initialsSize: 4 },
+  size24: { physicalSize: 24, iconSize: 8, iconStrokeWidth: 2, initialsSize: 10 },
+  size32: { physicalSize: 32, iconSize: 8, iconStrokeWidth: 2, initialsSize: 12 },
+  size40: { physicalSize: 40, iconSize: 12, iconStrokeWidth: 2, initialsSize: 14 },
+  size48: { physicalSize: 48, iconSize: 12, iconStrokeWidth: 2, initialsSize: 16 },
+  size56: { physicalSize: 56, iconSize: 16, iconStrokeWidth: 3, initialsSize: 18 },
+  size72: { physicalSize: 72, iconSize: 20, iconStrokeWidth: 3, initialsSize: 20 },
+  size100: { physicalSize: 100, iconSize: 28, iconStrokeWidth: 4, initialsSize: 36 },
+  size120: { physicalSize: 120, iconSize: 32, iconStrokeWidth: 4, initialsSize: 40 }
 };
 
 export function getSizeConfig(size: PersonaSize): PersonaSizeConfig {

--- a/packages/components/PersonaCoin/src/PersonaCoin.settings.ts
+++ b/packages/components/PersonaCoin/src/PersonaCoin.settings.ts
@@ -8,6 +8,7 @@ export const settings: IComposeSettings<IPersonaCoinType> = [
       horizontalIconAlignment: 'end',
       verticalIconAlignment: 'end',
       color: 'white', // initials is always 'white', unless overriden by token
+      iconStrokeColor: 'white', // icon stroke color is always 'white', unless overriden by token
       backgroundColor: convertCoinColor('lightBlue')
     }
   },

--- a/packages/components/PersonaCoin/src/PersonaCoin.tokens.icon.ts
+++ b/packages/components/PersonaCoin/src/PersonaCoin.tokens.icon.ts
@@ -6,10 +6,10 @@ import { calculateEffectiveSizes } from './PersonaCoin.helpers';
 
 const _iconKeyProps: (keyof IPersonaCoinTokens)[] = ['iconSize', 'size', 'coinSize'];
 
-function _buildIconStyles(tokenProps: IPersonaCoinTokens /*, theme: ITheme */): ImageProps {
+function _buildIconStyles(tokenProps: IPersonaCoinTokens, theme: ITheme): ImageProps {
   const { iconSize, iconStrokeWidth } = calculateEffectiveSizes(tokenProps);
   const iconSizeAdjusted = iconSize + iconStrokeWidth * 2;
-  const iconStrokeColor = tokenProps.iconStrokeColor || 'white';
+  const iconStrokeColor = tokenProps.iconStrokeColor || theme.colors.background;
 
   return {
     source: {},

--- a/packages/components/PersonaCoin/src/PersonaCoin.tokens.icon.ts
+++ b/packages/components/PersonaCoin/src/PersonaCoin.tokens.icon.ts
@@ -7,14 +7,21 @@ import { calculateEffectiveSizes } from './PersonaCoin.helpers';
 const _iconKeyProps: (keyof IPersonaCoinTokens)[] = ['iconSize', 'size', 'coinSize'];
 
 function _buildIconStyles(tokenProps: IPersonaCoinTokens /*, theme: ITheme */): ImageProps {
-  const { iconSize } = calculateEffectiveSizes(tokenProps);
+  const { iconSize, iconStrokeWidth } = calculateEffectiveSizes(tokenProps);
+  const iconSizeAdjusted = iconSize + iconStrokeWidth * 2;
+  const iconStrokeColor = tokenProps.iconStrokeColor || 'white';
 
   return {
     source: {},
     style: {
       position: 'absolute',
-      width: iconSize,
-      height: iconSize
+      width: iconSizeAdjusted,
+      height: iconSizeAdjusted,
+      bottom: -iconStrokeWidth,
+      end: -iconStrokeWidth,
+      borderRadius: iconSizeAdjusted / 2,
+      borderWidth: iconStrokeWidth,
+      borderColor: iconStrokeColor,
     }
   };
 }

--- a/packages/components/PersonaCoin/src/PersonaCoin.types.ts
+++ b/packages/components/PersonaCoin/src/PersonaCoin.types.ts
@@ -57,6 +57,8 @@ export type IconAlignment = 'start' | 'center' | 'end';
 export interface IPersonaCoinTokens extends IBackgroundColorTokens, IForegroundColorTokens, IPersonaConfigurableProps {
   coinSize?: number;
   iconSize?: number;
+  iconStrokeWidth?: number;
+  iconStrokeColor?: string;
   initialsSize?: number;
   horizontalIconAlignment?: IconAlignment;
   verticalIconAlignment?: IconAlignment;


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32
- [x] windows
- [x] android

### Description of changes

PersonCoin renders the presence icon with no border.  This change adds an `iconStrokeWidth` and `iconStrokeColor` token allowing a stroke to be rendered around the presence icon.

Additionally, the `.vscode/settings.json` file had `editor.formatOnSave": true` which caused Visual Studio Code to automatically format files on Save, but the formatting specified in the settings does not match the apparent coding styles of this repo.

### Verification

The change was tested using the iOS test app.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before](https://user-images.githubusercontent.com/30053638/91663610-3b846280-eaea-11ea-9bb7-7fc6e927265b.png) | ![after](https://user-images.githubusercontent.com/30053638/91663620-46d78e00-eaea-11ea-973f-3e915e40652a.png) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
