### PR TITLE
Fix import statement in Icon component

### DIFF
--- a/change/@fluentui-react-native-icon-2020-11-04-10-17-15-kinhln-fixIcon.json
+++ b/change/@fluentui-react-native-icon-2020-11-04-10-17-15-kinhln-fixIcon.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix import statement",
+  "packageName": "@fluentui-react-native/icon",
+  "email": "kinhln@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-04T18:17:15.430Z"
+}

--- a/packages/experimental/Icon/src/Icon.tsx
+++ b/packages/experimental/Icon/src/Icon.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { IconProps, SvgIconProps, FontIconProps } from './Icon.types';
-import * as ReactNative from 'react-native';
+import { Image, ImageStyle } from 'react-native';
 import { Text } from '@fluentui-react-native/text';
 import { SvgUri } from 'react-native-svg';
 import { mergeStyles } from '@fluentui-react-native/framework';
@@ -8,13 +8,13 @@ import * as assetRegistry from 'react-native/Libraries/Image/AssetRegistry';
 import { stagedComponent, mergeProps, getMemoCache } from '@fluentui-react-native/framework';
 import { useTheme } from '@fluentui-react-native/theme-types';
 
-const rasterImageStyleCache = getMemoCache<ReactNative.ImageStyle>();
+const rasterImageStyleCache = getMemoCache<ImageStyle>();
 
 function renderRasterImage(iconProps: IconProps) {
   const { width, height } = iconProps;
   const style = mergeStyles(iconProps.style, rasterImageStyleCache({ width: width, height: height }, [width, height])[0]);
 
-  return <ReactNative.Image source={iconProps.rasterImageSource.src} style={style} />;
+  return <Image source={iconProps.rasterImageSource.src} style={style} />;
 }
 
 function fontFamilyFromFontSrcFile(fontSrcFile: string, fontFamily: string): string {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

The current import statement in Icon.tsx to import types of React Native, `import * as RN from 'react-native'` is causing runtime error in a consumer project. 

This import statement shouldn't be used. We should import types explicitly.


### Verification

Tested in a consumer project. 

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
