### PR TITLE
Add dark theme support to theming (but leave it off for now)

### DIFF
--- a/change/@fluentui-react-native-default-theme-2020-09-25-12-33-55-dark-theme.json
+++ b/change/@fluentui-react-native-default-theme-2020-09-25-12-33-55-dark-theme.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "add light and dark awareness to default themes",
+  "packageName": "@fluentui-react-native/default-theme",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-25T19:33:45.968Z"
+}

--- a/change/@fluentui-react-native-experimental-framework-2020-08-18-10-50-19-split-foundation-settings.json
+++ b/change/@fluentui-react-native-experimental-framework-2020-08-18-10-50-19-split-foundation-settings.json
@@ -1,8 +1,0 @@
-{
-  "type": "patch",
-  "comment": "update code to use split out merge-props package",
-  "packageName": "@fluentui-react-native/experimental-framework",
-  "email": "jasonmo@microsoft.com",
-  "dependentChangeType": "patch",
-  "date": "2020-08-18T17:49:22.953Z"
-}

--- a/change/@fluentui-react-native-theme-2020-09-25-12-33-55-dark-theme.json
+++ b/change/@fluentui-react-native-theme-2020-09-25-12-33-55-dark-theme.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "add light and dark awareness to default themes",
+  "packageName": "@fluentui-react-native/theme",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-25T19:33:38.767Z"
+}

--- a/change/@fluentui-react-native-theme-types-2020-09-25-12-33-55-dark-theme.json
+++ b/change/@fluentui-react-native-theme-types-2020-09-25-12-33-55-dark-theme.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "add light and dark awareness to default themes",
+  "packageName": "@fluentui-react-native/theme-types",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-25T19:33:51.997Z"
+}

--- a/change/@fluentui-react-native-win32-theme-2020-09-25-12-33-55-dark-theme.json
+++ b/change/@fluentui-react-native-win32-theme-2020-09-25-12-33-55-dark-theme.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "add light and dark awareness to default themes",
+  "packageName": "@fluentui-react-native/win32-theme",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-25T19:33:55.506Z"
+}

--- a/change/@uifabricshared-immutable-merge-2020-08-12-12-47-49-depcheck.json
+++ b/change/@uifabricshared-immutable-merge-2020-08-12-12-47-49-depcheck.json
@@ -1,8 +1,0 @@
-{
-  "type": "patch",
-  "comment": "fix dependency errors",
-  "packageName": "@uifabricshared/immutable-merge",
-  "email": "jasonmo@microsoft.com",
-  "dependentChangeType": "patch",
-  "date": "2020-08-12T19:47:24.928Z"
-}

--- a/change/@uifabricshared-theming-ramp-2020-09-25-12-33-55-dark-theme.json
+++ b/change/@uifabricshared-theming-ramp-2020-09-25-12-33-55-dark-theme.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "add light and dark awareness to default themes",
+  "packageName": "@uifabricshared/theming-ramp",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-25T19:33:41.578Z"
+}

--- a/packages/experimental/theme/src/themeReference.test.ts
+++ b/packages/experimental/theme/src/themeReference.test.ts
@@ -61,7 +61,7 @@ const themeBase: Theme = {
     },
   },
   spacing: { s2: '4px', s1: '8px', m: '16px', l1: '20px', l2: '32px' },
-  host: {},
+  host: { appearance: 'light' },
   components: {},
 };
 

--- a/packages/framework/theming-ramp/src/Theme.test.ts
+++ b/packages/framework/theming-ramp/src/Theme.test.ts
@@ -32,7 +32,9 @@ const theme: Theme = {
       },
     },
   },
-  host: {},
+  host: {
+    appearance: 'light',
+  },
 };
 
 const partialTheme: PartialTheme = {

--- a/packages/framework/theming-ramp/src/Theme.test.ts
+++ b/packages/framework/theming-ramp/src/Theme.test.ts
@@ -105,6 +105,9 @@ describe('Theme tests', () => {
           },
         },
       },
+      host: {
+        appearance: 'light',
+      },
     });
   });
 });

