### PR TITLE
Comment out tests that crash the app for iOS and macOS

### DIFF
--- a/apps/fluent-tester/src/FluentTester/testPages.ios.ts
+++ b/apps/fluent-tester/src/FluentTester/testPages.ios.ts
@@ -1,11 +1,8 @@
 import { TestDescription } from './TestComponents';
 import { AvatarTest, HOMEPAGE_AVATAR_BUTTON } from './TestComponents/Avatar';
 import { ButtonTest, HOMEPAGE_BUTTON_BUTTON } from './TestComponents/Button';
-import { CalloutTest, HOMEPAGE_CALLOUT_BUTTON } from './TestComponents/Callout';
 import { CheckboxTest, HOMEPAGE_CHECKBOX_BUTTON } from './TestComponents/Checkbox';
-import { ContextualMenuTest, HOMEPAGE_CONTEXTUALMENU_BUTTON } from './TestComponents/ContextualMenu';
 import { ExperimentalButtonTest, HOMEPAGE_BUTTON_BUTTONEXPERIMENTAL } from './TestComponents/ButtonExperimental';
-import { FocusTrapTest, HOMEPAGE_FOCUSTRAPZONE_BUTTON } from './TestComponents/FocusTrapZone';
 import { HOMEPAGE_ICON_BUTTON, IconTest } from './TestComponents/Icon';
 import { HOMEPAGE_LINK_BUTTON, LinkTest } from './TestComponents/Link';
 import { NativeButtonTest, HOMEPAGE_NATIVEBUTTON_BUTTON } from './TestComponents/NativeButton';
@@ -35,26 +32,11 @@ export const tests: TestDescription[] = [
     component: NativeButtonTest,
     testPage: HOMEPAGE_NATIVEBUTTON_BUTTON,
   },
-  // {
-  //   name: 'Callout Test',
-  //   component: CalloutTest,
-  //   testPage: HOMEPAGE_CALLOUT_BUTTON,
-  // },
-  // {
-  //   name: 'ContextualMenu Test',
-  //   component: ContextualMenuTest,
-  //   testPage: HOMEPAGE_CONTEXTUALMENU_BUTTON,
-  // },
   {
     name: 'Experimental Button',
     component: ExperimentalButtonTest,
     testPage: HOMEPAGE_BUTTON_BUTTONEXPERIMENTAL,
   },
