### PR TITLE
Add apple theme static libraries to NuGet package

### DIFF
--- a/.ado/azure-pipelines.yml
+++ b/.ado/azure-pipelines.yml
@@ -146,45 +146,35 @@ jobs:
           publishJUnitResults: false
           javaHomeOption: 'JDKVersion'
           sonarQubeRunAnalysis: false
-
   # Uncomment this job to test changes to changes to the NuGet package
-  # Commented out by default because this job is much longer than the other PR jobs
-  - job: NuGetPublish
-    displayName: NuGet Publish
-    pool:
-      vmImage: 'macos-10.15'
-      demands: ['xcode', 'sh', 'npm']
-    timeoutInMinutes: 90 # how long to run the job before automatically cancelling
-    cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
-
-    steps:
-      - checkout: self
-        persistCredentials: true
-
-      - template: templates/setup-repo-min-build.yml
-
-      # Clean Derived Data
-      - script: |
-          rm -rf $(Build.Repository.LocalPath)/DerivedData
-        displayName: 'Clean DerivedData'
-
-      - script: |
-          sudo gem install cocoapods
-        displayName: 'Install CocoaPods Environment'
-
-      - script: |
-          yarn bundle ios
-        workingDirectory: $(Build.Repository.LocalPath)/apps/ios
-        displayName: 'yarn bundle iOS'
-
-      - script: |
-          yarn bundle macos
-        workingDirectory: $(Build.Repository.LocalPath)/apps/macos
-        displayName: 'yarn bundle macOS'
-
-      # Select proper Xcode version
-      - template: templates/apple-xcode-select.yml
-
-      - template: templates/apple-xcode-build-static-libs.yml
-
-      - template: templates/nuget-publish.yml
+  # We keep it commented out by default because this job is much longer than the other PR jobs
+  # - job: NuGetPublish
+  #   displayName: NuGet Publish
+  #   pool:
+  #     vmImage: 'macos-10.15'
+  #     demands: ['xcode', 'sh', 'npm']
+  #   timeoutInMinutes: 90 # how long to run the job before automatically cancelling
+  #   cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
+  #   steps:
+  #     - checkout: self
+  #       persistCredentials: true
+  #     - template: templates/setup-repo-min-build.yml
+  #     # Clean Derived Data
+  #     - script: |
+  #         rm -rf $(Build.Repository.LocalPath)/DerivedData
+  #       displayName: 'Clean DerivedData'
+  #     - script: |
+  #         sudo gem install cocoapods
+  #       displayName: 'Install CocoaPods Environment'
+  #     - script: |
+  #         yarn bundle ios
+  #       workingDirectory: $(Build.Repository.LocalPath)/apps/ios
+  #       displayName: 'yarn bundle iOS'
+  #     - script: |
+  #         yarn bundle macos
+  #       workingDirectory: $(Build.Repository.LocalPath)/apps/macos
+  #       displayName: 'yarn bundle macOS'
+  #     # Select proper Xcode version
+  #     - template: templates/apple-xcode-select.yml
+  #     - template: templates/apple-xcode-build-static-libs.yml
+  #     - template: templates/nuget-publish.yml

--- a/.ado/azure-pipelines.yml
+++ b/.ado/azure-pipelines.yml
@@ -146,3 +146,45 @@ jobs:
           publishJUnitResults: false
           javaHomeOption: 'JDKVersion'
           sonarQubeRunAnalysis: false
+
+  # Uncomment this job to test changes to changes to the NuGet package
+  # Commented out by default because this job is much longer than the other PR jobs
+  - job: NuGetPublish
+    displayName: NuGet Publish
+    pool:
+      vmImage: 'macos-10.15'
+      demands: ['xcode', 'sh', 'npm']
+    timeoutInMinutes: 90 # how long to run the job before automatically cancelling
+    cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
+
+    steps:
+      - checkout: self
+        persistCredentials: true
+
+      - template: templates/setup-repo-min-build.yml
+
+      # Clean Derived Data
+      - script: |
+          rm -rf $(Build.Repository.LocalPath)/DerivedData
+        displayName: 'Clean DerivedData'
+
+      - script: |
+          sudo gem install cocoapods
+        displayName: 'Install CocoaPods Environment'
+
+      - script: |
+          yarn bundle ios
+        workingDirectory: $(Build.Repository.LocalPath)/apps/ios
+        displayName: 'yarn bundle iOS'
+
+      - script: |
+          yarn bundle macos
+        workingDirectory: $(Build.Repository.LocalPath)/apps/macos
+        displayName: 'yarn bundle macOS'
+
+      # Select proper Xcode version
+      - template: templates/apple-xcode-select.yml
+
+      - template: templates/apple-xcode-build-static-libs.yml
+
+      - template: templates/nuget-publish.yml

