### PR TITLE
Pass the avatar prop "size" properly to "avatarSize" swift property

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -63,6 +63,7 @@
     "editor.formatOnSave": false
   },
   "cSpell.words": [
+    "Larrson",
     "TESTPAGE",
     "beachball",
     "consts",

--- a/apps/fluent-tester/src/FluentTester/TestComponents/Avatar/AvatarTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Avatar/AvatarTest.tsx
@@ -16,7 +16,7 @@ const avatar: React.FunctionComponent<{}> = () => {
   return (
     <Stack style={stackStyle}>
       <Text>Name</Text>
-      <Avatar primaryText="Kat Larson" />
+      <Avatar primaryText="Kat Larrson" />
       <Text>Name and Email</Text>
       <Avatar primaryText="Kat Larrson" secondaryText="Kat.Larrson@example.com" />
       <Text>Name, Email, and Image</Text>
@@ -30,27 +30,44 @@ const avatar: React.FunctionComponent<{}> = () => {
 };
 
 const stylizedAvatar: React.FunctionComponent<{}> = () => {
-  const CustomizedAvatar = Avatar.customize({
+  const ExtraSmallAvatar = Avatar.customize({
+    size: 'xSmall',
+  });
+
+  const SmallAvatar = Avatar.customize({
+    size: 'small',
+  });
+
+  const MediumAvatar = Avatar.customize({
+    size: 'medium',
+  });
+
+  const LargeAvatar = Avatar.customize({
+    size: 'large',
+  });
+
+  const ExtraLargeAvatar = Avatar.customize({
+    size: 'xLarge',
+  });
+
+  const ExtraExtraLargeAvatar = Avatar.customize({
     size: 'xxLarge',
   });
 
   return (
     <Stack style={stackStyle}>
-      <Text>Name</Text>
-      <CustomizedAvatar primaryText="Kat Larrson" />
-      <Text>Name and Email</Text>
-      <CustomizedAvatar primaryText="Kat Larrson" secondaryText="Kat.Larrson@example.com" />
-      <Text>Name, Email, and Image</Text>
-      <CustomizedAvatar primaryText="Kat Larrson" secondaryText="Kat.Larrson@example.com" imageSource={testImageSource} />
-      <Text>Name, Email, Image, and Presence</Text>
-      <CustomizedAvatar
-        primaryText="Kat Larrson"
-        secondaryText="Kat.Larrson@example.com"
-        imageSource={testImageSource}
-        presence="available"
-      />
-      <Text>Square Style</Text>
-      <CustomizedAvatar primaryText="FluentUI" avatarStyle="square" />
+      <Text>Extra Small</Text>
+      <ExtraSmallAvatar primaryText="Kat Larrson" />
+      <Text>Small</Text>
+      <SmallAvatar primaryText="Kat Larrson" />
+      <Text>Medium</Text>
+      <MediumAvatar primaryText="Kat Larrson" />
+      <Text>Large</Text>
+      <LargeAvatar primaryText="Kat Larrson" />
+      <Text>Extra Large</Text>
+      <ExtraLargeAvatar primaryText="Kat Larrson" />
+      <Text>Extra Extra Large</Text>
+      <ExtraExtraLargeAvatar primaryText="Kat Larrson" />
     </Stack>
   );
 };

--- a/apps/fluent-tester/src/FluentTester/TestComponents/Avatar/AvatarTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Avatar/AvatarTest.tsx
@@ -31,7 +31,7 @@ const avatar: React.FunctionComponent<{}> = () => {
 
 const stylizedAvatar: React.FunctionComponent<{}> = () => {
   const CustomizedAvatar = Avatar.customize({
-    size: 'large',
+    size: 'xxLarge',
   });
 
   return (

--- a/apps/ios/src/Podfile.lock
+++ b/apps/ios/src/Podfile.lock
@@ -296,7 +296,7 @@ PODS:
     - React-cxxreact (= 0.62.2)
     - React-jsi (= 0.62.2)
     - ReactCommon/callinvoker (= 0.62.2)
-  - ReactTestApp-DevSupport (0.2.14)
+  - ReactTestApp-DevSupport (0.3.2)
   - ReactTestApp-Resources (1.0.0-dev)
   - SwiftLint (0.41.0)
   - Yoga (1.14.0)
@@ -434,7 +434,7 @@ SPEC CHECKSUMS:
   React-RCTText: fae545b10cfdb3d247c36c56f61a94cfd6dba41d
   React-RCTVibration: 4356114dbcba4ce66991096e51a66e61eda51256
   ReactCommon: ed4e11d27609d571e7eee8b65548efc191116eb3
-  ReactTestApp-DevSupport: d3671526b8bfa3617b472b3a2404c1fe72fcdc1a
+  ReactTestApp-DevSupport: fac724ea8817d3874faf6c70a7cb65e383bbf2db
   ReactTestApp-Resources: 5950ae44720217c6778ff03fb1d906c8fb3ce483
   SwiftLint: c585ebd615d9520d7fbdbe151f527977b0534f1e
   Yoga: 3ebccbdd559724312790e7742142d062476b698e

--- a/apps/ios/src/Podfile.lock
+++ b/apps/ios/src/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
     - React-Core (= 0.62.2)
     - React-jsi (= 0.62.2)
     - ReactCommon/turbomodule/core (= 0.62.2)
-  - FluentUI-React-Native-Avatar (0.2.5):
+  - FluentUI-React-Native-Avatar (0.3.0):
     - MicrosoftFluentUI (~> 0.1.16)
     - React
   - FluentUI-React-Native-Shimmer (0.3.3):
@@ -296,7 +296,7 @@ PODS:
     - React-cxxreact (= 0.62.2)
     - React-jsi (= 0.62.2)
     - ReactCommon/callinvoker (= 0.62.2)
-  - ReactTestApp-DevSupport (0.3.2)
+  - ReactTestApp-DevSupport (0.2.14)
   - ReactTestApp-Resources (1.0.0-dev)
   - SwiftLint (0.41.0)
   - Yoga (1.14.0)
@@ -409,7 +409,7 @@ SPEC CHECKSUMS:
   DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
   FBLazyVector: 4aab18c93cd9546e4bfed752b4084585eca8b245
   FBReactNativeSpec: 5465d51ccfeecb7faa12f9ae0024f2044ce4044e
-  FluentUI-React-Native-Avatar: b2d40d426a6d3e4d627c2d30e1f2885caff20768
+  FluentUI-React-Native-Avatar: a1276fc37349a22465dcfdee8a46aeb3222a6b2f
   FluentUI-React-Native-Shimmer: 504dd3c43aea2d84855bdd369621069fab0274b2
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
@@ -434,7 +434,7 @@ SPEC CHECKSUMS:
   React-RCTText: fae545b10cfdb3d247c36c56f61a94cfd6dba41d
   React-RCTVibration: 4356114dbcba4ce66991096e51a66e61eda51256
   ReactCommon: ed4e11d27609d571e7eee8b65548efc191116eb3
-  ReactTestApp-DevSupport: fac724ea8817d3874faf6c70a7cb65e383bbf2db
+  ReactTestApp-DevSupport: d3671526b8bfa3617b472b3a2404c1fe72fcdc1a
   ReactTestApp-Resources: 5950ae44720217c6778ff03fb1d906c8fb3ce483
   SwiftLint: c585ebd615d9520d7fbdbe151f527977b0534f1e
   Yoga: 3ebccbdd559724312790e7742142d062476b698e

--- a/change/@fluentui-react-native-experimental-avatar-2020-12-11-17-40-52-avatar_size_fix.json
+++ b/change/@fluentui-react-native-experimental-avatar-2020-12-11-17-40-52-avatar_size_fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fixed bug where AvatarSize was not properly set",
+  "packageName": "@fluentui-react-native/experimental-avatar",
+  "email": "saadnajmi2@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-11T23:40:52.581Z"
+}

--- a/change/@fluentui-react-native-tester-2020-12-11-17-40-52-avatar_size_fix.json
+++ b/change/@fluentui-react-native-tester-2020-12-11-17-40-52-avatar_size_fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updated Avatar test to use xxLarge size",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "saadnajmi2@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-11T23:40:12.533Z"
+}

--- a/change/@fluentui-react-native-tester-win32-2020-12-11-17-40-52-avatar_size_fix.json
+++ b/change/@fluentui-react-native-tester-win32-2020-12-11-17-40-52-avatar_size_fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updated Avatar test to use xxLarge size",
+  "packageName": "@fluentui-react-native/tester-win32",
+  "email": "saadnajmi2@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-11T23:40:33.772Z"
+}

--- a/packages/experimental/Avatar/ios/MSFAvatarViewManager.m
+++ b/packages/experimental/Avatar/ios/MSFAvatarViewManager.m
@@ -51,7 +51,8 @@ RCT_ENUM_CONVERTER(MSFPresence, (@{
 
 @interface RCT_EXTERN_MODULE(MSFAvatarViewManager, RCTViewManager)
 
-RCT_EXPORT_VIEW_PROPERTY(avatarSize, MSFAvatarSize);
+RCT_REMAP_VIEW_PROPERTY(size, avatarSize, MSFAvatarSize);
+
 RCT_EXPORT_VIEW_PROPERTY(avatarBackgroundColor, UIColor);
 RCT_EXPORT_VIEW_PROPERTY(customBorderImage, UIImage);
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Avatar was not properly passing the "size" prop to the native "AvatarSize" property because we used the wrong macro. 
Changed the macro to fix this.

### Verification

Updated the Avatar test page to use "xxLarge" size to show the size difference better.

![Screen Shot 2020-12-11 at 9 55 08 PM](https://user-images.githubusercontent.com/6722175/101973450-df0f0400-3bfd-11eb-96be-3e2e2d24ba87.png)



### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
