### PR TITLE
Add tooltip support for Native Button

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/NativeButton/NativeButtonTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/NativeButton/NativeButtonTest.tsx
@@ -17,7 +17,13 @@ const nativeButton: React.FunctionComponent<{}> = () => {
   });
   return (
     <Stack style={stackStyle}>
-      <NativeButton title="Primary" image={icon} buttonStyle="primary" onPress={() => alert('Primary button clicked!')} />
+      <NativeButton
+        title="Primary"
+        image={icon}
+        buttonStyle="primary"
+        toolTip="Native Tooltip"
+        onPress={() => alert('Primary button clicked!')}
+      />
       <NativeButton title="Secondary" buttonStyle="secondary" image={icon} onPress={() => alert('Secondary button clicked! ')} />
       <NativeButton title="Borderless" buttonStyle="borderless" image={icon} onPress={() => alert('Borderless button clicked!')} />
       <NativeButton title="Acrylic" buttonStyle="acrylic" onPress={() => alert('Acrylic button clicked!')} />

--- a/change/@fluentui-react-native-experimental-native-button-2021-02-11-23-18-55-native-button-tooltip.json
+++ b/change/@fluentui-react-native-experimental-native-button-2021-02-11-23-18-55-native-button-tooltip.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "add tooltip support for native button",
+  "packageName": "@fluentui-react-native/experimental-native-button",
+  "email": "67026167+chiuam@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-12T04:18:55.558Z"
+}

--- a/change/@fluentui-react-native-tester-2021-02-11-23-18-55-native-button-tooltip.json
+++ b/change/@fluentui-react-native-tester-2021-02-11-23-18-55-native-button-tooltip.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "add tooltip support for native button",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "67026167+chiuam@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-12T04:18:32.073Z"
+}

--- a/packages/experimental/NativeButton/macos/MSFButtonViewManager.m
+++ b/packages/experimental/NativeButton/macos/MSFButtonViewManager.m
@@ -23,5 +23,6 @@ RCT_EXPORT_VIEW_PROPERTY(onPress, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(isImageTinted, BOOL);
 RCT_REMAP_VIEW_PROPERTY(buttonStyle, style, MSFButtonStyle);
 RCT_EXPORT_VIEW_PROPERTY(enabled, BOOL);
+RCT_EXPORT_VIEW_PROPERTY(toolTip, NSString);
 @end
 

--- a/packages/experimental/NativeButton/src/NativeButton.types.ts
+++ b/packages/experimental/NativeButton/src/NativeButton.types.ts
@@ -24,6 +24,10 @@ export interface NativeButtonProps {
    */
   enabled?: boolean;
   /*
+   * Shows the native tooltip when hovered.
+   */
+  toolTip?: string;
+  /*
    * A callback to call on button click event
    */
   onPress?: () => void;


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
Add tooltip support for Native Button.

### Verification
![image](https://user-images.githubusercontent.com/67026167/107728171-4fe4a200-6cbb-11eb-8f54-be1f11283a74.png)
Verified that Native Button on iOS is not affected.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [X] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
