### PR TITLE
Update FluentUI Apple dependency to 0.2.2, set minimum iOS to 13

### DIFF
--- a/apps/ios/src/Podfile
+++ b/apps/ios/src/Podfile
@@ -22,6 +22,7 @@ fi
 use_flipper!(false)
 use_test_app! do |target|
   target.app do
+    platform :ios, '13.0'
 
     pod 'FluentUI-React-Native-Avatar', :path => '../../../packages/experimental/Avatar/FluentUIReactNativeAvatar.podspec'
     pod 'FluentUI-React-Native-Shimmer', :path => '../../../packages/components/Shimmer/FluentUIReactNativeShimmer.podspec'

--- a/apps/ios/src/Podfile.lock
+++ b/apps/ios/src/Podfile.lock
@@ -9,16 +9,14 @@ PODS:
     - React-Core (= 0.63.4)
     - React-jsi (= 0.63.4)
     - ReactCommon/turbomodule/core (= 0.63.4)
-  - FluentUI-React-Native-Avatar (0.4.3):
-    - MicrosoftFluentUI/AvatarView_mac (~> 0.1.28)
-    - MicrosoftFluentUI/Controls_ios (~> 0.1.28)
+  - FluentUI-React-Native-Avatar (0.5.0):
+    - MicrosoftFluentUI (~> 0.2.2)
     - React
-  - FluentUI-React-Native-Button (0.3.1):
-    - MicrosoftFluentUI/Button_mac (~> 0.1.28)
-    - MicrosoftFluentUI/Controls_ios (~> 0.1.28)
+  - FluentUI-React-Native-Button (0.4.0):
+    - MicrosoftFluentUI (~> 0.2.2)
     - React
-  - FluentUI-React-Native-Shimmer (0.4.3):
-    - MicrosoftFluentUI (~> 0.1.28)
+  - FluentUI-React-Native-Shimmer (0.5.0):
+    - MicrosoftFluentUI (~> 0.2.2)
     - React
   - Folly (2020.01.13.00):
     - boost-for-react-native
@@ -30,57 +28,62 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - MicrosoftFluentUI (0.1.28):
-    - MicrosoftFluentUI/AvatarView_mac (= 0.1.28)
-    - MicrosoftFluentUI/Button_mac (= 0.1.28)
-    - MicrosoftFluentUI/Calendar_ios (= 0.1.28)
-    - MicrosoftFluentUI/Card_ios (= 0.1.28)
-    - MicrosoftFluentUI/CommandBar_ios (= 0.1.28)
-    - MicrosoftFluentUI/Controls_ios (= 0.1.28)
-    - MicrosoftFluentUI/Core_ios (= 0.1.28)
-    - MicrosoftFluentUI/Core_mac (= 0.1.28)
-    - MicrosoftFluentUI/DatePicker_mac (= 0.1.28)
-    - MicrosoftFluentUI/Drawer_ios (= 0.1.28)
-    - MicrosoftFluentUI/HUD_ios (= 0.1.28)
-    - MicrosoftFluentUI/Link_mac (= 0.1.28)
-    - MicrosoftFluentUI/Notification_ios (= 0.1.28)
-    - MicrosoftFluentUI/PillButtonBar_ios (= 0.1.28)
-    - MicrosoftFluentUI/PopupMenu_ios (= 0.1.28)
-    - MicrosoftFluentUI/Presenters_ios (= 0.1.28)
-    - MicrosoftFluentUI/Separator_mac (= 0.1.28)
-    - MicrosoftFluentUI/Shimmer_ios (= 0.1.28)
-    - MicrosoftFluentUI/TabBar_ios (= 0.1.28)
-    - MicrosoftFluentUI/Tooltip_ios (= 0.1.28)
-    - MicrosoftFluentUI/Utilities_ios (= 0.1.28)
-  - MicrosoftFluentUI/Calendar_ios (0.1.28):
+  - MicrosoftFluentUI (0.2.2):
+    - MicrosoftFluentUI/AvatarView_mac (= 0.2.2)
+    - MicrosoftFluentUI/Button_mac (= 0.2.2)
+    - MicrosoftFluentUI/Calendar_ios (= 0.2.2)
+    - MicrosoftFluentUI/Card_ios (= 0.2.2)
+    - MicrosoftFluentUI/CommandBar_ios (= 0.2.2)
+    - MicrosoftFluentUI/Controls_ios (= 0.2.2)
+    - MicrosoftFluentUI/Core_ios (= 0.2.2)
+    - MicrosoftFluentUI/Core_mac (= 0.2.2)
+    - MicrosoftFluentUI/DatePicker_mac (= 0.2.2)
+    - MicrosoftFluentUI/Drawer_ios (= 0.2.2)
+    - MicrosoftFluentUI/HUD_ios (= 0.2.2)
+    - MicrosoftFluentUI/Link_mac (= 0.2.2)
+    - MicrosoftFluentUI/Notification_ios (= 0.2.2)
+    - MicrosoftFluentUI/PillButtonBar_ios (= 0.2.2)
+    - MicrosoftFluentUI/PopupMenu_ios (= 0.2.2)
+    - MicrosoftFluentUI/Presenters_ios (= 0.2.2)
+    - MicrosoftFluentUI/SegmentedControl_ios (= 0.2.2)
+    - MicrosoftFluentUI/Separator_mac (= 0.2.2)
+    - MicrosoftFluentUI/Shimmer_ios (= 0.2.2)
+    - MicrosoftFluentUI/TabBar_ios (= 0.2.2)
+    - MicrosoftFluentUI/Tooltip_ios (= 0.2.2)
+    - MicrosoftFluentUI/Utilities_ios (= 0.2.2)
+  - MicrosoftFluentUI/Calendar_ios (0.2.2):
     - MicrosoftFluentUI/Presenters_ios
