### PR TITLE
Fix compressible type issue and export it

### DIFF
--- a/change/@fluentui-react-native-framework-6c558a96-0f19-42d5-836b-93111f1aa679.json
+++ b/change/@fluentui-react-native-framework-6c558a96-0f19-42d5-836b-93111f1aa679.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix type issue in compressible and export it",
+  "packageName": "@fluentui-react-native/framework",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/framework/framework/src/compressible.ts
+++ b/packages/framework/framework/src/compressible.ts
@@ -6,16 +6,17 @@ import { TokenSettings } from './useStyling';
 
 export function compressible<TProps, TTokens>(
   fn: StagedRender<TProps>,
-  useTokens?: UseTokens<TTokens>,
+  useTokens: UseTokens<TTokens>,
 ): CustomizableComponent<TProps, TTokens, Theme> {
-  const injectedWrapper = (props: TProps) => fn(props, useTokens);
-  const component: CustomizableComponent<TProps, TTokens, Theme> = stagedComponent(injectedWrapper);
+  type ThisComponent = CustomizableComponent<TProps, TTokens, Theme>;
 
-  if (useTokens) {
-    component.customize = (...tokens: TokenSettings<TTokens>[]) => {
-      const useTokensNew = useTokens.customize(...tokens);
-      return compressible(fn, useTokensNew);
-    };
-  }
+  const injectedWrapper = (props: TProps) => fn(props, useTokens);
+  const component = stagedComponent(injectedWrapper) as ThisComponent;
+
+  component.customize = (...tokens: TokenSettings<TTokens>[]) => {
+    const useTokensNew = useTokens.customize(...tokens);
+    return compressible(fn, useTokensNew);
+  };
+
   return component;
 }

--- a/packages/framework/framework/src/index.ts
+++ b/packages/framework/framework/src/index.ts
@@ -6,5 +6,6 @@ export * from '@fluentui-react-native/use-slots';
 export * from '@fluentui-react-native/immutable-merge';
 export * from '@fluentui-react-native/theme-types';
 export * from './compose';
+export * from './compressible';
 export * from './useStyling';
 export * from './useTokens';


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

When Alicia made the PR to export compressible correctly the web bundler surfaced a type issue though I'm not sure why it didn't surface in the local builds. Regardless this brought up a couple of things:

- it was a mistake to have the optional useTokens parameter, it needs to be required. This is because the returned type has a required .customize() helper but opting out of useTokens would cause .customize to be undefined.
- Also as a follow up for factory type functions the returned type can't really be conditional. TS just isn't smart enough to infer it correctly and it makes the usage difficult.
- The type error itself was the common issue of a function with an attached static that is required complaining that the static isn't set yet when you create the function. I don't know an easy way to bypass this. Maybe {() => {}, static: () => {}| syntax? I don't know, I need to play with it.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
