### PR TITLE
Fix macOS test app, update react-native-test-app dependency

### DIFF
--- a/apps/android/package.json
+++ b/apps/android/package.json
@@ -16,13 +16,13 @@
     "test": "fluentui-scripts jest",
     "bundle": "fluentui-scripts metro --cli",
     "bundle-dev": "fluentui-scripts metro --dev --cli",
-    "android": "npx react-native run-android "
+    "android": "react-native run-android "
   },
   "dependencies": {
     "@fluentui-react-native/tester": "^0.9.4",
     "react": "16.11.0",
     "react-native": "0.62.2",
-    "react-native-test-app": "0.2.1"
+    "react-native-test-app": "^0.2.1"
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",

--- a/apps/ios/package.json
+++ b/apps/ios/package.json
@@ -22,7 +22,7 @@
     "@fluentui-react-native/tester": "^0.9.4",
     "react": "16.11.0",
     "react-native": "0.62.2",
-    "react-native-test-app": "0.2.1"
+    "react-native-test-app": "^0.2.1"
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",

--- a/apps/ios/src/Podfile.lock
+++ b/apps/ios/src/Podfile.lock
@@ -246,7 +246,7 @@ PODS:
     - React-cxxreact (= 0.62.2)
     - React-jsi (= 0.62.2)
     - ReactCommon/callinvoker (= 0.62.2)
-  - ReactTestApp-DevSupport (0.2.1)
+  - ReactTestApp-DevSupport (0.2.9)
   - ReactTestApp-Resources (1.0.0-dev)
   - SwiftLint (0.40.1)
   - Yoga (1.14.0)
@@ -380,7 +380,7 @@ SPEC CHECKSUMS:
   React-RCTText: fae545b10cfdb3d247c36c56f61a94cfd6dba41d
   React-RCTVibration: 4356114dbcba4ce66991096e51a66e61eda51256
   ReactCommon: ed4e11d27609d571e7eee8b65548efc191116eb3
-  ReactTestApp-DevSupport: f69711ff52c61dc6622ba2ae512ca06143070a56
+  ReactTestApp-DevSupport: 9a0663d12f90115e646ddbf070566c646a7b9fd1
   ReactTestApp-Resources: 5950ae44720217c6778ff03fb1d906c8fb3ce483
   SwiftLint: bbfed21bf4451dcbd0f5cdbee44a18e06cf91b12
   Yoga: 3ebccbdd559724312790e7742142d062476b698e

--- a/apps/ios/src/Podfile.lock
+++ b/apps/ios/src/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
     - React-Core (= 0.62.2)
     - React-jsi (= 0.62.2)
     - ReactCommon/turbomodule/core (= 0.62.2)
-  - FluentUI-React-Native-Shimmer (0.2.1):
+  - FluentUI-React-Native-Shimmer (0.2.9):
     - MicrosoftFluentUI (~> 0.1.12)
     - React
   - Folly (2018.10.22.00):
@@ -356,7 +356,7 @@ SPEC CHECKSUMS:
   DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
   FBLazyVector: 4aab18c93cd9546e4bfed752b4084585eca8b245
   FBReactNativeSpec: 5465d51ccfeecb7faa12f9ae0024f2044ce4044e
-  FluentUI-React-Native-Shimmer: a0a9a2f085ccdf3297cba44a3fba435546aa0e4b
+  FluentUI-React-Native-Shimmer: 74b1e66f2672d4351b16ec36904f20fb1b41713c
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
   MicrosoftFluentUI: 6800fd4c017a5c5b946a24851ac2218748da45d2

--- a/apps/macos/app.json
+++ b/apps/macos/app.json
@@ -1,6 +1,6 @@
 {
-  "name": "FluentTester-macos",
-  "displayName": "FluentTester-macos",
+  "name": "FluentTester",
+  "displayName": "FluentTester",
   "components": [
     { "appKey": "FluentTester" }
   ]

--- a/apps/macos/launchPackager.command
+++ b/apps/macos/launchPackager.command
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Set terminal title
+echo -en "\\033]0;Metro\\a"
+clear
+
+THIS_DIR=$(cd -P "$(dirname "$(readlink "${BASH_SOURCE[0]}" || echo "${BASH_SOURCE[0]}")")" && pwd)
+
+# shellcheck source=/dev/null
+. "$THIS_DIR/packager.sh"
+
+if [[ -z "$CI" ]]; then
+  echo "Process terminated. Press <enter> to close the window"
+  read -r
+fi

--- a/apps/macos/package.json
+++ b/apps/macos/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@fluentui-react-native/tester": "^0.9.4",
     "react-native-macos": "^0.62.0-0",
-    "react-native-test-app": "0.2.1"
+    "react-native-test-app": "^0.2.1"
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",

--- a/apps/macos/packager.sh
+++ b/apps/macos/packager.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# scripts directory
+THIS_DIR=$(cd -P "$(dirname "$(readlink "${BASH_SOURCE[0]}" || echo "${BASH_SOURCE[0]}")")" && pwd)
+REACT_NATIVE_ROOT="$THIS_DIR/../../node_modules/react-native-macos"
+# Application root directory - General use case: react-native is a dependency
+PROJECT_ROOT="$THIS_DIR/"
+
+# check and assign NODE_BINARY env
+# shellcheck disable=SC1090
+source "$REACT_NATIVE_ROOT/scripts/node-binary.sh"
+
+# Start packager from PROJECT_ROOT
+cd "$PROJECT_ROOT" || exit
+"$NODE_BINARY" "$REACT_NATIVE_ROOT/cli.js" start "$@"

--- a/apps/macos/src/Podfile.lock
+++ b/apps/macos/src/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
   - boost-for-react-native (1.63.0)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.62.1)
-  - FBReactNativeSpec (0.62.1):
+  - FBLazyVector (0.62.13)
+  - FBReactNativeSpec (0.62.13):
     - RCT-Folly (= 2018.10.22.00)
-    - RCTRequired (= 0.62.1)
-    - RCTTypeSafety (= 0.62.1)
-    - React-Core (= 0.62.1)
-    - React-jsi (= 0.62.1)
-    - ReactCommon/turbomodule/core (= 0.62.1)
+    - RCTRequired (= 0.62.13)
+    - RCTTypeSafety (= 0.62.13)
+    - React-Core (= 0.62.13)
+    - React-jsi (= 0.62.13)
+    - ReactCommon/turbomodule/core (= 0.62.13)
   - glog (0.3.5)
   - RCT-Folly (2018.10.22.00):
     - boost-for-react-native
@@ -19,228 +19,228 @@ PODS:
     - boost-for-react-native
     - DoubleConversion
     - glog
-  - RCTRequired (0.62.1)
-  - RCTTypeSafety (0.62.1):
-    - FBLazyVector (= 0.62.1)
+  - RCTRequired (0.62.13)
+  - RCTTypeSafety (0.62.13):
+    - FBLazyVector (= 0.62.13)
     - RCT-Folly (= 2018.10.22.00)
-    - RCTRequired (= 0.62.1)
-    - React-Core (= 0.62.1)
-  - React (0.62.1):
-    - React-Core (= 0.62.1)
-    - React-Core/DevSupport (= 0.62.1)
-    - React-Core/RCTWebSocket (= 0.62.1)
-    - React-RCTActionSheet (= 0.62.1)
-    - React-RCTAnimation (= 0.62.1)
-    - React-RCTBlob (= 0.62.1)
-    - React-RCTImage (= 0.62.1)
-    - React-RCTLinking (= 0.62.1)
-    - React-RCTNetwork (= 0.62.1)
-    - React-RCTSettings (= 0.62.1)
-    - React-RCTText (= 0.62.1)
-    - React-RCTVibration (= 0.62.1)
-  - React-Core (0.62.1):
+    - RCTRequired (= 0.62.13)
+    - React-Core (= 0.62.13)
+  - React (0.62.13):
+    - React-Core (= 0.62.13)
+    - React-Core/DevSupport (= 0.62.13)
+    - React-Core/RCTWebSocket (= 0.62.13)
+    - React-RCTActionSheet (= 0.62.13)
+    - React-RCTAnimation (= 0.62.13)
+    - React-RCTBlob (= 0.62.13)
+    - React-RCTImage (= 0.62.13)
+    - React-RCTLinking (= 0.62.13)
+    - React-RCTNetwork (= 0.62.13)
+    - React-RCTSettings (= 0.62.13)
+    - React-RCTText (= 0.62.13)
+    - React-RCTVibration (= 0.62.13)
+  - React-Core (0.62.13):
     - glog
     - RCT-Folly (= 2018.10.22.00)
-    - React-Core/Default (= 0.62.1)
-    - React-cxxreact (= 0.62.1)
-    - React-jsi (= 0.62.1)
-    - React-jsiexecutor (= 0.62.1)
+    - React-Core/Default (= 0.62.13)
+    - React-cxxreact (= 0.62.13)
+    - React-jsi (= 0.62.13)
+    - React-jsiexecutor (= 0.62.13)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.62.1):
-    - glog
-    - RCT-Folly (= 2018.10.22.00)
-    - React-Core/Default
-    - React-cxxreact (= 0.62.1)
-    - React-jsi (= 0.62.1)
-    - React-jsiexecutor (= 0.62.1)
-    - Yoga
-  - React-Core/Default (0.62.1):
-    - glog
-    - RCT-Folly (= 2018.10.22.00)
-    - React-cxxreact (= 0.62.1)
-    - React-jsi (= 0.62.1)
-    - React-jsiexecutor (= 0.62.1)
-    - Yoga
-  - React-Core/DevSupport (0.62.1):
-    - glog
-    - RCT-Folly (= 2018.10.22.00)
-    - React-Core/Default (= 0.62.1)
-    - React-Core/RCTWebSocket (= 0.62.1)
-    - React-cxxreact (= 0.62.1)
-    - React-jsi (= 0.62.1)
-    - React-jsiexecutor (= 0.62.1)
-    - React-jsinspector (= 0.62.1)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.62.1):
+  - React-Core/CoreModulesHeaders (0.62.13):
     - glog
     - RCT-Folly (= 2018.10.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.62.1)
