### PR TITLE
Add Button static libraries to nuspec

### DIFF
--- a/package.nuspec
+++ b/package.nuspec
@@ -11,21 +11,27 @@
     <files>
       <!-- iOS device debug -->
       <file src="DerivedData\Build\Products\Debug-iphoneos\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Avatar.a" target="Debug-iphoneos"/>
+      <file src="DerivedData\Build\Products\Debug-iphoneos\FluentUI-React-Native-Button\libFluentUI-React-Native-Button.a" target="Debug-iphoneos"/>
       <file src="DerivedData\Build\Products\Debug-iphoneos\FluentUI-React-Native-Shimmer\libFluentUI-React-Native-Shimmer.a" target="Debug-iphoneos"/>
       <!-- iOS device ship -->
       <file src="DerivedData\Build\Products\Release-iphoneos\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Avatar.a" target="Ship-iphoneos"/>
+      <file src="DerivedData\Build\Products\Release-iphoneos\FluentUI-React-Native-Button\libFluentUI-React-Native-Button.a" target="Ship-iphoneos"/>
       <file src="DerivedData\Build\Products\Release-iphoneos\FluentUI-React-Native-Shimmer\libFluentUI-React-Native-Shimmer.a" target="Ship-iphoneos"/>
       <!-- iOS simulator debug -->
       <file src="DerivedData\Build\Products\Debug-iphonesimulator\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Avatar.a" target="Debug-iphonesimulator"/>
+      <file src="DerivedData\Build\Products\Debug-iphonesimulator\FluentUI-React-Native-Button\libFluentUI-React-Native-Button.a" target="Debug-iphonesimulator"/>
       <file src="DerivedData\Build\Products\Debug-iphonesimulator\FluentUI-React-Native-Shimmer\libFluentUI-React-Native-Shimmer.a" target="Debug-iphonesimulator"/>
       <!-- iOS simulator ship -->
       <file src="DerivedData\Build\Products\Release-iphonesimulator\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Avatar.a" target="Ship-iphonesimulator"/>
+      <file src="DerivedData\Build\Products\Release-iphonesimulator\FluentUI-React-Native-Button\libFluentUI-React-Native-Button.a" target="Ship-iphonesimulator"/>
       <file src="DerivedData\Build\Products\Release-iphonesimulator\FluentUI-React-Native-Shimmer\libFluentUI-React-Native-Shimmer.a" target="Ship-iphonesimulator"/>
 
       <!-- macOS debug -->
       <file src="DerivedData\Build\Products\Debug\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Avatar.a" target="Debug-macosx"/>
+      <file src="DerivedData\Build\Products\Debug\FluentUI-React-Native-Button\libFluentUI-React-Native-Button.a" target="Debug-macosx"/>
       <!-- macOS ship -->
       <file src="DerivedData\Build\Products\Release\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Avatar.a" target="Ship-macosx"/>
+      <file src="DerivedData\Build\Products\Release\FluentUI-React-Native-Button\libFluentUI-React-Native-Button.a" target="Ship-macosx"/>
 
       <!-- iOS Release jsbundle -->
       <file src="apps\ios\dist\index.bundle" target="ios"/>


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Followup change to #556 , we would like to add the built static libraries to our NuGet package. This change just adds the correct lines to the .nuspec file.

### Verification

Simple enough change such that it should be fine to do without the loop of copying the NuGet pipeline to our PI pipeline and uncommenting that I have done so far...


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