-  - MicrosoftFluentUI/Card_ios (0.1.28):
+    - MicrosoftFluentUI/SegmentedControl_ios
+  - MicrosoftFluentUI/Card_ios (0.2.2):
     - MicrosoftFluentUI/Controls_ios
-  - MicrosoftFluentUI/CommandBar_ios (0.1.28):
+  - MicrosoftFluentUI/CommandBar_ios (0.2.2):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/Controls_ios (0.1.28):
+  - MicrosoftFluentUI/Controls_ios (0.2.2):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/Core_ios (0.1.28)
-  - MicrosoftFluentUI/Drawer_ios (0.1.28):
+  - MicrosoftFluentUI/Core_ios (0.2.2)
+  - MicrosoftFluentUI/Drawer_ios (0.2.2):
     - MicrosoftFluentUI/Controls_ios
-  - MicrosoftFluentUI/HUD_ios (0.1.28):
+  - MicrosoftFluentUI/HUD_ios (0.2.2):
     - MicrosoftFluentUI/Controls_ios
-  - MicrosoftFluentUI/Notification_ios (0.1.28):
+  - MicrosoftFluentUI/Notification_ios (0.2.2):
     - MicrosoftFluentUI/Controls_ios
-  - MicrosoftFluentUI/PillButtonBar_ios (0.1.28):
+  - MicrosoftFluentUI/PillButtonBar_ios (0.2.2):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/PopupMenu_ios (0.1.28):
+  - MicrosoftFluentUI/PopupMenu_ios (0.2.2):
     - MicrosoftFluentUI/Drawer_ios
-  - MicrosoftFluentUI/Presenters_ios (0.1.28):
+  - MicrosoftFluentUI/Presenters_ios (0.2.2):
     - MicrosoftFluentUI/Controls_ios
-  - MicrosoftFluentUI/Shimmer_ios (0.1.28):
+  - MicrosoftFluentUI/SegmentedControl_ios (0.2.2):
+    - MicrosoftFluentUI/Controls_ios
+    - MicrosoftFluentUI/PillButtonBar_ios
+  - MicrosoftFluentUI/Shimmer_ios (0.2.2):
     - MicrosoftFluentUI/Core_ios
     - MicrosoftFluentUI/Utilities_ios
-  - MicrosoftFluentUI/TabBar_ios (0.1.28):
+  - MicrosoftFluentUI/TabBar_ios (0.2.2):
     - MicrosoftFluentUI/Controls_ios
-  - MicrosoftFluentUI/Tooltip_ios (0.1.28):
+  - MicrosoftFluentUI/Tooltip_ios (0.2.2):
     - MicrosoftFluentUI/Controls_ios
-  - MicrosoftFluentUI/Utilities_ios (0.1.28)
+  - MicrosoftFluentUI/Utilities_ios (0.2.2)
   - QRCodeReader.swift (10.1.0)
   - RCTRequired (0.63.4)
   - RCTTypeSafety (0.63.4):