--- a/packages/theming/default-theme/package.json
+++ b/packages/theming/default-theme/package.json
@@ -32,7 +32,8 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@fluentui-react-native/theme-types": ">=0.1.4 <1.0.0"
+    "@fluentui-react-native/theme-types": ">=0.1.4 <1.0.0",
+    "@fluentui-react-native/theme": ">=0.1.2 <1.0.0"
   },
   "devDependencies": {
     "@types/react": "^16.9.34",

--- a/packages/theming/default-theme/src/createDefaultTheme.ts
+++ b/packages/theming/default-theme/src/createDefaultTheme.ts
@@ -5,7 +5,7 @@ import { Theme } from '@fluentui-react-native/theme-types';
 
 export type AppearanceOptions = 'light' | 'dark';
 
-export interface DefaultThemeOptions {
+export interface ThemeOptions {
   /**
    * Should the baseline colors be light, dark, or use the values from the Appearance API from react-native.
    */
@@ -15,13 +15,22 @@ export interface DefaultThemeOptions {
    * Default appearance should the library to request this from native not be available
    */
   defaultAppearance?: AppearanceOptions;
+
+  /**
+   * If in a host that supports multiple areas within the app that use different palettes, this specifies the palette name to
+   * load.
+   *
+   * In Office this corresponds to regions like taskpanes, the ribbon, left navigation, and so on, but that concept could be extended
+   * to any host that wants to support this.
+   */
+  paletteName?: string;
 }
 
 function getCurrentAppearance(fallback: AppearanceOptions): AppearanceOptions {
   return (Appearance && Appearance.getColorScheme()) || fallback;
 }
 
-export function createDefaultTheme(options: DefaultThemeOptions = {}): ThemeReference {
+export function createDefaultTheme(options: ThemeOptions = {}): ThemeReference {
   const { defaultAppearance = 'light', appearance = 'light' } = options;
 
   const themeRef = new ThemeReference({} as Theme, () => {

--- a/packages/theming/default-theme/src/createDefaultTheme.ts
+++ b/packages/theming/default-theme/src/createDefaultTheme.ts
@@ -26,19 +26,17 @@ export interface ThemeOptions {
   paletteName?: string;
 }
 
-function getCurrentAppearance(fallback: AppearanceOptions): AppearanceOptions {
-  return (Appearance && Appearance.getColorScheme()) || fallback;
+function getCurrentAppearance(appearance: ThemeOptions['appearance'], fallback: AppearanceOptions): AppearanceOptions {
+  return appearance === 'dynamic' ? (Appearance && Appearance.getColorScheme()) || fallback : appearance;
 }
 
 export function createDefaultTheme(options: ThemeOptions = {}): ThemeReference {
-  const { defaultAppearance = 'light', appearance = 'light' } = options;
-
   const themeRef = new ThemeReference({} as Theme, () => {
-    const current = getCurrentAppearance(defaultAppearance);
+    const current = getCurrentAppearance(options.appearance, options.defaultAppearance || 'light');
     return current === 'light' ? defaultFluentTheme : defaultFluentDarkTheme;
   });
 
-  if (Appearance && appearance === 'dynamic') {
+  if (Appearance && options.appearance === 'dynamic') {
     Appearance.addChangeListener(() => {
       themeRef.invalidate();
     });

--- a/packages/theming/default-theme/src/createDefaultTheme.ts
+++ b/packages/theming/default-theme/src/createDefaultTheme.ts
@@ -1,0 +1,39 @@
+import { ThemeReference } from '@fluentui-react-native/theme';
+import { defaultFluentDarkTheme, defaultFluentTheme } from './defaultTheme';
+import { Appearance } from 'react-native';
+import { Theme } from '@fluentui-react-native/theme-types';
+
+export type AppearanceOptions = 'light' | 'dark';
+
+export interface DefaultThemeOptions {
+  /**
+   * Should the baseline colors be light, dark, or use the values from the Appearance API from react-native.
+   */
+  appearance?: AppearanceOptions | 'dynamic';
+
+  /**
+   * Default appearance should the library to request this from native not be available
+   */
+  defaultAppearance?: AppearanceOptions;
+}
+
+function getCurrentAppearance(fallback: AppearanceOptions): AppearanceOptions {
+  return (Appearance && Appearance.getColorScheme()) || fallback;
+}
+
+export function createDefaultTheme(options: DefaultThemeOptions = {}): ThemeReference {
+  const { defaultAppearance = 'light', appearance = 'light' } = options;
+
+  const themeRef = new ThemeReference({} as Theme, () => {
+    const current = getCurrentAppearance(defaultAppearance);
+    return current === 'light' ? defaultFluentTheme : defaultFluentDarkTheme;
+  });
+
+  if (Appearance && appearance === 'dynamic') {
+    Appearance.addChangeListener(() => {
+      themeRef.invalidate();
+    });
+  }
+
+  return themeRef;
+}

--- a/packages/theming/default-theme/src/defaultColors.ts
+++ b/packages/theming/default-theme/src/defaultColors.ts
@@ -17,7 +17,7 @@ export function paletteFromFabricColors(p: FabricWebPalette, isInverted?: boolea
     subText: p.neutralSecondary,
     bodyDivider: p.neutralLight,
 
-    disabledBackground: p.neutralLighter,
+    disabledBackground: isInverted ? p.neutralQuaternaryAlt : p.neutralLighter,
     disabledText: p.neutralTertiary,
     disabledBodyText: p.neutralTertiary,
     disabledSubtext: p.neutralQuaternary,
@@ -55,8 +55,8 @@ export function paletteFromFabricColors(p: FabricWebPalette, isInverted?: boolea
     buttonBackgroundPressed: p.neutralLight,
     buttonBackgroundDisabled: p.neutralLighter,
     buttonBorder: p.neutralSecondaryAlt,
-    buttonText: p.neutralPrimary,
-    buttonTextHovered: p.neutralDark,
+    buttonText: isInverted ? p.black : p.neutralPrimary,
+    buttonTextHovered: isInverted ? p.neutralPrimary : p.neutralDark,
     buttonTextChecked: p.neutralDark,
     buttonTextCheckedHovered: p.black,
     buttonTextPressed: p.neutralDark,
@@ -78,12 +78,12 @@ export function paletteFromFabricColors(p: FabricWebPalette, isInverted?: boolea
     accentButtonBackground: p.accent,
     accentButtonText: p.white,
 
-    menuBackground: p.white,
-    menuDivider: p.neutralTertiaryAlt,
-    menuIcon: p.themePrimary,
-    menuHeader: p.themePrimary,
-    menuItemBackgroundHovered: p.neutralLighter,
-    menuItemBackgroundPressed: p.neutralLight,
+    menuBackground: isInverted ? p.neutralLighter : p.white,
+    menuDivider: isInverted ? p.neutralTertiaryAlt : p.neutralTertiaryAlt,
+    menuIcon: isInverted ? p.themeDarkAlt : p.themePrimary,
+    menuHeader: isInverted ? p.black : p.themePrimary,
+    menuItemBackgroundHovered: isInverted ? p.neutralQuaternaryAlt : p.neutralLighter,
+    menuItemBackgroundPressed: isInverted ? p.neutralQuaternary : p.neutralLight,
     menuItemText: p.neutralPrimary,
     menuItemTextHovered: p.neutralDark,
 
@@ -145,5 +145,46 @@ export function getStockWebPalette(): ThemeColorDefinition {
       accent: '#0078d4',
       blackTranslucent40: 'rgba(0,0,0,.4)',
     }),
+  };
+}
+
+export function getStockWebDarkPalette(): ThemeColorDefinition {
+  return {
+    brand: defaultColorRamp,
+    neutral: defaultColorRamp,
+    warning: defaultColorRamp,
+    ...paletteFromFabricColors(
+      {
+        // colors takesn from fluentui DarkCustomizations.ts
+        themeDarker: '#82c7ff',
+        themeDark: '#6cb8f6',
+        themeDarkAlt: '#3aa0f3',
+        themePrimary: '#2899f5',
+        themeSecondary: '#0078d4',
+        themeTertiary: '#235a85',
+        themeLight: '#004c87',
+        themeLighter: '#043862',
+        themeLighterAlt: '#092c47',
+        black: '#ffffff',
+        neutralDark: '#faf9f8',
+        neutralPrimary: '#f3f2f1',
+        neutralPrimaryAlt: '#c8c6c4',
+        neutralSecondary: '#a19f9d',
+        neutralSecondaryAlt: '#979693',
+        neutralTertiary: '#797775',
+        neutralTertiaryAlt: '#484644',
+        neutralQuaternary: '#3b3a39',
+        neutralQuaternaryAlt: '#323130',
+        neutralLight: '#292827',
+        neutralLighter: '#252423',
+        neutralLighterAlt: '#201f1e',
+        white: '#1b1a19',
+        red: '#d13438',
+        accent: '#0078d4',
+        redDark: '#F1707B',
+        blackTranslucent40: 'rgba(0,0,0,.4)',
+      },
+      true,
+    ),
   };
 }

--- a/packages/theming/default-theme/src/defaultTheme.ts
+++ b/packages/theming/default-theme/src/defaultTheme.ts
@@ -1,6 +1,6 @@
 import { Theme, Typography, Spacing, FontWeightValue, FontSize, FontSizes, Variants } from '@fluentui-react-native/theme-types';
 import { Platform } from 'react-native';
-import { getStockWebPalette } from './defaultColors';
+import { getStockWebPalette, getStockWebDarkPalette } from './defaultColors';
 
 function _defaultTypography(): Typography {
   const defaultsDict = {
@@ -66,5 +66,13 @@ export const defaultFluentTheme: Theme = {
   typography: _defaultTypography(),
   spacing: defaultSpacing(),
   components: {},
-  host: {},
+  host: { appearance: 'light' },
+};
+
+export const defaultFluentDarkTheme: Theme = {
+  colors: getStockWebDarkPalette(),
+  typography: defaultFluentTheme.typography,
+  spacing: defaultFluentTheme.spacing,
+  components: {},
+  host: { appearance: 'dark' },
 };

--- a/packages/theming/default-theme/src/index.ts
+++ b/packages/theming/default-theme/src/index.ts
@@ -1,1 +1,2 @@
-export { defaultFluentTheme } from './defaultTheme';
+export { defaultFluentTheme, defaultFluentDarkTheme } from './defaultTheme';
+export * from './createDefaultTheme';

--- a/packages/theming/theme-types/src/Theme.types.ts
+++ b/packages/theming/theme-types/src/Theme.types.ts
@@ -2,6 +2,10 @@ import { ThemeColorDefinition } from './Color.types';
 import { OfficePalette } from './palette.types';
 import { Typography, PartialTypography } from './Typography.types';
 
+type TwoLevelPartial<T> = {
+  [K in keyof T]?: Partial<T[K]>;
+};
+
 export interface Spacing {
   s2: string;
   s1: string;
@@ -21,22 +25,39 @@ export interface Theme {
   componentTokens?: object;
   spacing: Spacing;
   host: {
+    // appearance of the theme, this corresponds to the react-native Appearance library values, though can be overwritten
+    appearance: 'light' | 'dark';
+
     // Office palette, if running in Office with the native module connected in the theme
     palette?: OfficePalette;
   };
 }
 
 /**
+ * Generally a partial theme is comprised of partial versions of the objects within the theme, with the exception of typography
+ * which has additional levels of hierarchy
+ */
+export type PartialTheme = Omit<TwoLevelPartial<Theme>, 'typography' | 'host'> & {
+  typography?: PartialTypography;
+  host?: TwoLevelPartial<Theme['host']>;
+};
+
+/**
  * A partially specified theme.
  *
  * Useful for overriding specific visual elements in a fully specified theme.
  */
-export interface PartialTheme {
+export interface PartialTheme2 {
   name?: string;
   colors?: Partial<ThemeColorDefinition>;
   typography?: PartialTypography;
   components?: { [key: string]: object };
   componentTokens?: object;
-  spacing?: Spacing;
-  host?: object;
+  spacing?: Partial<Spacing>;
+  host?: {
+    // appearance of the theme, this corresponds to the react-native Appearance library values, though can be overwritten
+    appearance?: 'light' | 'dark';
+
+    palette?: Partial<OfficePalette>;
+  };
 }

--- a/packages/theming/win32-theme/src/createOfficeTheme.ts
+++ b/packages/theming/win32-theme/src/createOfficeTheme.ts
@@ -1,5 +1,5 @@
 import { ThemeReference } from '@fluentui-react-native/theme';
-import { defaultFluentTheme } from '@fluentui-react-native/default-theme';
+import { createDefaultTheme, ThemeOptions } from '@fluentui-react-native/default-theme';
 import { getThemingModule } from './NativeModule/getThemingModule';
 import { CxxException, PlatformDefaultsChangedArgs } from './NativeModule/officeThemingModule';
 import { OfficePalette } from '@fluentui-react-native/theme-types';
@@ -18,11 +18,12 @@ function handlePaletteCall(palette: OfficePalette | CxxException): OfficePalette
  *
  * @param paletteName - optional specifier for the currently active office palette
  */
-export function createOfficeTheme(paletteName?: string): ThemeReference {
+export function createOfficeTheme(options: ThemeOptions = {}): ThemeReference {
   const [module, emitter] = getThemingModule();
   const ref = { module, emitter, themeName: module.initialHostThemeSetting || '' };
+  const { paletteName } = options;
 
-  const themeRef = new ThemeReference(defaultFluentTheme, () => {
+  const themeRef = new ThemeReference(createDefaultTheme(options), () => {
     const name = paletteName || '';
     const palette = handlePaletteCall(ref.module.getPalette(name));
     return createPartialOfficeTheme(module, ref.themeName, palette);


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

**Theme type changes**

- Added an entry under host that corresponds to the values returned by the react-native Appearance module
- Updated the partial type for themes to require less manual interventions

**Default Theme Changes**

- Added a dark theme, taken from the values in the fluentui repo
- Also updated the build semantic colors function with new inversion variants, also from fluentui
- Added a `createDefaultTheme` api that does the work of creating the light or dark theme, or switching between them if put in dynamic mode
- Added a new `ThemeOptions` interface to pass to create<X>Theme functions, this is defined at the base level with the idea that the settings can be conceptual and used for any theme that supports them.

**Win32 Theme Changes**

- It's now chained to default ThemeReference instead of directly chaining to the definition
- paletteName is specified via `ThemeOptions` now, other options are passed through to the creation function for the base

### Verification

Automated tests for now, none of this code should be used at this point.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
