### PR TITLE
Add "Segoe UI Semibold" font to defaults for semibold variants

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/Text/CustomizeUsage.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Text/CustomizeUsage.tsx
@@ -17,7 +17,6 @@ export const CustomizeUsage: React.FunctionComponent<{}> = () => {
   const BrushScriptMT = Text.customize({ tokens: { variant: 'heroStandard', fontFamily: 'Brush Script MT' } });
   const CourierNew = Text.customize({ tokens: { variant: 'headerStandard', fontFamily: 'Courier New' } });
   const Georgia = Text.customize({ tokens: { variant: 'subheaderStandard', fontFamily: 'Georgia' } });
-  const SegoeScript = Text.customize({ tokens: { variant: 'bodyStandard', fontFamily: 'Segoe Script' } });
   const TimesNewRoman = Text.customize({ tokens: { variant: 'secondaryStandard', fontFamily: 'Times New Roman' } });
   const Wingdings = Text.customize({ tokens: { variant: 'captionStandard', fontFamily: 'Wingdings' } });
 
@@ -38,7 +37,6 @@ export const CustomizeUsage: React.FunctionComponent<{}> = () => {
         <BrushScriptMT>Brush Script MT</BrushScriptMT>
         <CourierNew>Courier New</CourierNew>
         <Georgia>Georgia</Georgia>
-        <SegoeScript>Segoe Script</SegoeScript>
         <TimesNewRoman>TimesNewRoman</TimesNewRoman>
         <Wingdings>Wingdings</Wingdings>
       </Stack>

--- a/change/@fluentui-react-native-default-theme-2020-10-22-15-21-00-updateDefaults.json
+++ b/change/@fluentui-react-native-default-theme-2020-10-22-15-21-00-updateDefaults.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update default theme with semibold font",
+  "packageName": "@fluentui-react-native/default-theme",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-22T22:21:00.494Z"
+}

--- a/change/@fluentui-react-native-tester-2020-10-26-16-51-16-updateDefaults.json
+++ b/change/@fluentui-react-native-tester-2020-10-26-16-51-16-updateDefaults.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Remove Segoe Script from customized text examples",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "email not defined",
+  "dependentChangeType": "patch",
+  "date": "2020-10-26T23:51:16.940Z"
+}

