### PR TITLE
Callout DismissBehaviors

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/Callout/CalloutTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Callout/CalloutTest.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ScreenRect, Text, View, Switch, Picker } from 'react-native';
-import { Button, Callout, Separator, IFocusable, RestoreFocusEvent } from '@fluentui/react-native';
+import { Button, Callout, Separator, IFocusable, RestoreFocusEvent, Checkbox, DismissBehaviors } from '@fluentui/react-native';
 import { CALLOUT_TESTPAGE } from './consts';
 import { Test, TestSection, PlatformStatus } from '../Test';
 
@@ -16,6 +16,33 @@ const standardCallout: React.FunctionComponent<{}> = () => {
 
   const [isBeakVisible, setIsBeakVisible] = React.useState(false);
   const onIsBeakVisibleChange = React.useCallback((value) => setIsBeakVisible(value), []);
+
+  const [preventDismissOnKeyDown, setPreventDismissOnKeyDown] = React.useState(false);
+  const [preventDismissOnClickOutside, setPreventDismissOnClickOutside] = React.useState(false);
+  const [calloutDismissBehaviors, setDismissBehaviors] = React.useState<DismissBehaviors[]>();
+
+  const reEvaluateDismissBehaviors = React.useCallback(() => {
+    const dismissBehaviors: DismissBehaviors[] = [];
+    if (preventDismissOnClickOutside) {
+      dismissBehaviors.push('preventDismissOnClickOutside');
+    }
+    if (preventDismissOnKeyDown) {
+      dismissBehaviors.push('preventDismissOnKeyDown');
+    }
+    if (dismissBehaviors.length > 0) {
+      setDismissBehaviors(dismissBehaviors);
+    }
+  }, []);
+
+  const onPreventDismissOnKeyDownChange = React.useCallback((value) => {
+    setPreventDismissOnKeyDown(value);
+    reEvaluateDismissBehaviors();
+  }, []);
+
+  const onPreventDismissOnClickOutsideChange = React.useCallback((value) => {
+    setPreventDismissOnClickOutside(value);
+    reEvaluateDismissBehaviors();
+  }, []);
 
   const redTargetRef = React.useRef<View>(null);
   const blueTargetRef = React.useRef<View>(null);
@@ -90,6 +117,11 @@ const standardCallout: React.FunctionComponent<{}> = () => {
             <Switch value={isBeakVisible} onValueChange={onIsBeakVisibleChange} />
             <Text>Beak Visible</Text>
           </View>
+
+          <Text>Dismiss Behaviors</Text>
+          <Checkbox onChange={onPreventDismissOnKeyDownChange} label="Prevent Dismiss On Key Down" />
+          <Checkbox onChange={onPreventDismissOnClickOutsideChange} label="Prevent Dismiss On Click Outside" />
+
           <Picker
             prompt="Background Color"
             selectedValue={selectedBackgroundColor || colorDefault}
@@ -160,6 +192,7 @@ const standardCallout: React.FunctionComponent<{}> = () => {
             ...(selectedBorderColor && { borderColor: selectedBorderColor }),
             ...(selectedBackgroundColor && { backgroundColor: selectedBackgroundColor }),
             ...(selectedBorderWidth && { borderWidth: selectedBorderWidth }),
+            ...(calloutDismissBehaviors && { dismissBehaviors: calloutDismissBehaviors }),
           }}
         >
           <View style={{ padding: 20 }}>

--- a/apps/fluent-tester/src/FluentTester/TestComponents/Callout/CalloutTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Callout/CalloutTest.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ScreenRect, Text, View, Switch, Picker } from 'react-native';
-import { Button, Callout, Separator, IFocusable, RestoreFocusEvent, Checkbox, DismissBehaviors } from '@fluentui/react-native';
+import { Button, Callout, Separator, IFocusable, RestoreFocusEvent, DismissBehaviors } from '@fluentui/react-native';
 import { CALLOUT_TESTPAGE } from './consts';
 import { Test, TestSection, PlatformStatus } from '../Test';
 
