### PR TITLE
Fix iconColor not applying to svg icons

### DIFF
--- a/change/@fluentui-react-native-icon-d4131192-d0bc-4669-baa7-fd6d7d9b998b.json
+++ b/change/@fluentui-react-native-icon-d4131192-d0bc-4669-baa7-fd6d7d9b998b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix iconColor not applying for svg icons",
+  "packageName": "@fluentui-react-native/icon",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Icon/src/Icon.tsx
+++ b/packages/experimental/Icon/src/Icon.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { IconProps, SvgIconProps, FontIconProps } from './Icon.types';
-import { Image, ImageStyle, Platform, View } from 'react-native';
+import { Image, ImageStyle, Platform, View, ColorValue } from 'react-native';
 import { Text } from '@fluentui-react-native/text';
 import { mergeStyles, useFluentTheme } from '@fluentui-react-native/framework';
 import { stagedComponent, mergeProps, getMemoCache } from '@fluentui-react-native/framework';
@@ -51,18 +51,13 @@ function renderFontIcon(iconProps: IconProps) {
 
 function renderSvg(iconProps: IconProps) {
   const svgIconProps: SvgIconProps = iconProps.svgSource;
-  const { width, height } = iconProps;
+  const { width, height, color } = iconProps;
   const viewBox = iconProps.svgSource.viewBox;
-  const style = mergeStyles(iconProps.style, rasterImageStyleCache({ width: width, height: height }, [width, height])[0]);
+  const style = mergeStyles(iconProps.style, rasterImageStyleCache({ width, height }, [width, height])[0]);
 
   // react-native-svg is still on 0.61, and their color prop doesn't handle ColorValue
   // If a color for the icon is not supplied, fall back to white or black depending on appearance
-  const theme = useFluentTheme();
-  const iconColor = svgIconProps.color
-    ? svgIconProps.color
-    : getCurrentAppearance(theme.host.appearance, 'light') === 'dark'
-    ? '#FFFFFF'
-    : '#000000';
+  const iconColor = downgradeColor(color);
 
   if (svgIconProps.src) {
     return (
@@ -106,3 +101,11 @@ export const Icon = stagedComponent((props: IconProps) => {
 });
 
 export default Icon;
+
+function downgradeColor(color: ColorValue): string {
+  if (typeof color === 'string') {
+    return color as string;
+  }
+
+  return getCurrentAppearance(useFluentTheme().host.appearance, 'light') === 'dark' ? '#FFFFFF' : '#000000';
+}

--- a/packages/experimental/Icon/src/Icon.tsx
+++ b/packages/experimental/Icon/src/Icon.tsx
@@ -57,6 +57,7 @@ function renderSvg(iconProps: IconProps) {
 
   // react-native-svg is still on 0.61, and their color prop doesn't handle ColorValue
   // If a color for the icon is not supplied, fall back to white or black depending on appearance
+  // Tracked by issue #728
   const iconColor = downgradeColor(color);
 
   if (svgIconProps.src) {

--- a/packages/experimental/Icon/src/Icon.types.ts
+++ b/packages/experimental/Icon/src/Icon.types.ts
@@ -13,7 +13,6 @@ export interface SvgIconProps {
   uri?: string;
   src?: React.FC<SvgProps>;
   viewBox?: string;
-  color?: string;
 }
 
 export interface RasterImageIconProps {


### PR DESCRIPTION
Fixes #888 

### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

When I made my ColorValue changes, I split out the color prop for the SVG icon into a separate prop, since RN SVG is still on an older version of RN and doesn't support ColorValue yet, only taking string. However I did this without really understanding how the token/slot/styling system worked and broke things for other components.

This change removes the color prop on the SvgIconProps and makes the svg icon use the color prop on IconProps as its base instead. I implemented a downgradeColor function which falls back to an appropriate color if the color is not a string.

I'm open to suggestions on better ways to gracefully handle the downgrade, but this won't really be fixed until RN SVG can handle ColorValues.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/4602628/129818355-d59ed575-10d7-42d3-be89-58aa8deb4aa4.png) | ![image](https://user-images.githubusercontent.com/4602628/129818316-46112281-e88c-4ac2-b747-c597b45c61bf.png) |

These are actually both supposed to be red, but the customize for the iconColor token isn't working on the Button. Still looking into that.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
