### PR TITLE
Bump the anrdroid theme version manually

### DIFF
--- a/packages/theming/android-theme/package.json
+++ b/packages/theming/android-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/android-theme",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "A FluentUI React Native theme that pulls constants from FluentUI Android",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [X] android

### Description of changes

Publish CI is failing with the following error:
`ERROR: Attempting to bump to a version that already exists in the registry: @fluentui-react-native/android-theme@0.2.6`

This package version is supposed to be updated automatically, but something broke and it's out of sync with NPM. After checking on npmjs.com, the latest version is 0.2.7, so let's update to 0.2.8.

### Verification

This can be verified in the publish CI which is currently failing for everyone.

### Pull request checklist

This PR has considered (when applicable):
- [X] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
