### PR TITLE
Fix bug in NativeDatePicker

### DIFF
--- a/apps/ios/src/Podfile.lock
+++ b/apps/ios/src/Podfile.lock
@@ -18,14 +18,14 @@ PODS:
     - boost-for-react-native
     - DoubleConversion
     - glog
-  - FRNAvatar (0.11.8):
+  - FRNAvatar (0.11.9):
     - MicrosoftFluentUI (= 0.3.0)
     - MicrosoftFluentUI/Avatar_ios (= 0.3.0)
     - React
-  - FRNButton (0.7.11):
+  - FRNButton (0.7.12):
     - MicrosoftFluentUI (= 0.3.0)
     - React
-  - FRNDatePicker (0.3.3):
+  - FRNDatePicker (0.3.4):
     - MicrosoftFluentUI (= 0.3.0)
     - React
   - glog (0.3.5)
@@ -545,9 +545,9 @@ SPEC CHECKSUMS:
   FBLazyVector: 3bb422f41b18121b71783a905c10e58606f7dc3e
   FBReactNativeSpec: f2c97f2529dd79c083355182cc158c9f98f4bd6e
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
-  FRNAvatar: b2477748ea17a77744a7dec855a73b2c84f22771
-  FRNButton: aec4eca5f1a963042cdb472bf04881f39191934d
-  FRNDatePicker: ff7848325d64fd87d731795401e41263c5da69e1
+  FRNAvatar: b4a793a07f33294c990bef410a12191ccbe508fc
+  FRNButton: 34aec89b4aad59842203630cbdc470a38743f5b7
+  FRNDatePicker: 1bbfe4bc57507ac69c73d4ddcce0e0d77e493802
   glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
   MicrosoftFluentUI: b98d877a2122804132365aa167944f58ef4adb69
   QRCodeReader.swift: 373a389fe9a22d513c879a32a6f647c58f4ef572

--- a/change/@fluentui-react-native-experimental-native-date-picker-9b4e344d-116c-4ab7-8192-2b2613b82f40.json
+++ b/change/@fluentui-react-native-experimental-native-date-picker-9b4e344d-116c-4ab7-8192-2b2613b82f40.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix typo preventing native module constants from loading",
+  "packageName": "@fluentui-react-native/experimental-native-date-picker",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/NativeDatePicker/src/NativeDatePicker.tsx
+++ b/packages/experimental/NativeDatePicker/src/NativeDatePicker.tsx
@@ -1,5 +1,5 @@
 import { NativeModules } from 'react-native';
-export const NativeDatePicker = NativeModules.MSFDatePickerManager;
+export const NativeDatePicker = NativeModules.FRNDatePickerManager;
 export const { MSFDateTimePickerMode, MSFDateTimePickerDatePickerType, MSFDateTimePickerDateRangePresentation } = NativeDatePicker.getConstants();
 
 // Enums from the iOS DateTimePicker in FluentUI-Apple


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

In #899 , I forgot to rename one MSF -> FRN, which caused a bug where NativeDatePicker wouldn't initialize properly. I am fixing that now.

### Verification

Ran NativeDatePicker on iOS to ensure it works.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
