### PR TITLE
Bump @rnx-kit/dep-check to 1.5.16

### DIFF
--- a/apps/android/package.json
+++ b/apps/android/package.json
@@ -41,7 +41,7 @@
     "jest": "^24.9.0",
     "metro-react-native-babel-preset": "^0.59.0",
     "react-native-svg-transformer": "^0.14.3",
-    "react-native-test-app": "^0.6.3",
+    "react-native-test-app": "^0.7.0",
     "react-test-renderer": "~16.13.1"
   },
   "jest": {

--- a/apps/ios/package.json
+++ b/apps/ios/package.json
@@ -40,7 +40,7 @@
     "metro-config": "^0.59.0",
     "metro-react-native-babel-preset": "^0.59.0",
     "react-native-svg-transformer": "^0.14.3",
-    "react-native-test-app": "^0.6.3",
+    "react-native-test-app": "^0.7.0",
     "react-test-renderer": "~16.13.1"
   },
   "jest": {

--- a/apps/macos/package.json
+++ b/apps/macos/package.json
@@ -39,7 +39,7 @@
     "metro-config": "^0.59.0",
     "metro-react-native-babel-preset": "^0.59.0",
     "react-native-svg-transformer": "^0.14.3",
-    "react-native-test-app": "^0.6.3",
+    "react-native-test-app": "^0.7.0",
     "react-test-renderer": "~16.13.1"
   },
   "jest": {
@@ -55,7 +55,7 @@
       "entryPath": "index.js"
     },
     "capabilities": [
-      "core-ios",
+      "core",
       "core-macos",
       "react",
       "test-app"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,8 @@
     "react": "16.13.1",
     "react-art": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-native": "^0.63.4",
+    "react-native": "^0.63.2",
+    "react-native-svg": "^12.1.1",
     "react-native-svg-loader": "^1.0.0",
     "react-native-web": "^0.12.3"
   },
@@ -35,5 +36,14 @@
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",
     "webpack-dev-server": "3.10.3"
+  },
+  "rnx-kit": {
+    "reactNativeVersion": "^0.63",
+    "reactNativeDevVersion": "0.63.0",
+    "kitType": "app",
+    "capabilities": [
+      "core",
+      "react"
+    ]
   }
 }

--- a/apps/win32/package.json
+++ b/apps/win32/package.json
@@ -77,7 +77,7 @@
       "entryPath": "index.js"
     },
     "capabilities": [
-      "core-android",
+      "core",
       "react",
       "svg"
     ]

--- a/apps/windows/package.json
+++ b/apps/windows/package.json
@@ -47,7 +47,7 @@
     "jest": "^24.9.0",
     "metro-config": "^0.59.0",
     "metro-react-native-babel-preset": "^0.59.0",
-    "react-native-test-app": "^0.6.3",
+    "react-native-test-app": "^0.7.0",
     "react-test-renderer": "~16.13.1",
     "rimraf": "~3.0.2",
     "ts-node": "^8.10.1",
