### PR TITLE
Fix theme and brand picker crash for FURN Tester

### DIFF
--- a/apps/fluent-tester/src/FluentTester/theme/CustomThemes.ts
+++ b/apps/fluent-tester/src/FluentTester/theme/CustomThemes.ts
@@ -22,7 +22,7 @@ export const lightnessOptions = [
 ];
 
 export class TesterThemeReference extends ThemeReference {
-  private _themeName: ThemeNames = 'Default';
+  private _themeName: ThemeNames = 'Office';
   private _brand: OfficeBrand = 'Default';
 
   private options: ThemeOptions;
@@ -43,8 +43,10 @@ export class TesterThemeReference extends ThemeReference {
     return this._themeName;
   }
   public set themeName(newTheme: ThemeNames) {
-    this._themeName = newTheme;
-    this.invalidate();
+    if (newTheme !== this._themeName) {
+      this._themeName = newTheme;
+      this.invalidate();
+    }
   }
 
   /** get/set the theme appearance */
@@ -52,8 +54,10 @@ export class TesterThemeReference extends ThemeReference {
     return this.options.appearance;
   }
   public set appearance(lightness: ThemeOptions['appearance']) {
-    this.options.appearance = lightness;
-    this.baseTheme.invalidate();
+    if (lightness !== this.options.appearance) {
+      this.options.appearance = lightness;
+      this.baseTheme.invalidate();
+    }
   }
 
   /** get/set the applied brand */
@@ -61,8 +65,10 @@ export class TesterThemeReference extends ThemeReference {
     return this._brand;
   }
   public set brand(newBrand: OfficeBrand) {
-    this._brand = newBrand;
-    this.invalidate();
+    if (newBrand !== this._brand) {
+      this._brand = newBrand;
+      this.invalidate();
+    }
   }
 }
 

--- a/change/@fluentui-react-native-tester-2021-06-01-13-51-55-tester_theme_fix.json
+++ b/change/@fluentui-react-native-tester-2021-06-01-13-51-55-tester_theme_fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix theme picker on FURN tester",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-06-01T20:51:55.498Z"
+}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

The tester would freeze if the theme or brand pickers were used to pick a new theme or brand. The issue was an infinite render loop - the TesterThemeReference would invalidate the theme regardless of whether it was a different theme, which would force a new theme object to be created, which would cause a rerender, which would cause the theme picker to think something was picked again, which would cause the theme to be invalidated... etc.

The fix is to gate the invalidation to only occur if the theme/brand is a new value. Otherwise, invalidating is not necessary.

### Verification

Booted win32 tester and ensured that the tester stopped freezing after setting a new theme.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts

None above apply