### PR TITLE
Remove Icon change that breaks Icon on macOS

### DIFF
--- a/apps/ios/src/Podfile.lock
+++ b/apps/ios/src/Podfile.lock
@@ -9,14 +9,14 @@ PODS:
     - React-Core (= 0.63.4)
     - React-jsi (= 0.63.4)
     - ReactCommon/turbomodule/core (= 0.63.4)
-  - FluentUI-React-Native-Avatar (0.9.1):
+  - FluentUI-React-Native-Avatar (0.9.3):
     - MicrosoftFluentUI (~> 0.2.2)
     - MicrosoftFluentUI (~> 0.2.6)
     - React
-  - FluentUI-React-Native-Button (0.6.1):
+  - FluentUI-React-Native-Button (0.6.3):
     - MicrosoftFluentUI (~> 0.2.2)
     - React
-  - FluentUI-React-Native-Date-Picker (0.1.0):
+  - FluentUI-React-Native-Date-Picker (0.2.0):
     - MicrosoftFluentUI/Calendar_ios (~> 0.2.7)
     - React
   - Folly (2020.01.13.00):
@@ -525,9 +525,9 @@ SPEC CHECKSUMS:
   DoubleConversion: cde416483dac037923206447da6e1454df403714
   FBLazyVector: 3bb422f41b18121b71783a905c10e58606f7dc3e
   FBReactNativeSpec: f2c97f2529dd79c083355182cc158c9f98f4bd6e
-  FluentUI-React-Native-Avatar: 9790f7ace568f26aa6b1a527a3223b36f7841464
-  FluentUI-React-Native-Button: 4a0415d5d96a73f51e93de30563cc809d7a020f2
-  FluentUI-React-Native-Date-Picker: 43c1365938be8236940dfb0232c3ea7902ed3f50
+  FluentUI-React-Native-Avatar: 18822625d046e70f51c4c74e8f7e7221ca921b56
+  FluentUI-React-Native-Button: 3e04e8ed44ed357103fdc81eb37c496e82686916
+  FluentUI-React-Native-Date-Picker: af57505cfeaf1b97a0d2b12c46af26a189d892e8
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
   glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
   MicrosoftFluentUI: 6b3bfd52b232e9abc5cb228b9761a5f42869f4d3

--- a/apps/macos/src/Podfile.lock
+++ b/apps/macos/src/Podfile.lock
@@ -9,11 +9,11 @@ PODS:
     - React-Core (= 0.63.33)
     - React-jsi (= 0.63.33)
     - ReactCommon/turbomodule/core (= 0.63.33)
-  - FluentUI-React-Native-Avatar (0.9.0):
+  - FluentUI-React-Native-Avatar (0.9.3):
     - MicrosoftFluentUI (~> 0.2.2)
     - MicrosoftFluentUI (~> 0.2.6)
     - React
-  - FluentUI-React-Native-Button (0.6.0):
+  - FluentUI-React-Native-Button (0.6.3):
     - MicrosoftFluentUI (~> 0.2.2)
     - React
   - glog (0.3.5)
@@ -437,8 +437,8 @@ SPEC CHECKSUMS:
   DoubleConversion: 56a44bcfd14ab2ff66f5a146b2e875eb4b69b19b
   FBLazyVector: 462de4c12a5e12deaee114d2341679c6abde70e2
   FBReactNativeSpec: 8c128e7e95ec6907abcb1497208d81590ccba7e1
-  FluentUI-React-Native-Avatar: 5d5bcc8bd58079d32f82c398fd032cd77d43cddc
-  FluentUI-React-Native-Button: 3576b2637ae9f2dc45db1f03f5fadd2d8431dfa2
+  FluentUI-React-Native-Avatar: 18822625d046e70f51c4c74e8f7e7221ca921b56
+  FluentUI-React-Native-Button: 3e04e8ed44ed357103fdc81eb37c496e82686916
   glog: 1cb7c408c781ae8f35bbababe459b45e3dee4ec1
   MicrosoftFluentUI: 6b3bfd52b232e9abc5cb228b9761a5f42869f4d3
   RCT-Folly: 1347093ffe75e152d846f7e45a3ef901b60021aa

