### PR TITLE
Add prop hideInsideGapForBorder to experimental-avatar

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/Avatar/AvatarTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Avatar/AvatarTest.tsx
@@ -34,6 +34,8 @@ const avatar: React.FunctionComponent<{}> = () => {
       <Avatar primaryText="Kat Larrson" backgroundColor="teal" />
       <Text>Custom Border Image</Text>
       <Avatar primaryText="Kat Larrson" customBorderImageSource={rainbowGradientSource} />
+      <Text>Custom Border Image without gap</Text>
+      <Avatar primaryText="Kat Larrson" customBorderImageSource={rainbowGradientSource} hideInsideGapForBorder={true} />
     </Stack>
   );
 };

--- a/apps/ios/src/Podfile.lock
+++ b/apps/ios/src/Podfile.lock
@@ -14,8 +14,9 @@ PODS:
     - React
   - FluentUI-React-Native-Avatar (0.7.1):
     - MicrosoftFluentUI (~> 0.2.2)
+    - MicrosoftFluentUI (~> 0.2.6)
     - React
-  - FluentUI-React-Native-Button (0.5.3):
+  - FluentUI-React-Native-Button (0.5.4):
     - MicrosoftFluentUI (~> 0.2.2)
     - React
   - Folly (2020.01.13.00):
