### PR TITLE
Fix fontSize having value of 0 in Persona

### DIFF
--- a/change/@fluentui-react-native-persona-2021-07-07-15-45-35-fontsize_0.json
+++ b/change/@fluentui-react-native-persona-2021-07-07-15-45-35-fontsize_0.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Set fontsize to undefined if the fontSize is zero",
+  "packageName": "@fluentui-react-native/persona",
+  "email": "email not defined",
+  "dependentChangeType": "patch",
+  "date": "2021-07-07T22:45:35.680Z"
+}

--- a/packages/components/Persona/src/Persona.tokens.texts.ts
+++ b/packages/components/Persona/src/Persona.tokens.texts.ts
@@ -27,6 +27,7 @@ function buildTextStyleHelper(
 
   if (textStyle.fontSize === 0) {
     textStyle.display = 'none';
+    textStyle.fontSize = undefined;
   }
 
   return textStyle;


### PR DESCRIPTION
Fixes #765

### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [ ] android

### Description of changes

While trying to bump to using react-native-windows 0.63, there was a crash encountered in Persona if the fontSize value passed into the Text component is 0 in UWP.

Fix for this is to set the text style's fontSize to undefined when we set its display to none. RN supports undefined for any text style prop, so this is a safe way to tell RN that we're not providing a value for that font size.

Probably a better fix is to update the font tables to only have font sizes defined for the Persona sizes that matter, but this is to unblock the crash and it avoids adding checks for undefined.

### Verification

Tested that the Tester app does not crash when navigating to the Persona page in UWP.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
