### PR TITLE
Rename tokenProps to tokensThatAreAlsoProps for clarity in the use-slots package

### DIFF
--- a/change/@fluentui-react-native-framework-2020-09-09-12-03-22-use-styling-update.json
+++ b/change/@fluentui-react-native-framework-2020-09-09-12-03-22-use-styling-update.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "rename tokenProps to tokensThatAreAlsoProps in new framework",
+  "packageName": "@fluentui-react-native/framework",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-09T19:03:18.695Z"
+}

--- a/change/@fluentui-react-native-use-styling-2020-09-09-12-03-22-use-styling-update.json
+++ b/change/@fluentui-react-native-use-styling-2020-09-09-12-03-22-use-styling-update.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "rename tokenProps to tokensThatAreAlsoProps in new framework",
+  "packageName": "@fluentui-react-native/use-styling",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-09T19:03:22.655Z"
+}

--- a/packages/experimental/Stack/src/Stack.styling.ts
+++ b/packages/experimental/Stack/src/Stack.styling.ts
@@ -22,7 +22,7 @@ function _mapAlignment(horizontal: boolean, horizontalAlign: Alignment, vertical
   }
 }
 
-const tokenProps: (keyof StackTokenProps)[] = [
+const tokensThatAreAlsoProps: (keyof StackTokenProps)[] = [
   'childrenGap',
   'disableShrink',
   'gap',
@@ -122,7 +122,7 @@ const buildRootProps = buildProps<ViewProps, StackTokens>(
 
 export const stylingSettings: UseStylingOptions<StackProps, StackSlotProps, StackTokens> = {
   tokens: [stackName],
-  tokenProps,
+  tokensThatAreAlsoProps,
   slotProps: {
     root: buildRootProps,
     inner: buildInnerProps,

--- a/packages/experimental/Stack/src/StackItem/StackItem.styles.ts
+++ b/packages/experimental/Stack/src/StackItem/StackItem.styles.ts
@@ -14,7 +14,7 @@ export const stylingSettings: UseStylingOptions<StackItemProps, StackItemSlotPro
   /** no real defaults, just look up the name in the settings in case someone decides to set them */
   tokens: [stackItemName],
   /** all tokens are also props, so just copy props onto tokens */
-  tokenProps: true,
+  tokensThatAreAlsoProps: 'all',
   slotProps: {
     root: (tokenProps: StackItemTokens) => {
       const { grow, shrink, disableShrink, align, verticalFill, margin } = tokenProps;

--- a/packages/experimental/Text/src/Text.tsx
+++ b/packages/experimental/Text/src/Text.tsx
@@ -43,7 +43,7 @@ export type TextProps<TBase = ITextProps> = TBase &
  * These are the tokens which are also present in props. If specified in props this will override the values
  * from tokens.
  */
-const tokenProps: (keyof TextTokens)[] = ['variant', 'color'];
+const tokensThatAreAlsoProps: (keyof TextTokens)[] = ['variant', 'color'];
 
 /** Type to use for compose */
 interface TextType {
@@ -66,7 +66,7 @@ export const Text = compose<TextType>({
     textName,
   ],
   states: ['disabled'],
-  tokenProps,
+  tokensThatAreAlsoProps,
   slotProps: {
     root: buildProps<ITextProps, TextTokens>(
       (tokens: TextTokens, theme: ITheme) => ({

--- a/packages/experimental/framework/src/useStyling.ts
+++ b/packages/experimental/framework/src/useStyling.ts
@@ -2,7 +2,7 @@
  * Many of the types from use-styling take a theme as a type parameter. This re-exports them in such a way
  * as to be dependent on the core theme type
  */
-export { TokenPropMask, HasLayer, applyTokenLayers, UseStyling } from '@fluentui-react-native/use-styling';
+export { TokensThatAreAlsoProps, HasLayer, applyTokenLayers, UseStyling } from '@fluentui-react-native/use-styling';
 import {
   TokensFromTheme as TokensFromThemeBase,
   TokenSettings as TokenSettingsBase,
@@ -10,7 +10,7 @@ import {
   buildUseStyling as buildUseStylingBase,
   UseStyling,
   buildProps as buildPropsBase,
-  BuildPropsBase
+  BuildPropsBase,
 } from '@fluentui-react-native/use-styling';
 import { ITheme } from '@uifabricshared/theming-ramp';
 import { themeHelper } from './themeHelper';
@@ -19,7 +19,7 @@ export type BuildProps<TProps, TTokens> = BuildPropsBase<TProps, TTokens, ITheme
 
 export function buildProps<TProps, TTokens>(
   fn: (tokens: TTokens, theme: ITheme) => TProps,
-  keys?: (keyof TTokens)[]
+  keys?: (keyof TTokens)[],
 ): BuildProps<TProps, TTokens> {
   return buildPropsBase<TProps, TTokens, ITheme>(fn, keys);
 }
@@ -34,7 +34,7 @@ export type UseStylingOptions<TProps, TSlotProps, TTokens> = UseStylingOptionsBa
  * @param options - options which drive behavior for the generated styling hook
  */
 export function buildUseStyling<TProps, TSlotProps, TTokens>(
-  options: UseStylingOptions<TProps, TSlotProps, TTokens>
+  options: UseStylingOptions<TProps, TSlotProps, TTokens>,
 ): UseStyling<TProps, TSlotProps> {
   // create a cache instance for this use styling implementation
   return buildUseStylingBase(options, themeHelper);

--- a/packages/experimental/use-styling/README.md
+++ b/packages/experimental/use-styling/README.md
@@ -32,7 +32,15 @@ Now this example isn't particularly useful but demonstrates the basic role that 
 
 ## Quick Reference
 
-At the core of this system is the idea that: **`Tokens + Theme ==> Styles`**. The overall signature of the method is as follows:
+At the core of this system is the idea that: **`Tokens + Theme ==> Styles`**. This can be thought of as:
+
+- Your styles are produced via a recipe, defined as a function in `slotProps`
+- The tokens are the ingredients for your recipe
+- Some of those tokens come from constants
+- Some of those tokens come from the theme
+- Some tokens could even come from props but this is not the default and needs to be declared in `tokensThatAreAlsoProps`
+
+The overall signature of the method is as follows:
 
 ```ts
 const useStyling = buildUseStyling(
@@ -52,9 +60,9 @@ const useStyling = buildUseStyling(
     states?: ['hovered', 'pressed', 'disabled'],
 
     /* Step 3: Copy some/none/all props to Tokens */
-    tokenProps?: true /* all props are tokens */
-              | false /* no props are tokens */
-              | ['token1', 'token2'] /* list of tokens */,
+    tokensThatAreAlsoProps?: 'all' /* all props are tokens */
+              | 'none' | undefined /* no props are tokens */
+              | ['token1', 'token2'] /* list of tokens which also appear in props */,
 
     /* Step 4: Create props for child components from Tokens and Theme */
     slotProps?: {
@@ -106,16 +114,16 @@ const useStyling = buildUseStyling({
     /* fixed object */
     {
       borderWidth: 1,
-      borderRadius: 2
+      borderRadius: 2,
     },
     /* theme function */
     (theme: Theme) => {
       backgroundColor: theme.palette.bodyBackground || 'white';
     },
     /* name lookup */
-    'MyComponentName'
+    'MyComponentName',
   ],
-  ...otherSettings
+  ...otherSettings,
 });
 ```
 
@@ -170,7 +178,7 @@ const useStyling = buildUseStyling({
     /* token settings */
   ],
   states: ['hovered', 'pressed'],
-  ...otherSettings
+  ...otherSettings,
 });
 ```
 
@@ -209,17 +217,17 @@ const Button = (props: ButtonProps) => {
 };
 ```
 
-## Token Props
+## Tokens and Props
 
 The ideal scenario from a caching perspective, is for tokens and props to be completely separate. This keeps variability very low and reduces the need for frequent style recalculations. From the perspective of someone using the components this sharply limits flexibility. As a result it may be useful for some tokens to be surfaced as props on the component.
 
-Because props are not provided to the final stage of the `useStyling` workflow, if any props are also tokens, they need to be declared so that they can override the token values coming from the theme or constants. This is done via the `tokenProps` property. This has three behaviors:
+Because props are not provided to the final stage of the `useStyling` workflow, if any props are also tokens, they need to be declared so that they can override the token values coming from the theme or constants. This is done via the `tokensThatAreAlsoProps` property. This has three behaviors:
 
-| Value                  | Behavior                                                                                        |
-| ---------------------- | ----------------------------------------------------------------------------------------------- |
-| `false` or `undefined` | No properties are tokens and tokens will be left as is.                                         |
-| `true`                 | All properties should be considered tokens. This equates to: `tokens = { ...tokens, ...props }` |
-| `(keyof Tokens)[]`     | Provides a discrete list of values to copy from props to tokens (if present)                    |
+| Value                   | Behavior                                                                                        |
+| ----------------------- | ----------------------------------------------------------------------------------------------- |
+| `'none'` or `undefined` | No properties are tokens and tokens will be left as is.                                         |
+| `'all'`                 | All properties should be considered tokens. This equates to: `tokens = { ...tokens, ...props }` |
+| `(keyof Tokens)[]`      | Provides a discrete list of values to copy from props to tokens (if present)                    |
 
 ## Slot Props
 
@@ -239,8 +247,8 @@ The simplest way to provide props for a slot is by providing an object directly.
 const useStyling = buildUseStyling({
   ...precedingOptions,
   slotProps: {
-    slot1: { style: { display: 'flex' } }
-  }
+    slot1: { style: { display: 'flex' } },
+  },
 });
 ```
 
@@ -265,9 +273,9 @@ const slotFn = (tokens: Tokens, theme: Theme, cache: GetMemoValue<Props>) =>
   cache(() => {
     return {
       style: {
-        backgroundColor: tokens.backgroundColor
+        backgroundColor: tokens.backgroundColor,
         // etc.
-      }
+      },
     };
   }, [
     /* no keys, just direct cache the function result*/
@@ -281,9 +289,9 @@ const slotFn = (tokens: Tokens, theme: Theme, cache: GetMemoValue<Props>) => {
   const { backgroundColor, color, borderRadius } = tokens;
   return cache(
     () => ({
-      style: { backgroundColor, color, borderRadius }
+      style: { backgroundColor, color, borderRadius },
     }),
-    [backgroundColor, color, borderRadius]
+    [backgroundColor, color, borderRadius],
   )[0];
 };
 ```
@@ -298,10 +306,10 @@ const slotFn = buildProps(
     style: {
       backgroundColor: tokens.backgroundColor,
       color: tokens.color,
-      borderRadius: tokens.borderRadius
-    }
+      borderRadius: tokens.borderRadius,
+    },
   }),
-  ['backgroundColor', 'color', 'borderRadius']
+  ['backgroundColor', 'color', 'borderRadius'],
 );
 ```
 

--- a/packages/experimental/use-styling/src/buildProps.ts
+++ b/packages/experimental/use-styling/src/buildProps.ts
@@ -1,17 +1,19 @@
 import { GetMemoValue } from '@fluentui-react-native/memo-cache';
 
 /**
- * Denotes what props will be treated as tokens
- * - false | undefined : this means no properties should be treated as tokens
- * - true              : treat all props as tokens
- * - array of keys     : props matching that array should be treated as tokens
+ * Informs the framework of any tokens that also appear as props for the component.
+ * - 'none' | undefined : this means no properties should be treated as tokens, the tokens that will be passed in to buildProps
+ *                        will not be patched from props. This also means that for a given theme + state the tokens will not
+ *                        change. As a result this is the most efficient mode.
+ * - 'all'              : treat all props as tokens. Props will be spread into the tokens before the slot functions are called
+ * - array of keys      : this is the discrete list of tokens which also appear in props
  */
-export type TokenPropMask<TTokens> = (keyof TTokens)[] | boolean;
+export type TokensThatAreAlsoProps<TTokens> = (keyof TTokens)[] | 'all' | 'none';
 
 /**
  * Raw format for producing styles in a functional manner. These can only depend on tokens or theme as inputs.
  * - tokens:  these will be produced from the theme and component constants, then they will be potentially
- *            be modified by the props. See the TokenPropMask type for more details.
+ *            be modified by the props. See the TokensThatAreAlsoProps type for more details.
  * - theme:   the theme is provided for reference
  * The provided
  * cache will be scoped to the theme, slot, and tokens that are coming out of the theme.
@@ -22,7 +24,9 @@ export type BuildPropsBase<TProps, TTokens, TTheme> = (tokens: TTokens, theme: T
  * A refine function allows style functions to be updated based on tokens that are also props. Only those tokens that are also
  * props need to be considered as a key for caching
  */
-export type RefineFunctionBase<TProps, TTokens, TTheme> = (mask?: TokenPropMask<TTokens>) => BuildPropsBase<TProps, TTokens, TTheme>;
+export type RefineFunctionBase<TProps, TTokens, TTheme> = (
+  mask?: TokensThatAreAlsoProps<TTokens>,
+) => BuildPropsBase<TProps, TTokens, TTheme>;
 
 /**
  * Signature for a style function which can be optionally refined by the styling hook if prop masks are provided
@@ -40,13 +44,13 @@ export type BuildSlotProps<TSlotProps, TTokens, TTheme> = {
 
 function cacheStyleClosure<TProps, TTokens, TTheme>(
   fn: (tokens: TTokens, theme: TTheme) => TProps,
-  keys?: (keyof TTokens)[]
+  keys?: (keyof TTokens)[],
 ): RefinableBuildPropsBase<TProps, TTokens, TTheme> {
   return (tokens: TTokens, theme: TTheme, cache: GetMemoValue<TProps>) =>
     cache(() => fn(tokens, theme), (keys || []).map(key => tokens[key]))[0];
 }
 
-function refineKeys<TTokens>(keys: (keyof TTokens)[], mask?: TokenPropMask<TTokens>): (keyof TTokens)[] {
+function refineKeys<TTokens>(keys: (keyof TTokens)[], mask?: TokensThatAreAlsoProps<TTokens>): (keyof TTokens)[] {
   return typeof mask === 'object' && Array.isArray(mask) ? keys.filter(key => mask.findIndex(val => val === key) !== -1) : mask ? keys : [];
 }
 
@@ -58,7 +62,7 @@ function refineKeys<TTokens>(keys: (keyof TTokens)[], mask?: TokenPropMask<TToke
  */
 export function buildProps<TProps, TTokens, TTheme>(
   fn: (tokens: TTokens, theme: TTheme) => TProps,
-  keys?: (keyof TTokens)[]
+  keys?: (keyof TTokens)[],
 ): RefinableBuildPropsBase<TProps, TTokens, TTheme> {
   // wrap the provided function in the standard caching layer, basing it upon the provided keys
   const result = cacheStyleClosure(fn, keys);
@@ -66,7 +70,7 @@ export function buildProps<TProps, TTokens, TTheme>(
   // if results are being cached on keys, provide the ability to refine the function if a prop mask is specified
   result.refine =
     keys && keys.length > 0
-      ? (mask?: TokenPropMask<TTokens>) => {
+      ? (mask?: TokensThatAreAlsoProps<TTokens>) => {
           return cacheStyleClosure(fn, refineKeys(keys, mask));
         }
       : undefined;
@@ -83,7 +87,7 @@ export function buildProps<TProps, TTokens, TTheme>(
  */
 export function refinePropsFunctions<TSlotProps, TTokens, TTheme>(
   styles: BuildSlotProps<TSlotProps, TTokens, TTheme>,
-  mask: TokenPropMask<TTokens>
+  mask: TokensThatAreAlsoProps<TTokens>,
 ): BuildSlotProps<TSlotProps, TTokens, TTheme> {
   const result = {};
   Object.keys(styles).forEach(key => {

--- a/packages/experimental/use-styling/src/buildUseStyling.test.ts
+++ b/packages/experimental/use-styling/src/buildUseStyling.test.ts
@@ -17,11 +17,11 @@ const baseTokens: Tokens = {
   b: 'b-base',
   c: 'c-base',
   hover: {
-    c: 'c-base-hover'
+    c: 'c-base-hover',
   },
   press: {
-    c: 'c-base-press'
-  }
+    c: 'c-base-press',
+  },
 };
 
 interface Theme {
@@ -37,23 +37,23 @@ interface Theme {
 const defaultTheme: Theme = {
   vals: {
     foo: 'foo',
-    bar: 'bar'
+    bar: 'bar',
   },
   components: {
     uno: {
       a: 'uno-a',
-      c: 'uno-c'
+      c: 'uno-c',
     },
     dos: {
       b: 'dos-b',
-      c: 'dos-c'
-    }
-  }
+      c: 'dos-c',
+    },
+  },
 };
 
 const themeHelper: ThemeHelper<Theme> = {
   useTheme: () => defaultTheme,
-  getComponentInfo: (theme: Theme, name: string) => theme.components[name]
+  getComponentInfo: (theme: Theme, name: string) => theme.components[name],
 };
 
 interface Props {
@@ -75,8 +75,8 @@ const slotFn1 = (tokens: Tokens, theme: Theme) => {
       b: tokens.b,
       c: tokens.c,
       ...theme.vals,
-      instance: lastInstance++
-    }
+      instance: lastInstance++,
+    },
   } as Props;
 };
 
@@ -88,10 +88,10 @@ const slotFn2 = (tokens: Tokens) => {
       style: {
         a: tokens.a,
         b: tokens.b,
-        instance: lastInstance++
-      }
+        instance: lastInstance++,
+      },
     }),
-    [tokens.a, tokens.b]
+    [tokens.a, tokens.b],
   )[0];
 };
 
@@ -106,20 +106,20 @@ const baseOptions: UseStylingOptions<Props, TestSlotProps, Tokens, Theme> = {
     baseTokens,
     'uno',
     (theme: Theme) => ({
-      b: theme.vals.foo
-    })
+      b: theme.vals.foo,
+    }),
   ],
   states: ['hover', 'press'],
   slotProps: {
     slot1: {
       style: {
-        instance: lastInstance++
-      }
+        instance: lastInstance++,
+      },
     },
     slot2: buildProps(slotFn1, ['a', 'b', 'c']),
-    slot3: slotFn2
+    slot3: slotFn2,
   },
-  tokenProps: ['b']
+  tokensThatAreAlsoProps: ['b'],
 };
 
 describe('useStyling test suite', () => {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32
- [x] windows
- [x] android

### Description of changes

The entire intersection of props and tokens is somewhat confusing to people. To make it easier to understand this change:

- renames `tokenProps` to `tokensThatAreAlsoProps` in the settings object for the use-slots package
- changed the true value to be 'all', changed the false | undefined value to be 'none' | undefined (though really this is 'none'/falsy)

I then updated the documentation to hopefully add a bit more clarity.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