@@ -28,63 +29,63 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - MicrosoftFluentUI (0.2.3):
-    - MicrosoftFluentUI/ActivityIndicator_ios (= 0.2.3)
-    - MicrosoftFluentUI/ActivityViewAnimating_ios (= 0.2.3)
-    - MicrosoftFluentUI/Appearance_mac (= 0.2.3)
-    - MicrosoftFluentUI/Avatar_ios (= 0.2.3)
-    - MicrosoftFluentUI/AvatarView_mac (= 0.2.3)
-    - MicrosoftFluentUI/BadgeField_ios (= 0.2.3)
-    - MicrosoftFluentUI/BarButtonItems_ios (= 0.2.3)
-    - MicrosoftFluentUI/Button_ios (= 0.2.3)
-    - MicrosoftFluentUI/Button_mac (= 0.2.3)
-    - MicrosoftFluentUI/Calendar_ios (= 0.2.3)
-    - MicrosoftFluentUI/Card_ios (= 0.2.3)
-    - MicrosoftFluentUI/CommandBar_ios (= 0.2.3)
-    - MicrosoftFluentUI/Core_ios (= 0.2.3)
-    - MicrosoftFluentUI/Core_mac (= 0.2.3)
-    - MicrosoftFluentUI/DatePicker_mac (= 0.2.3)
-    - MicrosoftFluentUI/DotView_ios (= 0.2.3)
-    - MicrosoftFluentUI/Drawer_ios (= 0.2.3)
-    - MicrosoftFluentUI/DynamicColor_mac (= 0.2.3)
-    - MicrosoftFluentUI/EasyTapButton_ios (= 0.2.3)
-    - MicrosoftFluentUI/HUD_ios (= 0.2.3)
-    - MicrosoftFluentUI/IndeterminateProgressBar_ios (= 0.2.3)
-    - MicrosoftFluentUI/Label_ios (= 0.2.3)
-    - MicrosoftFluentUI/Link_mac (= 0.2.3)
-    - MicrosoftFluentUI/Navigation_ios (= 0.2.3)
-    - MicrosoftFluentUI/Notification_ios (= 0.2.3)
-    - MicrosoftFluentUI/Obscurable_ios (= 0.2.3)
-    - MicrosoftFluentUI/OtherCells_ios (= 0.2.3)
-    - MicrosoftFluentUI/PeoplePicker_ios (= 0.2.3)
-    - MicrosoftFluentUI/PillButtonBar_ios (= 0.2.3)
-    - MicrosoftFluentUI/PopupMenu_ios (= 0.2.3)
-    - MicrosoftFluentUI/Presenters_ios (= 0.2.3)
-    - MicrosoftFluentUI/ResizingHandleView_ios (= 0.2.3)
-    - MicrosoftFluentUI/ScrollView_ios (= 0.2.3)
-    - MicrosoftFluentUI/SegmentedControl_ios (= 0.2.3)
-    - MicrosoftFluentUI/Separator_ios (= 0.2.3)
-    - MicrosoftFluentUI/Separator_mac (= 0.2.3)
-    - MicrosoftFluentUI/Shimmer_ios (= 0.2.3)
-    - MicrosoftFluentUI/TabBar_ios (= 0.2.3)
-    - MicrosoftFluentUI/TableView_ios (= 0.2.3)
-    - MicrosoftFluentUI/Tooltip_ios (= 0.2.3)
-    - MicrosoftFluentUI/TouchForwardingView_ios (= 0.2.3)
-    - MicrosoftFluentUI/TwoLineTitleView_ios (= 0.2.3)
-    - MicrosoftFluentUI/Utilities_ios (= 0.2.3)
-  - MicrosoftFluentUI/ActivityIndicator_ios (0.2.3):
+  - MicrosoftFluentUI (0.2.7):
+    - MicrosoftFluentUI/ActivityIndicator_ios (= 0.2.7)
+    - MicrosoftFluentUI/ActivityViewAnimating_ios (= 0.2.7)
+    - MicrosoftFluentUI/Appearance_mac (= 0.2.7)
+    - MicrosoftFluentUI/Avatar_ios (= 0.2.7)
+    - MicrosoftFluentUI/AvatarView_mac (= 0.2.7)
+    - MicrosoftFluentUI/BadgeField_ios (= 0.2.7)
+    - MicrosoftFluentUI/BarButtonItems_ios (= 0.2.7)
+    - MicrosoftFluentUI/Button_ios (= 0.2.7)
+    - MicrosoftFluentUI/Button_mac (= 0.2.7)
+    - MicrosoftFluentUI/Calendar_ios (= 0.2.7)
+    - MicrosoftFluentUI/Card_ios (= 0.2.7)
+    - MicrosoftFluentUI/CommandBar_ios (= 0.2.7)
+    - MicrosoftFluentUI/Core_ios (= 0.2.7)
+    - MicrosoftFluentUI/Core_mac (= 0.2.7)
+    - MicrosoftFluentUI/DatePicker_mac (= 0.2.7)
+    - MicrosoftFluentUI/DotView_ios (= 0.2.7)
+    - MicrosoftFluentUI/Drawer_ios (= 0.2.7)
+    - MicrosoftFluentUI/DynamicColor_mac (= 0.2.7)
+    - MicrosoftFluentUI/EasyTapButton_ios (= 0.2.7)
+    - MicrosoftFluentUI/HUD_ios (= 0.2.7)
+    - MicrosoftFluentUI/IndeterminateProgressBar_ios (= 0.2.7)
+    - MicrosoftFluentUI/Label_ios (= 0.2.7)
+    - MicrosoftFluentUI/Link_mac (= 0.2.7)
+    - MicrosoftFluentUI/Navigation_ios (= 0.2.7)
+    - MicrosoftFluentUI/Notification_ios (= 0.2.7)
+    - MicrosoftFluentUI/Obscurable_ios (= 0.2.7)
+    - MicrosoftFluentUI/OtherCells_ios (= 0.2.7)
+    - MicrosoftFluentUI/PeoplePicker_ios (= 0.2.7)
+    - MicrosoftFluentUI/PillButtonBar_ios (= 0.2.7)
+    - MicrosoftFluentUI/PopupMenu_ios (= 0.2.7)
+    - MicrosoftFluentUI/Presenters_ios (= 0.2.7)
+    - MicrosoftFluentUI/ResizingHandleView_ios (= 0.2.7)
+    - MicrosoftFluentUI/ScrollView_ios (= 0.2.7)
+    - MicrosoftFluentUI/SegmentedControl_ios (= 0.2.7)
+    - MicrosoftFluentUI/Separator_ios (= 0.2.7)
+    - MicrosoftFluentUI/Separator_mac (= 0.2.7)
+    - MicrosoftFluentUI/Shimmer_ios (= 0.2.7)
+    - MicrosoftFluentUI/TabBar_ios (= 0.2.7)
+    - MicrosoftFluentUI/TableView_ios (= 0.2.7)
+    - MicrosoftFluentUI/Tooltip_ios (= 0.2.7)
+    - MicrosoftFluentUI/TouchForwardingView_ios (= 0.2.7)
+    - MicrosoftFluentUI/TwoLineTitleView_ios (= 0.2.7)
+    - MicrosoftFluentUI/Utilities_ios (= 0.2.7)
+  - MicrosoftFluentUI/ActivityIndicator_ios (0.2.7):
     - MicrosoftFluentUI/ActivityViewAnimating_ios
