### PR TITLE
Correct rendering the checkmark in checkbox when scaling text

### DIFF
--- a/change/@fluentui-react-native-checkbox-2021-02-23-11-24-23-checkboxTextScalingLayout.json
+++ b/change/@fluentui-react-native-checkbox-2021-02-23-11-24-23-checkboxTextScalingLayout.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Correct text scaled rendering of win32 checkbox with aspect ratio, alignment, and min-dimension changes",
+  "packageName": "@fluentui-react-native/checkbox",
+  "email": "ppatboyd@outlook.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-23T19:24:22.949Z"
+}

--- a/packages/components/Checkbox/src/Checkbox.settings.ts
+++ b/packages/components/Checkbox/src/Checkbox.settings.ts
@@ -9,7 +9,7 @@ export const settings: IComposeSettings<ICheckboxType> = [
       borderColor: 'menuItemText',
       color: 'menuItemText',
       backgroundColor: 'menuBackground',
-      textBorderColor: 'transparent'
+      textBorderColor: 'transparent',
     },
     root: {
       accessible: true,
@@ -21,34 +21,36 @@ export const settings: IComposeSettings<ICheckboxType> = [
         flexDirection: 'row',
         minHeight: 14,
         marginTop: 0,
-        position: 'relative'
-      }
+        position: 'relative',
+      },
     },
     checkbox: {
       style: {
-        height: 14,
-        width: 14,
-        marginEnd: 4,
         borderStyle: 'solid',
-        borderWidth: 1
-      }
+        borderWidth: 1,
+        minHeight: 14,
+        minWidth: 14,
+        marginEnd: 4,
+      },
     },
     checkmark: {
       style: {
+        aspectRatio: 1,
         position: 'relative',
         opacity: 0,
         fontSize: 10,
-        marginStart: 2,
-        top: -1
-      }
+        textAlign: 'center',
+        textAlignVertical: 'center',
+        top: -1,
+      },
     },
     content: {
       variant: 'bodyStandard',
       style: {
         borderStyle: 'solid',
         borderWidth: 2,
-        marginTop: 3
-      }
+        marginTop: 3,
+      },
     },
     _precedence: ['disabled', 'boxAtEnd', 'hovered', 'focused', 'pressed', 'checked'],
     _overrides: {
@@ -57,42 +59,42 @@ export const settings: IComposeSettings<ICheckboxType> = [
           backgroundColor: 'menuItemBackgroundHovered',
           textBorderColor: 'focusBorder',
           checkmarkColor: 'menuItemTextHovered',
-        }
+        },
       },
       checked: {
         checkmark: {
           style: {
-            opacity: 1
-          }
-        }
+            opacity: 1,
+          },
+        },
       },
       hovered: {
         tokens: {
           backgroundColor: 'menuItemBackgroundHovered',
           checkmarkColor: 'menuItemTextHovered',
-        }
+        },
       },
       disabled: {
         tokens: {
           borderColor: 'buttonBorderDisabled',
           color: 'disabledBodyText',
-          backgroundColor: 'background'
-        }
+          backgroundColor: 'background',
+        },
       },
       boxAtEnd: {
         checkbox: {
           style: {
             marginStart: 4,
-            marginEnd: 0
-          }
-        }
+            marginEnd: 0,
+          },
+        },
       },
       pressed: {
         tokens: {
-          backgroundColor: 'menuItemBackgroundPressed'
-        }
-      }
-    }
+          backgroundColor: 'menuItemBackgroundPressed',
+        },
+      },
+    },
   },
-  checkboxName
+  checkboxName,
 ];


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

The checkbox layout forced a 14x14 dip checkbox (width:14, height:14) which is inaccurate for allowing a checkbox to scale with text separate of DPI.  Forcing the aspect ratio:1 on the checkmark allows the the checkbox to use minWidth and minHeight and rely on the checkmark for shape and size, without enabling a small check symbol to make a checkmark too small.  Text alignment ensures the text is centered regardless of aspect ratio resolving by height or by width.

### Verification

![image](https://user-images.githubusercontent.com/41588892/108579755-4079e000-72dd-11eb-9809-13098344a5da.png)
![image](https://user-images.githubusercontent.com/41588892/108579772-54bddd00-72dd-11eb-81ad-42e424189b92.png)


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
