### PR TITLE
onDismiss not called when contextual menu is dismissed with item click

### DIFF
--- a/change/@fluentui-react-native-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui/react-native",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:41.311Z"
+}

--- a/change/@fluentui-react-native-adapters-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-adapters-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/adapters",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:46.208Z"
+}

--- a/change/@fluentui-react-native-button-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-button-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/button",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:15:52.506Z"
+}

--- a/change/@fluentui-react-native-callout-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-callout-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/callout",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:15:53.781Z"
+}

--- a/change/@fluentui-react-native-checkbox-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-checkbox-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/checkbox",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:15:56.301Z"
+}

--- a/change/@fluentui-react-native-component-cache-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-component-cache-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/component-cache",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:26.356Z"
+}

--- a/change/@fluentui-react-native-composition-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-composition-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/composition",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:20.818Z"
+}

--- a/change/@fluentui-react-native-contextual-menu-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-contextual-menu-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/contextual-menu",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-21T06:16:00.381Z"
+}

--- a/change/@fluentui-react-native-default-theme-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-default-theme-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/default-theme",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:42.459Z"
+}

--- a/change/@fluentui-react-native-experimental-avatar-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-experimental-avatar-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/experimental-avatar",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:16.962Z"
+}

--- a/change/@fluentui-react-native-experimental-button-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-experimental-button-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/experimental-button",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:18.699Z"
+}

--- a/change/@fluentui-react-native-experimental-text-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-experimental-text-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/experimental-text",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:19.743Z"
+}

--- a/change/@fluentui-react-native-focus-trap-zone-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-focus-trap-zone-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/focus-trap-zone",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:02.901Z"
+}

--- a/change/@fluentui-react-native-focus-zone-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-focus-zone-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/focus-zone",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:04.081Z"
+}

--- a/change/@fluentui-react-native-framework-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-framework-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/framework",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:21.845Z"
+}

--- a/change/@fluentui-react-native-immutable-merge-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-immutable-merge-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/immutable-merge",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:32.151Z"
+}

--- a/change/@fluentui-react-native-interactive-hooks-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-interactive-hooks-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/interactive-hooks",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:47.266Z"
+}

--- a/change/@fluentui-react-native-link-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-link-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/link",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:05.161Z"
+}

--- a/change/@fluentui-react-native-memo-cache-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-memo-cache-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/memo-cache",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:33.525Z"
+}

--- a/change/@fluentui-react-native-merge-props-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-merge-props-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/merge-props",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:34.461Z"
+}

--- a/change/@fluentui-react-native-persona-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-persona-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/persona",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:06.221Z"
+}

--- a/change/@fluentui-react-native-persona-coin-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-persona-coin-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/persona-coin",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:07.242Z"
+}

--- a/change/@fluentui-react-native-pressable-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-pressable-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/pressable",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:09.845Z"
+}

--- a/change/@fluentui-react-native-radio-group-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-radio-group-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/radio-group",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:11.014Z"
+}

--- a/change/@fluentui-react-native-separator-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-separator-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/separator",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:12.046Z"
+}

--- a/change/@fluentui-react-native-shimmer-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-shimmer-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/shimmer",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:13.532Z"
+}

--- a/change/@fluentui-react-native-stack-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-stack-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/stack",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:14.669Z"
+}

--- a/change/@fluentui-react-native-tester-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-tester-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:15:46.373Z"
+}

--- a/change/@fluentui-react-native-tester-win32-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-tester-win32-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/tester-win32",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:15:50.425Z"
+}

--- a/change/@fluentui-react-native-text-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-text-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/text",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:15.921Z"
+}

--- a/change/@fluentui-react-native-theme-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-theme-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/theme",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:22.845Z"
+}

--- a/change/@fluentui-react-native-theme-types-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-theme-types-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/theme-types",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:43.695Z"
+}

--- a/change/@fluentui-react-native-themed-stylesheet-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-themed-stylesheet-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/themed-stylesheet",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:37.878Z"
+}

--- a/change/@fluentui-react-native-tokens-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-tokens-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/tokens",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:48.372Z"
+}

--- a/change/@fluentui-react-native-use-slots-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-use-slots-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/use-slots",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:23.974Z"
+}

--- a/change/@fluentui-react-native-use-styling-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-use-styling-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/use-styling",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:25.135Z"
+}

--- a/change/@fluentui-react-native-win32-theme-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@fluentui-react-native-win32-theme-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@fluentui-react-native/win32-theme",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:45.110Z"
+}

--- a/change/@uifabricshared-foundation-composable-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@uifabricshared-foundation-composable-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@uifabricshared/foundation-composable",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:27.490Z"
+}

--- a/change/@uifabricshared-foundation-compose-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@uifabricshared-foundation-compose-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@uifabricshared/foundation-compose",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:28.890Z"
+}

--- a/change/@uifabricshared-foundation-settings-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@uifabricshared-foundation-settings-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@uifabricshared/foundation-settings",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:29.995Z"
+}

--- a/change/@uifabricshared-foundation-tokens-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@uifabricshared-foundation-tokens-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@uifabricshared/foundation-tokens",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:31.159Z"
+}

--- a/change/@uifabricshared-theme-registry-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@uifabricshared-theme-registry-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@uifabricshared/theme-registry",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:35.803Z"
+}

--- a/change/@uifabricshared-themed-settings-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@uifabricshared-themed-settings-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@uifabricshared/themed-settings",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:36.952Z"
+}

--- a/change/@uifabricshared-theming-ramp-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@uifabricshared-theming-ramp-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@uifabricshared/theming-ramp",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:38.932Z"
+}

--- a/change/@uifabricshared-theming-react-native-2020-10-20-23-16-48-fix-ondismiss.json
+++ b/change/@uifabricshared-theming-react-native-2020-10-20-23-16-48-fix-ondismiss.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "onDismiss not called when contextual menu is dismissed with item click",
+  "packageName": "@uifabricshared/theming-react-native",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-21T06:16:40.088Z"
+}

--- a/packages/components/ContextualMenu/src/ContextualMenu.tsx
+++ b/packages/components/ContextualMenu/src/ContextualMenu.tsx
@@ -43,8 +43,9 @@ export const ContextualMenu = compose<ContextualMenuType>({
 
     const dismissCallback = React.useCallback(
       () => {
+        userProps.onDismiss();
         setShowMenu(false);
-      }, [setShowMenu]);
+      }, [setShowMenu, userProps.onDismiss]);
 
     const [containerFocus, setContainerFocus] = React.useState(true);
     const toggleContainerFocus = React.useCallback(() => {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [X] windows
- [ ] android

### Description of changes
pass onDismiss prop to ContextualMenu's dismissCallback for ContextualMenuItem to access

### Verification
Manually tested by adding console.log to ContextualMenu's onDismiss and onShow props

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
