### PR TITLE
Bump checkbox version

### DIFF
--- a/change/@fluentui-react-native-checkbox-2020-09-21-18-37-55-bumpCheckboxVersion.json
+++ b/change/@fluentui-react-native-checkbox-2020-09-21-18-37-55-bumpCheckboxVersion.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "manual version bump on Checkbox",
+  "packageName": "@fluentui-react-native/checkbox",
+  "email": "taamireh@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-22T01:37:55.251Z"
+}

--- a/packages/components/Checkbox/package.json
+++ b/packages/components/Checkbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/checkbox",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "A cross-platform Checkbox component using the Fluent Design System",
   "main": "src/index.ts",
   "module": "src/index.ts",


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

Manually bumping Checkbox version -- this should fix the publish pipeline

### Verification

bump-versions bumped to 0.5.5