-  - MicrosoftFluentUI/ActivityViewAnimating_ios (0.2.3):
+  - MicrosoftFluentUI/ActivityViewAnimating_ios (0.2.7):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/Avatar_ios (0.2.3):
+  - MicrosoftFluentUI/Avatar_ios (0.2.7):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/BadgeField_ios (0.2.3):
+  - MicrosoftFluentUI/BadgeField_ios (0.2.7):
     - MicrosoftFluentUI/Label_ios
-  - MicrosoftFluentUI/BarButtonItems_ios (0.2.3):
+  - MicrosoftFluentUI/BarButtonItems_ios (0.2.7):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/Button_ios (0.2.3):
+  - MicrosoftFluentUI/Button_ios (0.2.7):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/Calendar_ios (0.2.3):
+  - MicrosoftFluentUI/Calendar_ios (0.2.7):
     - MicrosoftFluentUI/BarButtonItems_ios
     - MicrosoftFluentUI/DotView_ios
     - MicrosoftFluentUI/Label_ios
@@ -92,83 +93,83 @@ PODS:
     - MicrosoftFluentUI/SegmentedControl_ios
     - MicrosoftFluentUI/Separator_ios
     - MicrosoftFluentUI/TwoLineTitleView_ios
-  - MicrosoftFluentUI/Card_ios (0.2.3):
+  - MicrosoftFluentUI/Card_ios (0.2.7):
     - MicrosoftFluentUI/Label_ios
-  - MicrosoftFluentUI/CommandBar_ios (0.2.3):
+  - MicrosoftFluentUI/CommandBar_ios (0.2.7):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/Core_ios (0.2.3)
-  - MicrosoftFluentUI/DotView_ios (0.2.3):
+  - MicrosoftFluentUI/Core_ios (0.2.7)
+  - MicrosoftFluentUI/DotView_ios (0.2.7):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/Drawer_ios (0.2.3):
+  - MicrosoftFluentUI/Drawer_ios (0.2.7):
     - MicrosoftFluentUI/Obscurable_ios
     - MicrosoftFluentUI/ResizingHandleView_ios
     - MicrosoftFluentUI/Separator_ios
     - MicrosoftFluentUI/TouchForwardingView_ios
-  - MicrosoftFluentUI/EasyTapButton_ios (0.2.3):
+  - MicrosoftFluentUI/EasyTapButton_ios (0.2.7):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/HUD_ios (0.2.3):
+  - MicrosoftFluentUI/HUD_ios (0.2.7):
     - MicrosoftFluentUI/ActivityIndicator_ios
     - MicrosoftFluentUI/Label_ios
     - MicrosoftFluentUI/TouchForwardingView_ios
-  - MicrosoftFluentUI/IndeterminateProgressBar_ios (0.2.3):
+  - MicrosoftFluentUI/IndeterminateProgressBar_ios (0.2.7):
     - MicrosoftFluentUI/ActivityViewAnimating_ios