@@ -19,29 +19,30 @@ const standardCallout: React.FunctionComponent<{}> = () => {
 
   const [preventDismissOnKeyDown, setPreventDismissOnKeyDown] = React.useState(false);
   const [preventDismissOnClickOutside, setPreventDismissOnClickOutside] = React.useState(false);
-  const [calloutDismissBehaviors, setDismissBehaviors] = React.useState<DismissBehaviors[]>();
-
-  const reEvaluateDismissBehaviors = React.useCallback(() => {
-    const dismissBehaviors: DismissBehaviors[] = [];
-    if (preventDismissOnClickOutside) {
-      dismissBehaviors.push('preventDismissOnClickOutside');
-    }
-    if (preventDismissOnKeyDown) {
-      dismissBehaviors.push('preventDismissOnKeyDown');
-    }
-    if (dismissBehaviors.length > 0) {
-      setDismissBehaviors(dismissBehaviors);
-    }
-  }, []);
+  const [calloutDismissBehaviors, setDismissBehaviors] = React.useState<DismissBehaviors[]>([]);
 
   const onPreventDismissOnKeyDownChange = React.useCallback((value) => {
     setPreventDismissOnKeyDown(value);
-    reEvaluateDismissBehaviors();
+    if (value) {
+      setDismissBehaviors(calloutDismissBehaviors.concat('preventDismissOnKeyDown'));
+    } else {
+      const newDismissBehaviors = calloutDismissBehaviors.filter((value) => {
+        value != 'preventDismissOnKeyDown';
+      });
+      setDismissBehaviors(newDismissBehaviors);
+    }
   }, []);
 
   const onPreventDismissOnClickOutsideChange = React.useCallback((value) => {
     setPreventDismissOnClickOutside(value);
-    reEvaluateDismissBehaviors();
+    if (value) {
+      setDismissBehaviors(calloutDismissBehaviors.concat('preventDismissOnClickOutside'));
+    } else {
+      const newDismissBehaviors = calloutDismissBehaviors.filter((value) => {
+        value != 'preventDismissOnClickOutside';
+      });
+      setDismissBehaviors(newDismissBehaviors);
+    }
   }, []);
 
   const redTargetRef = React.useRef<View>(null);
@@ -118,9 +119,15 @@ const standardCallout: React.FunctionComponent<{}> = () => {
             <Text>Beak Visible</Text>
           </View>
 
-          <Text>Dismiss Behaviors</Text>
-          <Checkbox onChange={onPreventDismissOnKeyDownChange} label="Prevent Dismiss On Key Down" />
-          <Checkbox onChange={onPreventDismissOnClickOutsideChange} label="Prevent Dismiss On Click Outside" />
+          <View style={{ flexDirection: 'row' }}>
+            <Switch value={preventDismissOnKeyDown} onValueChange={onPreventDismissOnKeyDownChange} />
+            <Text>Prevent Dismiss On Key Down</Text>
+          </View>
+
+          <View style={{ flexDirection: 'row' }}>
+            <Switch value={preventDismissOnClickOutside} onValueChange={onPreventDismissOnClickOutsideChange} />
+            <Text>Prevent Dismiss On Click Outside</Text>
+          </View>
 
           <Picker
             prompt="Background Color"

--- a/apps/win32/package.json
+++ b/apps/win32/package.json
@@ -21,6 +21,7 @@
     "bundle-dev": "react-native rnx-bundle",
     "run-win32": "rex-win32 --bundle index.win32 --component FluentTester --windowTitle \"FluentUI Tester\" --basePath ./dist --pluginProps --debugBundlePath index --jsEngine v8",
     "run-win32-web": "rex-win32 --bundle index --component FluentTester --basePath ./dist --useWebDebugger --windowTitle \"FluentUI Tester\" --useFastRefresh --pluginProps --debugBundlePath index --jsEngine v8",
+    "run-win32-dev-web": "rex-win32 --bundle index --component FluentTester --basePath ./dist --useDevMain --useWebDebugger --windowTitle \"FluentUI Tester\" --useFastRefresh --pluginProps --debugBundlePath index --jsEngine v8",
     "run-win32-devmain": "rex-win32 --bundle index.win32 --component FluentTester --basePath ./dist --useDevMain --windowTitle \"FluentUI Tester\" --pluginProps --debugBundlePath index --jsEngine v8",
     "e2etest": "rimraf reports/* && wdio",
     "report": "allure generate allure-results --clean",

--- a/change/@fluentui-react-native-callout-2021-07-14-23-17-11-calloutDismissProps.json
+++ b/change/@fluentui-react-native-callout-2021-07-14-23-17-11-calloutDismissProps.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add dismiss behaviors and appropriate test page changes",
+  "packageName": "@fluentui-react-native/callout",
+  "email": "ppatboyd@outlook.com",
+  "dependentChangeType": "patch",
+  "date": "2021-07-15T06:17:11.873Z"
+}

--- a/change/@fluentui-react-native-tester-2021-07-14-23-17-11-calloutDismissProps.json
+++ b/change/@fluentui-react-native-tester-2021-07-14-23-17-11-calloutDismissProps.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add dismiss behaviors and appropriate test page changes",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ppatboyd@outlook.com",
+  "dependentChangeType": "patch",
+  "date": "2021-07-15T06:16:58.024Z"
+}