@@ -310,7 +313,7 @@ PODS:
     - React-jsi (= 0.63.4)
   - ReactTestApp-DevSupport (0.3.13)
   - ReactTestApp-Resources (1.0.0-dev)
-  - SwiftLint (0.42.0)
+  - SwiftLint (0.43.0)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -426,12 +429,12 @@ SPEC CHECKSUMS:
   DoubleConversion: cde416483dac037923206447da6e1454df403714
   FBLazyVector: 3bb422f41b18121b71783a905c10e58606f7dc3e
   FBReactNativeSpec: f2c97f2529dd79c083355182cc158c9f98f4bd6e
-  FluentUI-React-Native-Avatar: f43459273f21935f033da1f73c310a11bfb7302b
-  FluentUI-React-Native-Button: 8006a5f286d58d9f41d8f969038bea01ae508760
-  FluentUI-React-Native-Shimmer: 643f9fef0d8cfc3408bcef350e6d490adcb0a38a
+  FluentUI-React-Native-Avatar: b8c0be6e3cb27281c652aa1b1a3f117d763d64d5
+  FluentUI-React-Native-Button: e783548d3949e6f3bbd50143acb1b8229e04fe81
+  FluentUI-React-Native-Shimmer: 73d75d2ddf338ff75c15c1af81ccb2de4b22ed92
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
   glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
-  MicrosoftFluentUI: 2dfff618a4fed9d1539a568449323da2bedcccae
+  MicrosoftFluentUI: 8a1ef14a8479106c33822d05b774e04051bb33f2
   QRCodeReader.swift: 373a389fe9a22d513c879a32a6f647c58f4ef572
   RCTRequired: 082f10cd3f905d6c124597fd1c14f6f2655ff65e
   RCTTypeSafety: 8c9c544ecbf20337d069e4ae7fd9a377aadf504b
@@ -455,9 +458,9 @@ SPEC CHECKSUMS:
   ReactCommon: 73d79c7039f473b76db6ff7c6b159c478acbbb3b
   ReactTestApp-DevSupport: 12d9f285a44ff0cb7962a213621f87d3e6de9288
   ReactTestApp-Resources: 5950ae44720217c6778ff03fb1d906c8fb3ce483
-  SwiftLint: 4fa9579c63416865179bc416f0a92d55f009600d
+  SwiftLint: 0c645fdc6feed3e390c1701ab3cc669f88b42752
   Yoga: 4bd86afe9883422a7c4028c00e34790f560923d6
 
-PODFILE CHECKSUM: 92ad496f45726c3f2dfe3835c607a1b6ca267da8
+PODFILE CHECKSUM: a3155f67c06aeb3775b5449bc80a4a738902fe6c
 
 COCOAPODS: 1.10.1

--- a/apps/macos/src/Podfile
+++ b/apps/macos/src/Podfile
@@ -22,6 +22,7 @@ fi
 use_flipper!(false)
 use_test_app! do |target|
   target.app do
+    platform :osx, '10.14'
 
     pod 'FluentUI-React-Native-Apple-Theme', :path => '../../../packages/theming/apple-theme/FluentUIReactNativeAppleTheme.podspec'
     pod 'FluentUI-React-Native-Button', :path => '../../../packages/experimental/NativeButton/FluentUIReactNativeButton.podspec'

--- a/apps/macos/src/Podfile.lock
+++ b/apps/macos/src/Podfile.lock
@@ -9,50 +9,49 @@ PODS:
     - React-Core (= 0.63.1)
     - React-jsi (= 0.63.1)
     - ReactCommon/turbomodule/core (= 0.63.1)
-  - FluentUI-React-Native-Apple-Theme (0.1.1):
-    - MicrosoftFluentUI (~> 0.1.28)
+  - FluentUI-React-Native-Apple-Theme (0.2.0):
+    - MicrosoftFluentUI (~> 0.2.2)
     - React
-  - FluentUI-React-Native-Avatar (0.4.3):
-    - MicrosoftFluentUI/AvatarView_mac (~> 0.1.28)
-    - MicrosoftFluentUI/Controls_ios (~> 0.1.28)
+  - FluentUI-React-Native-Avatar (0.5.0):
+    - MicrosoftFluentUI (~> 0.2.2)
     - React