-  - MicrosoftFluentUI/Label_ios (0.2.3):
+  - MicrosoftFluentUI/Label_ios (0.2.7):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/Navigation_ios (0.2.3):
+  - MicrosoftFluentUI/Navigation_ios (0.2.7):
     - MicrosoftFluentUI/ActivityIndicator_ios
     - MicrosoftFluentUI/Avatar_ios
     - MicrosoftFluentUI/Separator_ios
     - MicrosoftFluentUI/TwoLineTitleView_ios
-  - MicrosoftFluentUI/Notification_ios (0.2.3):
+  - MicrosoftFluentUI/Notification_ios (0.2.7):
     - MicrosoftFluentUI/Label_ios
     - MicrosoftFluentUI/Obscurable_ios
     - MicrosoftFluentUI/Separator_ios
-  - MicrosoftFluentUI/Obscurable_ios (0.2.3):
+  - MicrosoftFluentUI/Obscurable_ios (0.2.7):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/OtherCells_ios (0.2.3):
+  - MicrosoftFluentUI/OtherCells_ios (0.2.7):
     - MicrosoftFluentUI/ActivityIndicator_ios
     - MicrosoftFluentUI/TableView_ios
-  - MicrosoftFluentUI/PeoplePicker_ios (0.2.3):
+  - MicrosoftFluentUI/PeoplePicker_ios (0.2.7):
     - MicrosoftFluentUI/Avatar_ios
     - MicrosoftFluentUI/BadgeField_ios
     - MicrosoftFluentUI/OtherCells_ios
     - MicrosoftFluentUI/Separator_ios
-  - MicrosoftFluentUI/PillButtonBar_ios (0.2.3):
+  - MicrosoftFluentUI/PillButtonBar_ios (0.2.7):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/PopupMenu_ios (0.2.3):
+  - MicrosoftFluentUI/PopupMenu_ios (0.2.7):
     - MicrosoftFluentUI/Drawer_ios
     - MicrosoftFluentUI/Label_ios
     - MicrosoftFluentUI/Separator_ios
     - MicrosoftFluentUI/TableView_ios
-  - MicrosoftFluentUI/Presenters_ios (0.2.3):
+  - MicrosoftFluentUI/Presenters_ios (0.2.7):
     - MicrosoftFluentUI/Obscurable_ios
-  - MicrosoftFluentUI/ResizingHandleView_ios (0.2.3):
+  - MicrosoftFluentUI/ResizingHandleView_ios (0.2.7):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/ScrollView_ios (0.2.3):
+  - MicrosoftFluentUI/ScrollView_ios (0.2.7):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/SegmentedControl_ios (0.2.3):
+  - MicrosoftFluentUI/SegmentedControl_ios (0.2.7):
     - MicrosoftFluentUI/Separator_ios
-  - MicrosoftFluentUI/Separator_ios (0.2.3):
+  - MicrosoftFluentUI/Separator_ios (0.2.7):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/Shimmer_ios (0.2.3):
+  - MicrosoftFluentUI/Shimmer_ios (0.2.7):
     - MicrosoftFluentUI/Core_ios
     - MicrosoftFluentUI/Utilities_ios
-  - MicrosoftFluentUI/TabBar_ios (0.2.3):
+  - MicrosoftFluentUI/TabBar_ios (0.2.7):
     - MicrosoftFluentUI/Avatar_ios
     - MicrosoftFluentUI/Label_ios
     - MicrosoftFluentUI/Separator_ios
-  - MicrosoftFluentUI/TableView_ios (0.2.3):
+  - MicrosoftFluentUI/TableView_ios (0.2.7):
     - MicrosoftFluentUI/Label_ios
     - MicrosoftFluentUI/Separator_ios
-  - MicrosoftFluentUI/Tooltip_ios (0.2.3):
+  - MicrosoftFluentUI/Tooltip_ios (0.2.7):
     - MicrosoftFluentUI/Label_ios
     - MicrosoftFluentUI/TouchForwardingView_ios
-  - MicrosoftFluentUI/TouchForwardingView_ios (0.2.3):
+  - MicrosoftFluentUI/TouchForwardingView_ios (0.2.7):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/TwoLineTitleView_ios (0.2.3):
+  - MicrosoftFluentUI/TwoLineTitleView_ios (0.2.7):
     - MicrosoftFluentUI/EasyTapButton_ios
     - MicrosoftFluentUI/Label_ios
