### PR TITLE
Fixing redbox on macOS from theming module

### DIFF
--- a/change/@fluentui-react-native-win32-theme-2020-10-06-15-01-34-nakambo-mac-redbox-theming-fix.json
+++ b/change/@fluentui-react-native-win32-theme-2020-10-06-15-01-34-nakambo-mac-redbox-theming-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fixing redbox on macOS from theming module",
+  "packageName": "@fluentui-react-native/win32-theme",
+  "email": "nakambo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-06T22:01:33.996Z"
+}

--- a/packages/theming/win32-theme/src/createPartialOfficeTheme.ts
+++ b/packages/theming/win32-theme/src/createPartialOfficeTheme.ts
@@ -33,6 +33,6 @@ export function createPartialOfficeTheme(module: OfficeThemingModule, themeName?
       // Office Branding Colors
       colors: getRamps(module),
     },
-    ...(themeName && { name: themeName }),
+    ...(!!themeName ? { name: themeName } : undefined),
   };
 }

--- a/packages/theming/win32-theme/src/createPartialOfficeTheme.ts
+++ b/packages/theming/win32-theme/src/createPartialOfficeTheme.ts
@@ -33,6 +33,6 @@ export function createPartialOfficeTheme(module: OfficeThemingModule, themeName?
       // Office Branding Colors
       colors: getRamps(module),
     },
-    ...(!!themeName ? { name: themeName } : undefined),
+    ...(themeName ? { name: themeName } : undefined),
   };
 }


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

macOS doesn't currently provide a theme (the theming support on macOS is limited).

I think with commit 59d0857d4244fb6b35fb2c9ca7d01cf2a073f461 we can now end up using the spread operator on a string to construct an object, which seems unintentional, since the following code

`Object.assign(translateOfficeTheme(themingModule, paletteCache, themeId), { name: _hostTheme })`

changed to

`{ /*other stuff*/, ...(_hostTheme && { name: _hostTheme }) }`

which is problematic because the empty string '' is falsy -- so instead of skipping the name field, we just end up trying to spread the empty string and trying to construct an object out of it, which the Object.es6.js polyfill is very unhappy about. This isn't a problem on Win32 because the theme is not falsy (i.e. not empty) on Win32.

### Verification

I've checked that we no longer redbox on macOS. Changes do not affect Win32 because the theme is never falsy on Win32 (which is why we never see it on Win32)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
