### PR TITLE
Remove componentTokens from theme, just use components

### DIFF
--- a/change/@fluentui-react-native-2020-09-28-12-46-01-theme-tokens.json
+++ b/change/@fluentui-react-native-2020-09-28-12-46-01-theme-tokens.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "remove extra componentTokens reference and route everything to components",
+  "packageName": "@fluentui/react-native",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-09-28T19:45:50.946Z"
+}

--- a/change/@fluentui-react-native-focus-zone-2020-09-28-12-46-01-theme-tokens.json
+++ b/change/@fluentui-react-native-focus-zone-2020-09-28-12-46-01-theme-tokens.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "remove extra componentTokens reference and route everything to components",
+  "packageName": "@fluentui-react-native/focus-zone",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-09-28T19:45:37.778Z"
+}

--- a/change/@fluentui-react-native-framework-2020-09-28-12-46-01-theme-tokens.json
+++ b/change/@fluentui-react-native-framework-2020-09-28-12-46-01-theme-tokens.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "remove extra componentTokens reference and route everything to components",
+  "packageName": "@fluentui-react-native/framework",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-28T19:45:46.072Z"
+}

--- a/change/@fluentui-react-native-tester-2020-09-28-12-46-01-theme-tokens.json
+++ b/change/@fluentui-react-native-tester-2020-09-28-12-46-01-theme-tokens.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "remove extra componentTokens reference and route everything to components",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-28T19:45:22.341Z"
+}

--- a/change/@fluentui-react-native-tester-win32-2020-09-28-12-46-01-theme-tokens.json
+++ b/change/@fluentui-react-native-tester-win32-2020-09-28-12-46-01-theme-tokens.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "remove extra componentTokens reference and route everything to components",
+  "packageName": "@fluentui-react-native/tester-win32",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-09-28T19:45:34.388Z"
+}

--- a/change/@fluentui-react-native-theme-types-2020-09-28-12-46-01-theme-tokens.json
+++ b/change/@fluentui-react-native-theme-types-2020-09-28-12-46-01-theme-tokens.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "remove extra componentTokens reference and route everything to components",
+  "packageName": "@fluentui-react-native/theme-types",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-28T19:46:01.922Z"
+}

--- a/packages/experimental/framework/src/themeHelper.ts
+++ b/packages/experimental/framework/src/themeHelper.ts
@@ -8,7 +8,7 @@ export const themeHelper: ThemeHelper<Theme> = {
     return React.useContext(ThemeContext) || defaultFluentTheme;
   },
   getComponentInfo: (theme: Theme, name: string) => {
-    const components = theme.componentTokens || {};
+    const components = theme.components || {};
     return components[name];
   },
 };

