### PR TITLE
Fix broken NuGet publish pipeline by fixing xcworkspace name

### DIFF
--- a/.ado/templates/apple-xcode-build-static-libs.yml
+++ b/.ado/templates/apple-xcode-build-static-libs.yml
@@ -18,7 +18,7 @@ steps:
   - template: apple-xcode-build.yml
     parameters:
       xcode_sdk: 'iphonesimulator'
-      xcode_workspacePath: 'apps/ios/src/FluentUITester.xcworkspace'
+      xcode_workspacePath: 'apps/ios/src/FluentTester.xcworkspace'
       xcode_actions: 'build'
       xcode_scheme: 'FluentTester'
       xcode_configuration: 'Debug'
@@ -28,7 +28,7 @@ steps:
   - template: apple-xcode-build.yml
     parameters:
       xcode_sdk: 'iphonesimulator'
-      xcode_workspacePath: 'apps/ios/src/FluentUITester.xcworkspace'
+      xcode_workspacePath: 'apps/ios/src/FluentTester.xcworkspace'
       xcode_actions: 'build'
       xcode_scheme: 'FluentTester'
       xcode_configuration: 'Release'
@@ -38,7 +38,7 @@ steps:
   - template: apple-xcode-build.yml
     parameters:
       xcode_sdk: 'iphoneos'
-      xcode_workspacePath: 'apps/ios/src/FluentUITester.xcworkspace'
+      xcode_workspacePath: 'apps/ios/src/FluentTester.xcworkspace'
       xcode_actions: 'build'
       xcode_scheme: 'FluentTester'
       xcode_configuration: 'Debug'
@@ -48,7 +48,7 @@ steps:
   - template: apple-xcode-build.yml
     parameters:
       xcode_sdk: 'iphoneos'
-      xcode_workspacePath: 'apps/ios/src/FluentUITester.xcworkspace'
+      xcode_workspacePath: 'apps/ios/src/FluentTester.xcworkspace'
       xcode_actions: 'build'
       xcode_scheme: 'FluentTester'
       xcode_configuration: 'Release'
@@ -58,7 +58,7 @@ steps:
   - template: apple-xcode-build.yml
     parameters:
       xcode_sdk: 'macosx'
-      xcode_workspacePath: 'apps/macos/src/FluentUITester.xcworkspace'
+      xcode_workspacePath: 'apps/macos/src/FluentTester.xcworkspace'
       xcode_actions: 'build'
       xcode_scheme: 'FluentTester'
       xcode_configuration: 'Debug'
@@ -68,7 +68,7 @@ steps:
   - template: apple-xcode-build.yml
     parameters:
       xcode_sdk: 'macosx'
-      xcode_workspacePath: 'apps/macos/src/FluentUITester.xcworkspace'
+      xcode_workspacePath: 'apps/macos/src/FluentTester.xcworkspace'
       xcode_actions: 'build'
       xcode_scheme: 'FluentTester'
       xcode_configuration: 'Release'

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -7,6 +7,7 @@
 Prereq: FluentUI Tester on iOS can only run on a Mac.
 
 1. Make sure you have followed the [Getting Started](../../README.md) instructions to install packages and build the entire FluentUI React Native repository. I.e. from the root of the repo:
+
 ```
     yarn && yarn build
 ```
@@ -17,6 +18,7 @@ Prereq: FluentUI Tester on iOS can only run on a Mac.
     cd apps/ios/src
     pod install
 ```
+
 Note: if you get the error: "CocoaPods could not find compatible versions for pod "MicrosoftFluentUI"," you may need to run `pod install --repo-update`.
 
 3. Return to the ios directory and run yarn ios to launch the FluentUI Tester app:
@@ -27,13 +29,15 @@ Note: if you get the error: "CocoaPods could not find compatible versions for po
 ```
 
 Troubleshooting
