### PR TITLE
Fix Button icon color props

### DIFF
--- a/apps/fluent-tester/src/RNTester/TestComponents/Button/ButtonIconTest.tsx
+++ b/apps/fluent-tester/src/RNTester/TestComponents/Button/ButtonIconTest.tsx
@@ -8,13 +8,14 @@ export const ButtonIconTest: React.FunctionComponent<{}> = () => {
   if (Platform.OS !== ('win32' as any)) {
     const CustomizedIconButton = Button.customize({
       tokens: { iconColor: 'red' },
+      content: { style: { marginStart: 5 } },
     });
 
     return (
       <View>
         <Stack style={stackStyle}>
           <Button icon={require('./icon_24x24.png')} content="Button with Icon" tooltip="button tooltip" />
-          <CustomizedIconButton icon={require('./icon_24x24.png')} content="Button with Customized Icon" tooltip="button tooltip"/>
+          <CustomizedIconButton icon={require('./icon_24x24.png')} content="Button with Customized Icon" tooltip="button tooltip" />
         </Stack>
       </View>
     );

--- a/apps/fluent-tester/src/RNTester/TestComponents/Button/ButtonIconTest.tsx
+++ b/apps/fluent-tester/src/RNTester/TestComponents/Button/ButtonIconTest.tsx
@@ -6,10 +6,15 @@ import { stackStyle } from '../Common/styles';
 
 export const ButtonIconTest: React.FunctionComponent<{}> = () => {
   if (Platform.OS !== ('win32' as any)) {
+    const CustomizedIconButton = Button.customize({
+      tokens: { iconColor: 'red' },
+    });
+
     return (
       <View>
         <Stack style={stackStyle}>
           <Button icon={require('./icon_24x24.png')} content="Button with Icon" tooltip="button tooltip" />
+          <CustomizedIconButton icon={require('./icon_24x24.png')} content="Button with Customized Icon" tooltip="button tooltip"/>
         </Stack>
       </View>
     );

--- a/change/@fluentui-react-native-button-2020-09-03-18-49-39-master.json
+++ b/change/@fluentui-react-native-button-2020-09-03-18-49-39-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix Button icon color props",
+  "packageName": "@fluentui-react-native/button",
+  "email": "tomun@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-03T16:49:39.693Z"
+}

--- a/change/@fluentui-react-native-tester-2020-09-03-18-49-39-master.json
+++ b/change/@fluentui-react-native-tester-2020-09-03-18-49-39-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix Button icon color props",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "tomun@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-03T16:49:35.868Z"
+}

--- a/packages/components/Button/src/Button.tsx
+++ b/packages/components/Button/src/Button.tsx
@@ -86,7 +86,7 @@ export const Button = compose<IButtonType>({
   styles: {
     root: [backgroundColorTokens, borderTokens],
     stack: [],
-    icon: [foregroundColorTokens, [{ source: 'iconColor', lookup: getPaletteFromTheme, target: 'overlayColor' }]],
+    icon: [{ source: 'iconColor', lookup: getPaletteFromTheme, target: 'tintColor' }],
     content: [textTokens, foregroundColorTokens]
   }
 });

--- a/packages/experimental/Button/src/Button.styling.ts
+++ b/packages/experimental/Button/src/Button.styling.ts
@@ -72,11 +72,10 @@ export const stylingSettings: UseStylingOptions<ButtonProps, ButtonSlotProps, Bu
     icon: buildProps(
       (tokens: ButtonTokens) => ({
         style: {
-          color: tokens.iconColor || tokens.color,
-          overlayColor: tokens.iconColor,
+          tintColor: tokens.iconColor,
         },
       }),
-      ['color', 'iconColor'],
+      ['iconColor'],
     ),
   },
 };


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32
- [x] windows
- [x] android

### Description of changes

The `<Button>` component throws an exception if the `icon` prop is used: 
```
Failed prop type: Invalid props.style key `color` supplied to `Image`.
```
The Button token `iconColor` was doing nothing.

The code was mapping `tokens.iconColor || tokens.color` to an RN Image style prop `color`, but not such prop exists.   It was also mapping `tokens.iconColor` to the RN Image style prop `overlayColor`, but the intention of [`overlayColor`](https://reactnative.dev/docs/image-style-props#overlaycolor) is to provide the color that appears behind the image if the component has rounded corners. 

This PR changes the mapping of `tokens.iconColor` to the RN Image style prop [`tintColor`](https://reactnative.dev/docs/image-style-props#tintcolor) which recolors all non-transparent pixels to the color.

Closing #351 

### Verification

A test case was added to the Button Test to validate that the `iconColor` token successfully recolors a button icon:

![IconButton](https://user-images.githubusercontent.com/30053638/92121430-907dec80-edfa-11ea-9d14-7425783490ed.png)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