-  - MicrosoftFluentUI/Utilities_ios (0.2.3)
+  - MicrosoftFluentUI/Utilities_ios (0.2.7)
   - QRCodeReader.swift (10.1.0)
   - RCTRequired (0.63.4)
   - RCTTypeSafety (0.63.4):
@@ -525,11 +526,11 @@ SPEC CHECKSUMS:
   FBLazyVector: 3bb422f41b18121b71783a905c10e58606f7dc3e
   FBReactNativeSpec: f2c97f2529dd79c083355182cc158c9f98f4bd6e
   FluentUI-React-Native-Apple-Theme: 5096ba1ccdce75cac6af8dfb6f43880828d6a8e1
-  FluentUI-React-Native-Avatar: 20e879a5477bf6a32510796d139d699dad5f7f5f
-  FluentUI-React-Native-Button: b882911504fd4b8ad21b6391b6fb49d908276f5e
+  FluentUI-React-Native-Avatar: dd54c12eafc90f3919238892bc6482a498947946
+  FluentUI-React-Native-Button: d6086871439748464c31c569feaa783001155228
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
   glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
-  MicrosoftFluentUI: 416cab05ebcf05dcaea0a1babc4de2ba69928026
+  MicrosoftFluentUI: 6b3bfd52b232e9abc5cb228b9761a5f42869f4d3
   QRCodeReader.swift: 373a389fe9a22d513c879a32a6f647c58f4ef572
   RCTRequired: 082f10cd3f905d6c124597fd1c14f6f2655ff65e
   RCTTypeSafety: 8c9c544ecbf20337d069e4ae7fd9a377aadf504b

--- a/apps/macos/src/Podfile.lock
+++ b/apps/macos/src/Podfile.lock
@@ -14,70 +14,71 @@ PODS:
     - React
   - FluentUI-React-Native-Avatar (0.7.1):
     - MicrosoftFluentUI (~> 0.2.2)
+    - MicrosoftFluentUI (~> 0.2.6)
     - React
-  - FluentUI-React-Native-Button (0.5.3):
+  - FluentUI-React-Native-Button (0.5.4):
     - MicrosoftFluentUI (~> 0.2.2)
     - React
   - glog (0.3.5)
