### PR TITLE
Edit contributing and add link to contributing from readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,7 +158,7 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 This repo manages semantic versioning and publishing using [Beachball](https://github.com/microsoft/beachball). When contributing, make sure to run the following before making a pull request:
 
 1. `yarn change` will take you through a command line wizard to generate change files
-2. Make sure to commit and push the newly generated change file
+2. Make sure to push the newly generated change file
 
 #### Testing changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,3 +140,50 @@ To add a native module that wraps a FluentUI Apple control:
       - This Swift file imports FluentUI Apple, and creates a subclass of RCTViewManager to instantiate and return your FluentUI Apple control. Objective-C methods like `requiresMainQueueSetup` and `constantsToExport` can be overridden here. It's important to note that in order for properties and methods to be available to React Native, they must add the `@objc` decorator to it's declaration.
    1. `MSF<new-component>ViewManager.m`
       - This is an extra Objective-C file needed because Swift does not support macros and React Native requires them to map JS props to the native properties of the control. (Macros like `RCT_EXPORT_VIEW_PROPERTY` and `RCT_EXPORT_METHOD`)/
+
+## Creating a pull request
+
+Thanks for your interest in contributing to the fluentui-react-native! We welcome all contributions. Here's information on how to prepare your change for a pull request.
+
+### Code of Conduct
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
+contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+### Prerequisites
+
+#### Beachball
+
+This repo manages semantic versioning and publishing using [Beachball](https://github.com/microsoft/beachball). When contributing, make sure to run the following before making a pull request:
+
+1. `yarn change` will take you through a command line wizard to generate change files
+2. Make sure to commit and push the newly generated change file
+
+#### Testing changes
+
+Before you create a pull request, test your changes with the FluentUI Tester on the platforms that are affected by your change. For more information on the FluentUI Tester, please follow instructions in the [FluentUI Tester readme](./apps/fluent-tester/README.md).
+
+#### Contributor License Agreement
+
+This project welcomes contributions and suggestions. Most contributions require you to agree to a
+Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
+the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
+
+When you submit a pull request, a CLA bot will automatically determine whether you need to provide
+a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
+provided by the bot. You will only need to do this once across all repos using our CLA.
+
+### Additional Considerations
+
+#### Update Documentation
+
+We welcome having documentation for our packages and components! Please add or update any relevant documentation for your changes.
+
+#### Accessibility
+
+Please test your change for keyboard navigation as well as compatibility with Voiceover and screen readers.
+
+#### Internationalization
+
+Consider if your change needs to have special handling for right-to-left languages, or other internationalization considerations.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ function HelloWorldApp() {
       style={{
         flex: 1,
         justifyContent: 'center',
-        alignItems: 'center'
+        alignItems: 'center',
       }}
     >
       <Text>Hello, world!</Text>
@@ -125,13 +125,7 @@ This repo manages semantic versioning and publishing using [Beachball](https://g
 
 ## Contributing
 
-This project welcomes contributions and suggestions. Most contributions require you to agree to a
-Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
-
-When you submit a pull request, a CLA bot will automatically determine whether you need to provide
-a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
-provided by the bot. You will only need to do this once across all repos using our CLA.
+Please visit our [contribution guide](./CONTRIBUTING.md) for more information on contributing to this repo.
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or

--- a/README.md
+++ b/README.md
@@ -116,13 +116,6 @@ To start developing in the repository you can:
 
 After a successful yarn build, you can explore FluentUI Tester, our demo application to play with each of the controls. To run FluentUI Tester, please follow instructions in the [FluentUI Tester readme](./apps/fluent-tester/README.md).
 
-### Beachball
-
-This repo manages semantic versioning and publishing using [Beachball](https://github.com/microsoft/beachball). When contributing, make sure to run the following before making a pull request:
-
-1. `yarn change` will take you through a command line wizard to generate change files
-2. Make sure to push the newly generated change file
-
 ## Contributing
 
 Please visit our [contribution guide](./CONTRIBUTING.md) for more information on contributing to this repo.

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ After a successful yarn build, you can explore FluentUI Tester, our demo applica
 This repo manages semantic versioning and publishing using [Beachball](https://github.com/microsoft/beachball). When contributing, make sure to run the following before making a pull request:
 
 1. `yarn change` will take you through a command line wizard to generate change files
-2. Make sure to commit and push the newly generated change file
+2. Make sure to push the newly generated change file
 
 ## Contributing
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

The contribution page was lacking information on how to prep a change for contributing to the repo. I figured it would be a good place to have more information and instructions on what to do to prep a PR. Information includes things to do and run (testing, beachball), and what to consider including in a change (documentation, accessibility, internationalization).

Additionally, I added a link to the page from the main README.

Open to any and all suggestions on organizing, wording, and information to add to the page!

### Verification

Ensured the links I added work.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
