### PR TITLE
Add FluentTester readme for ios

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -1,0 +1,26 @@
+`FluentUI Tester` is the test app that we use to test our FluentUI components during development.
+
+## Launch `FluentUI Tester` app on iOS
+
+Prereq: FluentUI Tester on iOS can only run on a Mac.
+
+1. Make sure you have followed the Getting Started instructions [here](../../README.md) to install packages and build the entire Fluent UI React Native repository. E.g. from the root of the repo:
+```
+    yarn && yarn build
+```
+
+2. Then go into `apps/ios/src` folder and run pod install:
+
+```
+    cd apps/ios/src
+    pod install
+```
+Note: if you get the error: "CocoaPods could not find compatible versions for pod "MicrosoftFluentUI"," you will need to run `pod repo update` and then run `pod install` again.
+
+3. Return to the ios directory and run yarn ios to launch the FluentUI Tester app:
+
+```
+    cd ..
+    yarn ios
+```
+Note: the first time you yarn ios, you receive an error and have to run "FluentUITester.xcworkspace" directly from Xcode. The workspace can be found in the apps/ios/src folder. After running the workspace the first time from Xcode, you will be able to `yarn ios` from the CLI.

--- a/apps/README.md
+++ b/apps/README.md
@@ -1,15 +1,15 @@
-`FluentUI Tester` is the test app that we use to test our FluentUI components during development.
+`FluentUI Tester` is the test app that we use to test our FluentUI components during development. It uses the [react-native-test app](https://github.com/microsoft/react-native-test-app) under the covers, and loads the FluentUI bundle.
 
 ## Launch `FluentUI Tester` app on iOS
 
 Prereq: FluentUI Tester on iOS can only run on a Mac.
 
-1. Make sure you have followed the Getting Started instructions [here](../../README.md) to install packages and build the entire Fluent UI React Native repository. E.g. from the root of the repo:
+1. Make sure you have followed the [Getting Started](../../README.md) instructions to install packages and build the entire FluentUI React Native repository. I.e. from the root of the repo:
 ```
     yarn && yarn build
 ```
 
-2. Then go into `apps/ios/src` folder and run pod install:
+2. Then go into `apps/ios/src` folder and run pod install to pull in the project-level Cocoapod dependencies defined in the podfile, and to generate a valid xcworkspace:
 
 ```
     cd apps/ios/src
@@ -23,4 +23,15 @@ Note: if you get the error: "CocoaPods could not find compatible versions for po
     cd ..
     yarn ios
 ```
-Note: the first time you yarn ios, you receive an error and have to run "FluentUITester.xcworkspace" directly from Xcode. The workspace can be found in the apps/ios/src folder. After running the workspace the first time from Xcode, you will be able to `yarn ios` from the CLI.
+
+Troubleshooting
+- The first time you yarn ios, you receive an error and have to run "FluentUITester.xcworkspace" directly from Xcode. The workspace can be found in the apps/ios/src folder. After running the workspace the first time from Xcode, you will be able to `yarn ios` from the CLI.
+- If the packager didn't launch in a separate terminal and your iOS simulator just shows a white screen for your app, you can run yarn start from apps/ios to launch it separately
+- If you want to do direct debugging via xcode, after the pod install, you can launch src/FluentUITester.xcworkspace and build/run the scheme "ReactTestApp"
+- If you want to have a clean rebuild of the generated iOS project, you can do the following:
+```
+cd apps/ios/
+rm src/FluentUITester.xcworkspace
+rm -r src/Pods/
+pod install --project-directory=src.
+```

--- a/apps/README.md
+++ b/apps/README.md
@@ -1,4 +1,4 @@
-`FluentUI Tester` is the test app that we use to test our FluentUI components during development. It uses the [react-native-test app](https://github.com/microsoft/react-native-test-app) under the covers, and loads the FluentUI bundle.
+`FluentUI Tester` is the test app that we use to test our FluentUI components during development. It uses the [react-native-test app](https://github.com/microsoft/react-native-test-app) under the covers, and loads the fluent-tester bundle.
 
 ## Launch `FluentUI Tester` app on iOS
 

--- a/apps/README.md
+++ b/apps/README.md
@@ -15,7 +15,7 @@ Prereq: FluentUI Tester on iOS can only run on a Mac.
     cd apps/ios/src
     pod install
 ```
-Note: if you get the error: "CocoaPods could not find compatible versions for pod "MicrosoftFluentUI"," you will need to run `pod repo update` and then run `pod install` again.
+Note: if you get the error: "CocoaPods could not find compatible versions for pod "MicrosoftFluentUI"," you may need to run `pod install --repo-update`.
 
 3. Return to the ios directory and run yarn ios to launch the FluentUI Tester app:
 


### PR DESCRIPTION
### Platforms Impacted
- [x ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Adding instructions for how to launch the FluentTester on iOS, following Saad's instructions after recent updates. Will update the main Fluent Tester readme to point to this page.

### Verification

Ran through the documentation as I was writing it.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