-  - MicrosoftFluentUI (0.2.3):
-    - MicrosoftFluentUI/ActivityIndicator_ios (= 0.2.3)
-    - MicrosoftFluentUI/ActivityViewAnimating_ios (= 0.2.3)
-    - MicrosoftFluentUI/Appearance_mac (= 0.2.3)
-    - MicrosoftFluentUI/Avatar_ios (= 0.2.3)
-    - MicrosoftFluentUI/AvatarView_mac (= 0.2.3)
-    - MicrosoftFluentUI/BadgeField_ios (= 0.2.3)
-    - MicrosoftFluentUI/BarButtonItems_ios (= 0.2.3)
-    - MicrosoftFluentUI/Button_ios (= 0.2.3)
-    - MicrosoftFluentUI/Button_mac (= 0.2.3)
-    - MicrosoftFluentUI/Calendar_ios (= 0.2.3)
-    - MicrosoftFluentUI/Card_ios (= 0.2.3)
-    - MicrosoftFluentUI/CommandBar_ios (= 0.2.3)
-    - MicrosoftFluentUI/Core_ios (= 0.2.3)
-    - MicrosoftFluentUI/Core_mac (= 0.2.3)
-    - MicrosoftFluentUI/DatePicker_mac (= 0.2.3)
-    - MicrosoftFluentUI/DotView_ios (= 0.2.3)
-    - MicrosoftFluentUI/Drawer_ios (= 0.2.3)
-    - MicrosoftFluentUI/DynamicColor_mac (= 0.2.3)
-    - MicrosoftFluentUI/EasyTapButton_ios (= 0.2.3)
-    - MicrosoftFluentUI/HUD_ios (= 0.2.3)
-    - MicrosoftFluentUI/IndeterminateProgressBar_ios (= 0.2.3)
-    - MicrosoftFluentUI/Label_ios (= 0.2.3)
-    - MicrosoftFluentUI/Link_mac (= 0.2.3)
-    - MicrosoftFluentUI/Navigation_ios (= 0.2.3)
-    - MicrosoftFluentUI/Notification_ios (= 0.2.3)
-    - MicrosoftFluentUI/Obscurable_ios (= 0.2.3)
-    - MicrosoftFluentUI/OtherCells_ios (= 0.2.3)
-    - MicrosoftFluentUI/PeoplePicker_ios (= 0.2.3)
-    - MicrosoftFluentUI/PillButtonBar_ios (= 0.2.3)
-    - MicrosoftFluentUI/PopupMenu_ios (= 0.2.3)
-    - MicrosoftFluentUI/Presenters_ios (= 0.2.3)
-    - MicrosoftFluentUI/ResizingHandleView_ios (= 0.2.3)
-    - MicrosoftFluentUI/ScrollView_ios (= 0.2.3)
-    - MicrosoftFluentUI/SegmentedControl_ios (= 0.2.3)
-    - MicrosoftFluentUI/Separator_ios (= 0.2.3)
-    - MicrosoftFluentUI/Separator_mac (= 0.2.3)
-    - MicrosoftFluentUI/Shimmer_ios (= 0.2.3)
-    - MicrosoftFluentUI/TabBar_ios (= 0.2.3)
-    - MicrosoftFluentUI/TableView_ios (= 0.2.3)
-    - MicrosoftFluentUI/Tooltip_ios (= 0.2.3)
-    - MicrosoftFluentUI/TouchForwardingView_ios (= 0.2.3)
-    - MicrosoftFluentUI/TwoLineTitleView_ios (= 0.2.3)
-    - MicrosoftFluentUI/Utilities_ios (= 0.2.3)
-  - MicrosoftFluentUI/Appearance_mac (0.2.3)
-  - MicrosoftFluentUI/AvatarView_mac (0.2.3):
+  - MicrosoftFluentUI (0.2.7):
+    - MicrosoftFluentUI/ActivityIndicator_ios (= 0.2.7)
+    - MicrosoftFluentUI/ActivityViewAnimating_ios (= 0.2.7)
+    - MicrosoftFluentUI/Appearance_mac (= 0.2.7)
+    - MicrosoftFluentUI/Avatar_ios (= 0.2.7)
+    - MicrosoftFluentUI/AvatarView_mac (= 0.2.7)
+    - MicrosoftFluentUI/BadgeField_ios (= 0.2.7)
+    - MicrosoftFluentUI/BarButtonItems_ios (= 0.2.7)
+    - MicrosoftFluentUI/Button_ios (= 0.2.7)
+    - MicrosoftFluentUI/Button_mac (= 0.2.7)
+    - MicrosoftFluentUI/Calendar_ios (= 0.2.7)
+    - MicrosoftFluentUI/Card_ios (= 0.2.7)
+    - MicrosoftFluentUI/CommandBar_ios (= 0.2.7)
+    - MicrosoftFluentUI/Core_ios (= 0.2.7)
+    - MicrosoftFluentUI/Core_mac (= 0.2.7)
+    - MicrosoftFluentUI/DatePicker_mac (= 0.2.7)
+    - MicrosoftFluentUI/DotView_ios (= 0.2.7)
+    - MicrosoftFluentUI/Drawer_ios (= 0.2.7)
+    - MicrosoftFluentUI/DynamicColor_mac (= 0.2.7)
+    - MicrosoftFluentUI/EasyTapButton_ios (= 0.2.7)
+    - MicrosoftFluentUI/HUD_ios (= 0.2.7)
+    - MicrosoftFluentUI/IndeterminateProgressBar_ios (= 0.2.7)
+    - MicrosoftFluentUI/Label_ios (= 0.2.7)
+    - MicrosoftFluentUI/Link_mac (= 0.2.7)
+    - MicrosoftFluentUI/Navigation_ios (= 0.2.7)
+    - MicrosoftFluentUI/Notification_ios (= 0.2.7)
+    - MicrosoftFluentUI/Obscurable_ios (= 0.2.7)
+    - MicrosoftFluentUI/OtherCells_ios (= 0.2.7)
+    - MicrosoftFluentUI/PeoplePicker_ios (= 0.2.7)
+    - MicrosoftFluentUI/PillButtonBar_ios (= 0.2.7)
+    - MicrosoftFluentUI/PopupMenu_ios (= 0.2.7)
+    - MicrosoftFluentUI/Presenters_ios (= 0.2.7)
+    - MicrosoftFluentUI/ResizingHandleView_ios (= 0.2.7)
+    - MicrosoftFluentUI/ScrollView_ios (= 0.2.7)
+    - MicrosoftFluentUI/SegmentedControl_ios (= 0.2.7)
+    - MicrosoftFluentUI/Separator_ios (= 0.2.7)
+    - MicrosoftFluentUI/Separator_mac (= 0.2.7)
+    - MicrosoftFluentUI/Shimmer_ios (= 0.2.7)
+    - MicrosoftFluentUI/TabBar_ios (= 0.2.7)
+    - MicrosoftFluentUI/TableView_ios (= 0.2.7)
+    - MicrosoftFluentUI/Tooltip_ios (= 0.2.7)
+    - MicrosoftFluentUI/TouchForwardingView_ios (= 0.2.7)
+    - MicrosoftFluentUI/TwoLineTitleView_ios (= 0.2.7)
+    - MicrosoftFluentUI/Utilities_ios (= 0.2.7)
+  - MicrosoftFluentUI/Appearance_mac (0.2.7)
+  - MicrosoftFluentUI/AvatarView_mac (0.2.7):
     - MicrosoftFluentUI/Core_mac
     - MicrosoftFluentUI/DynamicColor_mac
