### PR TITLE
Custom theming documentation

### DIFF
--- a/docs/pages/Theming/Basics.md
+++ b/docs/pages/Theming/Basics.md
@@ -63,3 +63,5 @@ export const Component = () => {
 ```
 
 The component will rerender if the theme is invalidated.
+
+If you'd prefer to put the component's styles into a `StyleSheet` instead of accessing the `theme` directly, you can use [themed `StyleSheets`](./ThemedStylesheet.md)

--- a/docs/pages/Theming/Basics.md
+++ b/docs/pages/Theming/Basics.md
@@ -29,7 +29,7 @@ The available theme is defined by the `ThemeProvider`. It takes in a `ThemeRefer
 A `ThemeReference` is a class that creates a theme based on either another `Theme` or a parent `ThemeReference`. You can learn more about `ThemeReference` [here](https://github.com/microsoft/fluentui-react-native/blob/master/packages/framework/theme/README.md). We have a built in `ThemeReference` which you can access by calling `createDefaultTheme()`
 
 ```tsx
-import { ThemeReference, ThemeProvider } from '@fluentui-react-native/theme';
+import { ThemeProvider } from '@fluentui-react-native/theme';
 import { createDefaultTheme } from '@fluentui-react-native/default-theme';
 
 // This will use the built-in theme from FURN.

--- a/docs/pages/Theming/CustomTheme.md
+++ b/docs/pages/Theming/CustomTheme.md
@@ -39,13 +39,17 @@ For example, if you want to change the settings on the [Button component](https:
 ```ts
 components: {
   Button: {
-    backgroundColor: 'primaryButtonBackground', // Different semantic color
-    color: 'neutralBackground1', // Alias token
+    tokens: {
+      backgroundColor: 'primaryButtonBackground', // Different semantic color
+      color: 'neutralBackground1', // Alias token
+    },
     _overrides:{
-      hovered: {
-        backgroundColor: theme.host.colors['AppShade10'], // Get brand color from host
-        color: theme.host.colors['Gray96'], // Get gray from host
-        borderColor: theme.host.palette.Bkg, // Get entry from palette from host
+      tokens:{
+        hovered: {
+          backgroundColor: theme.host.colors['AppShade10'], // Get brand color from host
+          color: theme.host.colors['Gray96'], // Get gray from host
+          borderColor: theme.host.palette.Bkg, // Get entry from palette from host
+        },
       },
     }
   },

--- a/docs/pages/Theming/CustomTheme.md
+++ b/docs/pages/Theming/CustomTheme.md
@@ -2,7 +2,7 @@
 
 One of the powerful aspects of FURN theming is that it is heavily customizable. We recognize that users may have a need to change various parts of default themes, so we allow for several ways to specify overrides.
 
-You can create a custom theme by either building on top of an existing ThemeReference or building one from scratch. This then can be used by [passing it into our ThemeProvider](./Basics.md), which makes the theme available for all child components of the provider.
+You can create a custom theme by either building on top of an existing `ThemeReference` or building one from scratch. This then can be used by [passing it into our `ThemeProvider`](./Basics.md), which makes the theme available for all child components of the provider.
 
 ## Different aspects of customization
 
@@ -22,7 +22,7 @@ interface Theme {
 }
 ```
 
-<font size=1>(Taken from the [Theme type definition](https://github.com/microsoft/fluentui-react-native/blob/master/packages/theming/theme-types/src/Theme.types.ts).)</font>
+<font size=1>(Taken from the [`Theme` type definition](https://github.com/microsoft/fluentui-react-native/blob/master/packages/theming/theme-types/src/Theme.types.ts).)</font>
 
 In order to have the theme override a particular component's styling, you'll need to specify a component's name and provide some overrides for the component's settings. The settings are an object that specifies how a component's tokens or slot's style are filled out.
 
@@ -34,23 +34,25 @@ components: {
 },
 ```
 
-For example, if you want to change the settings on the [Button component](https://github.com/microsoft/fluentui-react-native/blob/master/packages/components/Button/src/Button.tsx), you could do something like the following:
+For example, if you want to change the settings on the [Button component](https://github.com/microsoft/fluentui-react-native/blob/master/packages/components/Button/src/Button.settings.ts), you could do something like the following:
 
 ```ts
 components: {
   Button: {
     backgroundColor: 'primaryButtonBackground', // Different semantic color
     color: 'neutralBackground1', // Alias token
-    hovered: {
-      backgroundColor: theme.host.colors['AppShade10'], // Get brand color from host
-      color: theme.host.colors['Gray96'], // Get gray from host
-      borderColor: theme.host.palette.Bkg, // Get entry from palette from host
-    },
+    _overrides:{
+      hovered: {
+        backgroundColor: theme.host.colors['AppShade10'], // Get brand color from host
+        color: theme.host.colors['Gray96'], // Get gray from host
+        borderColor: theme.host.palette.Bkg, // Get entry from palette from host
+      },
+    }
   },
 },
 ```
 
-You can see what settings can be customized by looking at a component's settings file. For Button, that can be found [here](https://github.com/microsoft/fluentui-react-native/blob/master/packages/components/Button/src/Button.settings.ts).
+You can see what settings can be customized by looking at a component's settings, styling, or tokens file.
 
 The advantage of this approach is that the customizations are targetted to a particular component, so the changes are localized.
 
@@ -97,8 +99,24 @@ spacing: {
 }
 ```
 
-## Creating a custom ThemeReference
+## Creating a custom `ThemeReference`
+
+There are two ways to make a custom `ThemeReference`: you can tack onto an existing one using `ThemeRecipes`, or create one from scratch. Generally it's easier to extend one of the default ones we provide.
 
 ### Theme reipces
 
-### Theme from scratch
+We have a concept of `ThemeRecipes` which allow for layering of partial theme objects to create the ultimately desired theme. `ThemeRecipes` are functions which take a `Theme` and spit out a `PartialTheme`, which is then deep merged into the base them object.
+
+You can extend one of our default themes by creating a `ThemeReference` using the default theme as the base theme, and then your customization as a `ThemeRecipe`:
+
+```ts
+const theme = new ThemeReference(createDefaultTheme(),
+  (theme) => { return {{colors: {buttonBackground: 'red'}}}} // overrides the buttonBackground color token, all other colors are kept in tact
+);
+```
+
+A good example from our repo is [the Office theme](https://github.com/microsoft/fluentui-react-native/blob/master/packages/theming/win32-theme/src/createOfficeTheme.ts).
+
+### `ThemeReference` from scratch
+
+You can create your own `ThemeReference` and pass it into the `ThemeProvider`. To create a `ThemeReference` you'll need to define the base, and add any ThemeRecipes you'd like. You can find the type definition [here](https://github.com/microsoft/fluentui-react-native/blob/master/packages/framework/theme/src/themeReference.ts).

--- a/docs/pages/Theming/CustomTheme.md
+++ b/docs/pages/Theming/CustomTheme.md
@@ -118,11 +118,11 @@ import { ThemeReference, ThemeProvider } from '@fluentui-react-native/theme';
 import { createDefaultTheme } from '@fluentui-react-native/default-theme';
 
 const theme = new ThemeReference(createDefaultTheme(),
-  () => { return {{colors: {buttonBackground: 'red'}}}}, // overrides the buttonBackground color token, all other colors are kept in tact
+  () => { return {{ colors: { buttonBackground: 'red' }}}}, // overrides the buttonBackground color token, all other colors are kept in tact
   (theme) => {
     return {
-      {colors: {neutralBackground1: theme.colors.buttonBackground}}, // use information from theme to fill out other fields
-      {spacing: s1: '10px'}
+      { colors: { neutralBackground1: theme.colors.buttonBackground }}, // This is now red, because theme has previous recipe applied
+      { spacing: s1: '10px' }
     }},
   // other recipes
 );

--- a/docs/pages/Theming/CustomTheme.md
+++ b/docs/pages/Theming/CustomTheme.md
@@ -1,7 +1,104 @@
 # Customized Themes
 
-## Creating a ThemeReference
+One of the powerful aspects of FURN theming is that it is heavily customizable. We recognize that users may have a need to change various parts of default themes, so we allow for several ways to specify overrides.
 
-## Theme reipces
+You can create a custom theme by either building on top of an existing ThemeReference or building one from scratch. This then can be used by [passing it into our ThemeProvider](./Basics.md), which makes the theme available for all child components of the provider.
 
-## Adding theme recipes to THemeReference
+## Different aspects of customization
+
+There's two main ways to customize a FURN theme - you can specify how to customize components, or you can customize theme tokens directly by overriding certain tokens.
+
+### Components
+
+The FURN theme has a components property which can be used to customize components:
+
+```ts
+interface Theme {
+  ...
+  components: {
+    [key: string]: object,
+  };
+  ...
+}
+```
+
+<font size=1>(Taken from the [Theme type definition](https://github.com/microsoft/fluentui-react-native/blob/master/packages/theming/theme-types/src/Theme.types.ts).)</font>
+
+In order to have the theme override a particular component's styling, you'll need to specify a component's name and provide some overrides for the component's settings. The settings are an object that specifies how a component's tokens or slot's style are filled out.
+
+```ts
+components: {
+  <ComponentName>: {
+    <tokenName>: <overrideValue>
+  },
+},
+```
+
+For example, if you want to change the settings on the [Button component](https://github.com/microsoft/fluentui-react-native/blob/master/packages/components/Button/src/Button.tsx), you could do something like the following:
+
+```ts
+components: {
+  Button: {
+    backgroundColor: 'primaryButtonBackground', // Different semantic color
+    color: 'neutralBackground1', // Alias token
+    hovered: {
+      backgroundColor: theme.host.colors['AppShade10'], // Get brand color from host
+      color: theme.host.colors['Gray96'], // Get gray from host
+      borderColor: theme.host.palette.Bkg, // Get entry from palette from host
+    },
+  },
+},
+```
+
+You can see what settings can be customized by looking at a component's settings file. For Button, that can be found [here](https://github.com/microsoft/fluentui-react-native/blob/master/packages/components/Button/src/Button.settings.ts).
+
+The advantage of this approach is that the customizations are targetted to a particular component, so the changes are localized.
+
+### Changing theme tokens directly
+
+Theme tokens can be overridden directly as well. You can specify different color values for a particular set of color entries, add to the set of colors, or have different values for particular typography variants. You can see what can be overridden by looking at the [Theme type definition](https://github.com/microsoft/fluentui-react-native/blob/master/packages/theming/theme-types/src/Theme.types.ts).
+
+This approach can be preferred if you need the customizations to be applied to all components.
+
+#### Color example
+
+```ts
+color: {
+  buttonBackground: 'red',
+  neutralForeground1: theme.host.palette.Bkg,
+  otherToken: theme.colors.themePrimary,
+}
+```
+
+#### Typography example
+
+```ts
+typography: {
+  sizes: {
+    caption: 6,
+  },
+  weights: {
+    semiBold: '300',
+  },
+  families: {
+    cursive: 'Segoe UI',
+  },
+  variants: {
+    heroLargeSemibold: { face: 'cursive', size: 'heroLarge', weight: 'semiBold' }
+  }
+}
+```
+
+#### Spacing example
+
+```ts
+spacing: {
+  s1: '10px';
+}
+```
+
+## Creating a custom ThemeReference
+
+### Theme reipces
+
+### Theme from scratch

--- a/docs/pages/Theming/CustomTheme.md
+++ b/docs/pages/Theming/CustomTheme.md
@@ -114,9 +114,23 @@ We have a concept of `ThemeRecipes` which allow for layering of partial theme ob
 You can extend one of our default themes by creating a `ThemeReference` using the default theme as the base theme, and then your customization as a `ThemeRecipe`:
 
 ```ts
+import { ThemeReference, ThemeProvider } from '@fluentui-react-native/theme';
+import { createDefaultTheme } from '@fluentui-react-native/default-theme';
+
 const theme = new ThemeReference(createDefaultTheme(),
-  (theme) => { return {{colors: {buttonBackground: 'red'}}}} // overrides the buttonBackground color token, all other colors are kept in tact
+  () => { return {{colors: {buttonBackground: 'red'}}}}, // overrides the buttonBackground color token, all other colors are kept in tact
+  (theme) => {
+    return {
+      {colors: {neutralBackground1: theme.colors.buttonBackground}}, // use information from theme to fill out other fields
+      {spacing: s1: '10px'}
+    }},
+  // other recipes
 );
+
+// Use created theme reference in ThemeProvider
+<ThemeProvider theme={theme}>
+  <App />
+</ThemeProvider>
 ```
 
 A good example from our repo is [the Office theme](https://github.com/microsoft/fluentui-react-native/blob/master/packages/theming/win32-theme/src/createOfficeTheme.ts).

--- a/docs/pages/Theming/DefaultThemes.md
+++ b/docs/pages/Theming/DefaultThemes.md
@@ -14,11 +14,16 @@ On win32, we allow for better integration with an Office host.
 
 ## Integration with Office
 
-On win32, the we allow for integration with Office theming via an `OfficeThemingModule`. Office has a native module which provides information about the queried palette based on the current Office theme. FURN uses the information to populate `theme.colors`, but the palette is available as well under `theme.host.palette`.
+On win32, we allow for integration with Office theming via an `OfficeThemingModule`. Office has a native module which provides information about the queried palette based on the current Office theme. FURN uses the information to populate `theme.colors`, but the palette is available as well under `theme.host.palette`.
 
 You can create a theme using information from Office by calling `createOfficeTheme()`. By default, we use the `WhiteColors` palette. You can also ask for a specific palette's values by passing in a `paletteName` as part of the `ThemeOptions` passed into `createOfficeTheme()`:
 
 ```tsx
+import { ThemeProvider } from '@fluentui-react-native/theme';
+import { createOfficeTheme } from '@fluentui-react-native/win32-theme';
+import { useFluentTheme } from '@fluentui-react-native/framework';
+import { Text } from 'react-native';
+
 const AppWithOfficeTheme = () => {
   return (
     // Populate the theme with colors from PaletteName palette in Office.
@@ -29,7 +34,7 @@ const AppWithOfficeTheme = () => {
 };
 
 const AppContent = () => {
-  const officeTheme = useTheme();
+  const officeTheme = useFluentTheme();
   return (
     <>
       // bodyText property value of theme is determined by palette
@@ -41,6 +46,8 @@ const AppContent = () => {
 };
 ```
 
+You can take a look at how the palette is used to populate theme colors [here](https://github.com/microsoft/fluentui-react-native/blob/master/packages/theming/win32-theme/src/paletteFromOfficeColors.ts) and [here](https://github.com/microsoft/fluentui-react-native/blob/master/packages/theming/win32-theme/src/createAliasesFromPalette.ts).
+
 ## Example
 
 Here's how the button component looks by default on every platform:
@@ -48,9 +55,12 @@ Here's how the button component looks by default on every platform:
 ### Default (Web / Windows)
 
 ```tsx
+import { ThemeProvider } from '@fluentui-react-native/theme';
+import { createDefaultTheme } from '@fluentui-react-native/default-theme';
+
 <ThemeProvider theme={createDefaultTheme()}>
   <Button content={'Default Button'} />
-</ThemeProvider>
+</ThemeProvider>;
 ```
 
 ![Image of default button with default theme applied in FURN](./assets/default.png)
@@ -58,9 +68,12 @@ Here's how the button component looks by default on every platform:
 ### Android
 
 ```tsx
+import { ThemeProvider } from '@fluentui-react-native/theme';
+import { createAndroidTheme } from '@fluentui-react-native/android-theme';
+
 <ThemeProvider theme={createAndroidTheme()}>
   <Button content={'Button'} />
-</ThemeProvider>
+</ThemeProvider>;
 ```
 
 ![Image of default button with default Android theme applied in FURN](./assets/android.png)
@@ -68,9 +81,12 @@ Here's how the button component looks by default on every platform:
 ### iOS
 
 ```tsx
+import { ThemeProvider } from '@fluentui-react-native/theme';
+import { createAppleTheme } from '@fluentui-react-native/apple-theme';
+
 <ThemeProvider theme={createAppleTheme()}>
   <Button content={'Button'} />
-</ThemeProvider>
+</ThemeProvider>;
 ```
 
 ![Image of default button with default Apple theme on iOS applied in FURN](./assets/iOS.png)
@@ -78,9 +94,12 @@ Here's how the button component looks by default on every platform:
 ### MacOS
 
 ```tsx
+import { ThemeProvider } from '@fluentui-react-native/theme';
+import { createAppleTheme } from '@fluentui-react-native/apple-theme';
+
 <ThemeProvider theme={createAppleTheme()}>
   <Button content={'Button'} />
-</ThemeProvider>
+</ThemeProvider>;
 ```
 
 ![Image of default button with default Apple theme on Mac applied in FURN](./assets/macOS.png)
@@ -88,9 +107,12 @@ Here's how the button component looks by default on every platform:
 ### Win32 (Office)
 
 ```tsx
+import { ThemeProvider } from '@fluentui-react-native/theme';
+import { createOfficeTheme } from '@fluentui-react-native/win32-theme';
+
 <ThemeProvider theme={createOfficeTheme()}>
   <Button content={'Default Button'} />
-</ThemeProvider>
+</ThemeProvider>;
 ```
 
 ![Image of default button with Office White Colors theme applied in FURN](./assets/win32.png)

--- a/docs/pages/Theming/DefaultThemes.md
+++ b/docs/pages/Theming/DefaultThemes.md
@@ -21,7 +21,7 @@ You can create a theme using information from Office by calling `createOfficeThe
 ```tsx
 import { ThemeProvider } from '@fluentui-react-native/theme';
 import { createOfficeTheme } from '@fluentui-react-native/win32-theme';
-import { useFluentTheme } from '@fluentui-react-native/framework';
+import { useTheme } from '@fluentui-react-native/theme-types';
 import { Text } from 'react-native';
 
 const AppWithOfficeTheme = () => {
@@ -34,7 +34,7 @@ const AppWithOfficeTheme = () => {
 };
 
 const AppContent = () => {
-  const officeTheme = useFluentTheme();
+  const officeTheme = useTheme();
   return (
     <>
       // bodyText property value of theme is determined by palette

--- a/docs/pages/Theming/ThemedStylesheet.md
+++ b/docs/pages/Theming/ThemedStylesheet.md
@@ -1,0 +1,46 @@
+# Themed `StyleSheets`
+
+Themed `StyleSheets` allow you to create a `StyleSheet` using information from a FURN theme. The resulting objects are memoized onto the `Theme` object itself, so if you access them again they'll be cached if the `Theme` hasn't changed. You can then access styles off the `StyleSheet` as you usually would and pass them into components as the value for a `style` prop.
+
+## Defining a themed `StyleSheet`
+
+Defining a themed `StyleSheet` is similar to creating a RN `StyleSheet`, but it takes in a theme as an arg.
+
+```ts
+// Component.styles.ts
+import { themedStyleSheet } from '@fluentui-react-native/themed-stylesheet';
+import { Theme } from '@fluentui-react-native/theme-types';
+
+export const getThemedStyles = themedStyleSheet((theme: Theme) => {
+  return {
+    root: { minHeight: 382, paddingHorizontal: 16 },
+    container: { backgroundColor: theme.colors.background },
+    list: { flexDirection: 'row' },
+    content: { margin: 8 },
+  };
+});
+```
+
+## Using a themed `StyleSheet`
+
+You can use a themed `StyleSheet` as you would an RN `StyleSheet` that's generated via a function:
+
+```ts
+// Component.ts
+import { getThemedStyles } from './Component.styles.ts';
+import { useTheme } from '@fluentui-react-native/theme-types';
+
+export const Component = () => {
+  const styles = getThemedStyles(useTheme());
+
+  return (
+    <View style={styles.root}>
+      <Text style={styles.content}>Hello World!</Text>
+    </View>
+  );
+};
+```
+
+## Additional Reading
+
+For more detailed information, check out [our README](https://github.com/microsoft/fluentui-react-native/blob/master\packages\framework\themed-stylesheet\README.md).


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Adding documentation for creating custom FURN themes.

Aim is to provide clear examples of how to add custom themes. Thanks to @FalseLobster for her examples in her AccChecker example, some of this documentation was modeled off of that example.

If there are use cases missing please let me know!

### Verification

Sending documentation to some partners as a test run

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
