### PR TITLE
Fix typo in nuspec

### DIFF
--- a/.ado/azure-pipelines.yml
+++ b/.ado/azure-pipelines.yml
@@ -148,33 +148,33 @@ jobs:
           sonarQubeRunAnalysis: false
   # Uncomment this job to test changes to changes to the NuGet package
   # We keep it commented out by default because this job is much longer than the other PR jobs
-  # - job: NuGetPublish
-  #   displayName: NuGet Publish
-  #   pool:
-  #     vmImage: 'macos-10.15'
-  #     demands: ['xcode', 'sh', 'npm']
-  #   timeoutInMinutes: 90 # how long to run the job before automatically cancelling
-  #   cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
-  #   steps:
-  #     - checkout: self
-  #       persistCredentials: true
-  #     - template: templates/setup-repo-min-build.yml
-  #     # Clean Derived Data
-  #     - script: |
-  #         rm -rf $(Build.Repository.LocalPath)/DerivedData
-  #       displayName: 'Clean DerivedData'
-  #     - script: |
-  #         sudo gem install cocoapods
-  #       displayName: 'Install CocoaPods Environment'
-  #     - script: |
-  #         yarn bundle ios
-  #       workingDirectory: $(Build.Repository.LocalPath)/apps/ios
-  #       displayName: 'yarn bundle iOS'
-  #     - script: |
-  #         yarn bundle macos
-  #       workingDirectory: $(Build.Repository.LocalPath)/apps/macos
-  #       displayName: 'yarn bundle macOS'
-  #     # Select proper Xcode version
-  #     - template: templates/apple-xcode-select.yml
-  #     - template: templates/apple-xcode-build-static-libs.yml
-  #     - template: templates/nuget-publish.yml
+  - job: NuGetPublish
+    displayName: NuGet Publish
+    pool:
+      vmImage: 'macos-10.15'
+      demands: ['xcode', 'sh', 'npm']
+    timeoutInMinutes: 90 # how long to run the job before automatically cancelling
+    cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
+    steps:
+      - checkout: self
+        persistCredentials: true
+      - template: templates/setup-repo-min-build.yml
+      # Clean Derived Data
+      - script: |
+          rm -rf $(Build.Repository.LocalPath)/DerivedData
+        displayName: 'Clean DerivedData'
+      - script: |
+          sudo gem install cocoapods
+        displayName: 'Install CocoaPods Environment'
+      - script: |
+          yarn bundle ios
+        workingDirectory: $(Build.Repository.LocalPath)/apps/ios
+        displayName: 'yarn bundle iOS'
+      - script: |
+          yarn bundle macos
+        workingDirectory: $(Build.Repository.LocalPath)/apps/macos
+        displayName: 'yarn bundle macOS'
+      # Select proper Xcode version
+      - template: templates/apple-xcode-select.yml
+      - template: templates/apple-xcode-build-static-libs.yml
+      - template: templates/nuget-publish.yml

--- a/.ado/azure-pipelines.yml
+++ b/.ado/azure-pipelines.yml
@@ -148,33 +148,33 @@ jobs:
           sonarQubeRunAnalysis: false
   # Uncomment this job to test changes to changes to the NuGet package
   # We keep it commented out by default because this job is much longer than the other PR jobs
