### PR TITLE
chore: use @rnx-kit/jest-preset

### DIFF
--- a/scripts/package.json
+++ b/scripts/package.json
@@ -27,6 +27,7 @@
     "@babel/preset-typescript": "^7.8.0",
     "@microsoft/api-extractor": "^7.3.7",
     "@react-native-community/cli": "^4.14.0",
+    "@rnx-kit/jest-preset": "^0.1.0",
     "@types/enzyme": "^3.10.5",
     "@types/es6-collections": "^0.5.29",
     "@types/es6-promise": "0.0.32",

--- a/scripts/src/configs/configureJest.ts
+++ b/scripts/src/configs/configureJest.ts
@@ -1,10 +1,9 @@
-'use strict';
-
+import jestPreset from '@rnx-kit/jest-preset';
 import path from 'path';
-import { mergeConfigs } from './mergeConfigs';
 import { getPackageInfos } from 'workspace-tools';
-import { nodeModulesToRoot, resolveModule } from '../utils/resolvePaths';
-import { ensurePlatform, PlatformValue, getRNVersion, getAllPlatforms } from '../utils/platforms';
+import { mergeConfigs } from './mergeConfigs';
+import { ensurePlatform, PlatformValue } from '../utils/platforms';
+import { nodeModulesToRoot } from '../utils/resolvePaths';
 
 const moduleFileExtensions = ['ts', 'tsx', 'js', 'jsx', 'json'];
 
@@ -44,33 +43,10 @@ export function configureJest(customConfig?: object): object {
 }
 
 export function configureReactNativeJest(platform?: PlatformValue, customConfig?: object): object {
-  platform = ensurePlatform(platform, 'ios');
-  const rnPackage = getRNVersion(platform);
-  const rnPath = resolveModule(rnPackage) + '/';
-  console.log(rnPath);
-  console.log(platform);
-  console.log(require.resolve(rnPackage));
-
-  return mergeConfigs(
-    {
-      roots: ['<rootDir>/src', rnPath],
-      moduleFileExtensions,
-      transform: {
-        '^.+\\.(js|ts|tsx)?$': ['babel-jest', { cwd: __dirname, presets: ['module:metro-react-native-babel-preset'] }],
-      },
-      preset: 'react-native',
-      moduleNameMapper: {
-        '^react-native$': require.resolve(rnPackage),
-        '^react-native/(.*)': rnPath + '$1',
-      },
-      haste: {
-        defaultPlatform: platform,
-        platforms: getAllPlatforms(),
-      },
-      transformIgnorePatterns: ['node_modules/(?!(react-native)/)'],
-      verbose: false,
-      setupFilesAfterEnv: [path.join(__dirname, 'jest', 'setupEnzyme.js')],
-    },
-    customConfig,
-  );
+  return jestPreset(ensurePlatform(platform, 'ios'), {
+    roots: ['<rootDir>/src'],
+    verbose: false,
+    setupFilesAfterEnv: [path.join(__dirname, 'jest', 'setupEnzyme.js')],
+    ...customConfig,
+  });
 }

--- a/scripts/src/utils/platforms.ts
+++ b/scripts/src/utils/platforms.ts
@@ -14,26 +14,6 @@ const _rnVersions: { [key in PlatformValue]: string } = {
   windows: 'react-native-windows'
 };
 
