### PR TITLE
Bump rex-win32 to 14419.10000

### DIFF
--- a/apps/win32/package.json
+++ b/apps/win32/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@office-iss/react-native-win32": "^0.63.7",
-    "@office-iss/rex-win32": "0.63.28-devmain.14119.10000",
+    "@office-iss/rex-win32": "0.63.36-devmain.14419.10000",
     "@rnx-kit/cli": "^0.5.27",
     "@rnx-kit/metro-config": "^1.2.3",
     "@types/jasmine": "3.5.10",

--- a/change/@fluentui-react-native-tester-win32-582018b2-835a-402c-916b-c4c6ba759e03.json
+++ b/change/@fluentui-react-native-tester-win32-582018b2-835a-402c-916b-c4c6ba759e03.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Bump rex-win32 package",
+  "packageName": "@fluentui-react-native/tester-win32",
+  "email": "patboyd@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2167,10 +2167,10 @@
     use-subscription "^1.0.0"
     whatwg-fetch "^3.0.0"
 
-"@office-iss/rex-win32@0.63.28-devmain.14119.10000":
-  version "0.63.28-devmain.14119.10000"
-  resolved "https://registry.yarnpkg.com/@office-iss/rex-win32/-/rex-win32-0.63.28-devmain.14119.10000.tgz#f926c653f0807ff44cd9203a1730ace60141fdfb"
-  integrity sha512-cSFOBapadpAw7HxgCSuzxXDPOT77GJXQrY095v+KtD9wBApmKdo9xBmB1HoOfey4nbaQHIQjSUfkMyz7HkRpgQ==
+"@office-iss/rex-win32@0.63.36-devmain.14419.10000":
+  version "0.63.36-devmain.14419.10000"
+  resolved "https://pkgs.dev.azure.com/office/_packaging/Office/npm/registry/@office-iss/rex-win32/-/rex-win32-0.63.36-devmain.14419.10000.tgz#c6a0f23f08a290ed21506871d4e8a2cd923fa11a"
+  integrity sha1-xqDyPwiikO0hUGhx1OiizZI/oRo=
   dependencies:
     command-line-args "^5.0.2"
     command-line-usage "^5.0.5"


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ x ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Bumped rex-win32 to 14419.10000

### Verification

Opened test pages and exercised some controls

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
