### PR TITLE
Create useFluentTheme hook

### DIFF
--- a/change/@fluentui-react-native-framework-0d8da418-0398-4770-80f0-9b6ee21a99c2.json
+++ b/change/@fluentui-react-native-framework-0d8da418-0398-4770-80f0-9b6ee21a99c2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "create useFluentTheme helper",
+  "packageName": "@fluentui-react-native/framework",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-icon-a72522c5-2d5c-4e2e-bc41-a3b546cd74d7.json
+++ b/change/@fluentui-react-native-icon-a72522c5-2d5c-4e2e-bc41-a3b546cd74d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "create useFluentTheme helper",
+  "packageName": "@fluentui-react-native/icon",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Icon/src/Icon.tsx
+++ b/packages/experimental/Icon/src/Icon.tsx
@@ -2,12 +2,10 @@ import * as React from 'react';
 import { IconProps, SvgIconProps, FontIconProps } from './Icon.types';
 import { Image, ImageStyle, Platform, View } from 'react-native';
 import { Text } from '@fluentui-react-native/text';
-import { mergeStyles } from '@fluentui-react-native/framework';
+import { mergeStyles, useFluentTheme } from '@fluentui-react-native/framework';
 import { stagedComponent, mergeProps, getMemoCache } from '@fluentui-react-native/framework';
-import { useTheme } from '@fluentui-react-native/theme-types';
 import { getCurrentAppearance } from '@fluentui-react-native/theming-utils';
 import { SvgUri } from 'react-native-svg';
-import { defaultFluentTheme } from '@fluentui-react-native/default-theme';
 
 const rasterImageStyleCache = getMemoCache<ImageStyle>();
 
@@ -59,7 +57,7 @@ function renderSvg(iconProps: IconProps) {
 
   // react-native-svg is still on 0.61, and their color prop doesn't handle ColorValue
   // If a color for the icon is not supplied, fall back to white or black depending on appearance
-  const theme = useTheme() || defaultFluentTheme;
+  const theme = useFluentTheme();
   const iconColor = svgIconProps.color
     ? svgIconProps.color
     : getCurrentAppearance(theme.host.appearance, 'light') === 'dark'
@@ -84,7 +82,7 @@ function renderSvg(iconProps: IconProps) {
 }
 
 export const Icon = stagedComponent((props: IconProps) => {
-  const theme = useTheme() || defaultFluentTheme;
+  const theme = useFluentTheme();
 
   return (rest: IconProps) => {
     const color = props.color || theme.colors.buttonText;

--- a/packages/framework/framework/src/index.ts
+++ b/packages/framework/framework/src/index.ts
@@ -7,5 +7,6 @@ export * from '@fluentui-react-native/immutable-merge';
 export * from '@fluentui-react-native/theme-types';
 export * from './compose';
 export * from './compressible';
+export * from './useFluentTheme';
 export * from './useStyling';
 export * from './useTokens';

--- a/packages/framework/framework/src/themeHelper.ts
+++ b/packages/framework/framework/src/themeHelper.ts
@@ -1,9 +1,9 @@
 import { ThemeHelper } from '@fluentui-react-native/use-styling';
-import { Theme, useTheme } from '@fluentui-react-native/theme-types';
-import { defaultFluentTheme } from '@fluentui-react-native/default-theme';
+import { Theme } from '@fluentui-react-native/theme-types';
+import { useFluentTheme } from './useFluentTheme';
 
 export const themeHelper: ThemeHelper<Theme> = {
-  useTheme: () => useTheme() || defaultFluentTheme,
+  useTheme: () => useFluentTheme(),
   getComponentInfo: (theme: Theme, name: string) => {
     const components = theme.components || {};
     return components[name];

--- a/packages/framework/framework/src/useFluentTheme.ts
+++ b/packages/framework/framework/src/useFluentTheme.ts
@@ -1,0 +1,11 @@
+import { defaultFluentTheme } from '@fluentui-react-native/default-theme';
+import { Theme, useTheme } from '@fluentui-react-native/theme-types';
+
+/**
+ * Attempts to obtain a theme via the react context, failing that the default fluent theme will be returned. Used to ensure some theme
+ * object is provided for looking up color (and other) theme values
+ * @returns - a valid Theme object
+ */
+export function useFluentTheme(): Theme {
+  return useTheme() || defaultFluentTheme;
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This is split out from the experimental-text PR and creates a useFluentTheme helper which will try to obtain the theme from the context and will fall back to the default fluent theme.

This is important as people start building components that query the theme directly to ensure we standardize. The Icon component is an example of this and so part of this PR switches the usage in there.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