--- a/packages/theming/theme-types/src/Theme.types.ts
+++ b/packages/theming/theme-types/src/Theme.types.ts
@@ -22,7 +22,6 @@ export interface Theme {
   colors: ThemeColorDefinition;
   typography: Typography;
   components: { [key: string]: object };
-  componentTokens?: object;
   spacing: Spacing;
   host: {
     // appearance of the theme, this corresponds to the react-native Appearance library values, though can be overwritten
@@ -41,23 +40,3 @@ export type PartialTheme = Omit<TwoLevelPartial<Theme>, 'typography' | 'host'> &
   typography?: PartialTypography;
   host?: TwoLevelPartial<Theme['host']>;
 };
-
-/**
- * A partially specified theme.
- *
- * Useful for overriding specific visual elements in a fully specified theme.
- */
-export interface PartialTheme2 {
-  name?: string;
-  colors?: Partial<ThemeColorDefinition>;
-  typography?: PartialTypography;
-  components?: { [key: string]: object };
-  componentTokens?: object;
-  spacing?: Partial<Spacing>;
-  host?: {
-    // appearance of the theme, this corresponds to the react-native Appearance library values, though can be overwritten
-    appearance?: 'light' | 'dark';
-
-    palette?: Partial<OfficePalette>;
-  };
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1988,6 +1988,31 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
+"@office-iss/react-native-win32@0.62.0-preview.3":
+  version "0.62.0-preview.3"
+  resolved "https://registry.npmjs.org/@office-iss/react-native-win32/-/react-native-win32-0.62.0-preview.3.tgz#c3235311c5507c57b02e35853f17ae7da43ff54b"
+  integrity sha512-dbjnwHTcF3IcfrBER/sMYh7tBG290WIlhwPVNR7n48zonx432r+2KOBtXQ+GTqmmdv+QxfG8BZDIJmvIUv/+3Q==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+    abort-controller "^3.0.0"
+    art "^0.10.0"
+    base64-js "^1.1.2"
+    create-react-class "^15.6.3"
+    event-target-shim "^5.0.1"
+    fbjs "^1.0.0"
+    fbjs-scripts "^1.1.0"
+    invariant "^2.2.4"
+    nullthrows "^1.1.0"
+    pretty-format "^24.7.0"
+    promise "^7.1.1"
+    prop-types "^15.7.2"
+    react-clone-referenced-element "^1.0.1"
+    react-devtools-core "^3.6.0"
+    regenerator-runtime "^0.13.2"
+    scheduler "0.14.0"
+    stacktrace-parser "^0.1.3"
+    whatwg-fetch "^3.0.0"
+
 "@office-iss/react-native-win32@0.62.3":
   version "0.62.3"
   resolved "https://registry.yarnpkg.com/@office-iss/react-native-win32/-/react-native-win32-0.62.3.tgz#599d7c8adfa0d3fc1dbbaa3b4acea180c6b3b101"
@@ -12351,7 +12376,7 @@ nth-check@^1.0.2, nth-check@~1.0.1:
   dependencies:
     boolbase "~1.0.0"
 
-nullthrows@^1.1.1:
+nullthrows@^1.1.0, nullthrows@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/nullthrows/-/nullthrows-1.1.1.tgz#7818258843856ae971eae4208ad7d7eb19a431b1"
   integrity sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==
@@ -13640,6 +13665,14 @@ react-clone-referenced-element@^1.0.1:
   resolved "https://registry.yarnpkg.com/react-clone-referenced-element/-/react-clone-referenced-element-1.1.0.tgz#9cdda7f2aeb54fea791f3ab8c6ab96c7a77d0158"
   integrity sha512-FKOsfKbBkPxYE8576EM6uAfHC4rnMpLyH6/TJUL4WcHUEB3EUn8AxPjnnV/IiwSSzsClvHYK+sDELKN/EJ0WYg==
 
+react-devtools-core@^3.6.0:
+  version "3.6.3"
+  resolved "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-3.6.3.tgz#977d95b684c6ad28205f0c62e1e12c5f16675814"
+  integrity sha512-+P+eFy/yo8Z/UH9J0DqHZuUM5+RI2wl249TNvMx3J2jpUomLQa4Zxl56GEotGfw3PIP1eI+hVf1s53FlUONStQ==
+  dependencies:
+    shell-quote "^1.6.1"
+    ws "^3.3.1"
+
 react-devtools-core@^4.0.6:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-4.6.0.tgz#2443b3c6fac78b801702af188abc6d83d56224e6"
@@ -14503,6 +14536,14 @@ saxes@^5.0.0:
   integrity sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==
   dependencies:
     xmlchars "^2.2.0"
+
+scheduler@0.14.0:
+  version "0.14.0"
+  resolved "https://registry.npmjs.org/scheduler/-/scheduler-0.14.0.tgz#b392c23c9c14bfa2933d4740ad5603cc0d59ea5b"
+  integrity sha512-9CgbS06Kki2f4R9FjLSITjZo5BZxPsryiRNyL3LpvrM9WxcVmhlqAOc9E+KQbeI2nqej4JIIbOsfdL51cNb4Iw==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 scheduler@0.17.0, scheduler@^0.17.0:
   version "0.17.0"
@@ -16002,6 +16043,11 @@ ultron@1.0.x:
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.0.2.tgz#ace116ab557cd197386a4e88f4685378c8b2e4fa"
   integrity sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po=
 
+ultron@~1.1.0:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
+  integrity sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==
+
 unbzip2-stream@^1.3.3:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/unbzip2-stream/-/unbzip2-stream-1.4.2.tgz#84eb9e783b186d8fb397515fbb656f312f1a7dbf"
@@ -16947,6 +16993,15 @@ ws@^1.1.0, ws@^1.1.5:
   dependencies:
     options ">=0.0.5"
     ultron "1.0.x"
+
+ws@^3.3.1:
+  version "3.3.3"
+  resolved "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz#f1cf84fe2d5e901ebce94efaece785f187a228f2"
+  integrity sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==
+  dependencies:
+    async-limiter "~1.0.0"
+    safe-buffer "~5.1.0"
+    ultron "~1.1.0"
 
 ws@^5.2.0, ws@^5.2.2:
   version "5.2.2"


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Previously the experimental framework referenced a value called componentTokens, whereas the existing framework referenced a value called components. This just points them both at the components entry which is the long term entry we want people to use.

This also removes the old partial theme type which had been renamed to PartialTheme2 but was left in the code when it was supposed to have been removed.

It also appears that the yarn.lock file has changes after the latest publish so it also includes those changes.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

This is pretty much pure automation. We didn't have any references to componentTokens and so the built stuff should be sufficient.

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