--- a/package.nuspec
+++ b/package.nuspec
@@ -1,48 +1,48 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
-    <metadata>
-        <id>Microsoft.FluentUI.ReactNative</id>
-        <version>$buildNumber$</version>
-        <description>A react-native component library that implements the Fluent Design System.</description>
-        <authors>Microsoft</authors>
-        <projectUrl>https://github.com/microsoft/fluentui-react-native.git</projectUrl>
-        <repository type="git" url="$repoUri$" commit="$commitId$"/>
-    </metadata>
-    <files>
-      <!-- iOS device debug -->
-      <file src="DerivedData\Build\Products\Debug-iphoneos\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Apple-Theme.a" target="Debug-iphoneos"/>
-      <file src="DerivedData\Build\Products\Debug-iphoneos\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Avatar.a" target="Debug-iphoneos"/>
-      <file src="DerivedData\Build\Products\Debug-iphoneos\FluentUI-React-Native-Button\libFluentUI-React-Native-Button.a" target="Debug-iphoneos"/>
-      <file src="DerivedData\Build\Products\Debug-iphoneos\FluentUI-React-Native-Shimmer\libFluentUI-React-Native-Shimmer.a" target="Debug-iphoneos"/>
-      <!-- iOS device ship -->
-      <file src="DerivedData\Build\Products\Debug-iphoneos\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Apple-Theme.a" target="Ship-iphoneos"/>
-      <file src="DerivedData\Build\Products\Release-iphoneos\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Avatar.a" target="Ship-iphoneos"/>
-      <file src="DerivedData\Build\Products\Release-iphoneos\FluentUI-React-Native-Button\libFluentUI-React-Native-Button.a" target="Ship-iphoneos"/>
-      <file src="DerivedData\Build\Products\Release-iphoneos\FluentUI-React-Native-Shimmer\libFluentUI-React-Native-Shimmer.a" target="Ship-iphoneos"/>
-      <!-- iOS simulator debug -->
-      <file src="DerivedData\Build\Products\Debug-iphoneos\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Apple-Theme.a" target="Debug-iphonesimulator"/>
-      <file src="DerivedData\Build\Products\Debug-iphonesimulator\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Avatar.a" target="Debug-iphonesimulator"/>
-      <file src="DerivedData\Build\Products\Debug-iphonesimulator\FluentUI-React-Native-Button\libFluentUI-React-Native-Button.a" target="Debug-iphonesimulator"/>
-      <file src="DerivedData\Build\Products\Debug-iphonesimulator\FluentUI-React-Native-Shimmer\libFluentUI-React-Native-Shimmer.a" target="Debug-iphonesimulator"/>
-      <!-- iOS simulator ship -->
-      <file src="DerivedData\Build\Products\Debug-iphoneos\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Apple-Theme.a" target="Ship-iphonesimulator"/>
-      <file src="DerivedData\Build\Products\Release-iphonesimulator\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Avatar.a" target="Ship-iphonesimulator"/>
-      <file src="DerivedData\Build\Products\Release-iphonesimulator\FluentUI-React-Native-Button\libFluentUI-React-Native-Button.a" target="Ship-iphonesimulator"/>
-      <file src="DerivedData\Build\Products\Release-iphonesimulator\FluentUI-React-Native-Shimmer\libFluentUI-React-Native-Shimmer.a" target="Ship-iphonesimulator"/>
+  <metadata>
+    <id>Microsoft.FluentUI.ReactNative</id>
+    <version>$buildNumber$</version>
+    <description>A react-native component library that implements the Fluent Design System.</description>
+    <authors>Microsoft</authors>
+    <projectUrl>https://github.com/microsoft/fluentui-react-native.git</projectUrl>
+    <repository type="git" url="$repoUri$" commit="$commitId$"/>
+  </metadata>
+  <files>
+    <!-- iOS device debug -->
+    <file src="DerivedData\Build\Products\Debug-iphoneos\FluentUI-React-Native-Apple-Theme\libFluentUI-React-Native-Apple-Theme.a" target="Debug-iphoneos"/>
+    <file src="DerivedData\Build\Products\Debug-iphoneos\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Avatar.a" target="Debug-iphoneos"/>
+    <file src="DerivedData\Build\Products\Debug-iphoneos\FluentUI-React-Native-Button\libFluentUI-React-Native-Button.a" target="Debug-iphoneos"/>
+    <file src="DerivedData\Build\Products\Debug-iphoneos\FluentUI-React-Native-Shimmer\libFluentUI-React-Native-Shimmer.a" target="Debug-iphoneos"/>
+    <!-- iOS device ship -->
+    <file src="DerivedData\Build\Products\Debug-iphoneos\FluentUI-React-Native-Apple-Theme\libFluentUI-React-Native-Apple-Theme.a" target="Ship-iphoneos"/>
+    <file src="DerivedData\Build\Products\Release-iphoneos\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Avatar.a" target="Ship-iphoneos"/>
+    <file src="DerivedData\Build\Products\Release-iphoneos\FluentUI-React-Native-Button\libFluentUI-React-Native-Button.a" target="Ship-iphoneos"/>
+    <file src="DerivedData\Build\Products\Release-iphoneos\FluentUI-React-Native-Shimmer\libFluentUI-React-Native-Shimmer.a" target="Ship-iphoneos"/>
+    <!-- iOS simulator debug -->
+    <file src="DerivedData\Build\Products\Debug-iphoneos\FluentUI-React-Native-Apple-Theme\libFluentUI-React-Native-Apple-Theme.a" target="Debug-iphonesimulator"/>
+    <file src="DerivedData\Build\Products\Debug-iphonesimulator\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Avatar.a" target="Debug-iphonesimulator"/>
+    <file src="DerivedData\Build\Products\Debug-iphonesimulator\FluentUI-React-Native-Button\libFluentUI-React-Native-Button.a" target="Debug-iphonesimulator"/>
+    <file src="DerivedData\Build\Products\Debug-iphonesimulator\FluentUI-React-Native-Shimmer\libFluentUI-React-Native-Shimmer.a" target="Debug-iphonesimulator"/>
+    <!-- iOS simulator ship -->
+    <file src="DerivedData\Build\Products\Debug-iphoneos\FluentUI-React-Native-Apple-Theme\libFluentUI-React-Native-Apple-Theme.a" target="Ship-iphonesimulator"/>
+    <file src="DerivedData\Build\Products\Release-iphonesimulator\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Avatar.a" target="Ship-iphonesimulator"/>
+    <file src="DerivedData\Build\Products\Release-iphonesimulator\FluentUI-React-Native-Button\libFluentUI-React-Native-Button.a" target="Ship-iphonesimulator"/>
+    <file src="DerivedData\Build\Products\Release-iphonesimulator\FluentUI-React-Native-Shimmer\libFluentUI-React-Native-Shimmer.a" target="Ship-iphonesimulator"/>
 
