### PR TITLE
Add iOS theme native module

### DIFF
--- a/apps/ios/src/Podfile
+++ b/apps/ios/src/Podfile
@@ -23,6 +23,7 @@ use_flipper!(false)
 use_test_app! do |target|
   target.app do
 
+    pod 'FluentUI-React-Native-Apple-Theme', :path => '../../../packages/theming/apple-theme/FluentUIReactNativeAppleTheme.podspec'
     pod 'FluentUI-React-Native-Avatar', :path => '../../../packages/experimental/Avatar/FluentUIReactNativeAvatar.podspec'
     pod 'FluentUI-React-Native-Shimmer', :path => '../../../packages/components/Shimmer/FluentUIReactNativeShimmer.podspec'
     pod 'FluentUI-React-Native-Button', :path => '../../../packages/experimental/NativeButton/FluentUIReactNativeButton.podspec'

--- a/apps/ios/src/Podfile.lock
+++ b/apps/ios/src/Podfile.lock
@@ -435,7 +435,7 @@ SPEC CHECKSUMS:
   DoubleConversion: cde416483dac037923206447da6e1454df403714
   FBLazyVector: 3bb422f41b18121b71783a905c10e58606f7dc3e
   FBReactNativeSpec: f2c97f2529dd79c083355182cc158c9f98f4bd6e
-  FluentUI-React-Native-Apple-Theme: d04fd379b4d18d6b38a80685be904770e9185b5a
+  FluentUI-React-Native-Apple-Theme: 6e49bd84476c8cdd49e205fb1d791e8f009ef024
   FluentUI-React-Native-Avatar: 2eee15cc5a43322668b61e1a214927974b555adc
   FluentUI-React-Native-Button: 9485eb3b3ac48fe9ff7c8201cedc8a6302605acc
   FluentUI-React-Native-Shimmer: b1c87c072238a69fe0fdf10b79cdeb2299968330

--- a/apps/ios/src/Podfile.lock
+++ b/apps/ios/src/Podfile.lock
@@ -9,15 +9,18 @@ PODS:
     - React-Core (= 0.63.4)
     - React-jsi (= 0.63.4)
     - ReactCommon/turbomodule/core (= 0.63.4)
-  - FluentUI-React-Native-Avatar (0.4.3):
+  - FluentUI-React-Native-Apple-Theme (0.2.0):
+    - MicrosoftFluentUI (~> 0.1.28)
+    - React
+  - FluentUI-React-Native-Avatar (0.5.0):
     - MicrosoftFluentUI/AvatarView_mac (~> 0.1.28)
     - MicrosoftFluentUI/Controls_ios (~> 0.1.28)
     - React
-  - FluentUI-React-Native-Button (0.3.1):
+  - FluentUI-React-Native-Button (0.4.0):
     - MicrosoftFluentUI/Button_mac (~> 0.1.28)
     - MicrosoftFluentUI/Controls_ios (~> 0.1.28)
     - React
-  - FluentUI-React-Native-Shimmer (0.4.3):
+  - FluentUI-React-Native-Shimmer (0.5.0):
     - MicrosoftFluentUI (~> 0.1.28)
     - React
   - Folly (2020.01.13.00):
@@ -317,6 +320,7 @@ DEPENDENCIES:
   - DoubleConversion (from `../../../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../../../node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../../../node_modules/react-native/Libraries/FBReactNativeSpec`)
+  - FluentUI-React-Native-Apple-Theme (from `../../../packages/theming/apple-theme/FluentUIReactNativeAppleTheme.podspec`)
   - FluentUI-React-Native-Avatar (from `../../../packages/experimental/Avatar/FluentUIReactNativeAvatar.podspec`)
   - FluentUI-React-Native-Button (from `../../../packages/experimental/NativeButton/FluentUIReactNativeButton.podspec`)
   - FluentUI-React-Native-Shimmer (from `../../../packages/components/Shimmer/FluentUIReactNativeShimmer.podspec`)
@@ -364,6 +368,8 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native/Libraries/FBLazyVector"
   FBReactNativeSpec:
     :path: "../../../node_modules/react-native/Libraries/FBReactNativeSpec"
+  FluentUI-React-Native-Apple-Theme:
+    :path: "../../../packages/theming/apple-theme/FluentUIReactNativeAppleTheme.podspec"
   FluentUI-React-Native-Avatar:
     :path: "../../../packages/experimental/Avatar/FluentUIReactNativeAvatar.podspec"
   FluentUI-React-Native-Button:
@@ -426,9 +432,10 @@ SPEC CHECKSUMS:
   DoubleConversion: cde416483dac037923206447da6e1454df403714
   FBLazyVector: 3bb422f41b18121b71783a905c10e58606f7dc3e
   FBReactNativeSpec: f2c97f2529dd79c083355182cc158c9f98f4bd6e
-  FluentUI-React-Native-Avatar: f43459273f21935f033da1f73c310a11bfb7302b
-  FluentUI-React-Native-Button: 8006a5f286d58d9f41d8f969038bea01ae508760
-  FluentUI-React-Native-Shimmer: 643f9fef0d8cfc3408bcef350e6d490adcb0a38a
+  FluentUI-React-Native-Apple-Theme: 4598c975ee3c3c666415bacc7556b9ca69aeca7a
+  FluentUI-React-Native-Avatar: 57c82c274f0dc442242b8a1d5dadd769343c47d0
+  FluentUI-React-Native-Button: cfbeda7e92f76acb584df8d9ed79e932ad63bf1d
+  FluentUI-React-Native-Shimmer: 229d5ef2e3ae6dc24f6f5e3b407288eab6b7af43
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
   glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
   MicrosoftFluentUI: 2dfff618a4fed9d1539a568449323da2bedcccae
@@ -458,6 +465,6 @@ SPEC CHECKSUMS:
   SwiftLint: 4fa9579c63416865179bc416f0a92d55f009600d
   Yoga: 4bd86afe9883422a7c4028c00e34790f560923d6
 
-PODFILE CHECKSUM: 92ad496f45726c3f2dfe3835c607a1b6ca267da8
+PODFILE CHECKSUM: 2ede416aa5367b8b195aacbd9cc91b10233bdfb3
 
 COCOAPODS: 1.10.1

--- a/apps/macos/src/Podfile.lock
+++ b/apps/macos/src/Podfile.lock
@@ -406,7 +406,7 @@ SPEC CHECKSUMS:
   DoubleConversion: 56a44bcfd14ab2ff66f5a146b2e875eb4b69b19b
   FBLazyVector: 87ca368919ae0ec70816fb8a42252ef59dc05c94
   FBReactNativeSpec: 7c0591658d85effad209fc4f45b6c9760f9e5842
-  FluentUI-React-Native-Apple-Theme: d04fd379b4d18d6b38a80685be904770e9185b5a
+  FluentUI-React-Native-Apple-Theme: 6e49bd84476c8cdd49e205fb1d791e8f009ef024
   FluentUI-React-Native-Avatar: 2eee15cc5a43322668b61e1a214927974b555adc
   FluentUI-React-Native-Button: 9485eb3b3ac48fe9ff7c8201cedc8a6302605acc
   glog: 1cb7c408c781ae8f35bbababe459b45e3dee4ec1

--- a/packages/theming/apple-theme/FluentUIReactNativeAppleTheme.podspec
+++ b/packages/theming/apple-theme/FluentUIReactNativeAppleTheme.podspec
@@ -14,6 +14,10 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/microsoft/fluentui-react-native.git", :tag => "#{s.version}" }
   s.swift_version    = "5"
 
+  s.ios.deployment_target = "11"
+  s.ios.source_files      = "ios/*.{swift,h,m}"
+  s.ios.dependency 'MicrosoftFluentUI', '~> 0.1.28'
+
   s.osx.deployment_target = "10.14"
   s.osx.source_files      = "macos/*.{swift,h,m}"
   s.osx.dependency 'MicrosoftFluentUI', '~> 0.1.28'

--- a/packages/theming/apple-theme/FluentUIReactNativeAppleTheme.podspec
+++ b/packages/theming/apple-theme/FluentUIReactNativeAppleTheme.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/microsoft/fluentui-react-native.git", :tag => "#{s.version}" }
   s.swift_version    = "5"
 
-  s.ios.deployment_target = "11"
+  s.ios.deployment_target = "13.0"
   s.ios.source_files      = "ios/*.{swift,h,m}"
   s.ios.dependency 'MicrosoftFluentUI', '~> 0.2.2'
 

--- a/packages/theming/apple-theme/README.md
+++ b/packages/theming/apple-theme/README.md
@@ -1,10 +1,12 @@
 # Apple-theme
 