-- The first time you yarn ios, you receive an error and have to run "FluentUITester.xcworkspace" directly from Xcode. The workspace can be found in the apps/ios/src folder. After running the workspace the first time from Xcode, you will be able to `yarn ios` from the CLI.
+
+- The first time you yarn ios, you receive an error and have to run "FluentTester.xcworkspace" directly from Xcode. The workspace can be found in the apps/ios/src folder. After running the workspace the first time from Xcode, you will be able to `yarn ios` from the CLI.
 - If the packager didn't launch in a separate terminal and your iOS simulator just shows a white screen for your app, you can run yarn start from apps/ios to launch it separately
-- If you want to do direct debugging via xcode, after the pod install, you can launch src/FluentUITester.xcworkspace and build/run the scheme "ReactTestApp"
+- If you want to do direct debugging via xcode, after the pod install, you can launch src/FluentTester.xcworkspace and build/run the scheme "ReactTestApp"
 - If you want to have a clean rebuild of the generated iOS project, you can do the following:
+
 ```
 cd apps/ios/
-rm src/FluentUITester.xcworkspace
+rm src/FluentTester.xcworkspace
 rm -r src/Pods/
 pod install --project-directory=src.
 ```

--- a/apps/ios/react-native.config.js
+++ b/apps/ios/react-native.config.js
@@ -18,7 +18,7 @@
 module.exports = {
   project: {
     ios: {
-      project: 'src/FluentUITester.xcworkspace'
-    }
-  }
-}
+      project: 'src/FluentTester.xcworkspace',
+    },
+  },
+};

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -7,6 +7,7 @@
 Prereq: FluentUI Tester on macOS can only run on a Mac.
 
 1. Make sure you have followed the [Getting Started](../../README.md) instructions to install packages and build the entire FluentUI React Native repository. I.e. from the root of the repo:
+
 ```
     yarn && yarn build
 ```
@@ -17,6 +18,7 @@ Prereq: FluentUI Tester on macOS can only run on a Mac.
     cd apps/macos/src
     pod install
 ```
+
 Note: if you get the error: "CocoaPods could not find compatible versions for pod "MicrosoftFluentUI"," you may need to run `pod install --repo-update`.
 
 3. Return to the macos directory and first run yarn start. Then run yarn macos to launch the FluentUI Tester app:
@@ -27,11 +29,13 @@ Note: if you get the error: "CocoaPods could not find compatible versions for po
 ```
 
 Troubleshooting
-- If you want to do direct debugging via xcode, after the pod install, you can launch src/FluentUITester.xcworkspace and build/run the scheme "ReactTestApp"
+
+- If you want to do direct debugging via xcode, after the pod install, you can launch src/FluentTester.xcworkspace and build/run the scheme "ReactTestApp"
 - If you want to have a clean rebuild of the generated macOS project, you can do the following:
+
 ```
 cd apps/macos/
-rm src/FluentUITester.xcworkspace
+rm src/FluentTester.xcworkspace
 rm -r src/Pods/
 pod install --project-directory=src.
 ```

--- a/apps/macos/react-native.config.js
+++ b/apps/macos/react-native.config.js
@@ -20,8 +20,10 @@ const path = require('path');
 module.exports = {
   project: {
     ios: {
-      project: 'src/FluentUITester.xcworkspace'
-    }
+      project: 'src/FluentTester.xcworkspace',
+    },
   },
-  reactNativePath: path.dirname(require.resolve('react-native-macos/package.json'))
+  reactNativePath: path.dirname(
+    require.resolve('react-native-macos/package.json'),
+  ),
 };


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Our publish pipeline has been broken since #566 . This is because I changed the xcworkspace name of our test app (which is used to generate the static libraries in the NuGet Package) from `FluentUITester.xcworkspace` to `FluentTester.xcworkspace`. This caused the commands in our YML file to fail to build the iOS static libraries, and thus our NuGet pipeline failed.

Let's switch to the new name, and also remove all instances of the old `FluentUITester.xcworkspace` that we can find.

### Verification

Tested the pipeline on a fork of the repo. Results here https://dev.azure.com/ms/ui-fabric-react-native/_build/results?buildId=127845&view=logs&j=f22c9018-44f9-5836-07db-908da0f6bf23

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
