### PR TITLE
Bring useViewCommandFocus to macOS

### DIFF
--- a/change/@fluentui-react-native-interactive-hooks-126dc43e-9e24-47a7-9585-d348a939669a.json
+++ b/change/@fluentui-react-native-interactive-hooks-126dc43e-9e24-47a7-9585-d348a939669a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add macOS implementation of useViewCommandFocus",
+  "packageName": "@fluentui-react-native/interactive-hooks",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/utils/interactive-hooks/src/useViewCommandFocus.macos.ts
+++ b/packages/utils/interactive-hooks/src/useViewCommandFocus.macos.ts
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { findNodeHandle, NativeModules, View } from 'react-native';
+
+const setAndForwardRef = require('./setAndForwardRef');
+
+export type IFocusable = View;
+/**
+ * A hook to add an imperative focus method to functional components which simply dispatch a focus command to
+ * something View-derived on the native side.  In practice, this effectively applies to all components in our Win32
+ * react native implementation.
+ * @param forwardRef - The componentRef from your component's props where you're exposing a imperative focus method.
+ * @returns The inner View-type you're rendering that you want to dispatch to & focus on.
+ */
+export function useViewCommandFocus(
+  forwardedRef: React.Ref<View | null> | undefined,
+  // initialValue?: React.Component
+): (ref: React.ElementRef<any>) => void {
+  /**
+   * Set up the forwarding ref to enable adding the focus method.
+   */
+  const focusRef = React.useRef<React.Component>();
+
+  const _setNativeRef = setAndForwardRef({
+    getForwardedRef: () => forwardedRef,
+    setLocalRef: localRef => {
+      focusRef.current = localRef;
+
+      /**
+       * Add focus() as a callable function to the forwarded reference.
+       */
+      if (localRef) {
+        localRef.focus = () => {
+          NativeModules.UIManager.dispatchViewManagerCommand(
+            findNodeHandle(localRef),
+            NativeModules.UIManager.getViewManagerConfig('RCTView').Commands.focus,
+            null,
+          );
+        };
+      }
+    },
+  });
+  return _setNativeRef;
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

There's a hook called useViewCommandFocus a bunch of our components use that is only implemented for win32, and is a no-op on every other platform. Let's add it to macOS. I just copied the win32 version and changed "IViewWIn32" to "View"

Note that I think this hook doesn't need to exist, every standard react native ref has a `.focus()` method on it, so I don't know what functionality this adds.

### Verification

Not sure how to test this, we still don't have `enableFocusRing` set on most of our views =/ 

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
