### PR TITLE
Add ability to update brand tokens

### DIFF
--- a/apps/fluent-tester/src/FluentTester/theme/applyBrand.ts
+++ b/apps/fluent-tester/src/FluentTester/theme/applyBrand.ts
@@ -1,5 +1,21 @@
 export type OfficeBrand = 'Default' | 'Office' | 'Word' | 'Excel' | 'Powerpoint' | 'Outlook';
-type BrandRampKey = 'App1' | 'App2' | 'App3' | 'App4' | 'App5' | 'App6' | 'App7' | 'App8';
+type BrandRampKey =
+  | 'App1'
+  | 'App2'
+  | 'App3'
+  | 'App4'
+  | 'App5'
+  | 'App6'
+  | 'App7'
+  | 'App8'
+  | 'AppTint40'
+  | 'AppTint30'
+  | 'AppTint20'
+  | 'AppTint10'
+  | 'AppPrimary'
+  | 'AppShade10'
+  | 'AppShade20'
+  | 'AppShade30';
 type BrandRamps = { [K in OfficeBrand]: { [J in BrandRampKey]: string } };
 
 const brandColors: BrandRamps = {
@@ -19,6 +35,14 @@ const brandColors: BrandRamps = {
     App6: '#d83b01',
     App7: '#a22c01',
     App8: '#6c1e01',
+    AppTint40: '#f9dcd1',
+    AppTint30: '#f4beaa',
+    AppTint20: '#e8825d',
+    AppTint10: '#dd4f1b',
+    AppPrimary: '#d83b01',
+    AppShade10: '#c33400',
+    AppShade20: '#a52c00',
+    AppShade30: '#792000',
   },
   Word: {
     App1: '#E3ECFA',
@@ -29,6 +53,14 @@ const brandColors: BrandRamps = {
     App6: '#2B579A',
     App7: '#124078',
     App8: '#002050',
+    AppTint40: '#D2E0F4',
+    AppTint30: '#AEC6EB',
+    AppTint20: '#6794D7',
+    AppTint10: '#2E6AC5',
+    AppPrimary: '#185ABD',
+    AppShade10: '#1651AA',
+    AppShade20: '#13458F',
+    AppShade30: '#0E336A',
   },
   Excel: {
     App1: '#E9F5EE',
@@ -39,6 +71,14 @@ const brandColors: BrandRamps = {
     App6: '#217346',
     App7: '#0E5C2F',
     App8: '#004B1C',
+    AppTint40: '#CAEAD8',
+    AppTint30: '#A0D8B9',
+    AppTint20: '#55B17E',
+    AppTint10: '#218D51',
+    AppPrimary: '#107C41',
+    AppShade10: '#0F703B',
+    AppShade20: '#0C5F32',
+    AppShade30: '#094624',
   },
   Powerpoint: {
     App1: '#FCF0ED',
@@ -49,6 +89,14 @@ const brandColors: BrandRamps = {
     App6: '#B7472A',
     App7: '#A92B1A',
     App8: '#740912',
+    AppTint40: '#F6DBD4',
+    AppTint30: '#EDBCB0',
+    AppTint20: '#DC816A',
+    AppTint10: '#CB5031',
+    AppPrimary: '#C43E1C',
+    AppShade10: '#B13719',
+    AppShade20: '#952F15',
+    AppShade30: '#6E220F',
   },
   Outlook: {
     App1: '#CCE3F5',
@@ -59,6 +107,14 @@ const brandColors: BrandRamps = {
     App6: '#106EBE',
     App7: '#1664A7',
     App8: '#135995',
+    AppTint40: '#C7E0F4',
+    AppTint30: '#6CB8F6',
+    AppTint20: '#3AA0F3',
+    AppTint10: '#2899F5',
+    AppPrimary: '#0078D7',
+    AppShade10: '#106EBE',
+    AppShade20: '#005A9E',
+    AppShade30: '#004C87',
   },
 };
 
@@ -83,6 +139,29 @@ export const applyBrand = (currentBrand: string) => {
           link: ramp.App6,
           linkHovered: ramp.App7,
           linkPressed: ramp.App8,
+          neutralForeground2BrandHover: ramp.AppPrimary,
+          neutralForeground2BrandPressed: ramp.AppShade10,
+          neutralForeground3BrandHover: ramp.AppPrimary,
+          neutralForeground3BrandPressed: ramp.AppShade10,
+          brandForegroundLink: ramp.AppShade10,
+          brandForegroundLinkHover: ramp.AppShade20,
+          brandForegroundLinkPressed: ramp.AppShade30,
+          compoundBrandForeground1: ramp.AppPrimary,
+          compoundBrandForeground1Hover: ramp.AppShade10,
+          compoundBrandForeground1Pressed: ramp.AppShade20,
+          brandForeground1: ramp.AppPrimary,
+          brandForeground2: ramp.AppShade10,
+          brandBackground: ramp.AppPrimary,
+          brandBackgroundHover: ramp.AppShade10,
+          brandBackgroundPressed: ramp.AppShade30,
+          compoundBrandBackground1: ramp.AppPrimary,
+          compoundBrandBackground1Hover: ramp.AppShade10,
+          compoundBrandBackground1Pressed: ramp.AppShade20,
+          brandStroke1: ramp.AppPrimary,
+          brandStroke2: ramp.AppTint40,
+          compoundBrandStroke1: ramp.AppPrimary,
+          compoundBrandStroke1Hover: ramp.AppShade10,
+          compoundBrandStroke1Pressed: ramp.AppShade20,
         },
       }
     : {};

--- a/apps/fluent-tester/src/FluentTester/theme/applyTheme.ts
+++ b/apps/fluent-tester/src/FluentTester/theme/applyTheme.ts
@@ -1,5 +1,5 @@
-import { OfficePalette, PartialTheme, Theme } from '@fluentui-react-native/framework';
-import { createPartialOfficeTheme, getThemingModule } from '@fluentui-react-native/win32-theme';
+import {  PartialTheme, Theme } from '@fluentui-react-native/framework';
+import { createOfficeTheme,  getThemingModule } from '@fluentui-react-native/win32-theme';
 
 export type ThemeNames = 'Default' | 'Office' | 'Caterpillar' | 'Apple';
 
@@ -50,15 +50,14 @@ function applyCaterpillarTheme(parent: Theme): PartialTheme {
 }
 
 const themingModule = getThemingModule()[0];
-const officeBase = themingModule
-  ? createPartialOfficeTheme(themingModule, 'WhiteColors', themingModule.getPalette('WhiteColors') as OfficePalette)
-  : {};
 
 /** apply the currently active theme layering */
 export function applyTheme(parent: Theme, name: ThemeNames): PartialTheme {
   switch (name) {
     case 'Office':
-      return officeBase;
+      return themingModule
+      ? createOfficeTheme({ paletteName: 'WhiteColors' }).theme
+      : {};
     case 'Caterpillar':
       return applyCaterpillarTheme(parent);
     default:

--- a/change/@fluentui-react-native-tester-8ffeed25-1d89-4ac0-a2e4-98ecbc78e582.json
+++ b/change/@fluentui-react-native-tester-8ffeed25-1d89-4ac0-a2e4-98ecbc78e582.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update test code with brand changes",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-win32-theme-fd6da4ca-e0d9-49cf-a756-3202b58592ff.json
+++ b/change/@fluentui-react-native-win32-theme-fd6da4ca-e0d9-49cf-a756-3202b58592ff.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Initial implementation of brand alias tokens",
+  "packageName": "@fluentui-react-native/win32-theme",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/theming/win32-theme/src/createBrandedThemeWithAlias.ts
+++ b/packages/theming/win32-theme/src/createBrandedThemeWithAlias.ts
@@ -15,7 +15,6 @@ export function createBrandedThemeWithAlias(theme: Theme): Theme {
 }
 
 function overrideBrandAliasTokensWithOffice(theme: Theme): Partial<AliasColorTokens> {
-  console.log(theme.host.colors.AppPrimary);
   return {
     neutralForeground2BrandHover: theme.host.colors.AppPrimary,
     neutralForeground2BrandPressed: theme.host.colors.AppShade10,

--- a/packages/theming/win32-theme/src/createBrandedThemeWithAlias.ts
+++ b/packages/theming/win32-theme/src/createBrandedThemeWithAlias.ts
@@ -1,0 +1,44 @@
+import { Theme, AliasColorTokens } from '@fluentui-react-native/theme-types';
+
+export function createBrandedThemeWithAlias(theme: Theme): Theme {
+  if (!theme.host.colors) {
+    return theme;
+  }
+
+  return {
+    ...theme,
+    colors: {
+      ...theme.colors,
+      ...overrideBrandAliasTokensWithOffice(theme),
+    },
+  };
+}
+
+function overrideBrandAliasTokensWithOffice(theme: Theme): Partial<AliasColorTokens> {
+  console.log(theme.host.colors.AppPrimary);
+  return {
+    neutralForeground2BrandHover: theme.host.colors.AppPrimary,
+    neutralForeground2BrandPressed: theme.host.colors.AppShade10,
+    neutralForeground3BrandHover: theme.host.colors.AppPrimary,
+    neutralForeground3BrandPressed: theme.host.colors.AppShade10,
+    brandForegroundLink: theme.host.colors.AppShade10,
+    brandForegroundLinkHover: theme.host.colors.AppShade20,
+    brandForegroundLinkPressed: theme.host.colors.AppShade30,
+    compoundBrandForeground1: theme.host.colors.AppPrimary,
+    compoundBrandForeground1Hover: theme.host.colors.AppShade10,
+    compoundBrandForeground1Pressed: theme.host.colors.AppShade20,
+    brandForeground1: theme.host.colors.AppPrimary,
+    brandForeground2: theme.host.colors.AppShade10,
+    brandBackground: theme.host.colors.AppPrimary,
+    brandBackgroundHover: theme.host.colors.AppShade10,
+    brandBackgroundPressed: theme.host.colors.AppShade30,
+    compoundBrandBackground1: theme.host.colors.AppPrimary,
+    compoundBrandBackground1Hover: theme.host.colors.AppShade10,
+    compoundBrandBackground1Pressed: theme.host.colors.AppShade20,
+    brandStroke1: theme.host.colors.AppPrimary,
+    brandStroke2: theme.host.colors.AppTint40,
+    compoundBrandStroke1: theme.host.colors.AppPrimary,
+    compoundBrandStroke1Hover: theme.host.colors.AppShade10,
+    compoundBrandStroke1Pressed: theme.host.colors.AppShade20,
+  };
+}

--- a/packages/theming/win32-theme/src/createOfficeTheme.ts
+++ b/packages/theming/win32-theme/src/createOfficeTheme.ts
@@ -4,6 +4,7 @@ import { getThemingModule } from './NativeModule/getThemingModule';
 import { CxxException, PlatformDefaultsChangedArgs } from './NativeModule/officeThemingModule';
 import { OfficePalette, Theme, ThemeOptions } from '@fluentui-react-native/theme-types';
 import { createPartialOfficeTheme } from './createPartialOfficeTheme';
+import { createBrandedThemeWithAlias } from './createBrandedThemeWithAlias';
 import { createThemeWithAliases } from '@fluentui-react-native/theming-utils';
 
 function handlePaletteCall(palette: OfficePalette | CxxException): OfficePalette | undefined {
@@ -34,6 +35,9 @@ export function createOfficeTheme(options: ThemeOptions = {}): ThemeReference {
     },
     (theme: Theme) => {
       return createThemeWithAliases(theme);
+    },
+    (theme: Theme) => {
+      return createBrandedThemeWithAlias(theme);
     },
   );
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Added theme recipe to win32 theme to use ramp information to populate brand-related alias tokens. Entries are based on web tokens (so there will be a follow up to edit/replace this with the mapping from palette to tokens for win32 that I got earlier this week). Long term branded information will come from pipeline, but in the short term we can draw this information from the native module.

Also updated the tester to regenerate the office theme when the theme is changed via picker and update the brand-related information to include the new colors and entries (some entries are missing, so will have the wrong color in the tester - will follow up with separate PR).

Long term we should probably come up with a way to draw that information from either the pipeline or the host somehow and not hardcode it into the tester since that makes assumptions on how the themes are created and which entries are brand-dependent, but for now this is fine.

### Verification

Test app reflects host colors accurately

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