-    - React-jsi (= 0.62.1)
-    - React-jsiexecutor (= 0.62.1)
+    - React-cxxreact (= 0.62.13)
+    - React-jsi (= 0.62.13)
+    - React-jsiexecutor (= 0.62.13)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.62.1):
+  - React-Core/Default (0.62.13):
+    - glog
+    - RCT-Folly (= 2018.10.22.00)
+    - React-cxxreact (= 0.62.13)
+    - React-jsi (= 0.62.13)
+    - React-jsiexecutor (= 0.62.13)
+    - Yoga
+  - React-Core/DevSupport (0.62.13):
+    - glog
+    - RCT-Folly (= 2018.10.22.00)
+    - React-Core/Default (= 0.62.13)
+    - React-Core/RCTWebSocket (= 0.62.13)
+    - React-cxxreact (= 0.62.13)
+    - React-jsi (= 0.62.13)
+    - React-jsiexecutor (= 0.62.13)
+    - React-jsinspector (= 0.62.13)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.62.13):
     - glog
     - RCT-Folly (= 2018.10.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.62.1)
-    - React-jsi (= 0.62.1)
-    - React-jsiexecutor (= 0.62.1)
+    - React-cxxreact (= 0.62.13)
+    - React-jsi (= 0.62.13)
+    - React-jsiexecutor (= 0.62.13)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.62.1):
+  - React-Core/RCTAnimationHeaders (0.62.13):
     - glog
     - RCT-Folly (= 2018.10.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.62.1)