-  - FluentUI-React-Native-Button (0.3.1):
-    - MicrosoftFluentUI/Button_mac (~> 0.1.28)
-    - MicrosoftFluentUI/Controls_ios (~> 0.1.28)
+  - FluentUI-React-Native-Button (0.4.0):
+    - MicrosoftFluentUI (~> 0.2.2)
     - React
   - glog (0.3.5)
-  - MicrosoftFluentUI (0.1.28):
-    - MicrosoftFluentUI/AvatarView_mac (= 0.1.28)
-    - MicrosoftFluentUI/Button_mac (= 0.1.28)
-    - MicrosoftFluentUI/Calendar_ios (= 0.1.28)
-    - MicrosoftFluentUI/Card_ios (= 0.1.28)
-    - MicrosoftFluentUI/CommandBar_ios (= 0.1.28)
-    - MicrosoftFluentUI/Controls_ios (= 0.1.28)
-    - MicrosoftFluentUI/Core_ios (= 0.1.28)
-    - MicrosoftFluentUI/Core_mac (= 0.1.28)
-    - MicrosoftFluentUI/DatePicker_mac (= 0.1.28)
-    - MicrosoftFluentUI/Drawer_ios (= 0.1.28)
-    - MicrosoftFluentUI/HUD_ios (= 0.1.28)
-    - MicrosoftFluentUI/Link_mac (= 0.1.28)
-    - MicrosoftFluentUI/Notification_ios (= 0.1.28)
-    - MicrosoftFluentUI/PillButtonBar_ios (= 0.1.28)
-    - MicrosoftFluentUI/PopupMenu_ios (= 0.1.28)
-    - MicrosoftFluentUI/Presenters_ios (= 0.1.28)
-    - MicrosoftFluentUI/Separator_mac (= 0.1.28)
-    - MicrosoftFluentUI/Shimmer_ios (= 0.1.28)
-    - MicrosoftFluentUI/TabBar_ios (= 0.1.28)
-    - MicrosoftFluentUI/Tooltip_ios (= 0.1.28)
-    - MicrosoftFluentUI/Utilities_ios (= 0.1.28)
-  - MicrosoftFluentUI/AvatarView_mac (0.1.28):
+  - MicrosoftFluentUI (0.2.2):
+    - MicrosoftFluentUI/AvatarView_mac (= 0.2.2)
+    - MicrosoftFluentUI/Button_mac (= 0.2.2)
+    - MicrosoftFluentUI/Calendar_ios (= 0.2.2)
+    - MicrosoftFluentUI/Card_ios (= 0.2.2)
+    - MicrosoftFluentUI/CommandBar_ios (= 0.2.2)
+    - MicrosoftFluentUI/Controls_ios (= 0.2.2)
+    - MicrosoftFluentUI/Core_ios (= 0.2.2)
+    - MicrosoftFluentUI/Core_mac (= 0.2.2)
+    - MicrosoftFluentUI/DatePicker_mac (= 0.2.2)
+    - MicrosoftFluentUI/Drawer_ios (= 0.2.2)
+    - MicrosoftFluentUI/HUD_ios (= 0.2.2)
+    - MicrosoftFluentUI/Link_mac (= 0.2.2)
+    - MicrosoftFluentUI/Notification_ios (= 0.2.2)
+    - MicrosoftFluentUI/PillButtonBar_ios (= 0.2.2)
+    - MicrosoftFluentUI/PopupMenu_ios (= 0.2.2)
+    - MicrosoftFluentUI/Presenters_ios (= 0.2.2)
+    - MicrosoftFluentUI/SegmentedControl_ios (= 0.2.2)
+    - MicrosoftFluentUI/Separator_mac (= 0.2.2)
+    - MicrosoftFluentUI/Shimmer_ios (= 0.2.2)
+    - MicrosoftFluentUI/TabBar_ios (= 0.2.2)
+    - MicrosoftFluentUI/Tooltip_ios (= 0.2.2)
+    - MicrosoftFluentUI/Utilities_ios (= 0.2.2)
+  - MicrosoftFluentUI/AvatarView_mac (0.2.2):
     - MicrosoftFluentUI/Core_mac
-  - MicrosoftFluentUI/Button_mac (0.1.28):
+  - MicrosoftFluentUI/Button_mac (0.2.2):
     - MicrosoftFluentUI/Core_mac
-  - MicrosoftFluentUI/Core_mac (0.1.28)
-  - MicrosoftFluentUI/DatePicker_mac (0.1.28):
+  - MicrosoftFluentUI/Core_mac (0.2.2)
+  - MicrosoftFluentUI/DatePicker_mac (0.2.2):
     - MicrosoftFluentUI/Core_mac
