### PR TITLE
Add focusBorder to menuItems for keyboard focus

### DIFF
--- a/change/@fluentui-react-native-contextual-menu-a8d12d2d-de44-48f8-ab4c-33f2f8e755d0.json
+++ b/change/@fluentui-react-native-contextual-menu-a8d12d2d-de44-48f8-ab4c-33f2f8e755d0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add focusBorder to menuItems",
+  "packageName": "@fluentui-react-native/contextual-menu",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/ContextualMenu/src/ContextualMenuItem.settings.ts
+++ b/packages/components/ContextualMenu/src/ContextualMenuItem.settings.ts
@@ -7,7 +7,7 @@ export const settings: IComposeSettings<ContextualMenuItemType> = [
       backgroundColor: 'menuBackground',
       color: 'menuItemText',
       borderColor: 'transparent',
-      borderWidth: 1,
+      borderWidth: 2,
     },
     root: {
       accessible: true,

--- a/packages/components/ContextualMenu/src/ContextualMenuItem.settings.ts
+++ b/packages/components/ContextualMenu/src/ContextualMenuItem.settings.ts
@@ -46,28 +46,26 @@ export const settings: IComposeSettings<ContextualMenuItemType> = [
       },
       pressed: {
         tokens: {
-          backgroundColor: 'menuItemBackgroundHovered',
+          backgroundColor: 'menuItemBackgroundPressed',
           color: 'menuItemTextHovered',
+        },
+      },
+      hovered: {
+        tokens: {
+          color: 'menuItemTextHovered',
+          backgroundColor: 'menuItemBackgroundHovered',
         },
       },
       focused: {
         tokens: {
           color: 'menuItemTextHovered',
           backgroundColor: 'menuItemBackgroundHovered',
+          borderColor: 'focusBorder'
         },
         _overrides: {
-          disabled: {
-            tokens: {
-              borderColor: 'focusBorder',
-            },
-          },
           hovered: {
-            _overrides: {
-              disabled: {
-                tokens: {
-                  borderColor: 'transparent',
-                },
-              },
+            tokens: {
+              borderColor: 'transparent'
             },
           },
         },

--- a/packages/components/ContextualMenu/src/SubmenuItem.settings.ts
+++ b/packages/components/ContextualMenu/src/SubmenuItem.settings.ts
@@ -7,7 +7,7 @@ export const settings: IComposeSettings<SubmenuItemType> = [
       backgroundColor: 'menuBackground',
       color: 'menuItemText',
       borderColor: 'transparent',
-      borderWidth: 1,
+      borderWidth: 2,
     },
     root: {
       accessible: true,

--- a/packages/components/ContextualMenu/src/SubmenuItem.settings.ts
+++ b/packages/components/ContextualMenu/src/SubmenuItem.settings.ts
@@ -60,7 +60,7 @@ export const settings: IComposeSettings<SubmenuItemType> = [
       },
       pressed: {
         tokens: {
-          backgroundColor: 'menuItemBackgroundHovered',
+          backgroundColor: 'menuItemBackgroundPressed',
           color: 'menuItemTextHovered',
         },
       },
@@ -74,20 +74,12 @@ export const settings: IComposeSettings<SubmenuItemType> = [
         tokens: {
           color: 'menuItemTextHovered',
           backgroundColor: 'menuItemBackgroundHovered',
+          borderColor: 'focusBorder'
         },
         _overrides: {
-          disabled: {
-            tokens: {
-              borderColor: 'focusBorder',
-            },
-          },
           hovered: {
-            _overrides: {
-              disabled: {
-                tokens: {
-                  borderColor: 'transparent',
-                },
-              },
+            tokens: {
+              borderColor: 'transparent'
             },
           },
         },


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [X] macOS
- [X] win32 (Office)
- [X] windows
- [X] android

### Description of changes
ContextualMenuItem.settings
SubmenuItem.settings
 - set borderColor to focusBorder for keyboard focus 

### Verification
![border2px](https://user-images.githubusercontent.com/12578599/129942031-6ff79bc5-512c-43ef-8b6c-9f4d22ce09a6.PNG)

Fixing the following bug: [4460439](https://office.visualstudio.com/OC/_sprints/taskboard/CXE%20React/OC/CY21Q3%20(Jul-Sep)/2108-Aug/Aug02?workitem=4460439)

### Pull request checklist

This PR has considered (when applicable):
- [X] Automated Tests
- [X] Documentation and examples
- [X] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
