### PR TITLE
chore: use default type parameter to avoid banned types

### DIFF
--- a/change/@fluentui-react-native-button-26a0b320-422f-472d-bc52-1d7231586032.json
+++ b/change/@fluentui-react-native-button-26a0b320-422f-472d-bc52-1d7231586032.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Use default type parameter to avoid banned types",
+  "packageName": "@fluentui-react-native/button",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-contextual-menu-26611ec3-8c06-45fb-805c-67296502e870.json
+++ b/change/@fluentui-react-native-contextual-menu-26611ec3-8c06-45fb-805c-67296502e870.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Use default type parameter to avoid banned types",
+  "packageName": "@fluentui-react-native/contextual-menu",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-menu-button-cd35afdc-7d63-417c-a67c-1eabf3687628.json
+++ b/change/@fluentui-react-native-menu-button-cd35afdc-7d63-417c-a67c-1eabf3687628.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Use default type parameter to avoid banned types",
+  "packageName": "@fluentui-react-native/menu-button",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/components/Button/src/Button.android.tsx
+++ b/packages/components/Button/src/Button.android.tsx
@@ -66,8 +66,7 @@ export const Button = compose<IButtonType>({
     root: View,
     ripple: Pressable,
     stack: { slotType: View, filter: filterViewProps },
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    icon: { slotType: Icon as React.ComponentType<object> },
+    icon: { slotType: Icon as React.ComponentType },
     content: Text,
   },
   styles: {

--- a/packages/components/Button/src/Button.tsx
+++ b/packages/components/Button/src/Button.tsx
@@ -83,8 +83,7 @@ export const Button = compose<IButtonType>({
   slots: {
     root: View,
     stack: { slotType: View, filter: filterViewProps },
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    icon: { slotType: Icon as React.ComponentType<object> },
+    icon: { slotType: Icon as React.ComponentType },
     content: Text,
   },
   styles: {

--- a/packages/components/ContextualMenu/src/ContextualMenuItem.tsx
+++ b/packages/components/ContextualMenu/src/ContextualMenuItem.tsx
@@ -129,8 +129,7 @@ export const ContextualMenuItem = compose<ContextualMenuItemType>({
   slots: {
     root: View,
     stack: { slotType: View },
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    icon: { slotType: Icon as React.ComponentType<object> },
+    icon: { slotType: Icon as React.ComponentType },
     content: Text,
   },
   styles: {

--- a/packages/components/ContextualMenu/src/SubmenuItem.tsx
+++ b/packages/components/ContextualMenu/src/SubmenuItem.tsx
@@ -121,12 +121,10 @@ export const SubmenuItem = compose<SubmenuItemType>({
   slots: {
     root: View,
     leftstack: { slotType: View },
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    icon: { slotType: Icon as React.ComponentType<object> },
+    icon: { slotType: Icon as React.ComponentType },
     content: Text,
     rightstack: { slotType: View },
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    chevron: { slotType: Icon as React.ComponentType<object> }
+    chevron: { slotType: Icon as React.ComponentType }
   },
   styles: {
     root: [backgroundColorTokens, borderTokens],

--- a/packages/components/MenuButton/src/MenuButton.tsx
+++ b/packages/components/MenuButton/src/MenuButton.tsx
@@ -89,10 +89,8 @@ export const MenuButton = compose<MenuButtonType>({
   },
   slots: {
     root: React.Fragment,
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    button: { slotType: Button as React.ComponentType<object> },
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    contextualMenu: { slotType: ContextualMenu as React.ComponentType<object> },
+    button: { slotType: Button as React.ComponentType },
+    contextualMenu: { slotType: ContextualMenu as React.ComponentType },
     contextualMenuItems: React.Fragment,
   },
   styles: {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

The generic type parameter of `React.ComponentType` defaults to `{}` if unspecified. This means that the type parameter of `React.ComponentType<object>` is redundant, and we can avoid using a banned type.

### Verification

There's nothing to test.

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