-    - React-jsi (= 0.62.1)
-    - React-jsiexecutor (= 0.62.1)
+    - React-cxxreact (= 0.62.13)
+    - React-jsi (= 0.62.13)
+    - React-jsiexecutor (= 0.62.13)
     - Yoga
-  - React-Core/RCTImageHeaders (0.62.1):
+  - React-Core/RCTBlobHeaders (0.62.13):
     - glog
     - RCT-Folly (= 2018.10.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.62.1)
-    - React-jsi (= 0.62.1)
-    - React-jsiexecutor (= 0.62.1)
+    - React-cxxreact (= 0.62.13)
+    - React-jsi (= 0.62.13)
+    - React-jsiexecutor (= 0.62.13)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.62.1):
+  - React-Core/RCTImageHeaders (0.62.13):
     - glog
     - RCT-Folly (= 2018.10.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.62.1)
-    - React-jsi (= 0.62.1)
-    - React-jsiexecutor (= 0.62.1)
+    - React-cxxreact (= 0.62.13)
+    - React-jsi (= 0.62.13)
+    - React-jsiexecutor (= 0.62.13)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.62.1):
+  - React-Core/RCTLinkingHeaders (0.62.13):
     - glog
     - RCT-Folly (= 2018.10.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.62.1)
-    - React-jsi (= 0.62.1)
-    - React-jsiexecutor (= 0.62.1)
+    - React-cxxreact (= 0.62.13)
+    - React-jsi (= 0.62.13)
+    - React-jsiexecutor (= 0.62.13)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.62.1):
+  - React-Core/RCTNetworkHeaders (0.62.13):
     - glog
     - RCT-Folly (= 2018.10.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.62.1)
-    - React-jsi (= 0.62.1)
-    - React-jsiexecutor (= 0.62.1)
+    - React-cxxreact (= 0.62.13)
+    - React-jsi (= 0.62.13)
+    - React-jsiexecutor (= 0.62.13)
     - Yoga
-  - React-Core/RCTTextHeaders (0.62.1):
+  - React-Core/RCTSettingsHeaders (0.62.13):
     - glog
     - RCT-Folly (= 2018.10.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.62.1)
-    - React-jsi (= 0.62.1)
-    - React-jsiexecutor (= 0.62.1)
+    - React-cxxreact (= 0.62.13)
+    - React-jsi (= 0.62.13)
+    - React-jsiexecutor (= 0.62.13)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.62.1):
+  - React-Core/RCTTextHeaders (0.62.13):
     - glog
     - RCT-Folly (= 2018.10.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.62.1)