-  - job: NuGetPublish
-    displayName: NuGet Publish
-    pool:
-      vmImage: 'macos-10.15'
-      demands: ['xcode', 'sh', 'npm']
-    timeoutInMinutes: 90 # how long to run the job before automatically cancelling
-    cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
-    steps:
-      - checkout: self
-        persistCredentials: true
-      - template: templates/setup-repo-min-build.yml
-      # Clean Derived Data
-      - script: |
-          rm -rf $(Build.Repository.LocalPath)/DerivedData
-        displayName: 'Clean DerivedData'
-      - script: |
-          sudo gem install cocoapods
-        displayName: 'Install CocoaPods Environment'
-      - script: |
-          yarn bundle ios
-        workingDirectory: $(Build.Repository.LocalPath)/apps/ios
-        displayName: 'yarn bundle iOS'
-      - script: |
-          yarn bundle macos
-        workingDirectory: $(Build.Repository.LocalPath)/apps/macos
-        displayName: 'yarn bundle macOS'
-      # Select proper Xcode version
-      - template: templates/apple-xcode-select.yml
-      - template: templates/apple-xcode-build-static-libs.yml
-      - template: templates/nuget-publish.yml
+  # - job: NuGetPublish
+  #   displayName: NuGet Publish
+  #   pool:
+  #     vmImage: 'macos-10.15'
+  #     demands: ['xcode', 'sh', 'npm']
+  #   timeoutInMinutes: 90 # how long to run the job before automatically cancelling
+  #   cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
+  #   steps:
+  #     - checkout: self
+  #       persistCredentials: true
+  #     - template: templates/setup-repo-min-build.yml
+  #     # Clean Derived Data
+  #     - script: |
+  #         rm -rf $(Build.Repository.LocalPath)/DerivedData
+  #       displayName: 'Clean DerivedData'
+  #     - script: |
+  #         sudo gem install cocoapods
+  #       displayName: 'Install CocoaPods Environment'
+  #     - script: |
+  #         yarn bundle ios
+  #       workingDirectory: $(Build.Repository.LocalPath)/apps/ios
+  #       displayName: 'yarn bundle iOS'
+  #     - script: |
+  #         yarn bundle macos
+  #       workingDirectory: $(Build.Repository.LocalPath)/apps/macos
+  #       displayName: 'yarn bundle macOS'
+  #     # Select proper Xcode version
+  #     - template: templates/apple-xcode-select.yml
+  #     - template: templates/apple-xcode-build-static-libs.yml
+  #     - template: templates/nuget-publish.yml

--- a/package.nuspec
+++ b/package.nuspec
@@ -31,11 +31,11 @@
     <file src="DerivedData\Build\Products\Release-iphonesimulator\FluentUI-React-Native-Shimmer\libFluentUI-React-Native-Shimmer.a" target="Ship-iphonesimulator"/>
 
     <!-- macOS debug -->
-    <file src="DerivedData\Build\Products\Debug-iphoneos\FluentUI-React-Native-Apple-Theme\libFluentUI-React-Native-Apple-Theme.a" target="Debug-macosx"/>
+    <file src="DerivedData\Build\Products\Debug\FluentUI-React-Native-Apple-Theme\libFluentUI-React-Native-Apple-Theme.a" target="Debug-macosx"/>
     <file src="DerivedData\Build\Products\Debug\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Avatar.a" target="Debug-macosx"/>
     <file src="DerivedData\Build\Products\Debug\FluentUI-React-Native-Button\libFluentUI-React-Native-Button.a" target="Debug-macosx"/>
     <!-- macOS ship -->
-    <file src="DerivedData\Build\Products\Debug-iphoneos\FluentUI-React-Native-Apple-Theme\libFluentUI-React-Native-Apple-Theme.a" target="Ship-macosx"/>
+    <file src="DerivedData\Build\Products\Debug\FluentUI-React-Native-Apple-Theme\libFluentUI-React-Native-Apple-Theme.a" target="Ship-macosx"/>
     <file src="DerivedData\Build\Products\Release\FluentUI-React-Native-Avatar\libFluentUI-React-Native-Avatar.a" target="Ship-macosx"/>
     <file src="DerivedData\Build\Products\Release\FluentUI-React-Native-Button\libFluentUI-React-Native-Button.a" target="Ship-macosx"/>
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

We had a typo in our nuspec where we packed the iOS static library for the apple theme instead of the macOS one. This was noticed downstream as I was working on linking the libraries and noticed the architecture "x86_64" didn't exist for that library on macOS

### Verification

Uncomment the NuGet publish PR like before, and comment it out again before check in.
Successful Publish run: https://dev.azure.com/ms/ui-fabric-react-native/_build/results?buildId=154995&view=results

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