-      <!-- macOS debug -->
-      <file src="DerivedData\Build\Products\Debug-iphoneos\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Apple-Theme.a" target="Debug-macosx"/>
-      <file src="DerivedData\Build\Products\Debug\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Avatar.a" target="Debug-macosx"/>
-      <file src="DerivedData\Build\Products\Debug\FluentUI-React-Native-Button\libFluentUI-React-Native-Button.a" target="Debug-macosx"/>
-      <!-- macOS ship -->
-      <file src="DerivedData\Build\Products\Debug-iphoneos\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Apple-Theme.a" target="Ship-macosx"/>
-      <file src="DerivedData\Build\Products\Release\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Avatar.a" target="Ship-macosx"/>
-      <file src="DerivedData\Build\Products\Release\FluentUI-React-Native-Button\libFluentUI-React-Native-Button.a" target="Ship-macosx"/>
+    <!-- macOS debug -->
+    <file src="DerivedData\Build\Products\Debug-iphoneos\FluentUI-React-Native-Apple-Theme\libFluentUI-React-Native-Apple-Theme.a" target="Debug-macosx"/>
+    <file src="DerivedData\Build\Products\Debug\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Avatar.a" target="Debug-macosx"/>
+    <file src="DerivedData\Build\Products\Debug\FluentUI-React-Native-Button\libFluentUI-React-Native-Button.a" target="Debug-macosx"/>
+    <!-- macOS ship -->
+    <file src="DerivedData\Build\Products\Debug-iphoneos\FluentUI-React-Native-Apple-Theme\libFluentUI-React-Native-Apple-Theme.a" target="Ship-macosx"/>
+    <file src="DerivedData\Build\Products\Release\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Avatar.a" target="Ship-macosx"/>
+    <file src="DerivedData\Build\Products\Release\FluentUI-React-Native-Button\libFluentUI-React-Native-Button.a" target="Ship-macosx"/>
 
-      <!-- iOS Release jsbundle -->
-      <file src="apps\ios\dist\index.ios.jsbundle" target="ios\index.bundle"/>
+    <!-- iOS Release jsbundle -->
+    <file src="apps\ios\dist\index.ios.jsbundle" target="ios\index.bundle"/>
 
