### PR TITLE
Add patchTokens utility to use-tokens package

### DIFF
--- a/change/@fluentui-react-native-use-tokens-3aaeac88-f397-495d-b0c3-0ff6f7e7f797.json
+++ b/change/@fluentui-react-native-use-tokens-3aaeac88-f397-495d-b0c3-0ff6f7e7f797.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add patchTokens utility to use-tokens package",
+  "packageName": "@fluentui-react-native/use-tokens",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/framework/use-tokens/src/index.ts
+++ b/packages/framework/use-tokens/src/index.ts
@@ -2,3 +2,4 @@ export * from './applyPropsToTokens';
 export * from './applyTokenLayers';
 export * from './buildUseTokens';
 export * from './customizable';
+export * from './patchTokens';

--- a/packages/framework/use-tokens/src/patchTokens.test.ts
+++ b/packages/framework/use-tokens/src/patchTokens.test.ts
@@ -1,0 +1,50 @@
+import { patchTokens } from './patchTokens';
+import { getMemoCache } from '@fluentui-react-native/memo-cache';
+
+interface Tokens {
+  uno?: string;
+  dos?: string;
+  tres?: number;
+  quatro?: string | number;
+  cinco?: boolean;
+}
+
+const themeTokens: Tokens = {
+  uno: 'uno',
+  dos: 'dos',
+  tres: 3,
+  quatro: 4,
+  cinco: true,
+};
+
+describe('patchTokens tests', () => {
+  test('props get copied', () => {
+    const cache = getMemoCache();
+    const patchValues = { uno: 'one', quatro: 'quatro' };
+    const [tokens] = patchTokens(themeTokens, cache, patchValues);
+    expect(tokens).not.toBe(themeTokens);
+    for (const key in patchValues) {
+      expect(tokens[key]).toEqual(patchValues[key]);
+    }
+  });
+
+  test('no copied props does not change tokens', () => {
+    const cache = getMemoCache();
+    const patchValues1 = {};
+    const [tokens] = patchTokens(themeTokens, cache, patchValues1);
+    expect(tokens).toBe(themeTokens);
+
+    const patchValues2 = { tres: undefined };
+    const [tokens2] = patchTokens(themeTokens, cache, patchValues2);
+    expect(tokens2).toBe(themeTokens);
+  });
+
+  test('patching tokens cache independent of order', () => {
+    const cache = getMemoCache();
+    const patch1 = { uno: 'one', cinco: false };
+    const patch2 = { cinco: false, uno: 'one' };
+    const [tokens1] = patchTokens(themeTokens, cache, patch1);
+    const [tokens2] = patchTokens(themeTokens, cache, patch2);
+    expect(tokens1).toBe(tokens2);
+  });
+});

--- a/packages/framework/use-tokens/src/patchTokens.ts
+++ b/packages/framework/use-tokens/src/patchTokens.ts
@@ -1,0 +1,30 @@
+import { GetMemoValue } from '@fluentui-react-native/memo-cache';
+
+/**
+ * Take a set of tokens (and a memo-cache) and apply changes to those tokens from an additional set of tokens. Only keys which are
+ * not undefined will be applied and if no changes are detected the token object will be unchanged.
+ *
+ * @param tokens - base set of tokens to apply changes to, this will not be modified
+ * @param cache - cache corresponding to this set of tokens
+ * @param patchValues - new values to apply, values will be obtained via keys in the object
+ * @returns - a tuple consisting of a new tokens object and a new memo-cache
+ */
+export function patchTokens<TTokens>(
+  tokens: TTokens,
+  cache: GetMemoValue<TTokens>,
+  patchValues: TTokens,
+): [TTokens, GetMemoValue<TTokens>] {
+  // reduce the patch values to the set of keys that are defined, and sort them to ensure consistent ordering
+  const keys = Object.keys(patchValues)
+    .filter((v) => patchValues[v] !== undefined)
+    .sort();
+
+  // for each key get an updated tokens collection based on key + value. Value alone isn't sufficient as the values
+  // are not necessarily unique. i.e. { a: 'blue' } and { b: 'blue' } would cache to the same without the key
+  for (const key of keys) {
+    [tokens, cache] = cache(() => ({ ...tokens, [key]: patchValues[key] }), [key, patchValues[key]]);
+  }
+
+  // return the updated tokens and cache (if there were any keys applied)
+  return [tokens, cache];
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This creates a patchTokens utility in the use-tokens package which is a cleaner way of patching the set of tokens and caching the result. This can be used for props which are also tokens or any other calculated override values.

Split out of the experimental-text PR

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