-  - MicrosoftFluentUI/Link_mac (0.1.28):
+  - MicrosoftFluentUI/Link_mac (0.2.2):
     - MicrosoftFluentUI/Core_mac
-  - MicrosoftFluentUI/Separator_mac (0.1.28):
+  - MicrosoftFluentUI/Separator_mac (0.2.2):
     - MicrosoftFluentUI/Core_mac
   - RCT-Folly (2020.01.13.00):
     - boost-for-react-native
@@ -291,7 +290,7 @@ PODS:
     - React-jsi (= 0.63.1)
   - ReactTestApp-DevSupport (0.3.13)
   - ReactTestApp-Resources (1.0.0-dev)
-  - SwiftLint (0.42.0)
+  - SwiftLint (0.43.0)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -407,11 +406,11 @@ SPEC CHECKSUMS:
   DoubleConversion: 56a44bcfd14ab2ff66f5a146b2e875eb4b69b19b
   FBLazyVector: 87ca368919ae0ec70816fb8a42252ef59dc05c94
   FBReactNativeSpec: 7c0591658d85effad209fc4f45b6c9760f9e5842
-  FluentUI-React-Native-Apple-Theme: d05c13f08eb78c2ee8c311e91c240bcbaa603f8f
-  FluentUI-React-Native-Avatar: f43459273f21935f033da1f73c310a11bfb7302b
-  FluentUI-React-Native-Button: 8006a5f286d58d9f41d8f969038bea01ae508760
+  FluentUI-React-Native-Apple-Theme: 9fc6a02306577092f14b4ef37b92d0beb41f861c
+  FluentUI-React-Native-Avatar: b8c0be6e3cb27281c652aa1b1a3f117d763d64d5
+  FluentUI-React-Native-Button: e783548d3949e6f3bbd50143acb1b8229e04fe81
   glog: 1cb7c408c781ae8f35bbababe459b45e3dee4ec1
-  MicrosoftFluentUI: 2dfff618a4fed9d1539a568449323da2bedcccae
+  MicrosoftFluentUI: 8a1ef14a8479106c33822d05b774e04051bb33f2
   RCT-Folly: 1347093ffe75e152d846f7e45a3ef901b60021aa
   RCTRequired: f0ba811ba36bbe463b0151cbda362853106c13ac
   RCTTypeSafety: 10f774586f2956b7cf547cc97f2261eb22ee2a25
@@ -435,9 +434,9 @@ SPEC CHECKSUMS:
   ReactCommon: 2b36aa7cd56bc9a0376b013db964e8b17a6a18f9
   ReactTestApp-DevSupport: 12d9f285a44ff0cb7962a213621f87d3e6de9288
   ReactTestApp-Resources: 5950ae44720217c6778ff03fb1d906c8fb3ce483
-  SwiftLint: 4fa9579c63416865179bc416f0a92d55f009600d
+  SwiftLint: 0c645fdc6feed3e390c1701ab3cc669f88b42752
   Yoga: 6f6f412e10cf9acb93bb0e290613784603d2f0c9
 
-PODFILE CHECKSUM: 5d9a9585f42b172ddf51a902df243a9eacc188ff
+PODFILE CHECKSUM: 54d938735a7c78d6d745f1a0773f405a49414836
 
-COCOAPODS: 1.10.0
+COCOAPODS: 1.10.1

--- a/change/@fluentui-react-native-apple-theme-2021-03-06-15-47-24-update-fua.json
+++ b/change/@fluentui-react-native-apple-theme-2021-03-06-15-47-24-update-fua.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Update FluentUI Apple dependency to 0.2.2, set minimum iOS to 13",
+  "packageName": "@fluentui-react-native/apple-theme",
+  "email": "saadnajmi2@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2021-03-06T21:47:24.326Z"
+}

--- a/change/@fluentui-react-native-experimental-avatar-2021-03-06-15-47-24-update-fua.json
+++ b/change/@fluentui-react-native-experimental-avatar-2021-03-06-15-47-24-update-fua.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Update FluentUI Apple dependency to 0.2.2, set minimum iOS to 13",
+  "packageName": "@fluentui-react-native/experimental-avatar",
+  "email": "saadnajmi2@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2021-03-06T21:47:20.252Z"
+}