-      <!-- macOS Release jsbundle -->
-      <file src="apps\macos\dist\index.macos.jsbundle" target="macos\index.bundle"/>
-    </files>
+    <!-- macOS Release jsbundle -->
+    <file src="apps\macos\dist\index.macos.jsbundle" target="macos\index.bundle"/>
+  </files>
 </package>

--- a/package.nuspec
+++ b/package.nuspec
@@ -10,26 +10,32 @@
     </metadata>
     <files>
       <!-- iOS device debug -->
+      <file src="DerivedData\Build\Products\Debug-iphoneos\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Apple-Theme.a" target="Debug-iphoneos"/>
       <file src="DerivedData\Build\Products\Debug-iphoneos\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Avatar.a" target="Debug-iphoneos"/>
       <file src="DerivedData\Build\Products\Debug-iphoneos\FluentUI-React-Native-Button\libFluentUI-React-Native-Button.a" target="Debug-iphoneos"/>
       <file src="DerivedData\Build\Products\Debug-iphoneos\FluentUI-React-Native-Shimmer\libFluentUI-React-Native-Shimmer.a" target="Debug-iphoneos"/>
       <!-- iOS device ship -->
+      <file src="DerivedData\Build\Products\Debug-iphoneos\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Apple-Theme.a" target="Ship-iphoneos"/>
       <file src="DerivedData\Build\Products\Release-iphoneos\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Avatar.a" target="Ship-iphoneos"/>
       <file src="DerivedData\Build\Products\Release-iphoneos\FluentUI-React-Native-Button\libFluentUI-React-Native-Button.a" target="Ship-iphoneos"/>
       <file src="DerivedData\Build\Products\Release-iphoneos\FluentUI-React-Native-Shimmer\libFluentUI-React-Native-Shimmer.a" target="Ship-iphoneos"/>
       <!-- iOS simulator debug -->
+      <file src="DerivedData\Build\Products\Debug-iphoneos\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Apple-Theme.a" target="Debug-iphonesimulator"/>
       <file src="DerivedData\Build\Products\Debug-iphonesimulator\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Avatar.a" target="Debug-iphonesimulator"/>
       <file src="DerivedData\Build\Products\Debug-iphonesimulator\FluentUI-React-Native-Button\libFluentUI-React-Native-Button.a" target="Debug-iphonesimulator"/>
       <file src="DerivedData\Build\Products\Debug-iphonesimulator\FluentUI-React-Native-Shimmer\libFluentUI-React-Native-Shimmer.a" target="Debug-iphonesimulator"/>
       <!-- iOS simulator ship -->
+      <file src="DerivedData\Build\Products\Debug-iphoneos\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Apple-Theme.a" target="Ship-iphonesimulator"/>
       <file src="DerivedData\Build\Products\Release-iphonesimulator\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Avatar.a" target="Ship-iphonesimulator"/>
       <file src="DerivedData\Build\Products\Release-iphonesimulator\FluentUI-React-Native-Button\libFluentUI-React-Native-Button.a" target="Ship-iphonesimulator"/>
       <file src="DerivedData\Build\Products\Release-iphonesimulator\FluentUI-React-Native-Shimmer\libFluentUI-React-Native-Shimmer.a" target="Ship-iphonesimulator"/>
 
       <!-- macOS debug -->
+      <file src="DerivedData\Build\Products\Debug-iphoneos\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Apple-Theme.a" target="Debug-macosx"/>
       <file src="DerivedData\Build\Products\Debug\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Avatar.a" target="Debug-macosx"/>
       <file src="DerivedData\Build\Products\Debug\FluentUI-React-Native-Button\libFluentUI-React-Native-Button.a" target="Debug-macosx"/>
       <!-- macOS ship -->
+      <file src="DerivedData\Build\Products\Debug-iphoneos\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Apple-Theme.a" target="Ship-macosx"/>
       <file src="DerivedData\Build\Products\Release\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Avatar.a" target="Ship-macosx"/>
       <file src="DerivedData\Build\Products\Release\FluentUI-React-Native-Button\libFluentUI-React-Native-Button.a" target="Ship-macosx"/>
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

I never added the static libraries for the apple theme to the NuGet package. Let's do that now. 
Let's also add a (commented out) NuGetPublish PR job to our PR yml, that we only enable for reviews like this that change the NuGet package. Comment it in while doing a PR, and comment it out at the end of the PR to make sure it doesn't get run for every PR (It's a long job and would be annoying if we had to wait 1hr+ for PR validation).

### Verification

Succesfull job: https://dev.azure.com/ms/ui-fabric-react-native/_build/results?buildId=152805&view=logs&j=f22c9018-44f9-5836-07db-908da0f6bf23

Commenting out PR job now.

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
