### PR TITLE
Update Xcode to 12.4

### DIFF
--- a/.ado/scripts/xcode_select_current_version.sh
+++ b/.ado/scripts/xcode_select_current_version.sh
@@ -3,7 +3,7 @@
 if [ -n "$XCODE_PATH_OVERRIDE" ]; then # If someone calls this with the XCODE_PATH_OVERRIDE variable set to a path to a developer dir, use it instead
     XCODE_PATH="$XCODE_PATH_OVERRIDE"
 else
-    XCODE_PATH='/Applications/Xcode_12.app/Contents/Developer'
+    XCODE_PATH='/Applications/Xcode_12.4.app/Contents/Developer'
 fi
 
 echo "Running command: sudo xcode-select --switch $XCODE_PATH"


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

My #598 PR seems to be failing weirdly on building macOS. This **might** be fixed by updating the Xcode version. We should do this anyway because internally, Office is built up with Xcode 12.4.

### Verification

Mostly need to look at the PR CI and see how it goes. I've been using Xcode 12.4 personally already so I know FluentTester runs on that.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
