### PR TITLE
Fix usage of conditional hooks

### DIFF
--- a/change/@fluentui-react-native-button-3af61ccd-ab0e-4c6b-89cc-4df652833ff7.json
+++ b/change/@fluentui-react-native-button-3af61ccd-ab0e-4c6b-89cc-4df652833ff7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix usage of conditional hooks",
+  "packageName": "@fluentui-react-native/button",
+  "email": "nakambo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-checkbox-3e34480f-33f8-420e-a249-fa0a2088b16d.json
+++ b/change/@fluentui-react-native-checkbox-3e34480f-33f8-420e-a249-fa0a2088b16d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix usage of conditional hooks",
+  "packageName": "@fluentui-react-native/checkbox",
+  "email": "nakambo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-contextual-menu-2cd19085-6930-4ef1-8ec1-3db043abbffb.json
+++ b/change/@fluentui-react-native-contextual-menu-2cd19085-6930-4ef1-8ec1-3db043abbffb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix usage of conditional hooks",
+  "packageName": "@fluentui-react-native/contextual-menu",
+  "email": "nakambo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-button-c98fa621-8307-4f3d-b4cc-1d6a5c9c34c5.json
+++ b/change/@fluentui-react-native-experimental-button-c98fa621-8307-4f3d-b4cc-1d6a5c9c34c5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix usage of conditional hooks",
+  "packageName": "@fluentui-react-native/experimental-button",
+  "email": "nakambo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-link-9fd2a1f1-3b3c-4e2a-a07f-de279b0cff82.json
+++ b/change/@fluentui-react-native-link-9fd2a1f1-3b3c-4e2a-a07f-de279b0cff82.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix usage of conditional hooks",
+  "packageName": "@fluentui-react-native/link",
+  "email": "nakambo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-radio-group-4a6cd34e-5336-4b6b-8d6a-aa73e1ddb4cd.json
+++ b/change/@fluentui-react-native-radio-group-4a6cd34e-5336-4b6b-8d6a-aa73e1ddb4cd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix usage of conditional hooks",
+  "packageName": "@fluentui-react-native/radio-group",
+  "email": "nakambo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Button/src/Button.tsx
+++ b/packages/components/Button/src/Button.tsx
@@ -21,12 +21,13 @@ import { Icon } from '@fluentui-react-native/icon';
 export const Button = compose<IButtonType>({
   displayName: buttonName,
   usePrepareProps: (userProps: IButtonProps, useStyling: IUseComposeStyling<IButtonType>) => {
+    const defaultComponentRef = React.useRef(null);
     const {
       icon,
       content,
       onAccessibilityTap = userProps.onClick,
       accessibilityLabel = userProps.content,
-      componentRef = React.useRef(null),
+      componentRef = defaultComponentRef,
       testID,
       onClick,
       ...rest

--- a/packages/components/Checkbox/src/Checkbox.tsx
+++ b/packages/components/Checkbox/src/Checkbox.tsx
@@ -23,6 +23,7 @@ export const Checkbox = compose<ICheckboxType>({
   displayName: checkboxName,
 
   usePrepareProps: (userProps: ICheckboxProps, useStyling: IUseComposeStyling<ICheckboxType>) => {
+    const defaultComponentRef = React.useRef(null);
     const {
       ariaLabel,
       checked,
@@ -31,7 +32,7 @@ export const Checkbox = compose<ICheckboxType>({
       disabled,
       label,
       onChange,
-      componentRef = React.useRef(null),
+      componentRef = defaultComponentRef,
       ...rest
     } = userProps;
 

--- a/packages/components/ContextualMenu/src/ContextualMenuItem.tsx
+++ b/packages/components/ContextualMenu/src/ContextualMenuItem.tsx
@@ -23,6 +23,7 @@ import { createIconProps } from '@fluentui-react-native/interactive-hooks';
 export const ContextualMenuItem = compose<ContextualMenuItemType>({
   displayName: contextualMenuItemName,
   usePrepareProps: (userProps: ContextualMenuItemProps, useStyling: IUseComposeStyling<ContextualMenuItemType>) => {
+    const defaultComponentRef = React.useRef(null);
     const {
       disabled,
       itemKey,
@@ -31,7 +32,7 @@ export const ContextualMenuItem = compose<ContextualMenuItemType>({
       accessibilityLabel = userProps.text,
       onClick,
       testID,
-      componentRef = React.useRef(null),
+      componentRef = defaultComponentRef,
       ...rest
     } = userProps;
 

--- a/packages/components/ContextualMenu/src/SubmenuItem.tsx
+++ b/packages/components/ContextualMenu/src/SubmenuItem.tsx
@@ -23,6 +23,7 @@ import { createIconProps } from '@fluentui-react-native/interactive-hooks';
 export const SubmenuItem = compose<SubmenuItemType>({
   displayName: submenuItemName,
   usePrepareProps: (userProps: SubmenuItemProps, useStyling: IUseComposeStyling<SubmenuItemType>) => {
+    const defaultComponentRef = React.useRef(null);
     const {
       disabled,
       itemKey,
@@ -31,7 +32,7 @@ export const SubmenuItem = compose<SubmenuItemType>({
       accessibilityLabel = userProps.text,
       onClick,
       testID,
-      componentRef = React.useRef(null),
+      componentRef = defaultComponentRef,
       ...rest
     } = userProps;
 

--- a/packages/components/Link/src/Link.tsx
+++ b/packages/components/Link/src/Link.tsx
@@ -54,7 +54,8 @@ export const Link = compose<ILinkType>({
   displayName: linkName,
   settings,
   usePrepareProps: (userProps: ILinkProps, useStyling: IUseComposeStyling<ILinkType>): ILinkRenderData => {
-    const { content, onAccessibilityTap, componentRef = React.useRef(null), ...rest } = userProps;
+    const defaultComponentRef = React.useRef(null);
+    const { content, onAccessibilityTap, componentRef = defaultComponentRef, ...rest } = userProps;
 
     const [linkProps, linkState] = useAsLink(rest, componentRef);
     const onAccTap = onAccessibilityTap ? onAccessibilityTap : linkProps.onPress;

--- a/packages/components/RadioGroup/src/RadioButton.tsx
+++ b/packages/components/RadioGroup/src/RadioButton.tsx
@@ -17,7 +17,8 @@ export const RadioButton = compose<IRadioButtonType>({
   displayName: radioButtonName,
 
   usePrepareProps: (userProps: IRadioButtonProps, useStyling: IUseComposeStyling<IRadioButtonType>) => {
-    const { content, buttonKey, disabled, ariaLabel, componentRef = React.useRef(null), ariaPosInSet, ariaSetSize, ...rest } = userProps;
+    const defaultComponentRef = React.useRef(null);
+    const { content, buttonKey, disabled, ariaLabel, componentRef = defaultComponentRef, ariaPosInSet, ariaSetSize, ...rest } = userProps;
 
     // Grabs the context information from RadioGroup (currently selected button and client's onChange callback)
     const info = React.useContext(RadioGroupContext);

--- a/packages/experimental/Button/src/useButton.ts
+++ b/packages/experimental/Button/src/useButton.ts
@@ -4,7 +4,8 @@ import { ButtonProps, ButtonState } from './Button.types';
 
 export const useButton = (props: ButtonProps): ButtonState => {
   // attach the pressable state handlers
-  const { onClick, componentRef = React.useRef(null), ...rest } = props;
+  const defaultComponentRef = React.useRef(null);
+  const { onClick, componentRef = defaultComponentRef, ...rest } = props;
   const onClickWithFocus = useOnPressWithFocus(componentRef, onClick);
   const pressable = useAsPressable({ ...rest, onPress: onClickWithFocus });
   const onKeyUp = useKeyCallback(onClick, ' ', 'Enter');


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

There are various places in code where we do something like the following, which probably intends to read as grab the `componentRef` from `userProps` if present, otherwise make a new one:

`const { componentRef = React.useRef(null), ... rest } = userProps`

However, this is problematic if during one render pass a given component does not receive `componentRef` (so we make a ref) and in the next render pass it does (so we never try to use that ref we made earlier). The reason this is specifically problematic is that the `React.useRef(null)` **will not be called** if we were successful in extracting `componentRef` from `props`.

The implication here is that we invalidate a very important [rule of hooks](https://fb.me/rules-of-hooks/) -- that they must always be called in the same order. This will in turn lead to unexpected error messages in downstream\client code that uses Fluent components like the below:

> Warning: React has detected a change in the order of Hooks called by Button. This will lead to bugs and errors if not fixed. For more information, read the Rules of Hooks: https://fb.me/rules-of-hooks
> 
>    Previous render            Next render
>    ------------------------------------------------------
> 1. useMemo                    useMemo
> 2. useRef                     useCallback
>    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

To fix, let's just make sure we always call `React.useRef(null)` -- we can still toss it aside if not wanted by slightly tweaking how the code is structured.

### Verification

Testing:

* Sanity tested button, checkbox, and radio button components in the Win32 fluent tester
* I didn't attempt to repro the problem in the Fluent tester, but did validate the fix in the product where I originally discovered this problem.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
