### PR TITLE
chore: `rnx-start` is deprecated

### DIFF
--- a/apps/android/package.json
+++ b/apps/android/package.json
@@ -12,7 +12,7 @@
     "code-style": "fluentui-scripts code-style",
     "depcheck": "fluentui-scripts depcheck",
     "lint": "fluentui-scripts eslint",
-    "start": "react-native rnx-start",
+    "start": "react-native start",
     "test": "fluentui-scripts jest",
     "bundle": "react-native rnx-bundle --dev false",
     "bundle-dev": "react-native rnx-bundle",

--- a/apps/fluent-tester/package.json
+++ b/apps/fluent-tester/package.json
@@ -19,7 +19,7 @@
     "code-style": "fluentui-scripts code-style",
     "depcheck": "fluentui-scripts depcheck",
     "lint": "fluentui-scripts eslint",
-    "start": "react-native rnx-start",
+    "start": "react-native start",
     "test": "fluentui-scripts jest",
     "bundle": "react-native rnx-bundle --dev false"
   },

--- a/apps/ios/package.json
+++ b/apps/ios/package.json
@@ -12,7 +12,7 @@
     "code-style": "fluentui-scripts code-style",
     "depcheck": "fluentui-scripts depcheck",
     "lint": "fluentui-scripts eslint",
-    "start": "react-native rnx-start",
+    "start": "react-native start",
     "test": "fluentui-scripts jest",
     "bundle": "react-native rnx-bundle --dev false",
     "bundle-dev": "react-native rnx-bundle",

--- a/apps/macos/package.json
+++ b/apps/macos/package.json
@@ -13,7 +13,7 @@
     "code-style": "fluentui-scripts code-style",
     "depcheck": "fluentui-scripts depcheck",
     "lint": "fluentui-scripts eslint",
-    "start": "react-native rnx-start",
+    "start": "react-native start",
     "test": "fluentui-scripts jest",
     "macos": "react-native run-macos --scheme FluentTester --project-path src"
   },

--- a/apps/win32/package.json
+++ b/apps/win32/package.json
@@ -15,7 +15,7 @@
     "code-style": "fluentui-scripts code-style",
     "depcheck": "fluentui-scripts depcheck",
     "lint": "fluentui-scripts eslint",
-    "start": "react-native rnx-start --port 8081",
+    "start": "react-native start --port 8081",
     "test": "fluentui-scripts jest",
     "bundle": "react-native rnx-bundle --dev false",
     "bundle-dev": "react-native rnx-bundle",

--- a/apps/windows/package.json
+++ b/apps/windows/package.json
@@ -9,7 +9,7 @@
     "generate-report": "allure generate allure-results --clean && allure open",
     "lint": "eslint .",
     "report": "allure generate allure-results --clean",
-    "start": "react-native rnx-start",
+    "start": "react-native start",
     "test": "jest",
     "windows": "react-native run-windows"
   },

--- a/change/@fluentui-react-native-tester-2021-04-16-16-16-59-tido-remove-deprecated-rnx-start.json
+++ b/change/@fluentui-react-native-tester-2021-04-16-16-16-59-tido-remove-deprecated-rnx-start.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Use start instead of rnx-start",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none",
+  "date": "2021-04-16T14:16:56.921Z"
+}

--- a/change/@fluentui-react-native-tester-win32-2021-04-16-16-16-59-tido-remove-deprecated-rnx-start.json
+++ b/change/@fluentui-react-native-tester-win32-2021-04-16-16-16-59-tido-remove-deprecated-rnx-start.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Use start instead of rnx-start",
+  "packageName": "@fluentui-react-native/tester-win32",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none",
+  "date": "2021-04-16T14:16:59.224Z"
+}


### PR DESCRIPTION
### Platforms Impacted

- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

`rnx-start` is being removed because it currently does not provide any
value over vanilla `react-native start`.

See https://github.com/microsoft/rnx-kit/pull/139

### Verification

n/a

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
