### PR TITLE
docs: add how to bump react-native and where to find dep-check docs

### DIFF
--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -54,7 +54,7 @@ You can read more about this tool here:
 - If you would like to debug in Android Studio, you can do the following to open the project there:
 
 ```sh
-# Android
+# macOS
 open -a "Android Studio" .
 
 # Windows

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -12,28 +12,53 @@ Prereqs:
 
 1. Make sure you have followed the [Getting Started](../../README.md) instructions to install packages and build the entire FluentUI React Native repository. I.e. from the root of the repo:
 
-```
-    yarn && yarn build
+```sh
+yarn
+yarn build
 ```
 
 2. Then go into `apps/android` folder and simply run the the following
 
-```
+```sh
 yarn android
 ```
 
-Troubleshooting
+## Dependencies
+
+Dependencies are managed by
+[`@rnx-kit/dep-check`](https://github.com/microsoft/rnx-kit/tree/main/packages/dep-check).
+If you're looking to upgrade `react-native`, look for the `rnx-kit` section in
+`/apps/android/package.json`:
+
+```json
+{
+  ...
+  "rnx-kit": {
+    "reactNativeVersion": "^0.63",
+    "kitType": "app",
+    "bundle": {
+  ...
+}
+```
+
+Bump `reactNativeVersion`, and run `yarn rnx-dep-check --write`. This command
+will ensure that all relevant packages are bumped correctly.
+
+You can read more about this tool here:
+[`@rnx-kit/dep-check` design document](https://github.com/microsoft/rnx-kit/blob/main/packages/dep-check/DESIGN.md)
+
+## Troubleshooting
 
 - The first time you run your project, you may get errors about missing SDKs. Android Studio usually provides quick options to resolve these issues, but you can also go to Tools->SDK Manager to manually install or update SDK platforms or tools for your project.
 
 - If you would like to debug in Android Studio, you can do the following to open the project there:
 
-```
-    # Android
-    open -a "Android Studio" .
+```sh
+# Android
+open -a "Android Studio" .
 
-    # Windows
-    # Easiest to open from within Android Studio - see picture below
+# Windows
+# Easiest to open from within Android Studio - see picture below
 ```
 
 ![On Windows, it is easiest to open from within Android Studio, and the folder will show an Android Studio icon.](./../../assets/fluent_tester_android_windows_open.png)

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -8,34 +8,59 @@ Prereq: FluentUI Tester on iOS can only run on a Mac.
 
 1. Make sure you have followed the [Getting Started](../../README.md) instructions to install packages and build the entire FluentUI React Native repository. I.e. from the root of the repo:
 
-```
-    yarn && yarn build
+```sh
+yarn
+yarn build
 ```
 
 2. Then go into `apps/ios/src` folder and run pod install to pull in the project-level Cocoapod dependencies defined in the podfile, and to generate a valid xcworkspace:
 
-```
-    cd apps/ios/src
-    pod install
+```sh
+cd apps/ios/src
+pod install
 ```
 
 Note: if you get the error: "CocoaPods could not find compatible versions for pod "MicrosoftFluentUI"," you may need to run `pod install --repo-update`.
 
 3. Return to the ios directory and run yarn ios to launch the FluentUI Tester app:
 
-```
-    cd ..
-    yarn ios
+```sh
+cd ..
+yarn ios
 ```
 
-Troubleshooting
+## Dependencies
+
+Dependencies are managed by
+[`@rnx-kit/dep-check`](https://github.com/microsoft/rnx-kit/tree/main/packages/dep-check).
+If you're looking to upgrade `react-native`, look for the `rnx-kit` section in
+`/apps/ios/package.json`:
+
+```json
+{
+  ...
+  "rnx-kit": {
+    "reactNativeVersion": "^0.63",
+    "kitType": "app",
+    "bundle": {
+  ...
+}
+```
+
+Bump `reactNativeVersion`, and run `yarn rnx-dep-check --write`. This command
+will ensure that all relevant packages are bumped correctly.
+
+You can read more about this tool here:
+[`@rnx-kit/dep-check` design document](https://github.com/microsoft/rnx-kit/blob/main/packages/dep-check/DESIGN.md)
+
+## Troubleshooting
 
 - The first time you yarn ios, you receive an error and have to run "FluentTester.xcworkspace" directly from Xcode. The workspace can be found in the apps/ios/src folder. After running the workspace the first time from Xcode, you will be able to `yarn ios` from the CLI.
 - If the packager didn't launch in a separate terminal and your iOS simulator just shows a white screen for your app, you can run yarn start from apps/ios to launch it separately
 - If you want to do direct debugging via xcode, after the pod install, you can launch src/FluentTester.xcworkspace and build/run the scheme "ReactTestApp"
 - If you want to have a clean rebuild of the generated iOS project, you can do the following:
 
-```
+```sh
 cd apps/ios/
 rm src/FluentTester.xcworkspace
 rm -r src/Pods/

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -8,32 +8,57 @@ Prereq: FluentUI Tester on macOS can only run on a Mac.
 
 1. Make sure you have followed the [Getting Started](../../README.md) instructions to install packages and build the entire FluentUI React Native repository. I.e. from the root of the repo:
 
-```
-    yarn && yarn build
+```sh
+yarn
+yarn build
 ```
 
 2. Then go into `apps/macos/src` folder and run pod install to pull in the project-level Cocoapod dependencies defined in the podfile, and to generate a valid xcworkspace:
 
-```
-    cd apps/macos/src
-    pod install
+```sh
+cd apps/macos/src
+pod install
 ```
 
 Note: if you get the error: "CocoaPods could not find compatible versions for pod "MicrosoftFluentUI"," you may need to run `pod install --repo-update`.
 
 3. Return to the macos directory and first run yarn start. Then run yarn macos to launch the FluentUI Tester app:
 
-```
-    cd ..
-    yarn macos
+```sh
+cd ..
+yarn macos
 ```
 
-Troubleshooting
+## Dependencies
+
+Dependencies are managed by
+[`@rnx-kit/dep-check`](https://github.com/microsoft/rnx-kit/tree/main/packages/dep-check).
+If you're looking to upgrade `react-native`, look for the `rnx-kit` section in
+`/apps/macos/package.json`:
+
+```json
+{
+  ...
+  "rnx-kit": {
+    "reactNativeVersion": "^0.63",
+    "kitType": "app",
+    "bundle": {
+  ...
+}
+```
+
+Bump `reactNativeVersion`, and run `yarn rnx-dep-check --write`. This command
+will ensure that all relevant packages are bumped correctly.
+
+You can read more about this tool here:
+[`@rnx-kit/dep-check` design document](https://github.com/microsoft/rnx-kit/blob/main/packages/dep-check/DESIGN.md)
+
+## Troubleshooting
 
 - If you want to do direct debugging via xcode, after the pod install, you can launch src/FluentTester.xcworkspace and build/run the scheme "ReactTestApp"
 - If you want to have a clean rebuild of the generated macOS project, you can do the following:
 
-```
+```sh
 cd apps/macos/
 rm src/FluentTester.xcworkspace
 rm -r src/Pods/

--- a/apps/win32/README.md
+++ b/apps/win32/README.md
@@ -9,19 +9,19 @@
 2. Then go into `apps\win32` folder:
 
 ```
-    cd apps\win32
+cd apps\win32
 ```
 
 3. Build the FluentUI Tester bundle:
 
 ```
-    yarn bundle
+yarn bundle
 ```
 
 4. Launch the FluentUI Tester app:
 
 ```
-    yarn run-win32
+yarn run-win32
 ```
 
 5. You will see FluentUI Tester show up in a new window.
@@ -38,13 +38,13 @@ Note: we recommend using [Visual Studio Code](https://code.visualstudio.com/down
 3. Build the FluentUI Tester bundle with dev option. This will ensure source map is included in the bundle.
 
 ```
-    yarn bundle-dev
+yarn bundle-dev
 ```
 
 4. Launch the FluentUI Tester app:
 
 ```
-    yarn run-win32
+yarn run-win32
 ```
 
 5. Inside ReactTest, open the debug option menu and select the checkbox `Use Direct Debugger`
@@ -64,7 +64,7 @@ Note: we recommend using [Visual Studio Code](https://code.visualstudio.com/down
 3. Start the debug server:
 
 ```
-    yarn start
+yarn start
 ```
 
 4. Open Edge or Chrome and navigate to http://localhost:8081/debugger-ui
@@ -72,5 +72,29 @@ Note: we recommend using [Visual Studio Code](https://code.visualstudio.com/down
 5. Open another command prompt and go into the same location `apps\win32` and run:
 
 ```
-    yarn run-win32-web
+yarn run-win32-web
 ```
+
+## Dependencies
+
+Dependencies are managed by
+[`@rnx-kit/dep-check`](https://github.com/microsoft/rnx-kit/tree/main/packages/dep-check).
+If you're looking to upgrade `react-native`, look for the `rnx-kit` section in
+`/apps/win32/package.json`:
+
+```json
+{
+  ...
+  "rnx-kit": {
+    "reactNativeVersion": "^0.63",
+    "kitType": "app",
+    "bundle": {
+  ...
+}
+```
+
+Bump `reactNativeVersion`, and run `yarn rnx-dep-check --write`. This command
+will ensure that all relevant packages are bumped correctly.
+
+You can read more about this tool here:
+[`@rnx-kit/dep-check` design document](https://github.com/microsoft/rnx-kit/blob/main/packages/dep-check/DESIGN.md)

--- a/apps/windows/README.md
+++ b/apps/windows/README.md
@@ -25,6 +25,30 @@ As with normal UWP app development, the UWP test harness that loads the JS bundl
 1. Run `yarn` from the root of the repo
 2. From this directory, simply `yarn windows`
 
+## Dependencies
+
+Dependencies are managed by
+[`@rnx-kit/dep-check`](https://github.com/microsoft/rnx-kit/tree/main/packages/dep-check).
+If you're looking to upgrade `react-native`, look for the `rnx-kit` section in
+`/apps/windows/package.json`:
+
+```json
+{
+  ...
+  "rnx-kit": {
+    "reactNativeVersion": "^0.63",
+    "kitType": "app",
+    "bundle": {
+  ...
+}
+```
+
+Bump `reactNativeVersion`, and run `yarn rnx-dep-check --write`. This command
+will ensure that all relevant packages are bumped correctly.
+
+You can read more about this tool here:
+[`@rnx-kit/dep-check` design document](https://github.com/microsoft/rnx-kit/blob/main/packages/dep-check/DESIGN.md)
+
 ## Troubleshooting
 
 ### EPERM restoring NuGet packages

--- a/change/@fluentui-react-native-tester-win32-2021-06-25-21-15-28-tido-update-readme.json
+++ b/change/@fluentui-react-native-tester-win32-2021-06-25-21-15-28-tido-update-readme.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Added how to bump react-native and where to find dep-check docs",
+  "packageName": "@fluentui-react-native/tester-win32",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none",
+  "date": "2021-06-25T19:15:28.715Z"
+}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

Added docs for how to bump `react-native` and friends. And where to go to learn more about `@rnx-kit/dep-check`.

### Verification

Nothing to test.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
