### PR TITLE
Fix icon depending on theme being available

### DIFF
--- a/change/@fluentui-react-native-icon-cbd8fdac-3f04-446e-8b8f-033d961d88c8.json
+++ b/change/@fluentui-react-native-icon-cbd8fdac-3f04-446e-8b8f-033d961d88c8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Quickly fix icon bug",
+  "packageName": "@fluentui-react-native/icon",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Icon/src/Icon.tsx
+++ b/packages/experimental/Icon/src/Icon.tsx
@@ -7,6 +7,7 @@ import { stagedComponent, mergeProps, getMemoCache } from '@fluentui-react-nativ
 import { useTheme } from '@fluentui-react-native/theme-types';
 import { getCurrentAppearance } from '@fluentui-react-native/theming-utils';
 import { SvgUri } from 'react-native-svg';
+import { defaultFluentTheme } from '@fluentui-react-native/default-theme';
 
 const rasterImageStyleCache = getMemoCache<ImageStyle>();
 
@@ -58,7 +59,7 @@ function renderSvg(iconProps: IconProps) {
 
   // react-native-svg is still on 0.61, and their color prop doesn't handle ColorValue
   // If a color for the icon is not supplied, fall back to white or black depending on appearance
-  const theme = useTheme();
+  const theme = useTheme() || defaultFluentTheme;
   const iconColor = svgIconProps.color
     ? svgIconProps.color
     : getCurrentAppearance(theme.host.appearance, 'light') === 'dark'
@@ -83,7 +84,7 @@ function renderSvg(iconProps: IconProps) {
 }
 
 export const Icon = stagedComponent((props: IconProps) => {
-  const theme = useTheme();
+  const theme = useTheme() || defaultFluentTheme;
 
   return (rest: IconProps) => {
     const color = props.color || theme.colors.buttonText;


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Icon currently depends on theme provider being used, which is not a strict requirement. Add defaultThemeFluent to calls of useTheme() in case theme is not available.

This should be replaced with the useFluentTheme hook in the future, but we should unblock people first while that's being sorted out.

### Verification

Verified in tester that issue is fixed.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
