### PR TITLE
Fix Typescript build error from composeFactory.ts

### DIFF
--- a/change/@fluentui-react-native-composition-2020-10-31-05-12-15-fixComposeFactory.json
+++ b/change/@fluentui-react-native-composition-2020-10-31-05-12-15-fixComposeFactory.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update type of the tokens parameter to make TSC happy.",
+  "packageName": "@fluentui-react-native/composition",
+  "email": "kinhln@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-31T12:12:15.583Z"
+}

--- a/packages/experimental/composition/src/composeFactory.ts
+++ b/packages/experimental/composition/src/composeFactory.ts
@@ -1,4 +1,4 @@
-import { UseStylingOptions, ThemeHelper, HasLayer, buildUseStyling } from '@fluentui-react-native/use-styling';
+import { UseStylingOptions, TokenSettings, ThemeHelper, HasLayer, buildUseStyling } from '@fluentui-react-native/use-styling';
 import { UseSlotOptions, ComposableFunction, buildUseSlots, Slots, stagedComponent } from '@fluentui-react-native/use-slots';
 import { immutableMergeCore, MergeOptions } from '@fluentui-react-native/immutable-merge';
 
@@ -26,7 +26,7 @@ export type ComposeFactoryOptions<TProps, TSlotProps, TTokens, TTheme, TStatics 
 export type ComposeFactoryComponent<TProps, TSlotProps, TTokens, TTheme, TStatics extends object = object> = ComposableFunction<TProps> & {
   __options: ComposeFactoryOptions<TProps, TSlotProps, TTokens, TTheme, TStatics>;
   customize: (
-    ...tokens: UseStylingOptions<TProps, TSlotProps, TTokens, TTheme>['tokens']
+    ...tokens: TokenSettings<TTokens, TTheme>[]
   ) => ComposeFactoryComponent<TProps, TSlotProps, TTokens, TTheme, TStatics>;
   compose: (options: Partial<ComposeFactoryOptions<TProps, TSlotProps, TTokens, TTheme, TStatics>>) => ComposeFactoryComponent<TProps, TSlotProps, TTokens, TTheme, TStatics>;
 } & TStatics;


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

When I add `fluentui-react-native` package as a dependency in my repo, due to some unknown settings in it, I'm getting this build error from TS compiler: 

```[4:33:01 AM] x ../../node_modules/@fluentui-react-native/composition/lib/composeFactory.d.ts(21,17): error TS2370: A rest parameter must be of an array type.```

TSC couldn't infer that the actual type for the `tokens` parameter is indeed an array. 

So I'm updating the type here to use the direct type, rather than through `UseStylingOptions['tokens']`. It makes TSC happy, and the type is the same.

### Verification

Everything still builds successfully.

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