-Code and definitions for creating an Apple Theme for FluentUI React Native. Currently only implemented for macOS. iOS Apple theme progress is tracked at Github #596
+Code and definitions for creating an Apple Theme for FluentUI React Native.
+
+The theme first loads a base theme defined in JS, and then has a callback to layer a native theme defined in a native module on top of the base theme. This allows us to grab colors / constants / styling directly from FluentUI Apple, while still having a fallback as we wait for the native module to load.
 
 Some heuristics followed in this theme:
 
 - For most tokens, we default to prefer the apple system colors, using the FluentUI Apple Palette where it makes sense. These mappings are subject to change as we increment on the design.
 - On apple platforms, there tends to not be a "hover" state for components such as Button, so those tokens are mapped to be identical to the rest state (normal state) tokens.
-- Similarly, there is not a "checked" state for most components, so those tokens are mapped to the pressed state tokens.
+- Similarly, there is not a "checked" state for most components, so those tokens are mapped to the rest state tokens.
 - The typography is designed to match the variants provided by the [Apple HIG](https://developer.apple.com/design/human-interface-guidelines/macos/visual-design/typography/) for regular and "emphasized". As such, the "Semibold" variants do not always map to the semibold weight, but whatever weight the Apple HIG specifies.

--- a/packages/theming/apple-theme/ios/AppleThemeModule-Bridging-Header.h
+++ b/packages/theming/apple-theme/ios/AppleThemeModule-Bridging-Header.h
@@ -1,0 +1,4 @@
+#import <React/RCTBridgeModule.h>
+#import <React/RCTConvert.h>
+#import <React/RCTEventEmitter.h>
+#import <React/RCTUtils.h>

--- a/packages/theming/apple-theme/ios/AppleThemeModule.swift
+++ b/packages/theming/apple-theme/ios/AppleThemeModule.swift
@@ -2,27 +2,7 @@ import Foundation
 import FluentUI
 
 @objc(MSFAppleThemeModule)
-class AppleThemeModule: RCTEventEmitter, UITraitEnvironment {
-	
-	override init() {
-
-		if #available(iOS 13.0, *) {
-			traitCollection = UITraitCollection.current
-		} else {
-			// Fallback on earlier versions
-			traitCollection = UIScreen.main.traitCollection
-		}
-		super.init()
-	}
-	
-	// MARK: - UITraitEnvironment
-	
-	var traitCollection: UITraitCollection
-	
-	func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-		self.sendEvent(withName: Events.traitCollectionDidChange.name, body: theme)
-	}
-	
+class AppleThemeModule: RCTEventEmitter {
 
 	public enum Events: CaseIterable {
 		case traitCollectionDidChange
@@ -44,7 +24,7 @@ class AppleThemeModule: RCTEventEmitter, UITraitEnvironment {
 	var theme: [AnyHashable: Any] {
 		get {
 			if #available(iOS 12.0, *) {
-				let isDarkMode = traitCollection.userInterfaceStyle == .dark
+				let isDarkMode = UITraitCollection.current.userInterfaceStyle == .dark
 				return [
 					"colors": palette(),
 					"typography" : [
@@ -297,27 +277,16 @@ class AppleThemeModule: RCTEventEmitter, UITraitEnvironment {
 	func fontFamilies() -> [AnyHashable : Any] {
 			
 		let systemFontFamilyName = UIFont.systemFont(ofSize: 0).familyName
-			
-		if #available(iOS 13.0, *) {
-			let monospaceFontFamilyName = UIFont.monospacedSystemFont(ofSize: 0, weight: .regular).familyName
-			return [
-				"primary" : systemFontFamilyName,
-				"monospace" : monospaceFontFamilyName,
-				"secondary": systemFontFamilyName,
-				"cursive": systemFontFamilyName,
-				"sansSerif": systemFontFamilyName,
-				"serif": systemFontFamilyName
-			]
-		} else {
-			return [
-				"primary" : systemFontFamilyName,
-				"monospace" : systemFontFamilyName,
-				"secondary": systemFontFamilyName,
-				"cursive": systemFontFamilyName,
-				"sansSerif": systemFontFamilyName,
-				"serif": systemFontFamilyName
-			]
-		}
+		let monospaceFontFamilyName = UIFont.monospacedSystemFont(ofSize: 0, weight: .regular).familyName
+		return [
+			"primary" : systemFontFamilyName,
+			"monospace" : monospaceFontFamilyName,
+			"secondary": systemFontFamilyName,
+			"cursive": systemFontFamilyName,
+			"sansSerif": systemFontFamilyName,
+			"serif": systemFontFamilyName
+		]
+
 	}
 
 	/// Map the current FluentUI React Native font sizes approximately to their corresponding apple text style,
@@ -434,30 +403,12 @@ class AppleThemeModule: RCTEventEmitter, UITraitEnvironment {
 	override func startObserving() {
 		hasListeners = true;
 		
-		if #available(iOS 13.0, *) {
-			kvoToken = UITraitCollection.current.observe(\.userInterfaceStyle) {(traitCollection, change) in
-				guard self.bridge != nil else {
-					return
-				}
-				self.sendEvent(withName: Events.traitCollectionDidChange.name, body: self.theme)
+		kvoToken = UITraitCollection.current.observe(\.userInterfaceStyle) {(traitCollection, change) in
+			guard self.bridge != nil else {
+				return
 			}
-		} else {
-			// Fallback on earlier versions
+			self.sendEvent(withName: Events.traitCollectionDidChange.name, body: self.theme)
 		}
-		
-//		if #available(iOS 12.0, *) {
-//			kvoToken = traitCollection.observe(\.userInterfaceStyle) {(traitCollection, change) in
-//				guard self.bridge != nil else {
-//					return
-//				}
-//				self.sendEvent(withName: Events.traitCollectionDidChange.name, body: self.theme)
-//			}
-//		} else {
-//			// Fallback on earlier versions
-//		}
-		
-		
-		
 	}
 
 	override func stopObserving() {

--- a/packages/theming/apple-theme/ios/AppleThemeModule.swift
+++ b/packages/theming/apple-theme/ios/AppleThemeModule.swift
@@ -289,7 +289,7 @@ class AppleThemeModule: NSObject {
 	}
 
 	static func fontWeights() -> [UIFont.Weight : Any] {
-		/// Assume that the 9 values of Apples NSFont.Weight ramp map to the W3C font-weight ramp in the css-fonts spec
+		/// Assume that the 9 values of Apples UIFont.Weight ramp map to the W3C font-weight ramp in the css-fonts spec
 		/// https://www.w3.org/TR/css-fonts-4/#font-weight-prop
 		return [
 			.ultraLight : "100",
@@ -312,7 +312,7 @@ class AppleThemeModule: NSObject {
 			"captionStandard": [
 				"face" : families["primary"],
 				"size" : sizes["caption"],
-				"weight" : weights[.medium],
+				"weight" : weights[.regular],
 			],
 			"secondaryStandard": [
 				"face" : families["primary"],
@@ -347,7 +347,7 @@ class AppleThemeModule: NSObject {
 			"headerStandard": [
 				"face" : families["primary"],
 				"size" : sizes["header"],
-				"weight" : weights[.bold],
+				"weight" : weights[.semibold],
 			],
 			"headerSemibold": [
 				"face" : families["primary"],
@@ -362,7 +362,7 @@ class AppleThemeModule: NSObject {
 			"heroSemibold": [
 				"face" : families["primary"],
 				"size" : sizes["hero"],
-				"weight" : weights[.bold],
+				"weight" : weights[.semibold],
 			],
 			"heroLargeStandard": [
 				"face" : families["primary"],
@@ -372,7 +372,7 @@ class AppleThemeModule: NSObject {
 			"heroLargeSemibold": [
 				"face" : families["primary"],
 				"size" : sizes["heroLarge"],
-				"weight" : weights[.bold],
+				"weight" : weights[.semibold],
 			],
 		]
 	}

--- a/packages/theming/apple-theme/ios/AppleThemeModule.swift
+++ b/packages/theming/apple-theme/ios/AppleThemeModule.swift
@@ -1,0 +1,471 @@
+import Foundation
+import FluentUI
+
+@objc(MSFAppleThemeModule)
+class AppleThemeModule: RCTEventEmitter {
+
+	public enum Events: CaseIterable {
+		case AppleInterfaceThemeChanged
+		case AppleColorPreferencesChanged
+
+		var name: String {
+			switch self {
+			case .AppleInterfaceThemeChanged:
+				return "AppleInterfaceThemeChanged";
+			case .AppleColorPreferencesChanged:
+				return "AppleColorPreferencesChanged";
+			}
+		}
+	}
+
+	override var methodQueue: DispatchQueue {
+		get {
+			return DispatchQueue.main
+		}
+	}
+	
+	static var theme: [AnyHashable: Any] {
+		get {
+			// https://stackoverflow.com/questions/56968587/nscolor-systemcolor-not-changing-when-dark-light-mode-switched
+			// Due to some weirdness in how macOS handles appearance changes, we need this extra logic in order to convert
+			// the system colors to their corrent hex strings at the time of this method invokation.
+			let appearance = NSApp.effectiveAppearance
+			var _theme: [AnyHashable: Any]  = [:]
+			if #available(OSX 11.0, *) {
+				appearance.performAsCurrentDrawingAppearance({
+					_theme = calculateTheme()
+				})
+			} else {
+				NSAppearance.current = appearance
+				_theme = calculateTheme()
+			}
+			return _theme
+		}
+	}
+
+	static private func calculateTheme() -> [AnyHashable : Any] {
+		let isDarkMode = NSApplication.shared.effectiveAppearance.bestMatch(from: [.darkAqua]) == .darkAqua
+		return [
+			"colors": palette(),
+			"typography" : [
+				"sizes" : fontSizes(),
+				"weights" : fontWeights(),
+				"families" : fontFamilies(),
+				"variants" : fontVariants()
+			],
+			"host" : [
+				"appearance" : isDarkMode ? "dark" : "light"
+			]
+		]
+	}
+
+	override class func requiresMainQueueSetup() -> Bool {
+		
+		UITraitCollection.self
+		
+		return true
+	}
+
+	@objc(getApplePartialThemeWithCallback:)
+	func getApplePartialTheme(callback: RCTResponseSenderBlock) {
+		callback([NSNull(), AppleThemeModule.theme])
+	}
+	
+	// MARK: - Colors
+
+	static func palette() -> [AnyHashable : Any] {
+
+		// Lifted from FluentUI Button as they aren't exposed publicly.
+		let brandForegroundDisabled = NSColor(named: "ButtonColors/brandForegroundDisabled", bundle: FluentUIResources.resourceBundle)!
+		let brandBackgroundDisabled = NSColor(named: "ButtonColors/brandBackgroundDisabled", bundle: FluentUIResources.resourceBundle)!
+		let neutralInverted = NSColor(named: "ButtonColors/neutralInverted", bundle: FluentUIResources.resourceBundle)!
+//		let neutralForeground2 = NSColor(named: "ButtonColors/neutralForeground2", bundle: FluentUIResources.resourceBundle)!
+//		let neutralBackground2 = NSColor(named: "ButtonColors/neutralBackground2", bundle: FluentUIResources.resourceBundle)!
+//		let neutralStroke2 = NSColor(named: "ButtonColors/neutralStroke2", bundle: FluentUIResources.resourceBundle)!
+		let neutralForeground3 = NSColor(named: "ButtonColors/neutralForeground3", bundle: FluentUIResources.resourceBundle)!
+		let neutralBackground3 = NSColor(named: "ButtonColors/neutralBackground3", bundle: FluentUIResources.resourceBundle)!
+
+		return [
+			/* PaletteBackgroundColors & PaletteTextColors */
+
+			"background" : RCTColorToHexString(NSColor.windowBackgroundColor.cgColor),
+			"bodyStandoutBackground" : RCTColorToHexString(NSColor.underPageBackgroundColor.cgColor),
+			"bodyFrameBackground" : RCTColorToHexString(NSColor.windowBackgroundColor.cgColor),
+			"bodyFrameDivider" : RCTColorToHexString(NSColor.separatorColor.cgColor),
+			"bodyText" : RCTColorToHexString(NSColor.textColor.cgColor),
+			"bodyTextChecked" : RCTColorToHexString(NSColor.selectedTextColor.cgColor),
+			"subText" : RCTColorToHexString(NSColor.placeholderTextColor.cgColor),
+			"bodyDivider" : RCTColorToHexString(NSColor.separatorColor.cgColor),
+
+			"disabledBackground" : RCTColorToHexString(FluentUI.Colors.color(from: FluentUI.Colors.Palette.gray100).cgColor),
+			"disabledText" : RCTColorToHexString(NSColor.tertiaryLabelColor.cgColor),
+			"disabledBodyText" : RCTColorToHexString(NSColor.tertiaryLabelColor.cgColor),
+			"disabledSubtext" : RCTColorToHexString(NSColor.quaternaryLabelColor.cgColor),
+			"disabledBodySubtext" : RCTColorToHexString(NSColor.quaternaryLabelColor.cgColor),
+
+			"focusBorder" : "transparent",
+			"variantBorder" : RCTColorToHexString(NSColor.separatorColor.cgColor),
+			"variantBorderHovered" : RCTColorToHexString(NSColor.separatorColor.cgColor),
+			"defaultStateBackground" : RCTColorToHexString(NSColor.controlBackgroundColor.cgColor),
+
+			"errorText" : RCTColorToHexString(FluentUI.Colors.color(from: FluentUI.Colors.Palette.dangerPrimary).cgColor),
+			"warningText" : RCTColorToHexString(FluentUI.Colors.color(from: FluentUI.Colors.Palette.warningPrimary).cgColor),
+			"errorBackground" : RCTColorToHexString(FluentUI.Colors.color(from: FluentUI.Colors.Palette.dangerTint10).cgColor),
+			"blockingBackground" : RCTColorToHexString(FluentUI.Colors.color(from: FluentUI.Colors.Palette.dangerTint10).cgColor),
+			"warningBackground" : RCTColorToHexString(FluentUI.Colors.color(from: FluentUI.Colors.Palette.warningPrimary).cgColor),
+			"warningHighlight" : RCTColorToHexString(FluentUI.Colors.color(from: FluentUI.Colors.Palette.warningTint10).cgColor),
+			"successBackground" : RCTColorToHexString(FluentUI.Colors.color(from: FluentUI.Colors.Palette.successTint10).cgColor),
+
+			"inputBorder" : RCTColorToHexString(NSColor.separatorColor.cgColor),
+			"inputBorderHovered" : RCTColorToHexString(NSColor.separatorColor.cgColor),
+			"inputBackground" : RCTColorToHexString(NSColor.textBackgroundColor.cgColor),
+			"inputBackgroundChecked" : RCTColorToHexString(NSColor.textBackgroundColor.cgColor),
+			"inputBackgroundCheckedHovered" : RCTColorToHexString(NSColor.textBackgroundColor.cgColor),
+			"inputForegroundChecked" : RCTColorToHexString(FluentUI.Colors.color(from: FluentUI.Colors.Palette.communicationBlue).cgColor),
+			"inputFocusBorderAlt" : RCTColorToHexString(NSColor.keyboardFocusIndicatorColor.cgColor),
+			"smallInputBorder" : RCTColorToHexString(NSColor.separatorColor.cgColor),
+			"inputText" : RCTColorToHexString(NSColor.textColor.cgColor),
+			"inputTextHovered" : RCTColorToHexString(NSColor.textColor.cgColor),
+			"inputPlaceholderText" : RCTColorToHexString(NSColor.placeholderTextColor.cgColor),
+
+			// Set the default button tokens to match the Acrylic Button style
+			"buttonBackgroundChecked" : RCTColorToHexString(neutralBackground3.cgColor),
+			"buttonBackgroundHovered" : RCTColorToHexString(neutralBackground3.cgColor),
+			"buttonBackgroundCheckedHovered" : RCTColorToHexString(neutralBackground3.cgColor),
+			"buttonBackgroundPressed" : RCTColorToHexString(neutralBackground3.withSystemEffect(.pressed).cgColor),
+			"buttonBackgroundDisabled" : RCTColorToHexString(neutralBackground3.withSystemEffect(.disabled).cgColor),
+			"buttonText" : RCTColorToHexString(neutralForeground3.cgColor),
+			"buttonTextHovered" : RCTColorToHexString(neutralForeground3.cgColor),
+			"buttonTextChecked" : RCTColorToHexString(neutralForeground3.cgColor),
+			"buttonTextCheckedHovered" : RCTColorToHexString(neutralForeground3.cgColor),
+			"buttonTextPressed" : RCTColorToHexString(neutralForeground3.withSystemEffect(.pressed).cgColor),
+			"buttonTextDisabled" : RCTColorToHexString(neutralForeground3.withSystemEffect(.disabled).cgColor),
+			"buttonBorderDisabled" : "transparent",
+			"buttonBorderFocused" : "transparent",
+
+			"primaryButtonBackground" : RCTColorToHexString(FluentUI.Colors.primary.cgColor),
+			"primaryButtonBackgroundHovered" : RCTColorToHexString(FluentUI.Colors.primary.cgColor),
+			"primaryButtonBackgroundPressed" : RCTColorToHexString(FluentUI.Colors.primary.withSystemEffect(.pressed).cgColor),
+			"primaryButtonBackgroundDisabled" : RCTColorToHexString(brandBackgroundDisabled.cgColor),
+			"primaryButtonBorder" : "transparent",
+			"primaryButtonBorderFocused" : "transparent",
+			"primaryButtonText" : RCTColorToHexString(neutralInverted.cgColor),
+			"primaryButtonTextHovered" : RCTColorToHexString(neutralInverted.cgColor),
+			"primaryButtonTextPressed" : RCTColorToHexString(neutralInverted.withSystemEffect(.pressed).cgColor),
+			"primaryButtonTextDisabled" : RCTColorToHexString(brandForegroundDisabled.cgColor),
+
+			"accentButtonBackground" : RCTColorToHexString(FluentUI.Colors.primary.cgColor),
+			"accentButtonText" : RCTColorToHexString(neutralInverted.cgColor),
+
+			"menuBackground" : "transparent",
+			"menuDivider" : RCTColorToHexString(NSColor.separatorColor.cgColor),
+			"menuIcon" : RCTColorToHexString(NSColor.textColor.cgColor),
+			"menuHeader" : RCTColorToHexString(NSColor.headerTextColor.cgColor),
+			"menuItemBackgroundHovered" : "transparent",
+			"menuItemBackgroundPressed" : RCTColorToHexString(NSColor.selectedContentBackgroundColor.cgColor),
+			"menuItemText" : RCTColorToHexString(NSColor.textColor.cgColor),
+			"menuItemTextHovered" : RCTColorToHexString(NSColor.textColor.cgColor),
+
+			"listBackground" : "transparent",
+			"listText" : RCTColorToHexString(NSColor.textColor.cgColor),
+			"listItemBackgroundHovered" : "transparent",
+			"listItemBackgroundChecked" : "transparent",
+			"listItemBackgroundCheckedHovered" : "transparent",
+
+			"listHeaderBackgroundHovered" : RCTColorToHexString(NSColor.headerTextColor.cgColor),
+			"listHeaderBackgroundPressed" : RCTColorToHexString(NSColor.headerTextColor.cgColor),
+
+			"actionLink" : RCTColorToHexString(NSColor.linkColor.cgColor),
+			"actionLinkHovered" : RCTColorToHexString(NSColor.linkColor.cgColor),
+			"link" : RCTColorToHexString(NSColor.linkColor.cgColor),
+			"linkHovered" : RCTColorToHexString(NSColor.linkColor.cgColor),
+			"linkPressed" : RCTColorToHexString(NSColor.selectedControlColor.cgColor),
+
+			/* ControlColorTokens */
+
+			// Set the default button tokens to match the Acrylic Button style
+			"buttonBackground" : RCTColorToHexString(neutralBackground3.cgColor),
+			"buttonBorder" : "transparent",
+			"buttonContent" : RCTColorToHexString(neutralForeground3.cgColor),
+			"buttonIcon" : RCTColorToHexString(neutralForeground3.cgColor),
+
+			"buttonHoveredBackground" : RCTColorToHexString(neutralBackground3.cgColor),
+			"buttonHoveredBorder" : "transparent",
+			"buttonHoveredContent" : RCTColorToHexString(neutralForeground3.cgColor),
+			"buttonHoveredIcon" : RCTColorToHexString(neutralForeground3.cgColor),
+
+			"buttonFocusedBackground" : RCTColorToHexString(neutralForeground3.cgColor),
+			"buttonFocusedBorder" : "transparent",
+			"buttonFocusedContent" : RCTColorToHexString(neutralForeground3.cgColor),
+			"buttonFocusedIcon" : RCTColorToHexString(neutralForeground3.cgColor),
+
+			"buttonPressedBackground" : RCTColorToHexString(neutralBackground3.withSystemEffect(.pressed).cgColor),
+			"buttonPressedBorder" : "transparent",
+			"buttonPressedContent" : RCTColorToHexString(neutralForeground3.withSystemEffect(.pressed).cgColor),
+			"buttonPressedIcon" : RCTColorToHexString(neutralForeground3.withSystemEffect(.pressed).cgColor),
+
+			"buttonDisabledBackground" : RCTColorToHexString(neutralBackground3.withSystemEffect(.disabled).cgColor),
+			"buttonDisabledBorder" : "transparent",
+			"buttonDisabledContent" : RCTColorToHexString(neutralForeground3.withSystemEffect(.disabled).cgColor),
+			"buttonDisabledIcon" : RCTColorToHexString(neutralForeground3.withSystemEffect(.disabled).cgColor),
+
+			"ghostBackground" : "transparent",
+			"ghostBorder" : "transparent",
+			"ghostContent" : RCTColorToHexString(FluentUI.Colors.primary.cgColor),
+			"ghostIcon" : RCTColorToHexString(FluentUI.Colors.primary.cgColor),
+
+			"ghostHoveredBackground" : "transparent",
+			"ghostHoveredBorder" : "transparent",
+			"ghostHoveredContent" : RCTColorToHexString(FluentUI.Colors.primary.cgColor),
+			"ghostHoveredIcon" : RCTColorToHexString(FluentUI.Colors.primary.cgColor),
+
+			"ghostFocusedBackground" : "transparent",
+			"ghostFocusedBorder" : "transparent",
+			"ghostFocusedContent" : RCTColorToHexString(FluentUI.Colors.primary.cgColor),
+			"ghostFocusedIcon" : RCTColorToHexString(FluentUI.Colors.primary.cgColor),
+
+			"ghostPressedBackground" : "transparent",
+			"ghostPressedBorder" : "transparent",
+			"ghostPressedContent" : RCTColorToHexString(FluentUI.Colors.primary.withSystemEffect(.deepPressed).cgColor),
+			"ghostPressedIcon" : RCTColorToHexString(FluentUI.Colors.primary.withSystemEffect(.deepPressed).cgColor),
+
+			"ghostDisabledBackground" : "transparent",
+			"ghostDisabledBorder" : "transparent",
+			"ghostDisabledContent" : RCTColorToHexString(brandForegroundDisabled.cgColor),
+			"ghostDisabledIcon" : RCTColorToHexString(brandForegroundDisabled.cgColor),
+
+			"brandBackground" : RCTColorToHexString(FluentUI.Colors.primary.cgColor),
+			"brandBorder" : "transparent",
+			"brandContent" : RCTColorToHexString(neutralInverted.cgColor),
+			"brandIcon" : RCTColorToHexString(neutralInverted.cgColor),
+
+			"brandHoveredBackground" : RCTColorToHexString(FluentUI.Colors.primary.cgColor),
+			"brandHoveredBorder" : "transparent",
+			"brandHoveredContent" : RCTColorToHexString(neutralInverted.cgColor),
+			"brandHoveredIcon" : RCTColorToHexString(neutralInverted.cgColor),
+
+			"brandFocusedBackground" : RCTColorToHexString(FluentUI.Colors.primary.cgColor),
+			"brandFocusedBorder" : "transparent",
+			"brandFocusedContent" : RCTColorToHexString(neutralInverted.cgColor),
+			"brandFocusedIcon" : RCTColorToHexString(neutralInverted.cgColor),
+
+			"brandPressedBackground" : RCTColorToHexString(FluentUI.Colors.primary.withSystemEffect(.pressed).cgColor),
+			"brandPressedBorder" : "transparent",
+			"brandPressedContent" : RCTColorToHexString(neutralInverted.cgColor),
+			"brandPressedIcon" : RCTColorToHexString(neutralInverted.cgColor),
+
+			"brandDisabledBackground" : RCTColorToHexString(brandBackgroundDisabled.cgColor),
+			"brandDisabledBorder" : "transparent",
+			"brandDisabledContent" : RCTColorToHexString(brandForegroundDisabled.cgColor),
+			"brandDisabledIcon" : RCTColorToHexString(brandForegroundDisabled.cgColor),
+
+			"buttonCheckedBackground" : RCTColorToHexString(FluentUI.Colors.primary.cgColor),
+			"buttonCheckedContent" : RCTColorToHexString(neutralInverted.cgColor),
+			"buttonCheckedHoveredBackground" : RCTColorToHexString(FluentUI.Colors.primary.cgColor),
+			"buttonCheckedHoveredContent" : RCTColorToHexString(neutralInverted.cgColor),
+
+			"brandCheckedBackground" : RCTColorToHexString(FluentUI.Colors.primary.cgColor),
+			"brandCheckedContent" : RCTColorToHexString(neutralInverted.cgColor),
+			"brandCheckedHoveredBackground" : RCTColorToHexString(FluentUI.Colors.primary.cgColor),
+			"brandCheckedHoveredContent" : RCTColorToHexString(neutralInverted.cgColor),
+
+			"ghostCheckedBackground" : "transparent",
+			"ghostCheckedContent" : RCTColorToHexString(FluentUI.Colors.primary.cgColor),
+			"ghostCheckedHoveredBackground" : "transparent",
+			"ghostCheckedHoveredContent" : RCTColorToHexString(FluentUI.Colors.primary.cgColor),
+			"ghostCheckedHoveredBorder" : "transparent",
+
+			"ghostSecondaryContent" : RCTColorToHexString(FluentUI.Colors.primary.cgColor),
+			"ghostFocusedSecondaryContent" :RCTColorToHexString(FluentUI.Colors.primary.cgColor),
+			"ghostHoveredSecondaryContent" : RCTColorToHexString(FluentUI.Colors.primary.cgColor),
+			"ghostPressedSecondaryContent" : RCTColorToHexString(FluentUI.Colors.primary.withSystemEffect(.deepPressed).cgColor),
+
+			"brandSecondaryContent" : RCTColorToHexString(neutralInverted.cgColor),
+			"brandFocusedSecondaryContent" : RCTColorToHexString(neutralInverted.cgColor),
+			"brandHoveredSecondaryContent" : RCTColorToHexString(neutralInverted.cgColor),
+			"brandPressedSecondaryContent" : RCTColorToHexString(neutralInverted.withSystemEffect(.pressed).cgColor),
+
+			"buttonDisabledSecondaryContent" : RCTColorToHexString(brandForegroundDisabled.cgColor),
+			"buttonHoveredSecondaryContent" : RCTColorToHexString(neutralInverted.cgColor),
+			"buttonPressedSecondaryContent" : RCTColorToHexString(neutralInverted.cgColor),
+		]
+	}
+
+	// MARK: - Typography
+
+	static func fontFamilies() -> [AnyHashable : Any] {
+			
+		let systemFontFamilyName = UIFont.systemFont(ofSize: 0).familyName
+			
+		if #available(iOS 13.0, *) {
+			let monospaceFontFamilyName = UIFont.monospacedSystemFont(ofSize: 0, weight: .regular).familyName
+			return [
+				"primary" : systemFontFamilyName,
+				"monospace" : monospaceFontFamilyName,
+				"secondary": systemFontFamilyName,
+				"cursive": systemFontFamilyName,
+				"sansSerif": systemFontFamilyName,
+				"serif": systemFontFamilyName
+			]
+		} else {
+			return [
+				"primary" : systemFontFamilyName,
+				"monospace" : systemFontFamilyName,
+				"secondary": systemFontFamilyName,
+				"cursive": systemFontFamilyName,
+				"sansSerif": systemFontFamilyName,
+				"serif": systemFontFamilyName
+			]
+		}
+	}
+
+	/// Map the current FluentUI React Native font sizes approximately to their corresponding apple text style,
+	/// For older vesrions of macOS, fallback to the values described in the apple HIG:
+	/// https://developer.apple.com/design/human-interface-guidelines/macos/visual-design/typography/
+	/// These mappings and variants are subject to change as we moved to a unified cross platform Fluent typography ramp
+	static func fontSizes() -> [AnyHashable : Any] {
+		
+		
+		
+			return [
+				"caption" : FluentUI.Fonts.caption2.pointSize,
+				"secondary" : FluentUI.Fonts.caption1.pointSize,
+				"body" : FluentUI.Fonts.body.pointSize,
+				"subheader" : FluentUI.Fonts.subhead.pointSize,
+				"header" : FluentUI.Fonts.headline.pointSize,
+				"hero" : FluentUI.Fonts.title1.pointSize,
+				"heroLarge" : FluentUI.Fonts.largeTitle.pointSize
+			]
+	}
+
+	static func fontWeights() -> [UIFont.Weight : Any] {
+		/// Assume that the 9 values of Apples NSFont.Weight ramp map to the W3C font-weight ramp in the css-fonts spec
+		/// https://www.w3.org/TR/css-fonts-4/#font-weight-prop
+		return [
+			.ultraLight : "100",
+			.thin : "200",
+			.light : "300",
+			.regular : "400",
+			.medium : "500",
+			.semibold : "600",
+			.bold : "700",
+			.heavy : "800",
+			.black : "900",
+		]
+	}
+
+	static func fontVariants() -> [AnyHashable : Any] {
+		let families = fontFamilies()
+		let sizes = fontSizes()
+		let weights = fontWeights()
+		return [
+			"captionStandard": [
+				"face" : families["primary"],
+				"size" : sizes["caption"],
+				"weight" : weights[.medium],
+			],
+			"secondaryStandard": [
+				"face" : families["primary"],
+				"size" : sizes["secondary"],
+				"weight" : weights[.regular],
+			],
+			"secondarySemibold": [
+				"face" : families["primary"],
+				"size" : sizes["secondary"],
+				"weight" : weights[.semibold],
+			],
+			"bodyStandard": [
+				"face" : families["primary"],
+				"size" : sizes["body"],
+				"weight" : weights[.regular],
+			],
+			"bodySemibold": [
+				"face" : families["primary"],
+				"size" : sizes["body"],
+				"weight" : weights[.semibold],
+			],
+			"subheaderStandard": [
+				"face" : families["primary"],
+				"size" : sizes["subheader"],
+				"weight" : weights[.regular],
+			],
+			"subheaderSemibold": [
+				"face" : families["primary"],
+				"size" : sizes["subheader"],
+				"weight" : weights[.semibold],
+			],
+			"headerStandard": [
+				"face" : families["primary"],
+				"size" : sizes["header"],
+				"weight" : weights[.bold],
+			],
+			"headerSemibold": [
+				"face" : families["primary"],
+				"size" : sizes["header"],
+				"weight" : weights[.heavy],
+			],
+			"heroStandard": [
+				"face" : families["primary"],
+				"size" : sizes["hero"],
+				"weight" : weights[.regular],
+			],
+			"heroSemibold": [
+				"face" : families["primary"],
+				"size" : sizes["hero"],
+				"weight" : weights[.bold],
+			],
+			"heroLargeStandard": [
+				"face" : families["primary"],
+				"size" : sizes["heroLarge"],
+				"weight" : weights[.regular],
+			],
+			"heroLargeSemibold": [
+				"face" : families["primary"],
+				"size" : sizes["heroLarge"],
+				"weight" : weights[.bold],
+			],
+		]
+	}
+
+	// MARK: - Event Emitter
+
+	override func supportedEvents() -> [String]! {
+		return Events.allCases.map { $0.name }
+	}
+
+	override func startObserving() {
+		hasListeners = true;
+		
+			
+		kvoToken = NSApplication.shared.observe(\.effectiveAppearance) { (application, change) in
+			guard self.bridge != nil else {
+				return
+			}
+			self.sendEvent(withName: Events.AppleInterfaceThemeChanged.name, body: AppleThemeModule.theme)
+		}
+		
+		// Observe changes to control accent color
+		let notificationCenter = DistributedNotificationCenter.default()
+		notificationCenter.addObserver(forName: NSColor.systemColorsDidChangeNotification, object: nil, queue: OperationQueue.main) { (notification) in
+			if (self.hasListeners) {
+				guard self.bridge != nil else {
+					return
+				}
+				self.sendEvent(withName: Events.AppleInterfaceThemeChanged.name, body: AppleThemeModule.theme)
+			}
+		}
+
+		
+	}
+
+	override func stopObserving() {
+		let notificationCenter = DistributedNotificationCenter.default()
+		notificationCenter.removeObserver(self)
+		kvoToken?.invalidate()
+		hasListeners = false;
+	}
+
+	private var hasListeners = false
+	
+	private var kvoToken: NSKeyValueObservation?
+}

--- a/packages/theming/apple-theme/ios/AppleThemeModule.swift
+++ b/packages/theming/apple-theme/ios/AppleThemeModule.swift
@@ -433,8 +433,9 @@ class AppleThemeModule: RCTEventEmitter, UITraitEnvironment {
 
 	override func startObserving() {
 		hasListeners = true;
-		if #available(iOS 12.0, *) {
-			kvoToken = traitCollection.observe(\.userInterfaceStyle) {(traitCollection, change) in
+		
+		if #available(iOS 13.0, *) {
+			kvoToken = UITraitCollection.current.observe(\.userInterfaceStyle) {(traitCollection, change) in
 				guard self.bridge != nil else {
 					return
 				}
@@ -443,6 +444,20 @@ class AppleThemeModule: RCTEventEmitter, UITraitEnvironment {
 		} else {
 			// Fallback on earlier versions
 		}
+		
+//		if #available(iOS 12.0, *) {
+//			kvoToken = traitCollection.observe(\.userInterfaceStyle) {(traitCollection, change) in
+//				guard self.bridge != nil else {
+//					return
+//				}
+//				self.sendEvent(withName: Events.traitCollectionDidChange.name, body: self.theme)
+//			}
+//		} else {
+//			// Fallback on earlier versions
+//		}
+		
+		
+		
 	}
 
 	override func stopObserving() {

--- a/packages/theming/apple-theme/ios/MSFAppleThemeModule.m
+++ b/packages/theming/apple-theme/ios/MSFAppleThemeModule.m
@@ -1,0 +1,7 @@
+#import <React/RCTBridgeModule.h>
+
+@interface RCT_EXTERN_MODULE(MSFAppleThemeModule, NSObject)
+
+RCT_EXTERN_METHOD(getApplePartialThemeWithCallback:(RCTResponseSenderBlock)callback)
+
+@end

--- a/packages/theming/apple-theme/macos/AppleThemeModule.swift
+++ b/packages/theming/apple-theme/macos/AppleThemeModule.swift
@@ -438,15 +438,14 @@ class AppleThemeModule: RCTEventEmitter {
 
 	override func startObserving() {
 		hasListeners = true;
-		
-			
+
 		kvoToken = NSApplication.shared.observe(\.effectiveAppearance) { (application, change) in
 			guard self.bridge != nil else {
 				return
 			}
 			self.sendEvent(withName: Events.AppleInterfaceThemeChanged.name, body: AppleThemeModule.theme)
 		}
-		
+
 		// Observe changes to control accent color
 		let notificationCenter = DistributedNotificationCenter.default()
 		notificationCenter.addObserver(forName: NSColor.systemColorsDidChangeNotification, object: nil, queue: OperationQueue.main) { (notification) in
@@ -457,8 +456,6 @@ class AppleThemeModule: RCTEventEmitter {
 				self.sendEvent(withName: Events.AppleInterfaceThemeChanged.name, body: AppleThemeModule.theme)
 			}
 		}
-
-		
 	}
 
 	override func stopObserving() {

--- a/packages/theming/apple-theme/src/appleTypography.ios.ts
+++ b/packages/theming/apple-theme/src/appleTypography.ios.ts
@@ -4,8 +4,8 @@ import { FontSize, FontSizes, FontWeightValue, Typography, Variants } from '@flu
 export function appleTypography(): Typography {
   const appleDict = {
     sizes: {
-      caption: 12 as FontSize, // Caption 1
-      secondary: 16 as FontSize, // Callout
+      caption: 12 as FontSize, // Caption 2
+      secondary: 16 as FontSize, // Caption 1
       body: 17 as FontSize, // Body
       subheader: 15 as FontSize, // Subhead
       header: 17 as FontSize, // Headline

--- a/packages/theming/apple-theme/src/appleTypography.ios.ts
+++ b/packages/theming/apple-theme/src/appleTypography.ios.ts
@@ -44,7 +44,7 @@ export function appleTypography(): Typography {
       heroStandard: { face: 'primary', size: 'hero', weight: '400' },
       heroSemibold: { face: 'primary', size: 'hero', weight: '600' },
       heroLargeStandard: { face: 'primary', size: 'heroLarge', weight: '400' },
-      heroLargeSemibold: { face: 'primary', size: 'heroLarge', weight: '600' },
+      heroLargeSemibold: { face: 'primary', size: 100, weight: '600' },
     } as Variants,
   };
 

--- a/packages/theming/apple-theme/src/appleTypography.ios.ts
+++ b/packages/theming/apple-theme/src/appleTypography.ios.ts
@@ -44,7 +44,7 @@ export function appleTypography(): Typography {
       heroStandard: { face: 'primary', size: 'hero', weight: '400' },
       heroSemibold: { face: 'primary', size: 'hero', weight: '600' },
       heroLargeStandard: { face: 'primary', size: 'heroLarge', weight: '400' },
-      heroLargeSemibold: { face: 'primary', size: 100, weight: '600' },
+      heroLargeSemibold: { face: 'primary', size: 'heroLarge', weight: '600' },
     } as Variants,
   };
 

--- a/packages/theming/apple-theme/src/createAppleTheme.ios.ts
+++ b/packages/theming/apple-theme/src/createAppleTheme.ios.ts
@@ -8,7 +8,6 @@ let partialThemeFromNativeModule: PartialTheme;
 
 export function createAppleTheme(): ThemeReference {
   const baseAppleTheme = () => {
-    console.log('creating theme');
     const current = Appearance.getColorScheme();
     return current === 'light' ? BaseAppleLightThemeIOS : BaseAppleDarkThemeIOS;
   };
@@ -16,7 +15,6 @@ export function createAppleTheme(): ThemeReference {
   const loadNativeTheme = (appleThemeReference: ThemeReference) => {
     const module = NativeModules && NativeModules.MSFAppleThemeModule;
     if (module) {
-      console.log('Calling Native module once more');
       module.getApplePartialThemeWithCallback((error, applePartialTheme) => {
         if (error) {
           console.error(`Error retrieving apple theming module! ${error}`);
@@ -34,7 +32,6 @@ export function createAppleTheme(): ThemeReference {
   loadNativeTheme(appleThemeReference);
 
   Appearance.addChangeListener(() => {
-    console.log('Appearance changed!');
     loadNativeTheme(appleThemeReference);
   });
 

--- a/packages/theming/apple-theme/src/createAppleTheme.ios.ts
+++ b/packages/theming/apple-theme/src/createAppleTheme.ios.ts
@@ -21,7 +21,6 @@ export function createAppleTheme(): ThemeReference {
         }
         partialThemeFromNativeModule = applePartialTheme;
         appleThemeReference.update(baseAppleTheme, partialThemeFromNativeModule);
-        console.log('Native Module loaded, themeRef invalidated, appearance: ' + partialThemeFromNativeModule.host.appearance);
       });
     } else {
       console.warn('Apple native theming module not found');

--- a/packages/theming/apple-theme/src/createAppleTheme.ios.ts
+++ b/packages/theming/apple-theme/src/createAppleTheme.ios.ts
@@ -1,48 +1,7 @@
 import { ThemeReference } from '@fluentui-react-native/theme';
 import { PartialTheme, Theme } from '@fluentui-react-native/theme-types';
-import { Appearance, NativeEventEmitter, NativeModules, useColorScheme } from 'react-native';
+import { Appearance, NativeModules } from 'react-native';
 import { BaseAppleDarkThemeIOS, BaseAppleLightThemeIOS } from './appleTheme.ios';
-
-// Try 1 (Bad)
-
-// // Save this value between calls
-// let partialThemeFromNativeModule: PartialTheme;
-//
-// export function createAppleTheme(): ThemeReference {
-//   console.log('creating theme');
-
-//   const baseAppleTheme = () => {
-//     console.log('creating theme');
-//     const current = Appearance.getColorScheme();
-//     return current === 'light' ? BaseAppleLightThemeIOS : BaseAppleDarkThemeIOS;
-//   };
-
-//   const appleThemeReference = new ThemeReference({} as Theme, baseAppleTheme);
-
-//   const module = NativeModules && NativeModules.MSFAppleThemeModule;
-//   if (module) {
-//     module.getApplePartialThemeWithCallback((error, applePartialTheme) => {
-//       if (error) {
-//         console.error(`Error retrieving apple theming module! ${error}`);
-//       }
-//       partialThemeFromNativeModule = applePartialTheme;
-
-//       // Layer the native apple theming module values on top of the base Apple theme
-//       appleThemeReference.update(baseAppleTheme, applePartialTheme);
-//     });
-//   } else {
-//     console.warn('Apple native theming module not found');
-//   }
-
-//   Appearance.addChangeListener(() => {
-//     console.log('Appearance changed!');
-//     appleThemeReference.invalidate();
-//   });
-
-//   return appleThemeReference;
-// }
-
-// Try 2 (Good)
 
 // Save this value between calls
 let partialThemeFromNativeModule: PartialTheme;
@@ -54,7 +13,7 @@ export function createAppleTheme(): ThemeReference {
     return current === 'light' ? BaseAppleLightThemeIOS : BaseAppleDarkThemeIOS;
   };
 
-  const nativeThemeCallback = (appleThemeReference: ThemeReference) => {
+  const loadNativeTheme = (appleThemeReference: ThemeReference) => {
     const module = NativeModules && NativeModules.MSFAppleThemeModule;
     if (module) {
       console.log('Calling Native module once more');
@@ -64,7 +23,6 @@ export function createAppleTheme(): ThemeReference {
         }
         partialThemeFromNativeModule = applePartialTheme;
         appleThemeReference.update(baseAppleTheme, partialThemeFromNativeModule);
-        appleThemeReference.invalidate();
         console.log('Native Module loaded, themeRef invalidated, appearance: ' + partialThemeFromNativeModule.host.appearance);
       });
     } else {
@@ -72,53 +30,13 @@ export function createAppleTheme(): ThemeReference {
     }
   };
 
-  const themeRef = new ThemeReference({} as Theme, baseAppleTheme, partialThemeFromNativeModule);
-  nativeThemeCallback(themeRef);
+  const appleThemeReference = new ThemeReference({} as Theme, baseAppleTheme, partialThemeFromNativeModule);
+  loadNativeTheme(appleThemeReference);
 
   Appearance.addChangeListener(() => {
     console.log('Appearance changed!');
-    nativeThemeCallback(themeRef);
+    loadNativeTheme(appleThemeReference);
   });
 
-  return themeRef;
+  return appleThemeReference;
 }
-
-// Try 3 (Bad)
-
-// // Save this value between calls
-// let partialThemeFromNativeModule: PartialTheme;
-
-// export function createAppleTheme(): ThemeReference {
-//   const baseAppleTheme = () => {
-//     console.log('creating theme');
-//     const current = Appearance.getColorScheme();
-//     return current === 'light' ? BaseAppleLightThemeIOS : BaseAppleDarkThemeIOS;
-//   };
-
-//   const nativeTheme = () => {
-//     const module = NativeModules && NativeModules.MSFAppleThemeModule;
-//     if (module) {
-//       console.log('Calling Native module once more');
-//       module.getApplePartialThemeWithCallback((error, applePartialTheme) => {
-//         if (error) {
-//           console.error(`Error retrieving apple theming module! ${error}`);
-//         }
-//         partialThemeFromNativeModule = applePartialTheme;
-//         console.log('Native Module loaded, themeRef invalidated, appearance: ' + partialThemeFromNativeModule.host.appearance);
-//       });
-//     } else {
-//       console.warn('Apple native theming module not found');
-//     }
-
-//     return partialThemeFromNativeModule;
-//   };
-
-//   const themeRef = new ThemeReference({} as Theme, baseAppleTheme, nativeTheme);
-
-//   Appearance.addChangeListener(() => {
-//     console.log('Appearance changed!');
-//     themeRef.invalidate;
-//   });
-
-//   return themeRef;
-// }

--- a/packages/theming/apple-theme/src/createAppleTheme.ios.ts
+++ b/packages/theming/apple-theme/src/createAppleTheme.ios.ts
@@ -1,17 +1,39 @@
 import { ThemeReference } from '@fluentui-react-native/theme';
-import { Theme } from '@fluentui-react-native/theme-types';
-import { Appearance } from 'react-native';
+import { PartialTheme } from '@fluentui-react-native/theme-types';
+import { Appearance, NativeEventEmitter, NativeModules } from 'react-native';
 import { BaseAppleDarkThemeIOS, BaseAppleLightThemeIOS } from './appleTheme.ios';
 
+// Save this value between calls
+let partialThemeFromNativeModule: PartialTheme;
+
+const appleThemeReference = new ThemeReference(Appearance.getColorScheme() === 'light' ? BaseAppleLightThemeIOS : BaseAppleDarkThemeIOS);
+
 export function createAppleTheme(): ThemeReference {
-  const themeRef = new ThemeReference({} as Theme, () => {
-    const current = Appearance.getColorScheme();
-    return current === 'light' ? BaseAppleLightThemeIOS : BaseAppleDarkThemeIOS;
-  });
+  const module = NativeModules && NativeModules.MSFAppleThemeModule;
+  if (module) {
+    module.getApplePartialThemeWithCallback((error, applePartialTheme) => {
+      if (error) {
+        console.error(`Error retrieving apple theming module! ${error}`);
+      }
+      partialThemeFromNativeModule = applePartialTheme;
 
-  Appearance.addChangeListener(() => {
-    themeRef.invalidate();
-  });
+      // Layer the native apple theming module values on top of the base Apple theme
+      appleThemeReference.update(applePartialTheme);
+    });
 
-  return themeRef;
+    const emitter = new NativeEventEmitter(module);
+
+    const onAppleThemeChanged = (body: PartialTheme) => {
+      partialThemeFromNativeModule = body;
+      appleThemeReference.update(body);
+    };
+
+    emitter.addListener('traitCollectionDidChange', onAppleThemeChanged);
+  } else {
+    console.warn('Apple native theming module not found');
+  }
+
+  appleThemeReference.update(partialThemeFromNativeModule);
+
+  return appleThemeReference;
 }

--- a/packages/theming/apple-theme/src/createAppleTheme.ios.ts
+++ b/packages/theming/apple-theme/src/createAppleTheme.ios.ts
@@ -1,41 +1,38 @@
 import { ThemeReference } from '@fluentui-react-native/theme';
-import { PartialTheme } from '@fluentui-react-native/theme-types';
+import { PartialTheme, Theme } from '@fluentui-react-native/theme-types';
 import { Appearance, NativeEventEmitter, NativeModules, useColorScheme } from 'react-native';
 import { BaseAppleDarkThemeIOS, BaseAppleLightThemeIOS } from './appleTheme.ios';
 
+// Try 1 (Bad)
+
 // // Save this value between calls
 // let partialThemeFromNativeModule: PartialTheme;
-
-// const appleThemeReference = new ThemeReference(Appearance.getColorScheme() === 'light' ? BaseAppleLightThemeIOS : BaseAppleDarkThemeIOS);
-
+//
 // export function createAppleTheme(): ThemeReference {
 //   console.log('creating theme');
 
-//   // const module = NativeModules && NativeModules.MSFAppleThemeModule;
-//   // if (module) {
-//   //   module.getApplePartialThemeWithCallback((error, applePartialTheme) => {
-//   //     if (error) {
-//   //       console.error(`Error retrieving apple theming module! ${error}`);
-//   //     }
-//   //     partialThemeFromNativeModule = applePartialTheme;
+//   const baseAppleTheme = () => {
+//     console.log('creating theme');
+//     const current = Appearance.getColorScheme();
+//     return current === 'light' ? BaseAppleLightThemeIOS : BaseAppleDarkThemeIOS;
+//   };
 
-//   //     // Layer the native apple theming module values on top of the base Apple theme
-//   //     appleThemeReference.update(applePartialTheme);
-//   //   });
+//   const appleThemeReference = new ThemeReference({} as Theme, baseAppleTheme);
 
-//   //   const emitter = new NativeEventEmitter(module);
+//   const module = NativeModules && NativeModules.MSFAppleThemeModule;
+//   if (module) {
+//     module.getApplePartialThemeWithCallback((error, applePartialTheme) => {
+//       if (error) {
+//         console.error(`Error retrieving apple theming module! ${error}`);
+//       }
+//       partialThemeFromNativeModule = applePartialTheme;
 
-//   //   const onAppleThemeChanged = (body: PartialTheme) => {
-//   //     partialThemeFromNativeModule = body;
-//   //     appleThemeReference.update(partialThemeFromNativeModule);
-//   //   };
-
-//   //   emitter.addListener('traitCollectionDidChange', onAppleThemeChanged);
-//   // } else {
-//   //   console.warn('Apple native theming module not found');
-//   // }
-
-//   // appleThemeReference.update(partialThemeFromNativeModule);
+//       // Layer the native apple theming module values on top of the base Apple theme
+//       appleThemeReference.update(baseAppleTheme, applePartialTheme);
+//     });
+//   } else {
+//     console.warn('Apple native theming module not found');
+//   }
 
 //   Appearance.addChangeListener(() => {
 //     console.log('Appearance changed!');
@@ -45,17 +42,83 @@ import { BaseAppleDarkThemeIOS, BaseAppleLightThemeIOS } from './appleTheme.ios'
 //   return appleThemeReference;
 // }
 
+// Try 2 (Good)
+
+// Save this value between calls
+let partialThemeFromNativeModule: PartialTheme;
+
 export function createAppleTheme(): ThemeReference {
-  const themeRef = new ThemeReference({} as Theme, () => {
+  const baseAppleTheme = () => {
     console.log('creating theme');
     const current = Appearance.getColorScheme();
     return current === 'light' ? BaseAppleLightThemeIOS : BaseAppleDarkThemeIOS;
-  });
+  };
+
+  const nativeThemeCallback = (appleThemeReference: ThemeReference) => {
+    const module = NativeModules && NativeModules.MSFAppleThemeModule;
+    if (module) {
+      console.log('Calling Native module once more');
+      module.getApplePartialThemeWithCallback((error, applePartialTheme) => {
+        if (error) {
+          console.error(`Error retrieving apple theming module! ${error}`);
+        }
+        partialThemeFromNativeModule = applePartialTheme;
+        appleThemeReference.update(baseAppleTheme, partialThemeFromNativeModule);
+        appleThemeReference.invalidate();
+        console.log('Native Module loaded, themeRef invalidated, appearance: ' + partialThemeFromNativeModule.host.appearance);
+      });
+    } else {
+      console.warn('Apple native theming module not found');
+    }
+  };
+
+  const themeRef = new ThemeReference({} as Theme, baseAppleTheme, partialThemeFromNativeModule);
+  nativeThemeCallback(themeRef);
 
   Appearance.addChangeListener(() => {
     console.log('Appearance changed!');
-    themeRef.invalidate();
+    nativeThemeCallback(themeRef);
   });
 
   return themeRef;
 }
+
+// Try 3 (Bad)
+
+// // Save this value between calls
+// let partialThemeFromNativeModule: PartialTheme;
+
+// export function createAppleTheme(): ThemeReference {
+//   const baseAppleTheme = () => {
+//     console.log('creating theme');
+//     const current = Appearance.getColorScheme();
+//     return current === 'light' ? BaseAppleLightThemeIOS : BaseAppleDarkThemeIOS;
+//   };
+
+//   const nativeTheme = () => {
+//     const module = NativeModules && NativeModules.MSFAppleThemeModule;
+//     if (module) {
+//       console.log('Calling Native module once more');
+//       module.getApplePartialThemeWithCallback((error, applePartialTheme) => {
+//         if (error) {
+//           console.error(`Error retrieving apple theming module! ${error}`);
+//         }
+//         partialThemeFromNativeModule = applePartialTheme;
+//         console.log('Native Module loaded, themeRef invalidated, appearance: ' + partialThemeFromNativeModule.host.appearance);
+//       });
+//     } else {
+//       console.warn('Apple native theming module not found');
+//     }
+
+//     return partialThemeFromNativeModule;
+//   };
+
+//   const themeRef = new ThemeReference({} as Theme, baseAppleTheme, nativeTheme);
+
+//   Appearance.addChangeListener(() => {
+//     console.log('Appearance changed!');
+//     themeRef.invalidate;
+//   });
+
+//   return themeRef;
+// }

--- a/packages/theming/apple-theme/src/createAppleTheme.ios.ts
+++ b/packages/theming/apple-theme/src/createAppleTheme.ios.ts
@@ -1,39 +1,61 @@
 import { ThemeReference } from '@fluentui-react-native/theme';
 import { PartialTheme } from '@fluentui-react-native/theme-types';
-import { Appearance, NativeEventEmitter, NativeModules } from 'react-native';
+import { Appearance, NativeEventEmitter, NativeModules, useColorScheme } from 'react-native';
 import { BaseAppleDarkThemeIOS, BaseAppleLightThemeIOS } from './appleTheme.ios';
 
-// Save this value between calls
-let partialThemeFromNativeModule: PartialTheme;
+// // Save this value between calls
+// let partialThemeFromNativeModule: PartialTheme;
 
-const appleThemeReference = new ThemeReference(Appearance.getColorScheme() === 'light' ? BaseAppleLightThemeIOS : BaseAppleDarkThemeIOS);
+// const appleThemeReference = new ThemeReference(Appearance.getColorScheme() === 'light' ? BaseAppleLightThemeIOS : BaseAppleDarkThemeIOS);
+
+// export function createAppleTheme(): ThemeReference {
+//   console.log('creating theme');
+
+//   // const module = NativeModules && NativeModules.MSFAppleThemeModule;
+//   // if (module) {
+//   //   module.getApplePartialThemeWithCallback((error, applePartialTheme) => {
+//   //     if (error) {
+//   //       console.error(`Error retrieving apple theming module! ${error}`);
+//   //     }
+//   //     partialThemeFromNativeModule = applePartialTheme;
+
+//   //     // Layer the native apple theming module values on top of the base Apple theme
+//   //     appleThemeReference.update(applePartialTheme);
+//   //   });
+
+//   //   const emitter = new NativeEventEmitter(module);
+
+//   //   const onAppleThemeChanged = (body: PartialTheme) => {
+//   //     partialThemeFromNativeModule = body;
+//   //     appleThemeReference.update(partialThemeFromNativeModule);
+//   //   };
+
+//   //   emitter.addListener('traitCollectionDidChange', onAppleThemeChanged);
+//   // } else {
+//   //   console.warn('Apple native theming module not found');
+//   // }
+
+//   // appleThemeReference.update(partialThemeFromNativeModule);
+
+//   Appearance.addChangeListener(() => {
+//     console.log('Appearance changed!');
+//     appleThemeReference.invalidate();
+//   });
+
+//   return appleThemeReference;
+// }
 
 export function createAppleTheme(): ThemeReference {
-  const module = NativeModules && NativeModules.MSFAppleThemeModule;
-  if (module) {
-    module.getApplePartialThemeWithCallback((error, applePartialTheme) => {
-      if (error) {
-        console.error(`Error retrieving apple theming module! ${error}`);
-      }
-      partialThemeFromNativeModule = applePartialTheme;
+  const themeRef = new ThemeReference({} as Theme, () => {
+    console.log('creating theme');
+    const current = Appearance.getColorScheme();
+    return current === 'light' ? BaseAppleLightThemeIOS : BaseAppleDarkThemeIOS;
+  });
 
-      // Layer the native apple theming module values on top of the base Apple theme
-      appleThemeReference.update(applePartialTheme);
-    });
+  Appearance.addChangeListener(() => {
+    console.log('Appearance changed!');
+    themeRef.invalidate();
+  });
 
-    const emitter = new NativeEventEmitter(module);
-
-    const onAppleThemeChanged = (body: PartialTheme) => {
-      partialThemeFromNativeModule = body;
-      appleThemeReference.update(body);
-    };
-
-    emitter.addListener('traitCollectionDidChange', onAppleThemeChanged);
-  } else {
-    console.warn('Apple native theming module not found');
-  }
-
-  appleThemeReference.update(partialThemeFromNativeModule);
-
-  return appleThemeReference;
+  return themeRef;
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Like what we did for macOS, let's add a native module to the iOS theme that pulls the Theme/Constants directly from FluentUI Apple, rather than JS. There are a few differences from the macOS theme:
- Using KVO to observe appearance changes in our native module didn't work like it did in macOS. Instead, I add listeners on the JS side using the React Native Appearance API (similar to what the default theme does). We may want to add more listeners for accessibility events like BoldText / dynamic fonts / etc (https://reactnative.dev/docs/accessibilityinfo). 
- The macOS theme has a base apple theme, and ap partial theme loaded  from a native module as a recipe layered on top. The iOS theme has an empty object as a base,  a recipe for the base theme, and a recipe for the native module theme. I had to do it this way, because the iOS theme didn't play nicely when I used `DynamicColorIOS` & `PlatformColor` for it's palette. This is because those types resolve to `string | symbol` rather than `string`, which is incompatible with some of our theming infrastructure. To solve this, I do what the default theme does and define two (light and dark) themes that we switch between. 
    - This brings up the question: Why could I use `PlatformColor / DynamicColorMacOS` for the macOS theme? Probably some weirdness with the fact that iOS uses react-native, and macOS uses react-native-macos. I think there's definitely a followup to make sure theming plays nicely, or to just add support for `PlatformColor/DynamicColorIOS` to our theming infrastructure explicitly. 

### Verification

Verified that the native theme was in fact overlaid on top of the base JS theme by changing one value (heroLargeSemibold font size) to be oviously wrong in the JS, and seeing if it would get overwritten by the native theme. I also switched between light and dark and made sure the right callbacks were firing to load the appropriate themes.



### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