--- a/change/@fluentui-react-native-tester-win32-2021-07-14-23-17-11-calloutDismissProps.json
+++ b/change/@fluentui-react-native-tester-win32-2021-07-14-23-17-11-calloutDismissProps.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add dismiss behaviors and appropriate test page changes",
+  "packageName": "@fluentui-react-native/tester-win32",
+  "email": "ppatboyd@outlook.com",
+  "dependentChangeType": "patch",
+  "date": "2021-07-15T06:17:07.423Z"
+}

--- a/packages/components/Callout/src/Callout.types.ts
+++ b/packages/components/Callout/src/Callout.types.ts
@@ -26,6 +26,8 @@ export type DirectionalHint =
   | 'bottomCenter'
   | 'bottomRightEdge';
 
+export type DismissBehaviors = 'preventDismissOnKeyDown' | 'preventDismissOnClickOutside';
+
 export interface RestoreFocusEvent {
   nativeEvent: {
     /**
@@ -59,6 +61,20 @@ export interface ICalloutTokens extends IBackgroundColorTokens, CalloutBorderTok
    * to the anchor information.
    */
   directionalHint?: DirectionalHint;
+
+  /**
+   * Defines variations on how the callout dismissal may be controlled.  the async eventing
+   * of React-Native makes passing some aspects of dismissal control over to JS difficult.
+   * Moreover, the native platform or host may have competing priorities with regards to transient UI
+   * that generate bi-directional lifetime management between JS (which mounts and unmounts the
+   * component) and native (which may tear down the transient UI without JS input).
+   *
+   * This property provides control over the latter issue, enabling relevant native platform
+   * interactions with transient UI to be managed from JS.
+   *
+   * These behaviors should generally be orthogonal, and therefore combinable.
+   */
+  dismissBehaviors?: DismissBehaviors[];
 
   /**
    * Defines the size of the gap between the anchor and the Callout.  Not used if


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Callouts may need certain behaviors that are controlled by the native platform projection; partially due to the nature of the platform host and partially due to the async nature of React-Native.  These properties help control the behavior of the Callout for scenarios that need it.

Note that these are strong suggestions and not hard rules; again due to the nature of the platform host.

Mind that `preventDismissOnKeyDown` does not prevent escape, and has limited use outside of keyboard navigation purposes (between the callout surface and other surfaces).

### Verification

Added tests to CalloutTest page.
