### PR TITLE
Fix theming issues

### DIFF
--- a/apps/fluent-tester/src/FluentTester/theme/CustomThemes.ts
+++ b/apps/fluent-tester/src/FluentTester/theme/CustomThemes.ts
@@ -22,7 +22,7 @@ export const lightnessOptions = [
 ];
 
 export class TesterThemeReference extends ThemeReference {
-  private _themeName: ThemeNames = 'Office';
+  private _themeName: ThemeNames = 'Default';
   private _brand: OfficeBrand = 'Default';
 
   private options: ThemeOptions;

--- a/change/@fluentui-react-native-tester-2021-06-14-16-18-00-fallback_cast.json
+++ b/change/@fluentui-react-native-tester-2021-06-14-16-18-00-fallback_cast.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Return default theme of tester to Default",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-06-14T23:17:58.119Z"
+}

--- a/change/@fluentui-react-native-win32-theme-2021-06-14-16-18-00-fallback_cast.json
+++ b/change/@fluentui-react-native-win32-theme-2021-06-14-16-18-00-fallback_cast.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix a case where the exception can be undefined/null because cast fails",
+  "packageName": "@fluentui-react-native/win32-theme",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-06-14T23:18:00.471Z"
+}

--- a/packages/theming/win32-theme/src/createOfficeTheme.ts
+++ b/packages/theming/win32-theme/src/createOfficeTheme.ts
@@ -6,7 +6,8 @@ import { OfficePalette } from '@fluentui-react-native/theme-types';
 import { createPartialOfficeTheme } from './createPartialOfficeTheme';
 
 function handlePaletteCall(palette: OfficePalette | CxxException): OfficePalette | undefined {
-  return (palette as CxxException).message !== undefined ? undefined : (palette as OfficePalette);
+  const exception = palette as CxxException;
+  return exception && exception.message !== undefined ? undefined : (palette as OfficePalette);
 }
 
 /**


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

Some feedback was received about hitting an error message while trying to integrate with theming code, this change aims to deal with that. The message was "Unable to get property 'message' of undefined or null reference". Adding a check for the object being null/undefined before trying to get the message property off of the casted object.

Also reverting default theme to Default, which was a mistake change from #709 

### Verification

Booted tester and ensured default theme has been changed.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/4602628/121977086-00ca7e80-cd3a-11eb-8666-ef0c48803317.png)| ![image](https://user-images.githubusercontent.com/4602628/121977640-489dd580-cd3b-11eb-8be2-8101adcedc35.png)|

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
