### PR TITLE
Bump button version

### DIFF
--- a/change/@fluentui-react-native-button-2020-09-21-20-50-29-bumpButtonVersion.json
+++ b/change/@fluentui-react-native-button-2020-09-21-20-50-29-bumpButtonVersion.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "manually bump button version",
+  "packageName": "@fluentui-react-native/button",
+  "email": "taamireh@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-22T03:50:29.764Z"
+}

--- a/packages/components/Button/package.json
+++ b/packages/components/Button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/button",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "A cross-platform Button component using the Fluent Design System",
   "main": "src/index.ts",
   "module": "src/index.ts",


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

It turns out the button package had also been affected
