### PR TITLE
Fix start command in tester-win32

### DIFF
--- a/apps/win32/package.json
+++ b/apps/win32/package.json
@@ -15,7 +15,7 @@
     "code-style": "fluentui-scripts code-style",
     "depcheck": "fluentui-scripts depcheck",
     "lint": "fluentui-scripts eslint",
-    "start": "react-native rnx-start --server --port 8081",
+    "start": "react-native rnx-start --port 8081",
     "test": "fluentui-scripts jest",
     "bundle": "react-native rnx-bundle --dev false",
     "bundle-dev": "react-native rnx-bundle",

--- a/change/@fluentui-react-native-tester-win32-2021-03-03-08-11-21-fix-rnx-start.json
+++ b/change/@fluentui-react-native-tester-win32-2021-03-03-08-11-21-fix-rnx-start.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Fix rnx-start command line in tester-win32 package.",
+  "packageName": "@fluentui-react-native/tester-win32",
+  "email": "afoxman@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2021-03-03T16:11:21.360Z"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Fix the 'start' command in the scripts block of tester-win32 package.json. Remove '--server' which is extraneous.

### Verification

Manually running 'yarn start'.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
