### PR TITLE
Include files referenced by sourcemaps in published packages

### DIFF
--- a/change/@fluentui-react-native-apple-theme-2021-03-12-09-35-18-missingSourceMap.json
+++ b/change/@fluentui-react-native-apple-theme-2021-03-12-09-35-18-missingSourceMap.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Public source files that are needed for source map",
+  "packageName": "@fluentui-react-native/apple-theme",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2021-03-12T17:35:17.215Z"
+}

--- a/change/@fluentui-react-native-theme-2021-03-12-09-35-18-missingSourceMap.json
+++ b/change/@fluentui-react-native-theme-2021-03-12-09-35-18-missingSourceMap.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Public source files that are needed for source map",
+  "packageName": "@fluentui-react-native/theme",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2021-03-12T17:35:16.291Z"
+}

--- a/change/@fluentui-react-native-win32-theme-2021-03-12-09-35-18-missingSourceMap.json
+++ b/change/@fluentui-react-native-win32-theme-2021-03-12-09-35-18-missingSourceMap.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Public source files that are needed for source map",
+  "packageName": "@fluentui-react-native/win32-theme",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2021-03-12T17:35:17.998Z"
+}

--- a/packages/experimental/theme/.npmignore
+++ b/packages/experimental/theme/.npmignore
@@ -1,4 +1,3 @@
-src
 node_modules
 .gitignore
 .gitattributes

--- a/packages/theming/apple-theme/.npmignore
+++ b/packages/theming/apple-theme/.npmignore
@@ -1,4 +1,3 @@
-src
 node_modules
 .gitignore
 .gitattributes

--- a/packages/theming/win32-theme/.npmignore
+++ b/packages/theming/win32-theme/.npmignore
@@ -1,4 +1,3 @@
-src
 node_modules
 .gitignore
 .gitattributes


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

A few packages were not publishing their src directory, even though the sourcemap files would refer to files in that directory.  This means the sourcemaps dont really work for external users of these packages.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
