### PR TITLE
Disable "gap" prop on Stack when running in Chakra

### DIFF
--- a/change/@fluentui-react-native-stack-2021-07-13-15-29-39-stack_style_uwp.json
+++ b/change/@fluentui-react-native-stack-2021-07-13-15-29-39-stack_style_uwp.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix stack child component's style props causing issues in RNW 0.63",
+  "packageName": "@fluentui-react-native/stack",
+  "email": "email not defined",
+  "dependentChangeType": "patch",
+  "date": "2021-07-13T22:29:39.096Z"
+}

--- a/packages/components/Stack/src/Stack.tsx
+++ b/packages/components/Stack/src/Stack.tsx
@@ -12,6 +12,7 @@ import { backgroundColorTokens, borderTokens } from '@fluentui-react-native/toke
 import { buildStackRootStyles, buildStackInnerStyles } from './Stack.tokens';
 import { StyleProp, ViewStyle } from 'react-native';
 
+// Needed for TS to understand that __jsiExecutorDescription exists.
 declare global {
   /* eslint-disable-next-line @typescript-eslint/no-namespace*/
   namespace NodeJS {
@@ -30,12 +31,7 @@ const _styleKey = 'style';
 const render = (Slots: ISlots<IStackSlotProps>, renderData: IStackRenderData, ...children: React.ReactNode[]): JSX.Element => {
   const { gap, horizontal, wrap } = renderData.state!;
 
-  if (
-    gap &&
-    gap > 0 &&
-    children &&
-    (!global.hasOwnProperty('__jsiExecutorDescription') || global.__jsiExecutorDescription !== 'ChakraRuntime')
-  ) {
+  if (gap && gap > 0 && children && global.__jsiExecutorDescription !== 'ChakraRuntime') {
     const extraStyle: ViewStyle = horizontal ? { marginLeft: gap } : { marginTop: gap };
     /* eslint-disable @typescript-eslint/ban-ts-ignore */
     // @ts-ignore - TODO, fix typing error

--- a/packages/components/Stack/src/Stack.tsx
+++ b/packages/components/Stack/src/Stack.tsx
@@ -28,10 +28,11 @@ const render = (Slots: ISlots<IStackSlotProps>, renderData: IStackRenderData, ..
     children = React.Children.map(children, (child: React.ReactChild, index: number) => {
       if (React.isValidElement(child) && index > 0) {
         const childProps = child.props;
-        const mixedStyle = _mixinStyle(childProps[_styleKey], extraStyle);
-        const styleProp = Object.create({});
-        Object.defineProperty(styleProp, 'style', { value: mixedStyle, configurable: true });
-        return React.cloneElement(child, styleProp);
+        const extraProps = { style: _mixinStyle(childProps[_styleKey], extraStyle) };
+        return React.cloneElement(child, {
+          ...childProps,
+          ...extraProps,
+        });
       }
       return child;
     });

--- a/packages/components/Stack/src/Stack.tsx
+++ b/packages/components/Stack/src/Stack.tsx
@@ -28,11 +28,10 @@ const render = (Slots: ISlots<IStackSlotProps>, renderData: IStackRenderData, ..
     children = React.Children.map(children, (child: React.ReactChild, index: number) => {
       if (React.isValidElement(child) && index > 0) {
         const childProps = child.props;
-        const extraProps = { style: _mixinStyle(childProps[_styleKey], extraStyle) };
-        return React.cloneElement(child, {
-          ...childProps,
-          ...extraProps,
-        });
+        const mixedStyle = _mixinStyle(childProps[_styleKey], extraStyle);
+        const styleProp = Object.create({});
+        Object.defineProperty(styleProp, 'style', { value: mixedStyle, configurable: true });
+        return React.cloneElement(child, styleProp);
       }
       return child;
     });

--- a/packages/components/Stack/src/Stack.tsx
+++ b/packages/components/Stack/src/Stack.tsx
@@ -12,6 +12,15 @@ import { backgroundColorTokens, borderTokens } from '@fluentui-react-native/toke
 import { buildStackRootStyles, buildStackInnerStyles } from './Stack.tokens';
 import { StyleProp, ViewStyle } from 'react-native';
 
+declare global {
+  /* eslint-disable-next-line @typescript-eslint/no-namespace*/
+  namespace NodeJS {
+    interface Global {
+      __jsiExecutorDescription: any;
+    }
+  }
+}
+
 function _mixinStyle(style: StyleProp<object> | undefined, mixin: object): StyleProp<object> {
   return style ? [style, mixin] : mixin;
 }
@@ -21,7 +30,12 @@ const _styleKey = 'style';
 const render = (Slots: ISlots<IStackSlotProps>, renderData: IStackRenderData, ...children: React.ReactNode[]): JSX.Element => {
   const { gap, horizontal, wrap } = renderData.state!;
 
-  if (gap && gap > 0 && children) {
+  if (
+    gap &&
+    gap > 0 &&
+    children &&
+    (!global.hasOwnProperty('__jsiExecutorDescription') || global.__jsiExecutorDescription !== 'ChakraRuntime')
+  ) {
     const extraStyle: ViewStyle = horizontal ? { marginLeft: gap } : { marginTop: gap };
     /* eslint-disable @typescript-eslint/ban-ts-ignore */
     // @ts-ignore - TODO, fix typing error

--- a/packages/components/Stack/src/Stack.types.ts
+++ b/packages/components/Stack/src/Stack.types.ts
@@ -93,6 +93,7 @@ export interface IStackTokens extends FontTokens, IBackgroundColorTokens, IBorde
 
   /**
    * Gap between items, multiplied by theme gap spacing
+   * Does not work while running Chakra for reasons specific to that engine (refer to https://github.com/microsoft/fluentui-react-native/issues/767)
    */
   gap?: number;
 }

--- a/packages/experimental/Stack/src/Stack.tsx
+++ b/packages/experimental/Stack/src/Stack.tsx
@@ -7,6 +7,16 @@ import { filterViewProps } from '@fluentui-react-native/adapters';
 import { compose, withSlots, mergeProps, UseSlots, getMemoCache } from '@fluentui-react-native/framework';
 import { stylingSettings } from './Stack.styling';
 
+// Needed for TS to understand that __jsiExecutorDescription exists.
+declare global {
+  /* eslint-disable-next-line @typescript-eslint/no-namespace*/
+  namespace NodeJS {
+    interface Global {
+      __jsiExecutorDescription: any;
+    }
+  }
+}
+
 const mixinCache = getMemoCache<ViewProps>();
 
 /**
@@ -41,7 +51,7 @@ export const Stack = compose<StackType>({
     const { gap, horizontal, wrap, ...rest } = props;
     const Slots = useSlots(props);
     return (final: StackProps, ...children: React.ReactNode[]) => {
-      if (gap && gap > 0 && children) {
+      if (gap && gap > 0 && children && global.__jsiExecutorDescription !== 'ChakraRuntime') {
         const mixinProps = getMixinProps(horizontal, gap);
 
         /* eslint-disable @typescript-eslint/ban-ts-ignore */

--- a/packages/experimental/Stack/src/Stack.types.ts
+++ b/packages/experimental/Stack/src/Stack.types.ts
@@ -91,7 +91,8 @@ export interface StackTokenProps {
   wrap?: boolean;
 
   /**
-   * Gap between items, multiplied by theme gap spacing
+   * Gap between items, multiplied by theme gap spacing.
+   * Does not work while running Chakra for reasons specific to that engine (refer to https://github.com/microsoft/fluentui-react-native/issues/767)
    */
   gap?: number;
 }


### PR DESCRIPTION
Fixes #767 

### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

A workaround fix for an issue with Charka, RN, and Stack where we were seeing errors while running the RN Test App for Windows.

This issue seems to be a timing issue with using Chakra. While the code in the Stack component isn't inherently doing anything that isn't allowed by RN, it trips up a function which runs in debug bundles. We can't switch away from Chakra in UWP since the base test app, which we'll be switching to with #755, runs with Chakra and probably won't be using Hermes until 0.65. For now, we can disable the `gap` prop causing the issue in Chakra. Since Edge has switched to Chromium and RNW is trying to switch to Hermes, Chakra is less popular in usage so we think it's okay to not have the prop working when running Chakra.

I've tried other workarounds such as using Object.defineProperty directly, or using View components instead of marginTop/marginLeft to implement the spacing, to no avail. Short of removing the prop entirely, this is the best solution we have for this issue.

### Verification

Tested fix in UWP test app.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
