### PR TITLE
Revert submenu chevron svg

### DIFF
--- a/change/@fluentui-react-native-contextual-menu-2021-07-14-07-02-30-revertsvg.json
+++ b/change/@fluentui-react-native-contextual-menu-2021-07-14-07-02-30-revertsvg.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "revert chevron svg",
+  "packageName": "@fluentui-react-native/contextual-menu",
+  "email": "lehon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-07-14T14:02:30.917Z"
+}

--- a/packages/components/ContextualMenu/package.json
+++ b/packages/components/ContextualMenu/package.json
@@ -30,9 +30,7 @@
     "@fluentui-react-native/text": ">=0.9.6 <1.0.0",
     "@fluentui-react-native/tokens": ">=0.9.3 <1.0.0",
     "@uifabricshared/foundation-composable": ">=0.8.2 <1.0.0",
-    "@uifabricshared/foundation-settings": ">=0.9.1 <1.0.0",
-    "react-native-svg": "^12.1.1",
-    "react-native-svg-transformer": "^0.14.3"
+    "@uifabricshared/foundation-settings": ">=0.9.1 <1.0.0"
   },
   "devDependencies": {
     "@fluentui-react-native/pressable": ">=0.6.9 <1.0.0",

--- a/packages/components/ContextualMenu/src/@types/declarations.d.ts
+++ b/packages/components/ContextualMenu/src/@types/declarations.d.ts
@@ -1,5 +1,0 @@
-declare module '*.svg' {
-  import { SvgProps } from 'react-native-svg';
-  const content: React.FC<SvgProps>;
-  export default content;
-}

--- a/packages/components/ContextualMenu/src/SubmenuItem.tsx
+++ b/packages/components/ContextualMenu/src/SubmenuItem.tsx
@@ -17,9 +17,8 @@ import { backgroundColorTokens, borderTokens, textTokens, foregroundColorTokens,
 import { mergeSettings } from '@uifabricshared/foundation-settings';
 import { useAsPressable, useKeyCallback, useViewCommandFocus } from '@fluentui-react-native/interactive-hooks';
 import { CMContext } from './ContextualMenu';
-import { Icon, SvgIconProps, IconProps} from '@fluentui-react-native/icon';
+import { Icon} from '@fluentui-react-native/icon';
 import { createIconProps } from '@fluentui-react-native/interactive-hooks';
-import ChevronSvg from './assets/commoncontrolchevronforward.12.svg';
 
 export const SubmenuItem = compose<SubmenuItemType>({
   displayName: submenuItemName,
@@ -76,17 +75,6 @@ export const SubmenuItem = compose<SubmenuItemType>({
      */
     const onKeyUp = useKeyCallback(onItemHoverIn, ' ', 'Enter', 'ArrowRight');
 
-    const svgProps: SvgIconProps = {
-      src: ChevronSvg,
-      viewBox: '0 0 2048 2048',
-    };
-
-    const chevronProps: IconProps = {
-      svgSource: svgProps,
-      width: 12,
-      height: 12,
-    }
-
     // grab the styling information, referencing the state as well as the props
     const styleProps = useStyling(userProps, (override: string) => state[override] || userProps[override]);
     // create the merged slot props
@@ -99,7 +87,6 @@ export const SubmenuItem = compose<SubmenuItemType>({
       },
       content: { children: text, testID },
       icon: createIconProps(icon),
-      chevron: createIconProps(chevronProps)
     });
 
     return { slotProps, state };

--- a/packages/components/ContextualMenu/src/assets/commoncontrolchevronforward.12.svg
+++ b/packages/components/ContextualMenu/src/assets/commoncontrolchevronforward.12.svg
@@ -1,5 +1,0 @@
-<?xml version="1.0" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0,0,2048,2048">
-  <path class='OfficeIconColors_HighContrast' d='M 743 1767 l -121 -121 l 708 -707 l -708 -708 l 121 -121 l 828 829 z' />
-  <path class='OfficeIconColors_m22' d='M 743 1767 l -121 -121 l 708 -707 l -708 -708 l 121 -121 l 828 829 z' />
-</svg>


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [X] macOS
- [X] win32 (Office)
- [X] windows
- [X] android

### Description of changes

This [PR](https://github.com/microsoft/fluentui-react-native/pull/741) has broken our partners' ability to bundle. PR resolving a similar issue: [.](https://github.com/microsoft/fluentui-react-native/pull/782)

It will take partners some work to actually plumb the assets all the way through to devmain and setup delivery (Modern Comments).

This pr is to unblock Modern Comments, but will need a more robust way support submenu indicator in the near future. 

### Verification

Manual+Automated

### Pull request checklist

This PR has considered (when applicable):
- [X] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
