### PR TITLE
Fix tester-win32 web debugging / fast refresh

### DIFF
--- a/apps/win32/package.json
+++ b/apps/win32/package.json
@@ -19,9 +19,9 @@
     "test": "fluentui-scripts jest",
     "bundle": "react-native rnx-bundle --dev false",
     "bundle-dev": "react-native rnx-bundle",
-    "run-win32": "rex-win32 --bundle index.win32 --component FluentTester --windowTitle \"FluentUI Tester\" --basePath ./dist --pluginProps",
-    "run-win32-web": "rex-win32 --bundle index --component FluentTester --basePath ./dist --useWebDebugger --windowTitle \"FluentUI Tester\" --useFastRefresh --pluginProps",
-    "run-win32-devmain": "rex-win32 --bundle index.win32 --component FluentTester --basePath ./dist --useDevMain --windowTitle \"FluentUI Tester\" --pluginProps",
+    "run-win32": "rex-win32 --bundle index.win32 --component FluentTester --windowTitle \"FluentUI Tester\" --basePath ./dist --pluginProps --debugBundlePath index --jsEngine v8",
+    "run-win32-web": "rex-win32 --bundle index --component FluentTester --basePath ./dist --useWebDebugger --windowTitle \"FluentUI Tester\" --useFastRefresh --pluginProps --debugBundlePath index --jsEngine v8",
+    "run-win32-devmain": "rex-win32 --bundle index.win32 --component FluentTester --basePath ./dist --useDevMain --windowTitle \"FluentUI Tester\" --pluginProps --debugBundlePath index --jsEngine v8",
     "e2etest": "rimraf reports/* && wdio",
     "report": "allure generate allure-results --clean",
     "generate-report": "allure generate allure-results --clean && allure open"
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@office-iss/react-native-win32": "^0.63.7",
-    "@office-iss/rex-win32": "0.63.22-devmain.13903.10000",
+    "@office-iss/rex-win32": "0.63.28-devmain.14119.10000",
     "@react-native-community/eslint-config": "^1.1.0",
     "@rnx-kit/cli": "^0.0.3",
     "@types/jasmine": "3.5.10",

--- a/change/@fluentui-react-native-tester-win32-2021-05-19-17-48-30-updaterex.json
+++ b/change/@fluentui-react-native-tester-win32-2021-05-19-17-48-30-updaterex.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix livereload in win32 tester app",
+  "packageName": "@fluentui-react-native/tester-win32",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2021-05-20T00:48:30.585Z"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2140,10 +2140,10 @@
     use-subscription "^1.0.0"
     whatwg-fetch "^3.0.0"
 
-"@office-iss/rex-win32@0.63.22-devmain.13903.10000":
-  version "0.63.22-devmain.13903.10000"
-  resolved "https://registry.yarnpkg.com/@office-iss/rex-win32/-/rex-win32-0.63.22-devmain.13903.10000.tgz#65a2b84db099ca0be45b3e78236ce4432fd3fcfa"
-  integrity sha512-878IRGru03fqSoUc0vq4SnYimX2k2aIcCqjjyJbKaQKpJNe4QUtBU60sPVCDI8EkWOVaqJTpvhwS4nKjmqgNLg==
+"@office-iss/rex-win32@0.63.28-devmain.14119.10000":
+  version "0.63.28-devmain.14119.10000"
+  resolved "https://registry.yarnpkg.com/@office-iss/rex-win32/-/rex-win32-0.63.28-devmain.14119.10000.tgz#f926c653f0807ff44cd9203a1730ace60141fdfb"
+  integrity sha512-cSFOBapadpAw7HxgCSuzxXDPOT77GJXQrY095v+KtD9wBApmKdo9xBmB1HoOfey4nbaQHIQjSUfkMyz7HkRpgQ==
   dependencies:
     command-line-args "^5.0.2"
     command-line-usage "^5.0.5"


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Updates the version of rex-win32 we are using for the win32 tester app.  Modifies the command to launch rex to provide it with the correct entry file for web debugging / fast refresh to work.  Also modified it to use v8 by default, instead of ChakraCore.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
