### PR TITLE
Focus zone empty tabbable

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/FocusZone/FocusZoneTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/FocusZone/FocusZoneTest.tsx
@@ -80,29 +80,37 @@ const commonUsageFocusZone: React.FunctionComponent = () => {
 };
 
 const navigation2DFocusZone: React.FunctionComponent = () => {
-  const buttonRef = React.useRef<View>(null);
+  const buttonRefs = [];
+  const onClicks = [];
+  const [defaultTabbableElementIndex, setDefaultTabbableElementIndex] = React.useState<number>(5);
+
+  for (let i = 0; i <= 9; i++) {
+    buttonRefs.push(i == 0 ? undefined : React.useRef<View>(null));
+    onClicks.push(React.useCallback(() => { setDefaultTabbableElementIndex(i); }, [setDefaultTabbableElementIndex]));
+  }
 
   return (
     <View>
       <View>
         <Button content="Outside FocusZone" />
+        <Button content="Clear default tabble element" onClick={onClicks[0]} />
       </View>
-      <FocusZone use2DNavigation={true} defaultTabbableElement={buttonRef} isCircularNavigation={true}>
+      <FocusZone use2DNavigation={true} defaultTabbableElement={buttonRefs[defaultTabbableElementIndex]} isCircularNavigation={true}>
         <View style={focusZoneTestStyles.focusZoneContainer}>
           <View style={focusZoneTestStyles.focusZoneViewStyle}>
-            <Button content="#1" style={focusZoneTestStyles.focusZoneButton} />
-            <Button content="#2" style={focusZoneTestStyles.focusZoneButton} />
-            <Button content="#3" style={focusZoneTestStyles.focusZoneButton} />
+            <Button content="#1" style={focusZoneTestStyles.focusZoneButton} componentRef={buttonRefs[1]} onClick={onClicks[1]} />
+            <Button content="#2" style={focusZoneTestStyles.focusZoneButton} componentRef={buttonRefs[2]} onClick={onClicks[2]} />
+            <Button content="#3" style={focusZoneTestStyles.focusZoneButton} componentRef={buttonRefs[3]} onClick={onClicks[3]} />
           </View>
           <View style={focusZoneTestStyles.focusZoneViewStyle}>
-            <Button content="#4" style={focusZoneTestStyles.focusZoneButton} />
-            <Button content="#5" style={focusZoneTestStyles.focusZoneButton} componentRef={buttonRef} />
-            <Button content="#6" style={focusZoneTestStyles.focusZoneButton} />
+            <Button content="#4" style={focusZoneTestStyles.focusZoneButton} componentRef={buttonRefs[4]} onClick={onClicks[4]} />
+            <Button content="#5" style={focusZoneTestStyles.focusZoneButton} componentRef={buttonRefs[5]} onClick={onClicks[5]} />
+            <Button content="#6" style={focusZoneTestStyles.focusZoneButton} componentRef={buttonRefs[6]} onClick={onClicks[6]} />
           </View>
           <View style={focusZoneTestStyles.focusZoneViewStyle}>
-            <Button content="#7" style={focusZoneTestStyles.focusZoneButton} />
-            <Button content="#8" style={focusZoneTestStyles.focusZoneButton} />
-            <Button content="#9" style={focusZoneTestStyles.focusZoneButton} />
+            <Button content="#7" style={focusZoneTestStyles.focusZoneButton} componentRef={buttonRefs[7]} onClick={onClicks[7]} />
+            <Button content="#8" style={focusZoneTestStyles.focusZoneButton} componentRef={buttonRefs[8]} onClick={onClicks[8]} />
+            <Button content="#9" style={focusZoneTestStyles.focusZoneButton} componentRef={buttonRefs[9]} onClick={onClicks[9]} />
           </View>
         </View>
       </FocusZone>

--- a/change/@fluentui-react-native-focus-zone-0865e2c5-64e0-4be0-a6e7-304fdd7c3679.json
+++ b/change/@fluentui-react-native-focus-zone-0865e2c5-64e0-4be0-a6e7-304fdd7c3679.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixing empty default tabbable",
+  "packageName": "@fluentui-react-native/focus-zone",
+  "email": "nakambo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-a29c5478-9b30-4db5-bc91-534782809f77.json
+++ b/change/@fluentui-react-native-tester-a29c5478-9b30-4db5-bc91-534782809f77.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add actions for changing default tabbable",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "nakambo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/FocusZone/src/FocusZone.ts
+++ b/packages/components/FocusZone/src/FocusZone.ts
@@ -20,6 +20,8 @@ export const FocusZone = composable<FocusZoneType>({
     React.useLayoutEffect(() => {
       if (defaultTabbableElement?.current) {
         setTargetNativeTag(findNodeHandle(defaultTabbableElement.current));
+      } else {
+        setTargetNativeTag(undefined);
       }
     }, [defaultTabbableElement]);
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

There's code in Focus Zone written in a way such that once a default tabbable element is set, it can never be reset, no matter if the user of the focus zone passes a `undefined` defaultTabbableElement, or not pass it at all. Let's tweak that a little so that not-passing\resetting the defaultTabbableElement has the same effect as never having it set in the first place.

### Verification

Manual testing:

- Added action in the FocusZoneTest component to test the effect of setting any of the nine buttons as the default tabbable element plus another to clear it and checked that clearing the default tabbable makes the focus zone behave as expected (as if one was never set)
- Checked this sequence: set -> clear -> set -> clear

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [x] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