-  // {
-  //   name: 'Focus Trap Zone Test',
-  //   component: FocusTrapTest,
-  //   testPage: HOMEPAGE_FOCUSTRAPZONE_BUTTON,
-  // },
   {
     name: 'Pressable Test',
     component: PressableTest,

--- a/apps/fluent-tester/src/FluentTester/testPages.ios.ts
+++ b/apps/fluent-tester/src/FluentTester/testPages.ios.ts
@@ -35,26 +35,26 @@ export const tests: TestDescription[] = [
     component: NativeButtonTest,
     testPage: HOMEPAGE_NATIVEBUTTON_BUTTON,
   },
-  {
-    name: 'Callout Test',
-    component: CalloutTest,
-    testPage: HOMEPAGE_CALLOUT_BUTTON,
-  },
-  {
-    name: 'ContextualMenu Test',
-    component: ContextualMenuTest,
-    testPage: HOMEPAGE_CONTEXTUALMENU_BUTTON,
-  },
+  // {
+  //   name: 'Callout Test',
+  //   component: CalloutTest,
+  //   testPage: HOMEPAGE_CALLOUT_BUTTON,
+  // },
+  // {
+  //   name: 'ContextualMenu Test',
+  //   component: ContextualMenuTest,
+  //   testPage: HOMEPAGE_CONTEXTUALMENU_BUTTON,
+  // },
   {
     name: 'Experimental Button',
     component: ExperimentalButtonTest,
     testPage: HOMEPAGE_BUTTON_BUTTONEXPERIMENTAL,
   },
-  {
-    name: 'Focus Trap Zone Test',
-    component: FocusTrapTest,
-    testPage: HOMEPAGE_FOCUSTRAPZONE_BUTTON,
-  },
+  // {
+  //   name: 'Focus Trap Zone Test',
+  //   component: FocusTrapTest,
+  //   testPage: HOMEPAGE_FOCUSTRAPZONE_BUTTON,
+  // },
   {
     name: 'Pressable Test',
     component: PressableTest,

--- a/apps/fluent-tester/src/FluentTester/testPages.macos.ts
+++ b/apps/fluent-tester/src/FluentTester/testPages.macos.ts
@@ -30,26 +30,26 @@ export const tests: TestDescription[] = [
     component: ButtonTest,
     testPage: HOMEPAGE_BUTTON_BUTTON,
   },
-  {
-    name: 'Callout Test',
-    component: CalloutTest,
-    testPage: HOMEPAGE_CALLOUT_BUTTON,
-  },
-  {
-    name: 'ContextualMenu Test',
-    component: ContextualMenuTest,
-    testPage: HOMEPAGE_CONTEXTUALMENU_BUTTON,
-  },
+  // {
+  //   name: 'Callout Test',
+  //   component: CalloutTest,
+  //   testPage: HOMEPAGE_CALLOUT_BUTTON,
+  // },
+  // {
+  //   name: 'ContextualMenu Test',
+  //   component: ContextualMenuTest,
+  //   testPage: HOMEPAGE_CONTEXTUALMENU_BUTTON,
+  // },
   {
     name: 'Experimental Button',
     component: ExperimentalButtonTest,
     testPage: HOMEPAGE_BUTTON_BUTTONEXPERIMENTAL,
   },
-  {
-    name: 'Focus Trap Zone Test',
-    component: FocusTrapTest,
-    testPage: HOMEPAGE_FOCUSTRAPZONE_BUTTON,
-  },
+  // {
+  //   name: 'Focus Trap Zone Test',
+  //   component: FocusTrapTest,
+  //   testPage: HOMEPAGE_FOCUSTRAPZONE_BUTTON,
+  // },
   {
     name: 'Pressable Test',
     component: PressableTest,

--- a/apps/fluent-tester/src/FluentTester/testPages.macos.ts
+++ b/apps/fluent-tester/src/FluentTester/testPages.macos.ts
@@ -1,11 +1,8 @@
 import { TestDescription } from './TestComponents';
 import { AvatarTest, HOMEPAGE_AVATAR_BUTTON } from './TestComponents/Avatar';
 import { ButtonTest, HOMEPAGE_BUTTON_BUTTON } from './TestComponents/Button';
-import { CalloutTest, HOMEPAGE_CALLOUT_BUTTON } from './TestComponents/Callout';
 import { CheckboxTest, HOMEPAGE_CHECKBOX_BUTTON } from './TestComponents/Checkbox';
-import { ContextualMenuTest, HOMEPAGE_CONTEXTUALMENU_BUTTON } from './TestComponents/ContextualMenu';
 import { ExperimentalButtonTest, HOMEPAGE_BUTTON_BUTTONEXPERIMENTAL } from './TestComponents/ButtonExperimental';
-import { FocusTrapTest, HOMEPAGE_FOCUSTRAPZONE_BUTTON } from './TestComponents/FocusTrapZone';
 import { HOMEPAGE_ICON_BUTTON, IconTest } from './TestComponents/Icon';
 import { HOMEPAGE_LINK_BUTTON, LinkTest } from './TestComponents/Link';
 import { NativeButtonTest, HOMEPAGE_NATIVEBUTTON_BUTTON } from './TestComponents/NativeButton';
@@ -30,26 +27,11 @@ export const tests: TestDescription[] = [
     component: ButtonTest,
     testPage: HOMEPAGE_BUTTON_BUTTON,
   },
-  // {
-  //   name: 'Callout Test',
-  //   component: CalloutTest,
-  //   testPage: HOMEPAGE_CALLOUT_BUTTON,
-  // },
-  // {
-  //   name: 'ContextualMenu Test',
-  //   component: ContextualMenuTest,
-  //   testPage: HOMEPAGE_CONTEXTUALMENU_BUTTON,
-  // },
   {
     name: 'Experimental Button',
     component: ExperimentalButtonTest,
     testPage: HOMEPAGE_BUTTON_BUTTONEXPERIMENTAL,
   },
-  // {
-  //   name: 'Focus Trap Zone Test',
-  //   component: FocusTrapTest,
-  //   testPage: HOMEPAGE_FOCUSTRAPZONE_BUTTON,
-  // },
   {
     name: 'Pressable Test',
     component: PressableTest,

--- a/apps/fluent-tester/src/FluentTester/testPages.ts
+++ b/apps/fluent-tester/src/FluentTester/testPages.ts
@@ -16,6 +16,8 @@ import { HOMEPAGE_THEME_BUTTON, ThemeTest } from './TestComponents/Theme';
 import { HOMEPAGE_BUTTON_BUTTONEXPERIMENTAL, ExperimentalButtonTest } from './TestComponents/ButtonExperimental';
 import { HOMEPAGE_FOCUSZONE_BUTTON, FocusZoneTest } from './TestComponents/FocusZone';
 import { HOMEPAGE_ICON_BUTTON, IconTest } from './TestComponents/Icon';
+import { CalloutTest, HOMEPAGE_CALLOUT_BUTTON } from './TestComponents/Callout';
+import { ContextualMenuTest, HOMEPAGE_CONTEXTUALMENU_BUTTON } from './TestComponents/ContextualMenu';
 
 export const tests: TestDescription[] = [
   {
@@ -102,5 +104,15 @@ export const tests: TestDescription[] = [
     name: 'Experimental Button',
     component: ExperimentalButtonTest,
     testPage: HOMEPAGE_BUTTON_BUTTONEXPERIMENTAL,
+  },
+  {
+    name: 'Callout Test',
+    component: CalloutTest,
+    testPage: HOMEPAGE_CALLOUT_BUTTON,
+  },
+  {
+    name: 'ContextualMenu Test',
+    component: ContextualMenuTest,
+    testPage: HOMEPAGE_CONTEXTUALMENU_BUTTON,
   },
 ];

--- a/apps/ios/src/Podfile.lock
+++ b/apps/ios/src/Podfile.lock
@@ -12,11 +12,11 @@ PODS:
   - FluentUI-React-Native-Apple-Theme (0.4.2):
     - MicrosoftFluentUI (~> 0.2.2)
     - React
-  - FluentUI-React-Native-Avatar (0.7.1):
+  - FluentUI-React-Native-Avatar (0.8.0):
     - MicrosoftFluentUI (~> 0.2.2)
     - MicrosoftFluentUI (~> 0.2.6)
     - React
-  - FluentUI-React-Native-Button (0.5.4):
+  - FluentUI-React-Native-Button (0.5.5):
     - MicrosoftFluentUI (~> 0.2.2)
     - React
   - Folly (2020.01.13.00):
@@ -526,8 +526,8 @@ SPEC CHECKSUMS:
   FBLazyVector: 3bb422f41b18121b71783a905c10e58606f7dc3e
   FBReactNativeSpec: f2c97f2529dd79c083355182cc158c9f98f4bd6e
   FluentUI-React-Native-Apple-Theme: 5096ba1ccdce75cac6af8dfb6f43880828d6a8e1
-  FluentUI-React-Native-Avatar: dd54c12eafc90f3919238892bc6482a498947946
-  FluentUI-React-Native-Button: d6086871439748464c31c569feaa783001155228
+  FluentUI-React-Native-Avatar: c0b719b62701039e9e55787394c17e60567eaaf3
+  FluentUI-React-Native-Button: 3d80d0186638ce6e72abe7d6ec87e21380527d1e
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
   glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
   MicrosoftFluentUI: 6b3bfd52b232e9abc5cb228b9761a5f42869f4d3

--- a/apps/macos/src/Podfile.lock
+++ b/apps/macos/src/Podfile.lock
@@ -12,11 +12,11 @@ PODS:
   - FluentUI-React-Native-Apple-Theme (0.4.2):
     - MicrosoftFluentUI (~> 0.2.2)
     - React
-  - FluentUI-React-Native-Avatar (0.7.1):
+  - FluentUI-React-Native-Avatar (0.8.0):
     - MicrosoftFluentUI (~> 0.2.2)
     - MicrosoftFluentUI (~> 0.2.6)
     - React
-  - FluentUI-React-Native-Button (0.5.4):
+  - FluentUI-React-Native-Button (0.5.5):
     - MicrosoftFluentUI (~> 0.2.2)
     - React
   - glog (0.3.5)
@@ -444,8 +444,8 @@ SPEC CHECKSUMS:
   FBLazyVector: 87ca368919ae0ec70816fb8a42252ef59dc05c94
   FBReactNativeSpec: 7c0591658d85effad209fc4f45b6c9760f9e5842
   FluentUI-React-Native-Apple-Theme: 5096ba1ccdce75cac6af8dfb6f43880828d6a8e1
-  FluentUI-React-Native-Avatar: dd54c12eafc90f3919238892bc6482a498947946
-  FluentUI-React-Native-Button: d6086871439748464c31c569feaa783001155228
+  FluentUI-React-Native-Avatar: c0b719b62701039e9e55787394c17e60567eaaf3
+  FluentUI-React-Native-Button: 3d80d0186638ce6e72abe7d6ec87e21380527d1e
   glog: 1cb7c408c781ae8f35bbababe459b45e3dee4ec1
   MicrosoftFluentUI: 6b3bfd52b232e9abc5cb228b9761a5f42869f4d3
   RCT-Folly: 1347093ffe75e152d846f7e45a3ef901b60021aa

--- a/change/@fluentui-react-native-tester-2021-05-27-12-51-29-master.json
+++ b/change/@fluentui-react-native-tester-2021-05-27-12-51-29-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Comment out tests that crash the app for iOS and macOS",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "t-lindaweng@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-05-27T16:51:29.349Z"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ x] iOS
- [ x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Commented out the tests that crash the tester app for iOS and macOS. Tests commented out are Callout, ContextualMenu, and Focus Trap Zone.

### Verification

Tested by running both tester apps and confirming that the tests no longer showed up

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|![Simulator Screen Shot - iPhone 11 - 2021-05-26 at 16 56 52](https://user-images.githubusercontent.com/30802320/119730541-d88ae680-be43-11eb-9339-7b4ec4522f72.png)|![Simulator Screen Shot - iPhone 11 - 2021-05-26 at 16 56 32](https://user-images.githubusercontent.com/30802320/119730589-e7719900-be43-11eb-90e3-fd3ec8a52273.png) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