@@ -73,7 +73,7 @@
       "entryPath": "index.js"
     },
     "capabilities": [
-      "core-android",
+      "core",
       "core-windows",
       "react",
       "svg",

--- a/change/@fluentui-react-native-tester-win32-15a7c7b3-aaf8-4d29-989d-247fb13a1ec7.json
+++ b/change/@fluentui-react-native-tester-win32-15a7c7b3-aaf8-4d29-989d-247fb13a1ec7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Use `core` capability instead of `core-android` to avoid confusion",
+  "packageName": "@fluentui-react-native/tester-win32",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2371,10 +2371,10 @@
     cosmiconfig "^7.0.0"
     semver "^7.0.0"
 
-"@rnx-kit/config@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@rnx-kit/config/-/config-0.3.1.tgz#4d2715a5c9b171b81c5ec5dbff6d21d7406d225c"
-  integrity sha512-3YoOa7S5hoZEKBRu7+DFe8laatNNrUybOX8WpS1ikziedpNzioZPbLY4cayHQf5HIg7vLg7x/+FIWEEz0nblSw==
+"@rnx-kit/config@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@rnx-kit/config/-/config-0.3.2.tgz#7beb4123c050c184e23bdd0d16043df553bdc7f9"
+  integrity sha512-z8tOLR9YOkWSDw6AogkJdzMvhNFlLZ5AVwbMArjMJ9kJOCROhduLWzkwGGnUSEUq529FSq7gSMt6VKSha4sVCw==
   dependencies:
     cosmiconfig "^7.0.0"
     semver "^7.0.0"
@@ -2387,11 +2387,11 @@
     chalk "^4.1.0"
 
 "@rnx-kit/dep-check@^1.5.10", "@rnx-kit/dep-check@^1.5.9":
-  version "1.5.15"
-  resolved "https://registry.yarnpkg.com/@rnx-kit/dep-check/-/dep-check-1.5.15.tgz#22578c731249a1903118222a3810a8051e1f338d"
-  integrity sha512-6k3+YwP8I0q3rENICFcQQDsbmNHLmjg7i1Th/UcNX1NySwI1mLhErwSoz1BnsUDp33hbuP2fmvqrppmsHLOtfA==
+  version "1.5.16"
+  resolved "https://registry.yarnpkg.com/@rnx-kit/dep-check/-/dep-check-1.5.16.tgz#926a0685c877288079e774fb10d268c45322bf1e"
+  integrity sha512-nOuy0xanEVtzuL+cCkMfCXE+NfSyktv8WtYZ/LE+XWbZoi115eq8T32NinVRS/9BWjX9Q3MjJSAPoY4333gaGg==
   dependencies:
-    "@rnx-kit/config" "^0.3.1"
+    "@rnx-kit/config" "^0.3.2"
     "@rnx-kit/console" "^1.0.0"
     chalk "^4.1.0"
     find-up "^5.0.0"
@@ -14404,10 +14404,10 @@ react-native-svg@^12.1.1:
     css-select "^2.1.0"
     css-tree "^1.0.0-alpha.39"
 
-react-native-test-app@^0.6.3:
-  version "0.6.12"
-  resolved "https://registry.yarnpkg.com/react-native-test-app/-/react-native-test-app-0.6.12.tgz#d6e53e6280426b64bf65c013f631ae0009ba9634"
-  integrity sha512-XTjjcBa1noVR89dITWqP7A8DE6qwT4+ABMsWAi1cVDU2RH4rwsaKtrrcoiF1OL7szP/5jdzd9f32NiQRFa2Aaw==
+react-native-test-app@^0.7.0:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/react-native-test-app/-/react-native-test-app-0.7.1.tgz#b645500b4d028d284e47ce67f24f374f66681a8e"
+  integrity sha512-8atrCOP3NGPxZdE291PkBe+CXIX+NLFCERPXeGBMDg/9uDtgjwqKZAHElX2zl92c628FlVzQwImiSab3fyOJ0g==
   dependencies:
     chalk "^4.1.0"
     prompts "^2.4.0"
@@ -17596,11 +17596,13 @@ worker-farm@^1.7.0:
   dependencies:
     errno "~0.1.7"
 
-workspace-tools@^0.15.0:
-  version "0.15.1"
-  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.15.1.tgz#895d4defe1417d7f4948b6afe9d36acf3a6cd64e"
-  integrity sha512-Thp+DVHkzjMF3JWWEc6VES04FhkE6QqZL7Dyknh1bJowjbAntXp6Op8/JuH0MYrww4AgQnuvB1O5waVrmsHtBg==
+workspace-tools@^0.12.3:
+  version "0.12.3"
+  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.12.3.tgz#71da0c7acdd65576cb7f666aca132abdbe5c3eb9"
+  integrity sha512-Toq4VI4GJw5naWxgXNU5/mmuu6PeiCRRZDkVOoeJacqQ6r0zRGWVBxE4YXQp2SADTKdC1ATwqsE+6bcJTZUmpA==
   dependencies:
+    "@pnpm/lockfile-file" "^3.0.7"
+    "@pnpm/logger" "^3.2.2"
     "@yarnpkg/lockfile" "^1.1.0"
     find-up "^4.1.0"
     find-yarn-workspace-root "^1.2.1"
@@ -17611,13 +17613,11 @@ workspace-tools@^0.15.0:
     multimatch "^4.0.0"
     read-yaml-file "^2.0.0"
 
-workspace-tools@^0.12.3:
-  version "0.12.3"
-  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.12.3.tgz#71da0c7acdd65576cb7f666aca132abdbe5c3eb9"
-  integrity sha512-Toq4VI4GJw5naWxgXNU5/mmuu6PeiCRRZDkVOoeJacqQ6r0zRGWVBxE4YXQp2SADTKdC1ATwqsE+6bcJTZUmpA==
+workspace-tools@^0.15.0:
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.15.1.tgz#895d4defe1417d7f4948b6afe9d36acf3a6cd64e"
+  integrity sha512-Thp+DVHkzjMF3JWWEc6VES04FhkE6QqZL7Dyknh1bJowjbAntXp6Op8/JuH0MYrww4AgQnuvB1O5waVrmsHtBg==
   dependencies:
-    "@pnpm/lockfile-file" "^3.0.7"
-    "@pnpm/logger" "^3.2.2"
     "@yarnpkg/lockfile" "^1.1.0"
     find-up "^4.1.0"
     find-yarn-workspace-root "^1.2.1"


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Bumps @rnx-kit/dep-check to 1.5.16 so we can start using `core` as a capability for pulling in `react-native`.

### Verification

There's nothing to test.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