-  - MicrosoftFluentUI/Button_mac (0.2.3):
+  - MicrosoftFluentUI/Button_mac (0.2.7):
     - MicrosoftFluentUI/Core_mac
-  - MicrosoftFluentUI/Core_mac (0.2.3)
-  - MicrosoftFluentUI/DatePicker_mac (0.2.3):
+  - MicrosoftFluentUI/Core_mac (0.2.7)
+  - MicrosoftFluentUI/DatePicker_mac (0.2.7):
     - MicrosoftFluentUI/Appearance_mac
     - MicrosoftFluentUI/Core_mac
-  - MicrosoftFluentUI/DynamicColor_mac (0.2.3):
+  - MicrosoftFluentUI/DynamicColor_mac (0.2.7):
     - MicrosoftFluentUI/Appearance_mac
-  - MicrosoftFluentUI/Link_mac (0.2.3):
+  - MicrosoftFluentUI/Link_mac (0.2.7):
     - MicrosoftFluentUI/Core_mac
-  - MicrosoftFluentUI/Separator_mac (0.2.3):
+  - MicrosoftFluentUI/Separator_mac (0.2.7):
     - MicrosoftFluentUI/Core_mac
   - RCT-Folly (2020.01.13.00):
     - boost-for-react-native
@@ -443,10 +444,10 @@ SPEC CHECKSUMS:
   FBLazyVector: 87ca368919ae0ec70816fb8a42252ef59dc05c94
   FBReactNativeSpec: 7c0591658d85effad209fc4f45b6c9760f9e5842
   FluentUI-React-Native-Apple-Theme: 5096ba1ccdce75cac6af8dfb6f43880828d6a8e1
-  FluentUI-React-Native-Avatar: 20e879a5477bf6a32510796d139d699dad5f7f5f
-  FluentUI-React-Native-Button: b882911504fd4b8ad21b6391b6fb49d908276f5e
+  FluentUI-React-Native-Avatar: dd54c12eafc90f3919238892bc6482a498947946
+  FluentUI-React-Native-Button: d6086871439748464c31c569feaa783001155228
   glog: 1cb7c408c781ae8f35bbababe459b45e3dee4ec1
