### PR TITLE
Revert "Bump lage from 0.31.0 to 0.32.0"

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2107,6 +2107,14 @@
   dependencies:
     "@microsoft/node-core-library" "3.19.3"
 
+"@microsoft/task-scheduler@^2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/task-scheduler/-/task-scheduler-2.7.1.tgz#de2ebe6edb7ed882511051301f0e6f81732d7564"
+  integrity sha512-xSmX7xgLTtf3LwVOW5HCEL4qrSWYCmPsVzpJ7PTBayN0KA9acScgsLYaDE6tE26N//DtDEW6mi4RteWU4XSrjA==
+  dependencies:
+    memory-streams "^0.1.3"
+    p-graph "^1.1.0"
+
 "@microsoft/tsdoc@0.12.24":
   version "0.12.24"
   resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.12.24.tgz#30728e34ebc90351dd3aff4e18d038eed2c3e098"
@@ -11228,10 +11236,11 @@ labeled-stream-splicer@^2.0.0:
     stream-splicer "^2.0.0"
 
 "lage@>=0.17.4 <1.0.0":
-  version "0.32.0"
-  resolved "https://registry.yarnpkg.com/lage/-/lage-0.32.0.tgz#ad95496d3a932997db61c5b68baf952643baeaf7"
-  integrity sha512-I84t1zuSOEKK0UNR6vG/0cEZ/ZaPHvkO0y0t+9BPq8Hv1NK+yPXbXJuw+ia1ojlFsE3U4u8HkwZpHsROOqa3wg==
+  version "0.31.0"
+  resolved "https://registry.yarnpkg.com/lage/-/lage-0.31.0.tgz#f366d0acf9537b2a8451df3995c17f8673c3b9c3"
+  integrity sha512-PolpNI1UrMuWKbXyIJWh7dZ308VZB49N0izaheiUv24MJOyPLgFfbyUPE/MWmfO4TtVUMyEJX6imyiBFimoTlA==
   dependencies:
+    "@microsoft/task-scheduler" "^2.7.1"
     abort-controller "^3.0.0"
     backfill "^6.1.6"
     backfill-config "^6.1.3"
@@ -11242,7 +11251,6 @@ labeled-stream-splicer@^2.0.0:
     fast-glob "^3.2.2"
     git-url-parse "^11.1.2"
     npmlog "^4.1.2"
-    p-graph "^1.1.1"
     p-profiler "^0.2.1"
     workspace-tools "^0.16.2"
     yargs-parser "^18.1.3"
@@ -11817,6 +11825,13 @@ memory-fs@^0.5.0:
   dependencies:
     errno "^0.1.3"
     readable-stream "^2.0.1"
+
+memory-streams@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/memory-streams/-/memory-streams-0.1.3.tgz#d9b0017b4b87f1d92f55f2745c9caacb1dc93ceb"
+  integrity sha512-qVQ/CjkMyMInPaaRMrwWNDvf6boRZXaT/DbQeMYcCWuXPEBf1v8qChOc9OlEVQp2uOvRXa1Qu30fLmKhY6NipA==
+  dependencies:
+    readable-stream "~1.0.2"
 
 merge-deep@^3.0.2:
   version "3.0.3"
@@ -13085,10 +13100,10 @@ p-finally@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-2.0.1.tgz#bd6fcaa9c559a096b680806f4d657b3f0f240561"
   integrity sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==
 
-p-graph@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/p-graph/-/p-graph-1.1.1.tgz#9acf22ce5239afc7c08b4fd6e64b441eb171ecac"
-  integrity sha512-KdD5JEqSEbOYK5Yl4MKbHo8cNaJs+O6TW+HacoyPVau704KukYhJMhSXuC8tF332zqgB87pyAMf2FhQ54R0ugA==
+p-graph@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/p-graph/-/p-graph-1.1.0.tgz#c914cf067f8d4abc31a8a3cfcb932c213845df6a"
+  integrity sha512-IfwchSZEUfZHhdHrLSUPIbZfawOshc/UrTmdhT/BRjD428Fd78jVl4NUbIvWjUq+NxrenRjx8518VtQeIvbtMA==
 
 p-is-promise@^2.0.0:
   version "2.1.0"
@@ -14296,6 +14311,16 @@ readable-stream@^1.0.31:
   version "1.1.14"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
   integrity sha1-fPTFTvZI44EwhMY23SB54WbAgdk=
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
+
+readable-stream@~1.0.2:
+  version "1.0.34"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
+  integrity sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.1"


### PR DESCRIPTION
Reverts microsoft/fluentui-react-native#839

This broke stuff. Let's undo while we investigate if it's our bug or a bug on lage.