-    - React-jsi (= 0.62.1)
-    - React-jsiexecutor (= 0.62.1)
+    - React-cxxreact (= 0.62.13)
+    - React-jsi (= 0.62.13)
+    - React-jsiexecutor (= 0.62.13)
     - Yoga
-  - React-Core/RCTWebSocket (0.62.1):
+  - React-Core/RCTVibrationHeaders (0.62.13):
     - glog
     - RCT-Folly (= 2018.10.22.00)
-    - React-Core/Default (= 0.62.1)
-    - React-cxxreact (= 0.62.1)
-    - React-jsi (= 0.62.1)
-    - React-jsiexecutor (= 0.62.1)
+    - React-Core/Default
+    - React-cxxreact (= 0.62.13)
+    - React-jsi (= 0.62.13)
+    - React-jsiexecutor (= 0.62.13)
     - Yoga
-  - React-CoreModules (0.62.1):
-    - FBReactNativeSpec (= 0.62.1)
+  - React-Core/RCTWebSocket (0.62.13):
+    - glog
     - RCT-Folly (= 2018.10.22.00)
-    - RCTTypeSafety (= 0.62.1)
-    - React-Core/CoreModulesHeaders (= 0.62.1)
-    - React-RCTImage (= 0.62.1)
-    - ReactCommon/turbomodule/core (= 0.62.1)
-  - React-cxxreact (0.62.1):
+    - React-Core/Default (= 0.62.13)
+    - React-cxxreact (= 0.62.13)
+    - React-jsi (= 0.62.13)
+    - React-jsiexecutor (= 0.62.13)
+    - Yoga
+  - React-CoreModules (0.62.13):
+    - FBReactNativeSpec (= 0.62.13)
+    - RCT-Folly (= 2018.10.22.00)
+    - RCTTypeSafety (= 0.62.13)
+    - React-Core/CoreModulesHeaders (= 0.62.13)
+    - React-RCTImage (= 0.62.13)
+    - ReactCommon/turbomodule/core (= 0.62.13)
+  - React-cxxreact (0.62.13):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2018.10.22.00)
-    - React-jsinspector (= 0.62.1)
-  - React-jsi (0.62.1):
+    - React-jsinspector (= 0.62.13)
+  - React-jsi (0.62.13):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2018.10.22.00)
-    - React-jsi/Default (= 0.62.1)
-  - React-jsi/Default (0.62.1):
+    - React-jsi/Default (= 0.62.13)
+  - React-jsi/Default (0.62.13):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2018.10.22.00)
-  - React-jsiexecutor (0.62.1):
+  - React-jsiexecutor (0.62.13):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2018.10.22.00)
-    - React-cxxreact (= 0.62.1)
-    - React-jsi (= 0.62.1)
-  - React-jsinspector (0.62.1)
-  - React-RCTActionSheet (0.62.1):
-    - React-Core/RCTActionSheetHeaders (= 0.62.1)
-  - React-RCTAnimation (0.62.1):
-    - FBReactNativeSpec (= 0.62.1)
+    - React-cxxreact (= 0.62.13)
+    - React-jsi (= 0.62.13)
+  - React-jsinspector (0.62.13)
+  - React-RCTActionSheet (0.62.13):
+    - React-Core/RCTActionSheetHeaders (= 0.62.13)
+  - React-RCTAnimation (0.62.13):
+    - FBReactNativeSpec (= 0.62.13)
     - RCT-Folly (= 2018.10.22.00)
-    - RCTTypeSafety (= 0.62.1)
-    - React-Core/RCTAnimationHeaders (= 0.62.1)
-    - ReactCommon/turbomodule/core (= 0.62.1)
-  - React-RCTBlob (0.62.1):
-    - FBReactNativeSpec (= 0.62.1)
+    - RCTTypeSafety (= 0.62.13)
+    - React-Core/RCTAnimationHeaders (= 0.62.13)
+    - ReactCommon/turbomodule/core (= 0.62.13)
+  - React-RCTBlob (0.62.13):
+    - FBReactNativeSpec (= 0.62.13)
     - RCT-Folly (= 2018.10.22.00)
-    - React-Core/RCTBlobHeaders (= 0.62.1)
-    - React-Core/RCTWebSocket (= 0.62.1)
-    - React-jsi (= 0.62.1)
-    - React-RCTNetwork (= 0.62.1)
-    - ReactCommon/turbomodule/core (= 0.62.1)
-  - React-RCTImage (0.62.1):
-    - FBReactNativeSpec (= 0.62.1)
+    - React-Core/RCTBlobHeaders (= 0.62.13)
+    - React-Core/RCTWebSocket (= 0.62.13)
+    - React-jsi (= 0.62.13)
+    - React-RCTNetwork (= 0.62.13)
+    - ReactCommon/turbomodule/core (= 0.62.13)
+  - React-RCTImage (0.62.13):
+    - FBReactNativeSpec (= 0.62.13)
     - RCT-Folly (= 2018.10.22.00)
