### PR TITLE
Update lockfile and fix build error in focus zone

### DIFF
--- a/change/@fluentui-react-native-focus-zone-2020-09-29-10-31-48-clean-up-master.json
+++ b/change/@fluentui-react-native-focus-zone-2020-09-29-10-31-48-clean-up-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "remove reference from FocusZone to FocusTrapZone",
+  "packageName": "@fluentui-react-native/focus-zone",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-29T17:31:47.953Z"
+}

--- a/packages/components/FocusZone/src/FocusZone.ts
+++ b/packages/components/FocusZone/src/FocusZone.ts
@@ -5,9 +5,10 @@ import { IUseStyling, composable } from '@uifabricshared/foundation-composable';
 import { mergeSettings } from '@uifabricshared/foundation-settings';
 import { useViewCommandFocus } from '@fluentui-react-native/interactive-hooks';
 import { ensureNativeComponent } from '@fluentui-react-native/component-cache';
-import { filterOutComponentRef } from '../../FocusTrapZone';
 
 const RCTFocusZone = ensureNativeComponent('RCTFocusZone');
+
+const filterOutComponentRef = (propName) => propName !== 'componentRef';
 
 export const FocusZone = composable<FocusZoneType>({
   usePrepareProps: (userProps: FocusZoneProps, useStyling: IUseStyling<FocusZoneType>) => {
@@ -23,7 +24,14 @@ export const FocusZone = composable<FocusZoneType>({
     }, [defaultTabbableElement]);
 
     return {
-      slotProps: mergeSettings<FocusZoneSlotProps>(useStyling(userProps), { root: { ...rest, defaultTabbableElement: targetNativeTag, ref: ftzRef, navigateAtEnd: isCircularNavigation ? 'NavigateWrap' : 'NavigateStopAtEnds' } }),
+      slotProps: mergeSettings<FocusZoneSlotProps>(useStyling(userProps), {
+        root: {
+          ...rest,
+          defaultTabbableElement: targetNativeTag,
+          ref: ftzRef,
+          navigateAtEnd: isCircularNavigation ? 'NavigateWrap' : 'NavigateStopAtEnds',
+        },
+      }),
     };
   },
   slots: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2038,10 +2038,10 @@
     stacktrace-parser "^0.1.3"
     whatwg-fetch "^3.0.0"
 
-"@office-iss/rex-win32@0.62.12-tenantreactnativewin-13323":
-  version "0.62.12-tenantreactnativewin-13323"
-  resolved "https://registry.yarnpkg.com/@office-iss/rex-win32/-/rex-win32-0.62.12-tenantreactnativewin-13323.tgz#f30be8885c7d93b35e96f0e5ab4605209c1f2eb3"
-  integrity sha512-VcDaWtykmS43N1PZVUXhGVa/uwleXkS5VqLrLBJ7SZgTGgLou9cKrgQo0nHBKrS7akh8bhVWWqmW/EpokJMPIg==
+"@office-iss/rex-win32@0.62.12-tenantreactnativewin-13326":
+  version "0.62.12-tenantreactnativewin-13326"
+  resolved "https://registry.yarnpkg.com/@office-iss/rex-win32/-/rex-win32-0.62.12-tenantreactnativewin-13326.tgz#99fd09ca94a6731496386510a221609187418b73"
+  integrity sha512-HPFgEXvqRPHyn24ENcMyaq0PzM5/Q5MVbo+S0vzM3JwKvbIZJJhM0ecsmmx73tEwmdKDi8zyWVIdohEJcqxLiw==
   dependencies:
     command-line-args "^5.0.2"
     command-line-usage "^5.0.5"


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

I'm getting a build error on win32 because of the reference from FocusZone to FocusTrapZone. The function it is referencing is trivial enough that it can just be implemented.

This also bumps the lock file.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
