### PR TITLE
Fix tabbing behavior for Radio Group and key focus on Radio Button

### DIFF
--- a/change/@fluentui-react-native-radio-group-2021-05-10-11-22-56-radioFocusFix.json
+++ b/change/@fluentui-react-native-radio-group-2021-05-10-11-22-56-radioFocusFix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add logic to mantain selected button's ref",
+  "packageName": "@fluentui-react-native/radio-group",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-05-10T15:22:56.070Z"
+}

--- a/packages/components/RadioGroup/src/RadioButton.tsx
+++ b/packages/components/RadioGroup/src/RadioButton.tsx
@@ -29,7 +29,6 @@ export const RadioButton = compose<IRadioButtonType>({
       if (buttonKey != info.selectedKey) {
         info.onChange && info.onChange(buttonKey);
         info.updateSelectedButtonRef && componentRef && info.updateSelectedButtonRef(componentRef);
-        componentRef?.current?.focus();
       }
     };
 

--- a/packages/components/RadioGroup/src/RadioButton.tsx
+++ b/packages/components/RadioGroup/src/RadioButton.tsx
@@ -9,7 +9,7 @@ import { filterViewProps } from '@fluentui-react-native/adapters';
 import { ISlots, withSlots } from '@uifabricshared/foundation-composable';
 import { settings, radioButtonSelectActionLabel } from './RadioButton.settings';
 import { mergeSettings } from '@uifabricshared/foundation-settings';
-import { foregroundColorTokens, textTokens, borderTokens, backgroundColorTokens, getPaletteFromTheme} from '@fluentui-react-native/tokens';
+import { foregroundColorTokens, textTokens, borderTokens, backgroundColorTokens, getPaletteFromTheme } from '@fluentui-react-native/tokens';
 import { useAsPressable, useViewCommandFocus } from '@fluentui-react-native/interactive-hooks';
 import { RadioGroupContext } from './RadioGroup';
 
@@ -17,34 +17,48 @@ export const RadioButton = compose<IRadioButtonType>({
   displayName: radioButtonName,
 
   usePrepareProps: (userProps: IRadioButtonProps, useStyling: IUseComposeStyling<IRadioButtonType>) => {
-    const { content, buttonKey, disabled, ariaLabel, componentRef, ...rest } = userProps;
+    const { content, buttonKey, disabled, ariaLabel, componentRef = React.useRef(null), ...rest } = userProps;
 
     // Grabs the context information from RadioGroup (currently selected button and client's onChange callback)
     const info = React.useContext(RadioGroupContext);
 
+    const buttonRef = useViewCommandFocus(componentRef);
+
     /* We don't want to call the user's onChange multiple times on the same selection. */
     const changeSelection = () => {
-      if(buttonKey != info.selectedKey)
+      if (buttonKey != info.selectedKey) {
         info.onChange && info.onChange(buttonKey);
+        info.updateSelectedButtonRef && componentRef && info.updateSelectedButtonRef(componentRef);
+        componentRef?.current?.focus();
+      }
     };
 
+    /* We use the componentRef of the currently selected button to maintain the default tabbable
+    element in a RadioGroup. Since the componentRef isn't generated until after initial render,
+    we must update it once here. */
+    React.useEffect(() => {
+      if (buttonKey == info.selectedKey) {
+        info.updateSelectedButtonRef && componentRef && info.updateSelectedButtonRef(componentRef);
+      }
+    }, []);
+
     /* RadioButton changes selection when focus is moved between each RadioButton and on a click */
-    const pressable = useAsPressable({...rest,
+    const pressable = useAsPressable({
+      ...rest,
       onPress: () => {
         changeSelection();
       },
       onFocus: () => {
         changeSelection();
-      }});
-
-    const buttonRef = useViewCommandFocus(componentRef);
+      },
+    });
 
     // Used when creating accessibility properties in mergeSettings below
     const onAccessibilityAction = React.useCallback(
       (event: { nativeEvent: { actionName: any } }) => {
         switch (event.nativeEvent.actionName) {
           case 'Select':
-            info.onChange && info.onChange(buttonKey);
+            changeSelection();
             break;
         }
       },
@@ -54,7 +68,7 @@ export const RadioButton = compose<IRadioButtonType>({
     const state = {
       ...pressable.state,
       selected: info.selectedKey === userProps.buttonKey,
-      disabled: disabled || false
+      disabled: disabled || false,
     };
 
     // Grab the styling information from the userProps, referencing the state as well as the props.

--- a/packages/components/RadioGroup/src/RadioButton.tsx
+++ b/packages/components/RadioGroup/src/RadioButton.tsx
@@ -45,12 +45,8 @@ export const RadioButton = compose<IRadioButtonType>({
     /* RadioButton changes selection when focus is moved between each RadioButton and on a click */
     const pressable = useAsPressable({
       ...rest,
-      onPress: () => {
-        changeSelection();
-      },
-      onFocus: () => {
-        changeSelection();
-      },
+      onPress: changeSelection,
+      onFocus: changeSelection,
     });
 
     // Used when creating accessibility properties in mergeSettings below

--- a/packages/components/RadioGroup/src/RadioGroup.tsx
+++ b/packages/components/RadioGroup/src/RadioGroup.tsx
@@ -10,7 +10,7 @@ import {
   IRadioGroupState,
   IRadioGroupSlotProps,
   IRadioGroupRenderData,
-  IRadioGroupContext
+  IRadioGroupContext,
 } from './RadioGroup.types';
 import { compose, IUseComposeStyling } from '@uifabricshared/foundation-compose';
 import { ISlots, withSlots } from '@uifabricshared/foundation-composable';
@@ -23,7 +23,10 @@ export const RadioGroupContext = React.createContext<IRadioGroupContext>({
   selectedKey: null,
   onChange: (/* key: string */) => {
     return;
-  }
+  },
+  updateSelectedButtonRef: (/* ref: React.RefObject<any>*/) => {
+    return;
+  },
 });
 
 export const RadioGroup = compose<IRadioGroupType>({
@@ -35,24 +38,34 @@ export const RadioGroup = compose<IRadioGroupType>({
     // This hook updates the Selected Button and calls the customer's onClick function. This gets called after a button is pressed.
     const data = useSelectedKey(selectedKey || defaultSelectedKey || null, userProps.onChange);
 
+    const [selectedButtonRef, setSelectedButtonRef] = React.useState(React.useRef<View>(null));
+
+    const onSelectButtonRef = React.useCallback(
+      (ref: React.RefObject<View>) => {
+        setSelectedButtonRef(ref);
+      },
+      [setSelectedButtonRef],
+    );
+
     const state: IRadioGroupState = {
       context: {
         selectedKey: selectedKey ?? data.selectedKey,
-        onChange: data.onKeySelect
-      }
+        onChange: data.onKeySelect,
+        updateSelectedButtonRef: onSelectButtonRef,
+      },
     };
 
     const styleProps = useStyling(userProps, (override: string) => state[override] || userProps[override]);
 
     const ariaRoles = {
       accessibilityRole: 'radiogroup',
-      accessibilityLabel: ariaLabel || label
+      accessibilityLabel: ariaLabel || label,
     };
 
     const slotProps = mergeSettings<IRadioGroupSlotProps>(styleProps, {
       root: { rest, ...ariaRoles },
       label: { children: label },
-      container: { isCircularNavigation: true }
+      container: { isCircularNavigation: true, defaultTabbableElement: selectedButtonRef },
     });
 
     return { slotProps, state };
@@ -80,13 +93,13 @@ export const RadioGroup = compose<IRadioGroupType>({
   slots: {
     root: View,
     label: Text,
-    container: FocusZone
+    container: FocusZone,
   },
   styles: {
     root: [],
     label: [foregroundColorTokens, textTokens],
-    container: []
-  }
+    container: [],
+  },
 });
 
 export default RadioGroup;

--- a/packages/components/RadioGroup/src/RadioGroup.types.ts
+++ b/packages/components/RadioGroup/src/RadioGroup.types.ts
@@ -17,6 +17,11 @@ export interface IRadioGroupContext {
    ** Updates the selected button and calls the client’s onChange callback
    */
   onChange?: (key: string) => void;
+
+  /*
+   ** Updates the selected button's ref to set as the default tabbable element
+   */
+  updateSelectedButtonRef?: (ref: React.RefObject<any>) => void;
 }
 
 export interface IRadioGroupState {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Adds logic to maintain the currently selected button's ref so that it can be set as the default tabbable element of Radio Group

Addresses issue #604

### Verification

Tested locally with the Fluent Teser

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [x] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