--- a/change/@fluentui-react-native-experimental-native-button-2021-03-06-15-47-24-update-fua.json
+++ b/change/@fluentui-react-native-experimental-native-button-2021-03-06-15-47-24-update-fua.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Update FluentUI Apple dependency to 0.2.2, set minimum iOS to 13",
+  "packageName": "@fluentui-react-native/experimental-native-button",
+  "email": "saadnajmi2@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2021-03-06T21:47:22.300Z"
+}

--- a/change/@fluentui-react-native-shimmer-2021-03-06-15-47-24-update-fua.json
+++ b/change/@fluentui-react-native-shimmer-2021-03-06-15-47-24-update-fua.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Update FluentUI Apple dependency to 0.2.2, set minimum iOS to 13",
+  "packageName": "@fluentui-react-native/shimmer",
+  "email": "saadnajmi2@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2021-03-06T21:47:17.241Z"
+}

--- a/packages/components/Shimmer/FluentUIReactNativeShimmer.podspec
+++ b/packages/components/Shimmer/FluentUIReactNativeShimmer.podspec
@@ -14,9 +14,9 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/microsoft/fluentui-react-native.git", :tag => "#{s.version}" }
   s.swift_version    = "5"
 
-  s.ios.deployment_target = "11.0"
+  s.ios.deployment_target = "13.0"
   s.ios.source_files      = "ios/*.{swift,h,m}"
 
   s.dependency 'React'
-  s.dependency 'MicrosoftFluentUI', '~> 0.1.28'
+  s.dependency 'MicrosoftFluentUI', '~> 0.2.2'
 end

--- a/packages/experimental/Avatar/FluentUIReactNativeAvatar.podspec
+++ b/packages/experimental/Avatar/FluentUIReactNativeAvatar.podspec
@@ -14,13 +14,13 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/microsoft/fluentui-react-native.git", :tag => "#{s.version}" }
   s.swift_version    = "5"
 
-  s.ios.deployment_target = "11.0"
+  s.ios.deployment_target = "13.0"
   s.ios.source_files      = "ios/*.{swift,h,m}"
-  s.ios.dependency 'MicrosoftFluentUI/Controls_ios', '~> 0.1.28'
+  s.ios.dependency 'MicrosoftFluentUI', '~> 0.2.2'
 
   s.osx.deployment_target = "10.14"
   s.osx.source_files      = "macos/*.{swift,h,m}"
-  s.osx.dependency 'MicrosoftFluentUI/AvatarView_mac', '~> 0.1.28'
+  s.osx.dependency 'MicrosoftFluentUI', '~> 0.2.2'
 
   s.dependency 'React'
 end

--- a/packages/experimental/NativeButton/FluentUIReactNativeButton.podspec
+++ b/packages/experimental/NativeButton/FluentUIReactNativeButton.podspec
@@ -15,13 +15,13 @@ Pod::Spec.new do |s|
   s.swift_version    = "5"
   s.dependency 'React'
 
-  s.ios.deployment_target = "11.0"
+  s.ios.deployment_target = "13.0"
   s.ios.source_files      = "ios/*.{swift,h,m}"
-  s.ios.dependency 'MicrosoftFluentUI/Controls_ios', '~> 0.1.28'
+  s.ios.dependency 'MicrosoftFluentUI', '~> 0.2.2'
 
   s.osx.deployment_target = "10.14"
   s.osx.source_files      = "macos/*.{swift,h,m}"
-  s.osx.dependency 'MicrosoftFluentUI/Button_mac', '~> 0.1.28'
+  s.osx.dependency 'MicrosoftFluentUI', '~> 0.2.2'
 
 
 end

--- a/packages/theming/apple-theme/FluentUIReactNativeAppleTheme.podspec
+++ b/packages/theming/apple-theme/FluentUIReactNativeAppleTheme.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.osx.deployment_target = "10.14"
   s.osx.source_files      = "macos/*.{swift,h,m}"
-  s.osx.dependency 'MicrosoftFluentUI', '~> 0.1.28'
+  s.osx.dependency 'MicrosoftFluentUI', '~> 0.2.2'
 
   s.dependency 'React'
 end


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

We are at the 0.2.x releases of FluentUI Apple. Let's update out podspecs and also set our iOS minimum to iOS 13 in accordance. macOS stays at 10.14.

### Verification

Built and launched the iOS and macOS test apps.

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
