### PR TITLE
Move testid to fix text header for test app

### DIFF
--- a/apps/fluent-tester/src/FluentTester/FluentTester.tsx
+++ b/apps/fluent-tester/src/FluentTester/FluentTester.tsx
@@ -87,12 +87,11 @@ export const FluentTester: React.FunctionComponent<FluentTesterProps> = (props: 
     const theme = useTheme();
 
     return (
-      <View style={fluentTesterStyles.header}>
+      <View style={fluentTesterStyles.header} testID={BASE_TESTPAGE}>
         <Text
           style={[fluentTesterStyles.testHeader]}
           variant="heroLargeSemibold"
           color={theme.host.palette?.TextEmphasis}
-          testID={BASE_TESTPAGE}
         >
           ⚛ FluentUI Tests
         </Text>
@@ -106,12 +105,11 @@ export const FluentTester: React.FunctionComponent<FluentTesterProps> = (props: 
     const theme = useTheme();
 
     return (
-      <View style={mobileStyles.header}>
+      <View style={mobileStyles.header} testID={BASE_TESTPAGE}>
         <Text
           style={[fluentTesterStyles.testHeader]}
           variant="heroLargeSemibold"
           color={theme.host.palette?.TextEmphasis}
-          testID={BASE_TESTPAGE}
         >
           ⚛ FluentUI Tests
         </Text>

--- a/apps/fluent-tester/src/FluentTester/FluentTester.tsx
+++ b/apps/fluent-tester/src/FluentTester/FluentTester.tsx
@@ -87,7 +87,7 @@ export const FluentTester: React.FunctionComponent<FluentTesterProps> = (props: 
     const theme = useTheme();
 
     return (
-      <View style={fluentTesterStyles.header} testID={BASE_TESTPAGE}>
+      <View style={fluentTesterStyles.header}>
         <Text
           style={[fluentTesterStyles.testHeader]}
           variant="heroLargeSemibold"
@@ -95,6 +95,8 @@ export const FluentTester: React.FunctionComponent<FluentTesterProps> = (props: 
         >
           ⚛ FluentUI Tests
         </Text>
+        {/* Workaround for testID prop on text component affecting text size */}
+        <Text testID={BASE_TESTPAGE}> </Text>
         <ThemePickers />
       </View>
     );
@@ -105,11 +107,12 @@ export const FluentTester: React.FunctionComponent<FluentTesterProps> = (props: 
     const theme = useTheme();
 
     return (
-      <View style={mobileStyles.header} testID={BASE_TESTPAGE}>
+      <View style={mobileStyles.header}>
         <Text
           style={[fluentTesterStyles.testHeader]}
           variant="heroLargeSemibold"
           color={theme.host.palette?.TextEmphasis}
+          testID={BASE_TESTPAGE}
         >
           ⚛ FluentUI Tests
         </Text>

--- a/change/@fluentui-react-native-tester-ca3bb92e-0695-4bbd-b558-8898c105afa2.json
+++ b/change/@fluentui-react-native-tester-ca3bb92e-0695-4bbd-b558-8898c105afa2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "move testid to fix text",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
Fixes #917 

### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [x] windows
- [ ] android

### Description of changes

@JasonVMo debugged into the tester text here and found that, somehow, the testID prop being set was making it so that the Segoe UI Semibold font wouldn't render at the specified size.

🤷‍♂️

Fix here is to move the testID to a dummy Text component.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/4602628/130521857-cc33e86b-65d3-423a-aeb8-89b5d6ec9a57.png) | ![image](https://user-images.githubusercontent.com/4602628/130521625-7fd2c1d5-5ed5-4df3-87aa-8b42116c8218.png) |

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
