### PR TITLE
Android Text Theme

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/Text/CustomizeUsage.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Text/CustomizeUsage.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 import { Stack } from '@fluentui-react-native/stack';
 import { Text } from '@fluentui/react-native';
 import { stackStyle } from '../Common/styles';
@@ -13,11 +13,31 @@ export const CustomizeUsage: React.FunctionComponent<{}> = () => {
   const IndigoHeroBold = Text.customize({ tokens: { variant: 'heroStandard', fontWeight: '700', color: '#4b0082' } });
   const PurpleHeroLargeBold = Text.customize({ tokens: { variant: 'heroLargeStandard', fontWeight: '700', color: '#8402c4' } });
 
-  const ArialBlack = Text.customize({ tokens: { variant: 'heroLargeStandard', fontFamily: 'Arial Black' } });
+  // Android has a limited fontFamily support and unknown fonts fallback to sans-serif (Roboto).
+  // Custom fonts (ttf, otf) are supported but need to be linked using 'react-native link'
+  // The supported font families can be found as <aliases> at https://android.googlesource.com/platform/frameworks/base/+/master/data/fonts/fonts.xml
+  const CustomFontNames = {
+    ...Platform.select({
+      android: {
+        ArialBlack: 'arial',
+        CourierNew: 'courier new',
+        Georgia: 'georgia',
+        TimesNewRoman: 'times new roman',
+      },
+      default: {
+        ArialBlack: 'Arial Black',
+        CourierNew: 'Courier New',
+        Georgia: 'Georgia',
+        TimesNewRoman: 'Times New Roman',
+      },
+    }),
+  };
+
+  const ArialBlack = Text.customize({ tokens: { variant: 'heroLargeStandard', fontFamily: CustomFontNames.ArialBlack } });
   const BrushScriptMT = Text.customize({ tokens: { variant: 'heroStandard', fontFamily: 'Brush Script MT' } });
-  const CourierNew = Text.customize({ tokens: { variant: 'headerStandard', fontFamily: 'Courier New' } });
-  const Georgia = Text.customize({ tokens: { variant: 'subheaderStandard', fontFamily: 'Georgia' } });
-  const TimesNewRoman = Text.customize({ tokens: { variant: 'secondaryStandard', fontFamily: 'Times New Roman' } });
+  const CourierNew = Text.customize({ tokens: { variant: 'headerStandard', fontFamily: CustomFontNames.CourierNew } });
+  const Georgia = Text.customize({ tokens: { variant: 'subheaderStandard', fontFamily: CustomFontNames.Georgia } });
+  const TimesNewRoman = Text.customize({ tokens: { variant: 'secondaryStandard', fontFamily: CustomFontNames.TimesNewRoman } });
   const Wingdings = Text.customize({ tokens: { variant: 'captionStandard', fontFamily: 'Wingdings' } });
 
   return (

--- a/apps/fluent-tester/src/FluentTester/TestComponents/Text/CustomizeUsage.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Text/CustomizeUsage.tsx
@@ -13,35 +13,8 @@ export const CustomizeUsage: React.FunctionComponent<{}> = () => {
   const IndigoHeroBold = Text.customize({ tokens: { variant: 'heroStandard', fontWeight: '700', color: '#4b0082' } });
   const PurpleHeroLargeBold = Text.customize({ tokens: { variant: 'heroLargeStandard', fontWeight: '700', color: '#8402c4' } });
 
-  // Android has a limited fontFamily support and unknown fonts fallback to sans-serif (Roboto).
-  // Custom fonts (ttf, otf) are supported but need to be linked using 'react-native link'
-  // The supported font families can be found as <aliases> at https://android.googlesource.com/platform/frameworks/base/+/master/data/fonts/fonts.xml
-  const CustomFontNames = {
-    ...Platform.select({
-      android: {
-        ArialBlack: 'arial',
-        CourierNew: 'courier new',
-        Georgia: 'georgia',
-        TimesNewRoman: 'times new roman',
-      },
-      default: {
-        ArialBlack: 'Arial Black',
-        CourierNew: 'Courier New',
-        Georgia: 'Georgia',
-        TimesNewRoman: 'Times New Roman',
-      },
-    }),
-  };
-
-  const ArialBlack = Text.customize({ tokens: { variant: 'heroLargeStandard', fontFamily: CustomFontNames.ArialBlack } });
-  const BrushScriptMT = Text.customize({ tokens: { variant: 'heroStandard', fontFamily: 'Brush Script MT' } });
-  const CourierNew = Text.customize({ tokens: { variant: 'headerStandard', fontFamily: CustomFontNames.CourierNew } });
-  const Georgia = Text.customize({ tokens: { variant: 'subheaderStandard', fontFamily: CustomFontNames.Georgia } });
-  const TimesNewRoman = Text.customize({ tokens: { variant: 'secondaryStandard', fontFamily: CustomFontNames.TimesNewRoman } });
-  const Wingdings = Text.customize({ tokens: { variant: 'captionStandard', fontFamily: 'Wingdings' } });
-
-  return (
-    <View>
+  const CustomUsageStack = () => {
+    return (
       <Stack style={stackStyle} gap={5}>
         <RedCaptionBold>RedCaptionBold</RedCaptionBold>
         <OrangeSecondaryBold>OrangeSecondaryBold</OrangeSecondaryBold>
@@ -51,7 +24,40 @@ export const CustomizeUsage: React.FunctionComponent<{}> = () => {
         <IndigoHeroBold>IndigoHeroBold</IndigoHeroBold>
         <PurpleHeroLargeBold>PurpleHeroLargeBold</PurpleHeroLargeBold>
       </Stack>
+    );
+  };
 
+  // Android has a limited fontFamily support and unknown fonts fallback to sans-serif (Roboto).
+  // Custom fonts (ttf, otf) are supported but need to be linked using 'react-native link'
+  // The supported font families can be found as <aliases> at https://android.googlesource.com/platform/frameworks/base/+/master/data/fonts/fonts.xml
+  const CustomFontNames = {
+    ...Platform.select({
+      android: {
+        CourierNew: 'courier new',
+        Georgia: 'georgia',
+        TimesNewRoman: 'times new roman',
+      },
+      default: {
+        CourierNew: 'Courier New',
+        Georgia: 'Georgia',
+        TimesNewRoman: 'Times New Roman',
+      },
+    }),
+  };
+
+  const ArialBlack = Text.customize({ tokens: { variant: 'heroLargeStandard', fontFamily: 'Arial Black' } });
+  const BrushScriptMT = Text.customize({ tokens: { variant: 'heroStandard', fontFamily: 'Brush Script MT' } });
+  const CourierNew = Text.customize({ tokens: { variant: 'headerStandard', fontFamily: CustomFontNames.CourierNew } });
+  const Georgia = Text.customize({ tokens: { variant: 'subheaderStandard', fontFamily: CustomFontNames.Georgia } });
+  const TimesNewRoman = Text.customize({ tokens: { variant: 'secondaryStandard', fontFamily: CustomFontNames.TimesNewRoman } });
+  const Wingdings = Text.customize({ tokens: { variant: 'captionStandard', fontFamily: 'Wingdings' } });
+
+  // Examples of supported Android fonts.
+  const Arial = Text.customize({ tokens: { variant: 'heroLargeStandard', fontFamily: 'arial' } });
+  const ComingSoon = Text.customize({ tokens: { variant: 'heroStandard', fontFamily: 'casual' } });
+
+  const CustomFontStack = () => {
+    return (
       <Stack style={stackStyle} gap={5}>
         <ArialBlack>Arial Black</ArialBlack>
         <BrushScriptMT>Brush Script MT</BrushScriptMT>
@@ -60,6 +66,29 @@ export const CustomizeUsage: React.FunctionComponent<{}> = () => {
         <TimesNewRoman>TimesNewRoman</TimesNewRoman>
         <Wingdings>Wingdings</Wingdings>
       </Stack>
+    );
+  };
+  const CustomFontStackAndroid = () => {
+    return (
+      <Stack style={stackStyle} gap={5}>
+        <Arial>Arial</Arial>
+        <ComingSoon>ComingSoon</ComingSoon>
+        <CourierNew>Courier New</CourierNew>
+        <Georgia>Georgia</Georgia>
+        <TimesNewRoman>TimesNewRoman</TimesNewRoman>
+      </Stack>
+    );
+  };
+
+  return Platform.OS == 'android' ? (
+    <View>
+      <CustomUsageStack />
+      <CustomFontStackAndroid />
+    </View>
+  ) : (
+    <View>
+      <CustomUsageStack />
+      <CustomFontStack />
     </View>
   );
 };

--- a/change/@fluentui-react-native-android-theme-2021-04-20-17-29-28-android-text.json
+++ b/change/@fluentui-react-native-android-theme-2021-04-20-17-29-28-android-text.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update android-text theme and test",
+  "packageName": "@fluentui-react-native/android-theme",
+  "email": "tamasane@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2021-04-20T11:59:28.927Z"
+}

--- a/change/@fluentui-react-native-tester-2021-04-20-17-29-28-android-text.json
+++ b/change/@fluentui-react-native-tester-2021-04-20-17-29-28-android-text.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update android-text theme and test",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "tamasane@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2021-04-20T11:59:14.807Z"
+}

--- a/packages/theming/android-theme/README.md
+++ b/packages/theming/android-theme/README.md
@@ -3,3 +3,11 @@
 Code and definitions for creating an Android Theme for FluentUI React Native.
 
 The theme follows color, typography, spacing and other values to closely match [FluentUI Android](https://github.com/microsoft/fluentui-android). The theme is work in progress and changes are expected.
+
+## Typography and Fonts
+
+The theme package contains font families, weights, sizes, variants as per the FluentUI Typography guidelines. The families object points to corresponding system fonts.
+
+Note:
+Android only supports the following fontWeight values: "normal" (same as "400"), "bold" (same as "700"). Any other fontWeight value defaults to "400".
+This theme contains families - primary for (Roboto, weight="400"), primarySemibold for (Roboto, weight="500") and primaryLight for (Roboto, weight="300")

--- a/packages/theming/android-theme/README.md
+++ b/packages/theming/android-theme/README.md
@@ -8,6 +8,5 @@ The theme follows color, typography, spacing and other values to closely match [
 
 The theme package contains font families, weights, sizes, variants as per the FluentUI Typography guidelines. The families object points to corresponding system fonts.
 
-Note:
-Android only supports the following fontWeight values: "normal" (same as "400"), "bold" (same as "700"). Any other fontWeight value defaults to "400".
-This theme contains families - primary for (Roboto, weight="400"), primarySemibold for (Roboto, weight="500") and primaryLight for (Roboto, weight="300")
+Note: Android only supports the following fontWeight values: `"normal" (same as "400"), "bold" (same as "700")`. Any other fontWeight value defaults to "400".  
+This theme contains families - `primary` for (Roboto, weight="400"), `primarySemibold` for (Roboto, weight="500") and `primaryLight` for (Roboto, weight="300")

--- a/packages/theming/android-theme/src/androidTypography.ts
+++ b/packages/theming/android-theme/src/androidTypography.ts
@@ -24,10 +24,10 @@ export function androidTypography(): Typography {
     },
     families: {
       primary: 'sans-serif', // sans-serif, weight=400
-      primaryBold: 'sans-serif-medium', // sans-serif, weight=500
+      primarySemibold: 'sans-serif-medium', // sans-serif, weight=500
       primaryLight: 'sans-serif-light', // sans-serif, weight=300
       secondary: 'System',
-      cursive: 'System',
+      cursive: 'cursive',
       monospace: 'monospace',
       sansSerif: 'sans-serif',
       serif: 'serif',
@@ -35,17 +35,17 @@ export function androidTypography(): Typography {
     variants: {
       captionStandard: { face: 'primary', size: 'caption' },
       secondaryStandard: { face: 'primary', size: 'secondary' },
-      secondarySemibold: { face: 'primaryBold', size: 'secondary' },
+      secondarySemibold: { face: 'primarySemibold', size: 'secondary' },
       bodyStandard: { face: 'primary', size: 'body' },
-      bodySemibold: { face: 'primaryBold', size: 'body' },
+      bodySemibold: { face: 'primarySemibold', size: 'body' },
       subheaderStandard: { face: 'primary', size: 'subheader' },
-      subheaderSemibold: { face: 'primaryBold', size: 'subheader' },
+      subheaderSemibold: { face: 'primarySemibold', size: 'subheader' },
       headerStandard: { face: 'primary', size: 'header' },
-      headerSemibold: { face: 'primaryBold', size: 'header' },
+      headerSemibold: { face: 'primarySemibold', size: 'header' },
       heroStandard: { face: 'primary', size: 'hero' },
-      heroSemibold: { face: 'primaryBold', size: 'hero' },
+      heroSemibold: { face: 'primarySemibold', size: 'hero' },
       heroLargeStandard: { face: 'primary', size: 'heroLarge' },
-      heroLargeSemibold: { face: 'primaryBold', size: 'heroLarge' },
+      heroLargeSemibold: { face: 'primarySemibold', size: 'heroLarge' },
     } as Variants,
   };
 

--- a/packages/theming/android-theme/src/androidTypography.ts
+++ b/packages/theming/android-theme/src/androidTypography.ts
@@ -17,13 +17,15 @@ export function androidTypography(): Typography {
       heroLarge: 28 as FontSize, // Headline
     } as FontSizes,
     weights: {
-      light: '300' as FontWeightValue,
+      // The font weights do not work for Android since RN 0.60 (https://github.com/facebook/react-native/issues/25696)
+      // The workaround is to use font aliases from android source (https://android.googlesource.com/platform/frameworks/base/+/master/data/fonts/fonts.xml)
       regular: '400' as FontWeightValue,
-      medium: '500' as FontWeightValue,
       semiBold: '500' as FontWeightValue,
     },
     families: {
-      primary: 'Roboto',
+      primary: 'sans-serif', // sans-serif, weight=400
+      primaryBold: 'sans-serif-medium', // sans-serif, weight=500
+      primaryLight: 'sans-serif-light', // sans-serif, weight=300
       secondary: 'System',
       cursive: 'System',
       monospace: 'monospace',
@@ -31,19 +33,19 @@ export function androidTypography(): Typography {
       serif: 'serif',
     },
     variants: {
-      captionStandard: { face: 'primary', size: 'caption', weight: '400' },
-      secondaryStandard: { face: 'primary', size: 'secondary', weight: '400' },
-      secondarySemibold: { face: 'primary', size: 'secondary', weight: '500' },
-      bodyStandard: { face: 'primary', size: 'body', weight: '400' },
-      bodySemibold: { face: 'primary', size: 'body', weight: '500' },
-      subheaderStandard: { face: 'primary', size: 'subheader', weight: '400' },
-      subheaderSemibold: { face: 'primary', size: 'subheader', weight: '500' },
-      headerStandard: { face: 'primary', size: 'header', weight: '400' },
-      headerSemibold: { face: 'primary', size: 'header', weight: '500' },
-      heroStandard: { face: 'primary', size: 'hero', weight: '400' },
-      heroSemibold: { face: 'primary', size: 'hero', weight: '500' },
-      heroLargeStandard: { face: 'primary', size: 'heroLarge', weight: '400' },
-      heroLargeSemibold: { face: 'primary', size: 'heroLarge', weight: '500' },
+      captionStandard: { face: 'primary', size: 'caption' },
+      secondaryStandard: { face: 'primary', size: 'secondary' },
+      secondarySemibold: { face: 'primaryBold', size: 'secondary' },
+      bodyStandard: { face: 'primary', size: 'body' },
+      bodySemibold: { face: 'primaryBold', size: 'body' },
+      subheaderStandard: { face: 'primary', size: 'subheader' },
+      subheaderSemibold: { face: 'primaryBold', size: 'subheader' },
+      headerStandard: { face: 'primary', size: 'header' },
+      headerSemibold: { face: 'primaryBold', size: 'header' },
+      heroStandard: { face: 'primary', size: 'hero' },
+      heroSemibold: { face: 'primaryBold', size: 'hero' },
+      heroLargeStandard: { face: 'primary', size: 'heroLarge' },
+      heroLargeSemibold: { face: 'primaryBold', size: 'heroLarge' },
     } as Variants,
   };
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [x] android

### Description of changes

- The android-theme did not contain correct typography. The customisation of text on android is limited as very few font families are supported and there is bug in setting the font-weight values. This change addresses these limitations and applies workarounds to make typography compliant to Fluent Design guidelines.
- This change also updates the CustomUsage in Fluent-tester-app which shows example use cases for other supported font-families on android.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before-android-text-part1](https://user-images.githubusercontent.com/23552252/115395800-ea081f80-a201-11eb-9094-ed9bb05ae7fa.png) | ![after-android-text-part01](https://user-images.githubusercontent.com/23552252/115395974-1b80eb00-a202-11eb-9978-74b11510d916.png) |
| ![before-android-text-part2](https://user-images.githubusercontent.com/23552252/115396111-466b3f00-a202-11eb-9ec7-1f4ab467b586.png) | ![after-android-text-part02](https://user-images.githubusercontent.com/23552252/117368111-b48d5280-aee0-11eb-837f-5a8825a8aade.png) |



### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
