### PR TITLE
Renamed "icon" to "startIcon" in Button component

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/Button/ButtonIconTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Button/ButtonIconTest.tsx
@@ -27,9 +27,13 @@ export const ButtonIconTest: React.FunctionComponent = () => {
   return (
     <View>
       <Stack style={stackStyle}>
-        <Button icon={testImage} content="Button with png Icon" tooltip="button tooltip" />
-        {svgIconsEnabled ? <Button icon={{ ...iconProps, color: 'red' }} content="Button with svg Icon" tooltip="button tooltip" /> : null}
-        {svgIconsEnabled ? <CustomizedIconButton icon={iconProps} content="Button with Customized Icon" tooltip="button tooltip" /> : null}
+        <Button startIcon={testImage} content="Button with png Icon" tooltip="button tooltip" />
+        {svgIconsEnabled ? (
+          <Button startIcon={{ ...iconProps, color: 'red' }} content="Button with svg Icon" tooltip="button tooltip" />
+        ) : null}
+        {svgIconsEnabled ? (
+          <CustomizedIconButton startIcon={iconProps} content="Button with Customized Icon" tooltip="button tooltip" />
+        ) : null}
         <Text>End Button icon</Text>
         {svgIconsEnabled ? <CustomizedIconButton endIcon={iconProps} content="Button with Right Icon" tooltip="button tooltip" /> : null}
       </Stack>

--- a/apps/fluent-tester/src/FluentTester/TestComponents/MenuButton/NestedMenuButtonTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/MenuButton/NestedMenuButtonTest.tsx
@@ -51,7 +51,7 @@ export const NestedMenuButton: React.FunctionComponent = () => {
       itemKey: '4',
       text: 'SubmenuItem svg icon',
       componentRef: React.useRef(null),
-      icon: iconProps,
+      startIcon: iconProps,
       onHoverIn: toggleShowSubmenu,
       showSubmenu,
       submenuProps: {
@@ -62,7 +62,7 @@ export const NestedMenuButton: React.FunctionComponent = () => {
       },
       submenuItems: [
         {
-          icon: iconProps,
+          startIcon: iconProps,
           text: 'SubmenuItem svg icon',
           itemKey: '1',
         },
@@ -140,7 +140,12 @@ export const NestedMenuButton: React.FunctionComponent = () => {
             <Text>Last Submenu Item Clicked: </Text>
             {lastSubmenuItemClicked > 0 ? <Text style={textColor}>{lastSubmenuItemClicked}</Text> : <Text style={textColor}>none</Text>}
           </Text>
-          <MenuButton icon={rasterImageProps} content="Press for Nested MenuButton" menuItems={nestedMenuItems} onItemClick={onItemClick} />
+          <MenuButton
+            startIcon={rasterImageProps}
+            content="Press for Nested MenuButton"
+            menuItems={nestedMenuItems}
+            onItemClick={onItemClick}
+          />
         </View>
       </View>
     </View>

--- a/apps/fluent-tester/src/FluentTester/TestComponents/MenuButton/StandardMenuButtonTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/MenuButton/StandardMenuButtonTest.tsx
@@ -58,14 +58,14 @@ export const StandardMenuButton: React.FunctionComponent = () => {
               />
               <Text>MenuButton with icon</Text>
               <MenuButton
-                icon={iconProps}
+                startIcon={iconProps}
                 content="MenuButton"
                 menuItems={menuItems}
                 onItemClick={onItemClick}
                 contextualMenu={contextualMenuProps}
               />
               <Text>MenuButton with only icon</Text>
-              <MenuButton icon={iconProps} menuItems={menuItems} onItemClick={onItemClick} contextualMenu={contextualMenuProps} />
+              <MenuButton startIcon={iconProps} menuItems={menuItems} onItemClick={onItemClick} contextualMenu={contextualMenuProps} />
               <Text>Disabled MenuButton</Text>
               <MenuButton disabled content="Disabled MenuButton" menuItems={menuItems} />
             </View>
@@ -81,14 +81,20 @@ export const StandardMenuButton: React.FunctionComponent = () => {
               <Text>Primary MenuButton with icon</Text>
               <MenuButton
                 primary
-                icon={iconProps}
+                startIcon={iconProps}
                 content="Primary MenuButton"
                 menuItems={menuItems}
                 onItemClick={onItemClick}
                 contextualMenu={contextualMenuProps}
               />
               <Text>Primary MenuButton with only icon</Text>
-              <MenuButton primary icon={iconProps} menuItems={menuItems} onItemClick={onItemClick} contextualMenu={contextualMenuProps} />
+              <MenuButton
+                primary
+                startIcon={iconProps}
+                menuItems={menuItems}
+                onItemClick={onItemClick}
+                contextualMenu={contextualMenuProps}
+              />
               <Text>Primary Disabled MenuButton</Text>
               <MenuButton primary disabled content="Disabled Primary MenuButton" menuItems={menuItems} />
             </View>

--- a/apps/fluent-tester/src/FluentTester/TestComponents/MenuButton/testData.ts
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/MenuButton/testData.ts
@@ -13,7 +13,7 @@ export const menuItems: MenuButtonItemProps[] = [
   {
     itemKey: '1',
     text: 'MenuItem 1',
-    icon: testImage,
+    startIcon: testImage,
   },
   {
     itemKey: '2',

--- a/packages/components/Button/src/Button.android.tsx
+++ b/packages/components/Button/src/Button.android.tsx
@@ -15,7 +15,7 @@ import { Icon } from '@fluentui-react-native/icon';
 export const Button = compose<IButtonType>({
   displayName: buttonName,
   usePrepareProps: (userProps: IButtonProps, useStyling: IUseComposeStyling<IButtonType>) => {
-    const { icon, content, accessibilityLabel = userProps.content, testID, onClick, ...rest } = userProps;
+    const { startIcon, endIcon, content, accessibilityLabel = userProps.content, testID, onClick, ...rest } = userProps;
     // attach the pressable state handlers
     const pressable = useAsPressable({ ...rest, onPress: onClick });
     // set up state
@@ -24,7 +24,8 @@ export const Button = compose<IButtonType>({
         ...pressable.state,
         disabled: !!userProps.disabled,
         content: !!content,
-        icon: !!icon,
+        startIcon: !!startIcon,
+        endIcon: !!endIcon,
       },
     };
 
@@ -42,7 +43,8 @@ export const Button = compose<IButtonType>({
         focusable: !state.info.disabled,
       },
       content: { children: content, testID: testID },
-      icon: createIconProps(icon),
+      startIcon: createIconProps(startIcon),
+      endIcon: createIconProps(endIcon),
     });
 
     return { slotProps, state };
@@ -54,9 +56,10 @@ export const Button = compose<IButtonType>({
       <Slots.root>
         <Slots.ripple>
           <Slots.stack>
-            {info.icon && <Slots.icon />}
+            {info.startIcon && <Slots.startIcon />}
             {info.content && <Slots.content />}
             {children}
+            {info.endIcon && <Slots.endIcon />}
           </Slots.stack>
         </Slots.ripple>
       </Slots.root>
@@ -66,14 +69,14 @@ export const Button = compose<IButtonType>({
     root: View,
     ripple: Pressable,
     stack: { slotType: View, filter: filterViewProps },
-    icon: { slotType: Icon as React.ComponentType },
+    startIcon: { slotType: Icon as React.ComponentType },
     content: Text,
   },
   styles: {
     root: [backgroundColorTokens, borderTokens],
     ripple: [],
     stack: [],
-    icon: [{ source: 'iconColor', lookup: getPaletteFromTheme, target: 'color' }],
+    startIcon: [{ source: 'iconColor', lookup: getPaletteFromTheme, target: 'color' }],
     content: [textTokens, foregroundColorTokens],
   },
 });

--- a/packages/components/Button/src/Button.settings.android.ts
+++ b/packages/components/Button/src/Button.settings.android.ts
@@ -33,7 +33,7 @@ export const settings: IComposeSettings<IButtonType> = [
     content: {
       variant: 'bodySemibold',
     },
-    icon: {
+    startIcon: {
       style: {
         marginEnd: 10,
       },

--- a/packages/components/Button/src/Button.settings.ts
+++ b/packages/components/Button/src/Button.settings.ts
@@ -27,7 +27,7 @@ export const settings: IComposeSettings<IButtonType> = [
         marginStart: 2
       }
     },
-    icon: {
+    startIcon: {
       style: {
         marginEnd: 2
       }

--- a/packages/components/Button/src/Button.settings.win32.ts
+++ b/packages/components/Button/src/Button.settings.win32.ts
@@ -27,7 +27,7 @@ export const settings: IComposeSettings<IButtonType> = [
         marginStart: 2
       }
     },
-    icon: {
+    startIcon: {
       style: {
         marginEnd: 2
       }

--- a/packages/components/Button/src/Button.tsx
+++ b/packages/components/Button/src/Button.tsx
@@ -24,7 +24,7 @@ export const Button = compose<IButtonType>({
   usePrepareProps: (userProps: IButtonProps, useStyling: IUseComposeStyling<IButtonType>) => {
     const defaultComponentRef = React.useRef(null);
     const {
-      icon,
+      startIcon,
       endIcon,
       content,
       onAccessibilityTap = userProps.onClick,
@@ -46,8 +46,8 @@ export const Button = compose<IButtonType>({
         ...pressable.state,
         disabled: !!userProps.disabled,
         content: !!content,
-        icon: !!icon,
-        endIcon: !!userProps.endIcon,
+        startIcon: !!startIcon,
+        endIcon: !!endIcon,
       },
     };
 
@@ -66,7 +66,7 @@ export const Button = compose<IButtonType>({
         onKeyUp: onKeyUp,
       },
       content: { children: content, testID: testID },
-      icon: createIconProps(icon),
+      startIcon: createIconProps(startIcon),
       endIcon: createIconProps(endIcon),
     });
 
@@ -79,7 +79,7 @@ export const Button = compose<IButtonType>({
     return (
       <Slots.root>
         <Slots.stack>
-          {info.icon && <Slots.icon />}
+          {info.startIcon && <Slots.startIcon />}
           {info.content && <Slots.content />}
           {children}
           {info.endIcon && <Slots.endIcon />}
@@ -90,14 +90,14 @@ export const Button = compose<IButtonType>({
   slots: {
     root: View,
     stack: { slotType: View, filter: filterViewProps },
-    icon: { slotType: Icon as React.ComponentType },
+    startIcon: { slotType: Icon as React.ComponentType },
     content: Text,
     endIcon: { slotType: Icon as React.ComponentType },
   },
   styles: {
     root: [backgroundColorTokens, borderTokens],
     stack: [],
-    icon: [{ source: 'iconColor', lookup: getPaletteFromTheme, target: 'color' }],
+    startIcon: [{ source: 'iconColor', lookup: getPaletteFromTheme, target: 'color' }],
     content: [textTokens, foregroundColorTokens],
     endIcon: [{ source: 'iconColor', lookup: getPaletteFromTheme, target: 'color' }],
   },

--- a/packages/components/Button/src/Button.types.ts
+++ b/packages/components/Button/src/Button.types.ts
@@ -19,9 +19,9 @@ export interface IButtonInfo extends IPressableState {
   disabled?: boolean;
 
   /**
-   * Button icon.
+   * Button start icon.
    */
-  icon?: boolean;
+  startIcon?: boolean;
 
   /**
    * Button text.
@@ -88,7 +88,7 @@ export interface IButtonTokens extends FontTokens, IForegroundColorTokens, IBack
   /**
    * Source URL or name of the icon to show on the Button.
    */
-  icon?: IconSourcesType;
+  startIcon?: IconSourcesType;
   endIcon?: IconSourcesType;
 }
 
@@ -99,9 +99,9 @@ export interface IButtonProps extends Omit<IPressableProps, 'onPress'> {
   content?: string;
 
   /**
-   * Source URL or name of the icon to show on the Button.
+   * Source URL or name of the start icon to show on the Button.
    */
-  icon?: IconSourcesType;
+  startIcon?: IconSourcesType;
   /**
    * A RefObject to access the IButton interface. Use this to access the public methods and properties of the component.
    */
@@ -120,7 +120,7 @@ export interface IButtonSlotProps {
   root: React.PropsWithRef<IViewProps>;
   ripple?: PressableProps; // This slot exists to enable ripple-effect in android. It does not affect other platforms.
   stack: ViewProps;
-  icon: IconProps;
+  startIcon: IconProps;
   content: ITextProps;
   endIcon: IconProps;
 }

--- a/packages/components/Button/src/PrimaryButton/PrimaryButton.settings.win32.ts
+++ b/packages/components/Button/src/PrimaryButton/PrimaryButton.settings.win32.ts
@@ -12,7 +12,7 @@ export const settings: IComposeSettings<IButtonType> = [
     endIcon: {
       color: '#ffffff',
     },
-    icon: {
+    startIcon: {
       color: '#ffffff',
     },
     _overrides: {

--- a/packages/components/MenuButton/src/MenuButton.macos.tsx
+++ b/packages/components/MenuButton/src/MenuButton.macos.tsx
@@ -19,7 +19,7 @@ import {
 export const MenuButton = compose<MenuButtonType>({
   displayName: MenuButtonName,
   usePrepareProps: (userProps: MenuButtonProps, useStyling: IUseComposeStyling<MenuButtonType>) => {
-    const { menuItems, content, icon, disabled, onItemClick } = userProps;
+    const { menuItems, content, startIcon, disabled, onItemClick } = userProps;
 
     const state: MenuButtonState = {
       context: {},
@@ -49,7 +49,7 @@ export const MenuButton = compose<MenuButtonType>({
       root: {
         content: content,
         disabled: disabled,
-        image: icon,
+        image: startIcon,
         menuItems: menuItems,
         onItemClick: OnItemClickRerouted,
         onSubmenuItemClick: OnSubmenuItemClickRerouted,

--- a/packages/components/MenuButton/src/MenuButton.tsx
+++ b/packages/components/MenuButton/src/MenuButton.tsx
@@ -30,7 +30,7 @@ const getChevronIcon = (color: string = defaultIconColor) => {
 export const MenuButton = compose<MenuButtonType>({
   displayName: MenuButtonName,
   usePrepareProps: (userProps: MenuButtonProps, useStyling: IUseComposeStyling<MenuButtonType>) => {
-    const { menuItems, content, icon, disabled, onItemClick, contextualMenu, primary } = userProps;
+    const { menuItems, content, startIcon, disabled, onItemClick, contextualMenu, primary } = userProps;
 
     const stdBtnRef = useRef(null);
     const [showContextualMenu, setShowContextualMenu] = useState(false);
@@ -85,7 +85,7 @@ export const MenuButton = compose<MenuButtonType>({
     const buttonProps = {
       content,
       disabled,
-      icon,
+      startIcon,
       componentRef: stdBtnRef,
       onClick: toggleShowContextualMenu,
       endIcon: chevronIconProps,


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [ ] windows
- [X] android

Renamed "icon" prop to "startIcon" prop in Button component.
We added endIcon to the Button that's why we need to rename "icon" to "startIcon".

### Verification
Checked manually

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [X] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
