### PR TITLE
Use peer dependencies for react-native version not dependencies

### DIFF
--- a/change/@fluentui-react-native-android-theme-2021-07-20-17-19-30-RNNotAsDep.json
+++ b/change/@fluentui-react-native-android-theme-2021-07-20-17-19-30-RNNotAsDep.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Use peer dependencies for react-native version not dependencies",
+  "packageName": "@fluentui-react-native/android-theme",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2021-07-21T00:19:25.417Z"
+}

--- a/change/@fluentui-react-native-apple-theme-2021-07-20-17-19-30-RNNotAsDep.json
+++ b/change/@fluentui-react-native-apple-theme-2021-07-20-17-19-30-RNNotAsDep.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Use peer dependencies for react-native version not dependencies",
+  "packageName": "@fluentui-react-native/apple-theme",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2021-07-21T00:19:26.970Z"
+}

--- a/change/@fluentui-react-native-theme-types-2021-07-20-17-19-30-RNNotAsDep.json
+++ b/change/@fluentui-react-native-theme-types-2021-07-20-17-19-30-RNNotAsDep.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Use peer dependencies for react-native version not dependencies",
+  "packageName": "@fluentui-react-native/theme-types",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2021-07-21T00:19:27.757Z"
+}

--- a/change/@fluentui-react-native-theming-utils-2021-07-20-17-19-30-RNNotAsDep.json
+++ b/change/@fluentui-react-native-theming-utils-2021-07-20-17-19-30-RNNotAsDep.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Use peer dependencies for react-native version not dependencies",
+  "packageName": "@fluentui-react-native/theming-utils",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2021-07-21T00:19:28.556Z"
+}

--- a/change/@fluentui-react-native-tokens-2021-07-20-17-19-30-RNNotAsDep.json
+++ b/change/@fluentui-react-native-tokens-2021-07-20-17-19-30-RNNotAsDep.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Use peer dependencies for react-native version not dependencies",
+  "packageName": "@fluentui-react-native/tokens",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2021-07-21T00:19:30.458Z"
+}

--- a/change/@fluentui-react-native-win32-theme-2021-07-20-17-19-30-RNNotAsDep.json
+++ b/change/@fluentui-react-native-win32-theme-2021-07-20-17-19-30-RNNotAsDep.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Use peer dependencies for react-native version not dependencies",
+  "packageName": "@fluentui-react-native/win32-theme",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2021-07-21T00:19:29.385Z"
+}

--- a/packages/theming/android-theme/package.json
+++ b/packages/theming/android-theme/package.json
@@ -35,13 +35,13 @@
   "license": "MIT",
   "dependencies": {
     "@fluentui-react-native/theme-types": ">=0.8.0 <1.0.0",
-    "@fluentui-react-native/theme": ">=0.5.5 <1.0.0",
-    "react-native": "^0.63.4"
+    "@fluentui-react-native/theme": ">=0.5.5 <1.0.0"
   },
   "devDependencies": {
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1"
+    "@uifabricshared/eslint-config-rules": "^0.1.1",
+    "react-native": "^0.63.4"
   },
   "peerDependencies": {
     "react": "^16.13.1",

--- a/packages/theming/apple-theme/package.json
+++ b/packages/theming/apple-theme/package.json
@@ -33,14 +33,14 @@
     "@fluentui-react-native/default-theme": ">=0.6.5 <1.0.0",
     "@fluentui-react-native/theme": ">=0.5.5 <1.0.0",
     "@fluentui-react-native/theme-types": ">=0.8.0 <1.0.0",
-    "@fluentui-react-native/theming-utils": "^0.2.3",
-    "react-native": "^0.63.4"
+    "@fluentui-react-native/theming-utils": "^0.2.3"
   },
   "devDependencies": {
     "@types/react": "^16.13.1",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1"
+    "@uifabricshared/eslint-config-rules": "^0.1.1",
+    "react-native": "^0.63.4"
   },
   "peerDependencies": {
     "react": ">=16.13.1",

--- a/packages/theming/theme-types/package.json
+++ b/packages/theming/theme-types/package.json
@@ -33,13 +33,12 @@
   "keywords": [],
   "author": "",
   "license": "MIT",
-  "dependencies": {
-    "react-native": "^0.63.4"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@types/react": "^16.9.34",
     "@types/react-native": "^0.63.0",
     "react": "16.13.1",
+    "react-native": "^0.63.4",
     "@uifabricshared/build-native": "^0.1.1",
     "@uifabricshared/eslint-config-rules": "^0.1.1"
   },

--- a/packages/theming/theming-utils/package.json
+++ b/packages/theming/theming-utils/package.json
@@ -27,13 +27,13 @@
     "prettier-fix": "fluentui-scripts prettier --fix true"
   },
   "dependencies": {
-    "@fluentui-react-native/theme-types": ">=0.8.0 <1.0.0",
-    "react-native": "^0.63.4"
+    "@fluentui-react-native/theme-types": ">=0.8.0 <1.0.0"
   },
   "devDependencies": {
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1"
+    "@uifabricshared/eslint-config-rules": "^0.1.1",
+    "react-native": "^0.63.4"
   },
   "peerDependencies": {
     "react": ">=16.13.1",

--- a/packages/theming/win32-theme/package.json
+++ b/packages/theming/win32-theme/package.json
@@ -36,15 +36,15 @@
   "dependencies": {
     "@fluentui-react-native/default-theme": ">=0.6.5 <1.0.0",
     "@fluentui-react-native/theme-types": ">=0.8.0 <1.0.0",
-    "@fluentui-react-native/theme": ">=0.5.5 <1.0.0",
-    "react-native": "^0.63.4"
+    "@fluentui-react-native/theme": ">=0.5.5 <1.0.0"
   },
   "devDependencies": {
     "@types/react": "^16.9.34",
     "@types/react-native": "^0.63.0",
     "react": "16.13.1",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1"
+    "@uifabricshared/eslint-config-rules": "^0.1.1",
+    "react-native": "^0.63.4"
   },
   "peerDependencies": {
     "react": ">=16.13.1",

--- a/packages/utils/tokens/package.json
+++ b/packages/utils/tokens/package.json
@@ -25,13 +25,13 @@
   "dependencies": {
     "@fluentui-react-native/adapters": ">=0.6.2 <1.0.0",
     "@uifabricshared/foundation-tokens": ">=0.9.1 <1.0.0",
-    "@uifabricshared/theming-ramp": ">=0.14.3 <1.0.0",
-    "react-native": "^0.63.4"
+    "@uifabricshared/theming-ramp": ">=0.14.3 <1.0.0"
   },
   "devDependencies": {
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1"
+    "@uifabricshared/eslint-config-rules": "^0.1.1",
+    "react-native": "^0.63.4"
   },
   "peerDependencies": {
     "react-native": ">=0.63.4"


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

The packages shouldn't bring in an additional RN dependencies, but instead rely on the version from the peerDependency.

### Verification

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