-export function getRNVersion(platform?: PlatformValue): string {
-  return (platform && _rnVersions[platform]) || _rnVersions.default;
-}
-
-export function getAllRNVersions(): string[] {
-  return Object.keys(_rnVersions)
-    .map(ver => _rnVersions[ver])
-    .filter(pkg => {
-      try {
-        return require.resolve(pkg);
-      } catch {
-        return false;
-      }
-    });
-}
-
-export function getAllPlatforms(): string[] {
-  return Object.keys(_rnVersions).filter(plat => plat !== _defaultPlatform);
-}
-
 export function findPlatformFromArgv(toSet?: PlatformValue): PlatformValue | undefined {
   for (let index = 0; index < process.argv.length; index++) {
     if (process.argv[index] === '--platform') {
@@ -58,8 +38,4 @@ export function ensurePlatform(platform?: PlatformValue, defaultOverride?: Platf
     process.argv.push('--platform', platform);
   }
   return platform || defaultOverride || _defaultPlatform;
-}
-
-export function findReactNativePackage(): string {
-  return getRNVersion(findPlatform());
 }

--- a/scripts/src/utils/resolvePaths.ts
+++ b/scripts/src/utils/resolvePaths.ts
@@ -1,8 +1,6 @@
-'use strict';
-
+import findUp from 'find-up';
 import fs from 'fs';
 import path from 'path';
-import findUp from 'find-up';
 
 export function nodeModulesToRoot(): string[] {
   const results = [];
@@ -16,35 +14,4 @@ export function nodeModulesToRoot(): string[] {
     return fs.existsSync(gitRoot) ? findUp.stop : undefined;
   });
   return results;
-}
-
-/**
- * take a path, call path.normalize, then make sure it uses forward slashes
- * @param base - path to put into forward slashed form
- */
-export function normalizeToUnixPath(base: string): string {
-  return path.normalize(base).replace(/\\/g, '/');
-}
-
-function queryModule(name: string, direct?: boolean): string {
-  const cur = direct
-    ? path.resolve(require.resolve(name, { paths: [process.cwd()] }))
-    : path.resolve(require.resolve(name + '/package.json', { paths: [process.cwd()] }), '..');
-  return normalizeToUnixPath(fs.realpathSync(cur));
-}
-
-/**
- * Resolve a module to a true, normalized, non-symlink path
- * @param moduleName - name of the module to resolve
- */
-export function resolveModule(moduleName: string): string {
-  return queryModule(moduleName);
-}
-
-/**
- * Resolve a file reference to a true, normalized, non-symlink path
- * @param fileName - file to resolve
- */
-export function resolveFile(fileName: string) {
-  return queryModule(fileName, true);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -992,7 +992,7 @@
     core-js "^2.6.5"
     regenerator-runtime "^0.13.4"
 
-"@babel/preset-env@^7.8.0":
+"@babel/preset-env@^7.0.0", "@babel/preset-env@^7.8.0":
   version "7.14.8"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.14.8.tgz#254942f5ca80ccabcfbb2a9f524c74bca574005b"
   integrity sha512-a9aOppDU93oArQ51H+B8M1vH+tayZbuBqzjOhntGetZVa+4tTu5jp+XTwqHGG2lxslqomPYVSjIxQkFwXzgnxg==
@@ -1094,7 +1094,7 @@
     "@babel/plugin-transform-react-jsx-development" "^7.12.17"
     "@babel/plugin-transform-react-pure-annotations" "^7.12.1"
 
-"@babel/preset-typescript@^7.8.0":
+"@babel/preset-typescript@^7.0.0", "@babel/preset-typescript@^7.8.0":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.14.5.tgz#aa98de119cf9852b79511f19e7f44a2d379bcce0"
   integrity sha512-u4zO6CdbRKbS9TypMqrlGH7sd2TAJppZwn3c/ZRLeO/wGsbddxgbPDUZVNrie3JWYLQ9vpineKlsrWFvO6Pwkw==
@@ -2458,6 +2458,15 @@
     semver "^7.0.0"
     workspace-tools "^0.16.2"
     yargs "^16.0.0"
+
+"@rnx-kit/jest-preset@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@rnx-kit/jest-preset/-/jest-preset-0.1.0.tgz#e1863a3962e703ec31ea425e50fd8ce1242f4bae"
+  integrity sha512-6d3B7c1eHCoJ2npolnJwcKhM5lgDL7Ipx3ui8H3iTA2++D0FV7XmC7Vp+okK4ZH3H1Y7+HZvXmSM7Rw5pK668g==
+  dependencies:
+    "@babel/preset-env" "^7.0.0"
+    "@babel/preset-typescript" "^7.0.0"
+    find-up "^5.0.0"
 
 "@rnx-kit/metro-config@^1.2.3":
   version "1.2.3"


### PR DESCRIPTION
### Platforms Impacted

- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

`@rnx-kit/jest-preset` embeds a significant portion of what `configureJest` does, including configuring `jest-haste-map` to pick up the correct platform extensions, remapping `react-native`, and transpiling TypeScript.

### Verification

All existing tests should pass.

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
