### PR TITLE
Update Android test app eslint dependencies

### DIFF
--- a/apps/android/package.json
+++ b/apps/android/package.json
@@ -28,8 +28,9 @@
   "devDependencies": {
     "@babel/core": "^7.6.2",
     "@babel/runtime": "^7.6.2",
-    "@react-native-community/eslint-config": "^0.0.5",
-    "@uifabricshared/build-native": "0.1.1",
+    "@react-native-community/eslint-config": "^1.1.0",
+    "@uifabricshared/build-native": "^0.1.1",
+    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "babel-jest": "^24.9.0",
     "eslint": "^6.5.1",
     "jest": "^24.9.0",

--- a/apps/android/package.json
+++ b/apps/android/package.json
@@ -32,7 +32,6 @@
     "@uifabricshared/build-native": "^0.1.1",
     "@uifabricshared/eslint-config-rules": "^0.1.1",
     "babel-jest": "^24.9.0",
-    "eslint": "^6.5.1",
     "jest": "^24.9.0",
     "metro-react-native-babel-preset": "^0.58.0",
     "react-test-renderer": "~16.11.0"


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32
- [ ] windows
- [x] android

### Description of changes

The combination of #441 and #421 going in simultaneously meant that we added an android test app with old eslint dependencies, causing `yarn lint` to fail, and thus CI to fail. Let's update the eslint dependencies and fix what formatting we need to get CI passing again

### Verification

`yarn && yarn lint` locally

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