--- a/change/@fluentui-react-native-checkbox-2021-06-24-15-28-13-revert-icon-change.json
+++ b/change/@fluentui-react-native-checkbox-2021-06-24-15-28-13-revert-icon-change.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add a README",
+  "packageName": "@fluentui-react-native/checkbox",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-06-24T20:28:13.154Z"
+}

--- a/change/@fluentui-react-native-icon-2021-06-24-15-08-07-revert-icon-change.json
+++ b/change/@fluentui-react-native-icon-2021-06-24-15-08-07-revert-icon-change.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "revert change that breaks icon on macOS",
+  "packageName": "@fluentui-react-native/icon",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-06-24T20:08:07.239Z"
+}

--- a/packages/components/Checkbox/README.md
+++ b/packages/components/Checkbox/README.md
@@ -1,0 +1,9 @@
+# Checkbox
+
+A cross-platform Checkbox component using the Fluent Design System.
+
+Supported Platforms: Android, iOS, macOS, web, windows, win32
+
+Note that on iOS, the more common control to use is a Switch
+https://developer.apple.com/design/human-interface-guidelines/ios/controls/switches/
+https://reactnative.dev/docs/switch

--- a/packages/experimental/Icon/src/Icon.tsx
+++ b/packages/experimental/Icon/src/Icon.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { IconProps, SvgIconProps, FontIconProps } from './Icon.types';
-import { ColorValue, Image, ImageStyle, Platform, processColor, View } from 'react-native';
+import { Image, ImageStyle, Platform, View } from 'react-native';
 import { Text } from '@fluentui-react-native/text';
-import { Color, SvgUri } from 'react-native-svg';
 import { mergeStyles } from '@fluentui-react-native/framework';
 import { stagedComponent, mergeProps, getMemoCache } from '@fluentui-react-native/framework';
 import { useTheme } from '@fluentui-react-native/theme-types';
 import { getCurrentAppearance } from '@fluentui-react-native/theming-utils';
+import { SvgUri } from 'react-native-svg';
 
 const rasterImageStyleCache = getMemoCache<ImageStyle>();
 
@@ -68,13 +68,13 @@ function renderSvg(iconProps: IconProps) {
   if (svgIconProps.src) {
     return (
       <View style={style}>
-        <svgIconProps.src viewBox={viewBox} width={width} height={height} color={color} />
+        <svgIconProps.src viewBox={viewBox} width={width} height={height} color={iconColor} />
       </View>
     );
   } else if (svgIconProps.uri) {
     return (
       <View style={style}>
-        <SvgUri uri={svgIconProps.uri} viewBox={viewBox} width={width} height={height} color={color} />
+        <SvgUri uri={svgIconProps.uri} viewBox={viewBox} width={width} height={height} color={iconColor} />
       </View>
     );
   } else {

--- a/packages/experimental/Icon/src/Icon.tsx
+++ b/packages/experimental/Icon/src/Icon.tsx
@@ -65,10 +65,6 @@ function renderSvg(iconProps: IconProps) {
     ? '#FFFFFF'
     : '#000000';
 
-  // The svg color can be set using either style.color or iconProps.color, where style.color is preferred in case both are set.
-  const colorString = (style as any).color !== undefined ? (style as any).color : iconColor;
-  const color = (Platform.OS == 'macos' ? processColor(colorString as ColorValue) : colorString) as Color;
-
   if (svgIconProps.src) {
     return (
       <View style={style}>


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This should resolve the macOS side of #739 

I am undoing code added in #716 that would otherwise break macOS. A longer discussion of why this is bad is [here](https://github.com/microsoft/fluentui-react-native/pull/716/files#r655534695).

Tl;Dr: 
`processColor` is a private API that should not be called directly. Furthermore, we are converting an object (ColorValue) to a string and then calling processColor() on it, which is incorrect (ColorValue might be a semantic color, not a string).
Let's just remove the code.

I'm also adding a really simple README to Checkbox to address a comment by @harrieshin that clients should probably not use checkbox on iOS and use a switch instead.

### Verification

This is reverting code that was added, so it should be safe. I'll still click through the macOS app to make sure things work as expected.

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