--- a/packages/theming/default-theme/src/defaultTheme.ts
+++ b/packages/theming/default-theme/src/defaultTheme.ts
@@ -19,7 +19,7 @@ function _defaultTypography(): Typography {
     },
     families: {
       primary: 'Segoe UI',
-      secondary: 'System',
+      secondary: 'Segoe UI Semibold',
       cursive: 'System',
       monospace: 'System',
       sansSerif: 'System',
@@ -28,17 +28,17 @@ function _defaultTypography(): Typography {
     variants: {
       captionStandard: { face: 'primary', size: 'caption', weight: 'regular' },
       secondaryStandard: { face: 'primary', size: 'secondary', weight: 'regular' },
-      secondarySemibold: { face: 'Segoe UI Semibold', size: 'secondary', weight: 'semiBold' },
+      secondarySemibold: { face: 'secondary', size: 'secondary', weight: 'semiBold' },
       bodyStandard: { face: 'primary', size: 'body', weight: 'regular' },
-      bodySemibold: { face: 'Segoe UI Semibold', size: 'body', weight: 'semiBold' },
+      bodySemibold: { face: 'secondary', size: 'body', weight: 'semiBold' },
       subheaderStandard: { face: 'primary', size: 'subheader', weight: 'regular' },
-      subheaderSemibold: { face: 'Segoe UI Semibold', size: 'subheader', weight: 'semiBold' },
+      subheaderSemibold: { face: 'secondary', size: 'subheader', weight: 'semiBold' },
       headerStandard: { face: 'primary', size: 'header', weight: 'regular' },
-      headerSemibold: { face: 'Segoe UI Semibold', size: 'header', weight: 'semiBold' },
+      headerSemibold: { face: 'secondary', size: 'header', weight: 'semiBold' },
       heroStandard: { face: 'primary', size: 'hero', weight: 'regular' },
-      heroSemibold: { face: 'Segoe UI Semibold', size: 'hero', weight: 'semiBold' },
+      heroSemibold: { face: 'secondary', size: 'hero', weight: 'semiBold' },
       heroLargeStandard: { face: 'primary', size: 'heroLarge', weight: 'regular' },
-      heroLargeSemibold: { face: 'Segoe UI Semibold', size: 'heroLarge', weight: 'semiBold' },
+      heroLargeSemibold: { face: 'secondary', size: 'heroLarge', weight: 'semiBold' },
     } as Variants,
   };
 

--- a/packages/theming/default-theme/src/defaultTheme.ts
+++ b/packages/theming/default-theme/src/defaultTheme.ts
@@ -28,17 +28,17 @@ function _defaultTypography(): Typography {
     variants: {
       captionStandard: { face: 'primary', size: 'caption', weight: 'regular' },
       secondaryStandard: { face: 'primary', size: 'secondary', weight: 'regular' },
-      secondarySemibold: { face: 'primary', size: 'secondary', weight: 'semiBold' },
+      secondarySemibold: { face: 'Segoe UI Semibold', size: 'secondary', weight: 'semiBold' },
       bodyStandard: { face: 'primary', size: 'body', weight: 'regular' },
-      bodySemibold: { face: 'primary', size: 'body', weight: 'semiBold' },
+      bodySemibold: { face: 'Segoe UI Semibold', size: 'body', weight: 'semiBold' },
       subheaderStandard: { face: 'primary', size: 'subheader', weight: 'regular' },
-      subheaderSemibold: { face: 'primary', size: 'subheader', weight: 'semiBold' },
+      subheaderSemibold: { face: 'Segoe UI Semibold', size: 'subheader', weight: 'semiBold' },
       headerStandard: { face: 'primary', size: 'header', weight: 'regular' },
-      headerSemibold: { face: 'primary', size: 'header', weight: 'semiBold' },
+      headerSemibold: { face: 'Segoe UI Semibold', size: 'header', weight: 'semiBold' },
       heroStandard: { face: 'primary', size: 'hero', weight: 'regular' },
-      heroSemibold: { face: 'primary', size: 'hero', weight: 'semiBold' },
+      heroSemibold: { face: 'Segoe UI Semibold', size: 'hero', weight: 'semiBold' },
       heroLargeStandard: { face: 'primary', size: 'heroLarge', weight: 'regular' },
-      heroLargeSemibold: { face: 'primary', size: 'heroLarge', weight: 'semiBold' },
+      heroLargeSemibold: { face: 'Segoe UI Semibold', size: 'heroLarge', weight: 'semiBold' },
     } as Variants,
   };
 

--- a/packages/theming/default-theme/src/defaultTheme.ts
+++ b/packages/theming/default-theme/src/defaultTheme.ts
@@ -19,7 +19,7 @@ function _defaultTypography(): Typography {
     },
     families: {
       primary: 'Segoe UI',
-      secondary: 'Segoe UI Semibold',
+      secondary: 'System',
       cursive: 'System',
       monospace: 'System',
       sansSerif: 'System',
@@ -28,17 +28,17 @@ function _defaultTypography(): Typography {
     variants: {
       captionStandard: { face: 'primary', size: 'caption', weight: 'regular' },
       secondaryStandard: { face: 'primary', size: 'secondary', weight: 'regular' },
-      secondarySemibold: { face: 'secondary', size: 'secondary', weight: 'semiBold' },
+      secondarySemibold: { face: 'primary', size: 'secondary', weight: 'semiBold' },
       bodyStandard: { face: 'primary', size: 'body', weight: 'regular' },
-      bodySemibold: { face: 'secondary', size: 'body', weight: 'semiBold' },
+      bodySemibold: { face: 'primary', size: 'body', weight: 'semiBold' },
       subheaderStandard: { face: 'primary', size: 'subheader', weight: 'regular' },
-      subheaderSemibold: { face: 'secondary', size: 'subheader', weight: 'semiBold' },
+      subheaderSemibold: { face: 'primary', size: 'subheader', weight: 'semiBold' },
       headerStandard: { face: 'primary', size: 'header', weight: 'regular' },
-      headerSemibold: { face: 'secondary', size: 'header', weight: 'semiBold' },
+      headerSemibold: { face: 'primary', size: 'header', weight: 'semiBold' },
       heroStandard: { face: 'primary', size: 'hero', weight: 'regular' },
-      heroSemibold: { face: 'secondary', size: 'hero', weight: 'semiBold' },
+      heroSemibold: { face: 'primary', size: 'hero', weight: 'semiBold' },
       heroLargeStandard: { face: 'primary', size: 'heroLarge', weight: 'regular' },
-      heroLargeSemibold: { face: 'secondary', size: 'heroLarge', weight: 'semiBold' },
+      heroLargeSemibold: { face: 'primary', size: 'heroLarge', weight: 'semiBold' },
     } as Variants,
   };
 
@@ -52,6 +52,36 @@ function _defaultTypography(): Typography {
       serif: 'System',
     };
     defaultsDict.families = familiesDictApple;
+  }
+
+  // In certain cases on win32, semibold font renders incorrectly so 'Segoe UI Semibold' is used
+  if (Platform.OS === ('win32' as any)) {
+    const familiesDictWin32 = {
+      primary: 'Segoe UI',
+      secondary: 'Segoe UI Semibold',
+      cursive: 'System',
+      monospace: 'System',
+      sansSerif: 'System',
+      serif: 'System',
+    };
+    defaultsDict.families = familiesDictWin32;
+
+    const variantsDictWin32 = {
+      captionStandard: { face: 'primary', size: 'caption', weight: 'regular' },
+      secondaryStandard: { face: 'primary', size: 'secondary', weight: 'regular' },
+      secondarySemibold: { face: 'secondary', size: 'secondary', weight: 'semiBold' },
+      bodyStandard: { face: 'primary', size: 'body', weight: 'regular' },
+      bodySemibold: { face: 'secondary', size: 'body', weight: 'semiBold' },
+      subheaderStandard: { face: 'primary', size: 'subheader', weight: 'regular' },
+      subheaderSemibold: { face: 'secondary', size: 'subheader', weight: 'semiBold' },
+      headerStandard: { face: 'primary', size: 'header', weight: 'regular' },
+      headerSemibold: { face: 'secondary', size: 'header', weight: 'semiBold' },
+      heroStandard: { face: 'primary', size: 'hero', weight: 'regular' },
+      heroSemibold: { face: 'secondary', size: 'hero', weight: 'semiBold' },
+      heroLargeStandard: { face: 'primary', size: 'heroLarge', weight: 'regular' },
+      heroLargeSemibold: { face: 'secondary', size: 'heroLarge', weight: 'semiBold' },
+    } as Variants;
+    defaultsDict.variants = variantsDictWin32;
   }
 
   return defaultsDict;


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Adds "Segoe UI Semibold" font to defaults for semibold variants. 

Previously, using "Segoe UI" for semibold variants rendered as bold when rich labels were being used. I have a native change that fixes this so this just updates the default fallback values.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| 
![image](https://user-images.githubusercontent.com/22876140/96938805-28559980-1480-11eb-90e6-280062392782.png)
 | 
![image](https://user-images.githubusercontent.com/22876140/96938863-491def00-1480-11eb-8740-ce6110d303fb.png)
 |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