-    - RCTTypeSafety (= 0.62.1)
-    - React-Core/RCTImageHeaders (= 0.62.1)
-    - React-RCTNetwork (= 0.62.1)
-    - ReactCommon/turbomodule/core (= 0.62.1)
-  - React-RCTLinking (0.62.1):
-    - FBReactNativeSpec (= 0.62.1)
-    - React-Core/RCTLinkingHeaders (= 0.62.1)
-    - ReactCommon/turbomodule/core (= 0.62.1)
-  - React-RCTNetwork (0.62.1):
-    - FBReactNativeSpec (= 0.62.1)
+    - RCTTypeSafety (= 0.62.13)
+    - React-Core/RCTImageHeaders (= 0.62.13)
+    - React-RCTNetwork (= 0.62.13)
+    - ReactCommon/turbomodule/core (= 0.62.13)
+  - React-RCTLinking (0.62.13):
+    - FBReactNativeSpec (= 0.62.13)
+    - React-Core/RCTLinkingHeaders (= 0.62.13)
+    - ReactCommon/turbomodule/core (= 0.62.13)
+  - React-RCTNetwork (0.62.13):
+    - FBReactNativeSpec (= 0.62.13)
     - RCT-Folly (= 2018.10.22.00)
-    - RCTTypeSafety (= 0.62.1)
-    - React-Core/RCTNetworkHeaders (= 0.62.1)
-    - ReactCommon/turbomodule/core (= 0.62.1)
-  - React-RCTSettings (0.62.1):
-    - FBReactNativeSpec (= 0.62.1)
+    - RCTTypeSafety (= 0.62.13)
+    - React-Core/RCTNetworkHeaders (= 0.62.13)
+    - ReactCommon/turbomodule/core (= 0.62.13)
+  - React-RCTSettings (0.62.13):
+    - FBReactNativeSpec (= 0.62.13)
     - RCT-Folly (= 2018.10.22.00)
-    - RCTTypeSafety (= 0.62.1)
-    - React-Core/RCTSettingsHeaders (= 0.62.1)
-    - ReactCommon/turbomodule/core (= 0.62.1)
-  - React-RCTText (0.62.1):
-    - React-Core/RCTTextHeaders (= 0.62.1)
-  - React-RCTVibration (0.62.1):
-    - FBReactNativeSpec (= 0.62.1)
+    - RCTTypeSafety (= 0.62.13)
+    - React-Core/RCTSettingsHeaders (= 0.62.13)
+    - ReactCommon/turbomodule/core (= 0.62.13)
+  - React-RCTText (0.62.13):
+    - React-Core/RCTTextHeaders (= 0.62.13)
+  - React-RCTVibration (0.62.13):
+    - FBReactNativeSpec (= 0.62.13)
     - RCT-Folly (= 2018.10.22.00)
-    - React-Core/RCTVibrationHeaders (= 0.62.1)
-    - ReactCommon/turbomodule/core (= 0.62.1)
-  - ReactCommon/callinvoker (0.62.1):
+    - React-Core/RCTVibrationHeaders (= 0.62.13)
+    - ReactCommon/turbomodule/core (= 0.62.13)
+  - ReactCommon/callinvoker (0.62.13):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2018.10.22.00)
-    - React-cxxreact (= 0.62.1)
-  - ReactCommon/turbomodule/core (0.62.1):
+    - React-cxxreact (= 0.62.13)
+  - ReactCommon/turbomodule/core (0.62.13):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2018.10.22.00)
-    - React-Core (= 0.62.1)
-    - React-cxxreact (= 0.62.1)
-    - React-jsi (= 0.62.1)
-    - ReactCommon/callinvoker (= 0.62.1)
+    - React-Core (= 0.62.13)
+    - React-cxxreact (= 0.62.13)
+    - React-jsi (= 0.62.13)
+    - ReactCommon/callinvoker (= 0.62.13)
   - ReactTestApp-DevSupport (0.2.1)
   - ReactTestApp-Resources (1.0.0-dev)
   - SwiftLint (0.39.2)
@@ -345,34 +345,34 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost-for-react-native: dabda8622e76020607c2ae1e65cc0cda8b61479d
   DoubleConversion: 681b789128e5512811c81706e9b361209f40d21e