-  MicrosoftFluentUI: 416cab05ebcf05dcaea0a1babc4de2ba69928026
+  MicrosoftFluentUI: 6b3bfd52b232e9abc5cb228b9761a5f42869f4d3
   RCT-Folly: 1347093ffe75e152d846f7e45a3ef901b60021aa
   RCTRequired: f0ba811ba36bbe463b0151cbda362853106c13ac
   RCTTypeSafety: 10f774586f2956b7cf547cc97f2261eb22ee2a25

--- a/change/@fluentui-react-native-experimental-avatar-2021-05-21-18-05-38-hideInsideGapForBorder.json
+++ b/change/@fluentui-react-native-experimental-avatar-2021-05-21-18-05-38-hideInsideGapForBorder.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add hideInsideGapForBorder prop to experimental avatar",
+  "packageName": "@fluentui-react-native/experimental-avatar",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-05-21T23:05:38.916Z"
+}

--- a/change/@fluentui-react-native-tester-2021-05-21-18-05-38-hideInsideGapForBorder.json
+++ b/change/@fluentui-react-native-tester-2021-05-21-18-05-38-hideInsideGapForBorder.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add hideInsideGapForBorder prop to experimental avatar",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-05-21T23:05:29.040Z"
+}

--- a/packages/experimental/Avatar/FluentUIReactNativeAvatar.podspec
+++ b/packages/experimental/Avatar/FluentUIReactNativeAvatar.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = "13.0"
   s.ios.source_files      = "ios/*.{swift,h,m}"
-  s.ios.dependency 'MicrosoftFluentUI', '~> 0.2.2'
+  s.ios.dependency 'MicrosoftFluentUI', '~> 0.2.6'
 
   s.osx.deployment_target = "10.14"
   s.osx.source_files      = "macos/*.{swift,h,m}"

--- a/packages/experimental/Avatar/ios/MSFAvatarViewManager.m
+++ b/packages/experimental/Avatar/ios/MSFAvatarViewManager.m
@@ -69,7 +69,9 @@ RCT_REMAP_VIEW_PROPERTY(accessibilityLabel, overrideAccessibilityLabel, NSString
 
 RCT_EXPORT_VIEW_PROPERTY(preferredFallbackImageStyle, MSFAvatarFallbackImageStyle);
 
-RCT_REMAP_VIEW_PROPERTY(hasPointerInteractionIOS, hasPointerInteraction, bool)
+RCT_REMAP_VIEW_PROPERTY(hasPointerInteractionIOS, hasPointerInteraction, bool);
+
+RCT_EXPORT_VIEW_PROPERTY(hideInsideGapForBorder, BOOL);
 
 RCT_CUSTOM_VIEW_PROPERTY(avatarData, MSFAvatarData, MSFAvatarView)
 {

--- a/packages/experimental/Avatar/src/Avatar.tsx
+++ b/packages/experimental/Avatar/src/Avatar.tsx
@@ -102,6 +102,11 @@ export type otherAvatarProps = {
    * Set to true to enable the iPadOS pointer interactions on the avatar view, false by default.
    */
   hasPointerInteractionIOS?: boolean;
+
+  /**
+   * Set to true to not have inside gap between content of the avatarView to its border
+   */
+  hideInsideGapForBorder?: boolean;
 };
 
 export type AvatarTokens = {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This change adds a prop to hide the gap between the Avatar and the border. I'm only doing this change for iOS for now as the macOS native avatar border API is a bit different, and would require more work than this simple addition to get working.

### Verification

Added a test case to the iOS test app.

![Screen Shot 2021-05-21 at 5 47 18 PM](https://user-images.githubusercontent.com/6722175/119205783-dbaa5f00-ba5e-11eb-92a1-bc53f15ae096.png)


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
