### PR TITLE
🐛 Export compressible from @fluentui-react-native/framework

### DIFF
--- a/change/@fluentui-react-native-framework-b86661f7-c5e3-4489-9355-58aa88a12198.json
+++ b/change/@fluentui-react-native-framework-b86661f7-c5e3-4489-9355-58aa88a12198.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "🐛 Export compressible from @furn/framework",
+  "packageName": "@fluentui-react-native/framework",
+  "email": "aliciakds88@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/framework/framework/src/index.ts
+++ b/packages/framework/framework/src/index.ts
@@ -6,5 +6,6 @@ export * from '@fluentui-react-native/use-slots';
 export * from '@fluentui-react-native/immutable-merge';
 export * from '@fluentui-react-native/theme-types';
 export * from './compose';
+export * from './compressible';
 export * from './useStyling';
 export * from './useTokens';


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Jason added compressible as an optional way to write components, but he didn't export it from the index of the package he added it to.

### Verification

I made component using it (separate PR)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