-  FBLazyVector: 4cccc4ac9816ce336701763ca24877286d8b681a
-  FBReactNativeSpec: 150543c16ce5c258d5aaf12ae2ae994a1237d615
+  FBLazyVector: adad564ca6f9749138c12e734daefb84f327b01a
+  FBReactNativeSpec: 5ee223b0e296ca3646d90ae3f5965f223f9d6fd7
   glog: d86cb3634e15ec6d8cd9a1c7c1b9d6fa295beb37
   RCT-Folly: 71ece0166f9c96c1ec9279eeb0317baf533c020f
-  RCTRequired: e183b4ec3b3651e83c81568b918a274b8bc099db
-  RCTTypeSafety: f1b73ad47c3bda0695695188254708b20856d5b7
-  React: 3c009f39e0dca4c26386bbac7af671cab8c98f5b
-  React-Core: a78e0e78dc7798cfddfe07da4beae854de7bcb00
-  React-CoreModules: 2e8e91fe4d4af1b492c0806068ef570eac678c34
-  React-cxxreact: f4e3c0a083c1c97a665f9770367100eacc9dde24
-  React-jsi: 75dcebdd14a57bc052b46d316a56617faffb518b
-  React-jsiexecutor: 42cfdf5c3d2664c08ad6f66358fa83ffb1f734e0
-  React-jsinspector: 490839681e1c43c7c0e38dbcb2e581d76e509b72
-  React-RCTActionSheet: de9959e2ea34242108e5a51d79b0f10a67245363
-  React-RCTAnimation: d6347f13c2543e19b2abdd97bd2cb183d5668a70
-  React-RCTBlob: 78ec255b47dc176f7cba94a0c9eba5d9749a2bdc
-  React-RCTImage: e63bdfd21005fe1aea7f13677873260579c6c891
-  React-RCTLinking: 0668870012eeb661b1c48b30cd4027b901971fa2
-  React-RCTNetwork: 719f35fad1d03d8c1d945c587dd7fd7476f66b24
-  React-RCTSettings: 67aff9438c39896150cc63c07d36aa46ccd8c815
-  React-RCTText: 74947882a3d7632add1490f29f5be0aba6cc2587
-  React-RCTVibration: 2bb1044cc49aba5810d09fcb658b18f4df69aec9
-  ReactCommon: 5832dcdbcccc6bdc11f99181df74ed5f2b47789a
+  RCTRequired: a85f94b0020b13f662fe6e91bf64e1a250ceed8e
+  RCTTypeSafety: af561b56a3573f5ee4ebde599bcd00f11b54da43
+  React: 1df518ab8ad0ff08e6e9bd0e7b2feb784d5b98cc
+  React-Core: f03594c3c0def3535eaa8a69fc00cd0f0f59da91
+  React-CoreModules: 32667c2644e5379e4e5c6e9f03ac8e31beae4e94
+  React-cxxreact: 33a19428a05f2b5be87d16c2329540b82b17caac
+  React-jsi: 2201cea7013c8a52f9263f82bae3b51c55f73f37
+  React-jsiexecutor: f78e39b801210e77cd829c869249aa013d712697
+  React-jsinspector: 35e3dc1668c54859e279cfff02d77ef35052bf08
+  React-RCTActionSheet: 8c998e9decfb1bac0a51d8e4ab62d794614b4bc4
+  React-RCTAnimation: 09b466088a201d9ff918b57f357ac787bcc2690e
+  React-RCTBlob: 6c3a159339d4b51194324ec9707ab7156d84aaaa
+  React-RCTImage: 467212a137db1c2e70cef4a27702af079e5c1446
+  React-RCTLinking: 5a09264a8d705f82d5e15f7e26175ace873c8ad7
+  React-RCTNetwork: b9fef0eee6cff1364e30fc3ae8e702e1d2f9e2a6
+  React-RCTSettings: c946e5a4a18ae20b2f2f9be071957fef909fc40e
+  React-RCTText: 87bd51dbdb9f701760924b535be9e41e1f80aad9
+  React-RCTVibration: 5c1a6bf9e28ef049bf4f5abc82bb2d9707def273
+  ReactCommon: 658d0557123c61326f5b8769cb88cc6886a30497
   ReactTestApp-DevSupport: f69711ff52c61dc6622ba2ae512ca06143070a56
   ReactTestApp-Resources: 5950ae44720217c6778ff03fb1d906c8fb3ce483
   SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
-  Yoga: af4be6a73a3dfa9f8108031e617610931101b809
+  Yoga: e64d2b3528e7b1449411a4e7db07f651f1b1c241
 
 PODFILE CHECKSUM: b8260e89765fe64a76f2ab9a33e724b2dbe0124d
 
-COCOAPODS: 1.9.1
+COCOAPODS: 1.9.3

