### PR TITLE
Fix some alias token from palette entries

### DIFF
--- a/change/@fluentui-react-native-win32-theme-267dbf34-75cf-4ed6-9a37-9d44264a25c5.json
+++ b/change/@fluentui-react-native-win32-theme-267dbf34-75cf-4ed6-9a37-9d44264a25c5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix entries",
+  "packageName": "@fluentui-react-native/win32-theme",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/theming/win32-theme/src/createAliasesFromPalette.ts
+++ b/packages/theming/win32-theme/src/createAliasesFromPalette.ts
@@ -15,9 +15,8 @@ export function createAliasesFromPalette(palette: OfficePalette): Partial<AliasC
     compoundBrandForeground1Pressed: palette.TextEmphasisPressed,
 
     neutralForegroundInverted: palette.TextCtlSubtleSelectionHighlight,
-    neutralForegroundInvertedLink: palette.TextCtlEmphasis,
-    neutralForegroundInvertedLinkHover: palette.TextCtlEmphasisHover,
-    neutralForegroundInvertedLinkPressed: palette.TextCtlEmphasisPressed,
+    neutralForegroundOnBrand: palette.TextCtlEmphasis,
+    neutralForegroundInvertedLink: palette.ThumbToggleSwitchOnHover,
 
     neutralBackground1: palette.Bkg,
     neutralBackground1Hover: palette.BkgHover,
@@ -28,6 +27,8 @@ export function createAliasesFromPalette(palette: OfficePalette): Partial<AliasC
     neutralBackground3: palette.BkgSubtle,
     neutralBackgroundInverted: palette.BkgSelectionHighlight,
     neutralBackgroundDisabled: palette.BkgCtlDisabled,
+
+    neutralStencil1: palette.SliderBuffer,
 
     brandBackground: palette.BkgCtlEmphasis,
     brandBackgroundHover: palette.BkgCtlEmphasisHover,

--- a/packages/theming/win32-theme/src/createAliasesFromPalette.ts
+++ b/packages/theming/win32-theme/src/createAliasesFromPalette.ts
@@ -16,7 +16,9 @@ export function createAliasesFromPalette(palette: OfficePalette): Partial<AliasC
 
     neutralForegroundInverted: palette.TextCtlSubtleSelectionHighlight,
     neutralForegroundOnBrand: palette.TextCtlEmphasis,
-    neutralForegroundInvertedLink: palette.ThumbToggleSwitchOnHover,
+    neutralForegroundInvertedLink: palette.BkgToggleSwitchOff,
+    neutralForegroundInvertedLinkHover: palette.BkgToggleSwitchOffHover,
+    neutralForegroundInvertedLinkPressed: palette.BkgToggleSwitchOffPressed,
 
     neutralBackground1: palette.Bkg,
     neutralBackground1Hover: palette.BkgHover,


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Design had a few corrections for which palette entries map to which vNext tokens. Making those changes here.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/4602628/129804085-3acc63bc-4c44-4acd-9fcc-d733214a522c.png) | ![image](https://user-images.githubusercontent.com/4602628/129803652-1e76e53d-df76-42cc-8b90-9e4b24affe3e.png) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