--- a/apps/macos/src/Podfile.lock
+++ b/apps/macos/src/Podfile.lock
@@ -241,7 +241,7 @@ PODS:
     - React-cxxreact (= 0.62.13)
     - React-jsi (= 0.62.13)
     - ReactCommon/callinvoker (= 0.62.13)
-  - ReactTestApp-DevSupport (0.2.1)
+  - ReactTestApp-DevSupport (0.2.9)
   - ReactTestApp-Resources (1.0.0-dev)
   - SwiftLint (0.39.2)
   - Yoga (1.14.0)
@@ -368,7 +368,7 @@ SPEC CHECKSUMS:
   React-RCTText: 87bd51dbdb9f701760924b535be9e41e1f80aad9
   React-RCTVibration: 5c1a6bf9e28ef049bf4f5abc82bb2d9707def273
   ReactCommon: 658d0557123c61326f5b8769cb88cc6886a30497
-  ReactTestApp-DevSupport: f69711ff52c61dc6622ba2ae512ca06143070a56
+  ReactTestApp-DevSupport: 9a0663d12f90115e646ddbf070566c646a7b9fd1
   ReactTestApp-Resources: 5950ae44720217c6778ff03fb1d906c8fb3ce483
   SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
   Yoga: e64d2b3528e7b1449411a4e7db07f651f1b1c241

--- a/apps/macos/src/index.tsx
+++ b/apps/macos/src/index.tsx
@@ -1,17 +1,8 @@
 'use strict';
 
 import {FluentTesterApp} from '@fluentui-react-native/tester';
-import * as React from 'react';
-import {AppRegistry, SafeAreaView} from 'react-native-macos';
+import {AppRegistry} from 'react-native-macos';
 
-const FluentTester: React.FunctionComponent = () => {
-  return (
-    <SafeAreaView>
-      <FluentTesterApp />
-    </SafeAreaView>
-  );
-};
+AppRegistry.registerComponent('FluentTester', () => FluentTesterApp);
 
-AppRegistry.registerComponent('FluentTester', () => FluentTester);
-
-export default FluentTester;
+export default FluentTesterApp;

--- a/apps/macos/src/index.tsx
+++ b/apps/macos/src/index.tsx
@@ -1,8 +1,17 @@
 'use strict';
 
 import {FluentTesterApp} from '@fluentui-react-native/tester';
-import {AppRegistry} from 'react-native-macos';
+import * as React from 'react';
+import {AppRegistry, SafeAreaView} from 'react-native-macos';
 
-AppRegistry.registerComponent('FluentTester', () => FluentTesterApp);
+const FluentTester: React.FunctionComponent = () => {
+  return (
+    <SafeAreaView>
+      <FluentTesterApp />
+    </SafeAreaView>
+  );
+};
+
+AppRegistry.registerComponent('FluentTester', () => FluentTester);
 
 export default FluentTester;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5602,6 +5602,15 @@ cliui@^6.0.0:
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
 
+cliui@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.1.tgz#a4cb67aad45cd83d8d05128fc9f4d8fbb887e6b3"
+  integrity sha512-rcvHOWyGyid6I1WjT/3NatKj2kDt9OdSHSXpyLXaMWFbKpGACNW8pRhhdPUq9MWUOdwn8Rz9AVETjF4105rZZQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
+
 clone-deep@^0.2.4:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-0.2.4.tgz#4e73dd09e9fb971cc38670c5dced9c1896481cc6"
@@ -7207,6 +7216,11 @@ es6-weak-map@^2.0.1:
     es6-iterator "^2.0.3"
     es6-symbol "^3.1.1"
 
+escalade@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.0.tgz#e8e2d7c7a8b76f6ee64c2181d6b8151441602d4e"
+  integrity sha512-mAk+hPSO8fLDkhV7V0dXazH5pDc6MrjBTPyD3VeKzxnVFjH1MIxbCdqGZB9O8+EwWakZs3ZCbDS4IpRt79V1ig==
+
 escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
@@ -8563,7 +8577,7 @@ get-caller-file@^1.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
   integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
 
-get-caller-file@^2.0.1:
+get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -13761,17 +13775,17 @@ react-native-svg@^11.0.0:
     css-select "^2.1.0"
     css-tree "^1.0.0-alpha.39"
 
-react-native-test-app@0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/react-native-test-app/-/react-native-test-app-0.2.1.tgz#57600ba8b6ea4fbd5099af5da7eb518a9e94b5fc"
-  integrity sha512-y4Bguo1Io43OHzt3MrMRTnl5K+C/4xE5BdRs6eMfRT+esZ0V9VkTWEJ9uh8cdhbBu2wPHn2wpRKv2earSRQEWw==
+react-native-test-app@^0.2.1:
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/react-native-test-app/-/react-native-test-app-0.2.9.tgz#41b669e5906f5998631b725fc0abd78951ac0d31"
+  integrity sha512-ruH9+Z7gEPEEZ7F1GCN9EsHK8ddD14RSDwAESJJ9bQfbh1HhInR9W8WAA+Rs2bhIpPAjZ+fTfWw/AsOvKf9h0g==
   dependencies:
     "@react-native-community/cli" "^4.5.1"
     "@react-native-community/cli-platform-android" "^4.5.1"
     "@react-native-community/cli-platform-ios" "^4.5.0"
     chalk "^4.1.0"
     plop "^2.6.0"
-    yargs "^15.4.1"
+    yargs "^16.0.0"
 
 react-native-web@0.12.3, react-native-web@^0.12.3:
   version "0.12.3"
@@ -16947,6 +16961,15 @@ wrap-ansi@^6.2.0:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -17139,6 +17162,11 @@ xtend@^4.0.0, xtend@~4.0.1:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
 
+y18n@^5.0.1:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.2.tgz#48218df5da2731b4403115c39a1af709c873f829"
+  integrity sha512-CkwaeZw6dQgqgPGeTWKMXCRmMcBgETFlTml1+ZOO+q7kGst8NREJ+eWwFNPVUQ4QGdAaklbqCZHH6Zuep1RjiA==
+
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
@@ -17194,6 +17222,11 @@ yargs-parser@^18.1.2, yargs-parser@^18.1.3:
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
+
+yargs-parser@^20.0.0:
+  version "20.2.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.1.tgz#28f3773c546cdd8a69ddae68116b48a5da328e77"
+  integrity sha512-yYsjuSkjbLMBp16eaOt7/siKTjNVjMm3SoJnIg3sEh/JsvqVVDyjRKmaJV4cl+lNIgq6QEco2i3gDebJl7/vLA==
 
 yargs@12.0.2:
   version "12.0.2"
@@ -17281,7 +17314,7 @@ yargs@^14.2.0:
     y18n "^4.0.0"
     yargs-parser "^15.0.1"
 
-yargs@^15.0.1, yargs@^15.0.2, yargs@^15.1.0, yargs@^15.3.0, yargs@^15.4.0, yargs@^15.4.1:
+yargs@^15.0.1, yargs@^15.0.2, yargs@^15.1.0, yargs@^15.3.0, yargs@^15.4.0:
   version "15.4.1"
   resolved "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
   integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==
@@ -17297,6 +17330,19 @@ yargs@^15.0.1, yargs@^15.0.2, yargs@^15.1.0, yargs@^15.3.0, yargs@^15.4.0, yargs
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+yargs@^16.0.0:
+  version "16.0.3"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.0.3.tgz#7a919b9e43c90f80d4a142a89795e85399a7e54c"
+  integrity sha512-6+nLw8xa9uK1BOEOykaiYAJVh6/CjxWXK/q9b5FpRgNslt8s22F2xMBqVIKgCRjNgGvGPBy8Vog7WN7yh4amtA==
+  dependencies:
+    cliui "^7.0.0"
+    escalade "^3.0.2"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.1"
+    yargs-parser "^20.0.0"
 
 yarn-install@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
The macOS test app would not automatically launch the packager when run. Furthermore, when I did run it, I got the logbox error:
`Unhandled JS Exception: ReferenceError: Can't find variable: FluentTester`

Comparing the macOS test app source files with the iOS test app source files helped figure out the problems.

### Platforms Impacted
- [x] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [x] android

### Description of changes

 - For some reason, the `launchPackager.command` and `packager.sh`files got deleted from the macOS test app directory. Add them back. They are copies of the iOS one with one string change: `react-native -> react-native-macos`
- Change the name key inside `apps/macos/app.json` from `"FluentTester-macos` to `"FluentTester`. This matches how we do it on the other platforms that use `react-native-test-app`.
- Update `apps/macos/src/index.tsx` to export `FluentTesterApp`, not `FluentTester`
- Update the `react-native-test-app` dependency in our projects to use the latest patch version. Development has been consistent in this repo and it would be easier if we just got the latest non-breaking changes more easily.

### Verification

Ran the macOS, iOS, and Android test apps to make sure they ran properly.


![Screen Shot 2020-10-05 at 12 20 42 PM](https://user-images.githubusercontent.com/6722175/95131134-6c237180-0712-11eb-9a18-6220b961a2ab.png)
![Screen Shot 2020-10-05 at 12 38 49 PM](https://user-images.githubusercontent.com/6722175/95131157-75144300-0712-11eb-9b7e-7b2f41871d31.png)
![Screen Shot 2020-10-05 at 1 38 25 PM](https://user-images.githubusercontent.com/6722175/95131172-780f3380-0712-11eb-9f2c-7f6cd1fcb961.png)


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
