### PR TITLE
Simplify creating win32 theme

### DIFF
--- a/change/@fluentui-react-native-theming-utils-a7c7b5cd-a7ab-4b1b-8c93-a0769313a3b1.json
+++ b/change/@fluentui-react-native-theming-utils-a7c7b5cd-a7ab-4b1b-8c93-a0769313a3b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove unneeded step",
+  "packageName": "@fluentui-react-native/theming-utils",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-win32-theme-37a56376-4250-421a-a301-f089f31a9fcc.json
+++ b/change/@fluentui-react-native-win32-theme-37a56376-4250-421a-a301-f089f31a9fcc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove unneeded step",
+  "packageName": "@fluentui-react-native/win32-theme",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/theming/theming-utils/src/getCurrentAppearance.ts
+++ b/packages/theming/theming-utils/src/getCurrentAppearance.ts
@@ -2,5 +2,9 @@ import { Appearance } from 'react-native';
 import { AppearanceOptions, ThemeOptions } from '@fluentui-react-native/theme-types';
 
 export function getCurrentAppearance(appearance: ThemeOptions['appearance'], fallback: AppearanceOptions): AppearanceOptions {
+  if (appearance === undefined) {
+    return fallback;
+  }
+
   return appearance === 'dynamic' ? (Appearance && Appearance.getColorScheme()) || fallback : appearance;
 }

--- a/packages/theming/win32-theme/src/createOfficeTheme.ts
+++ b/packages/theming/win32-theme/src/createOfficeTheme.ts
@@ -5,7 +5,6 @@ import { CxxException, PlatformDefaultsChangedArgs } from './NativeModule/office
 import { OfficePalette, Theme, ThemeOptions } from '@fluentui-react-native/theme-types';
 import { createPartialOfficeTheme } from './createPartialOfficeTheme';
 import { createBrandedThemeWithAlias } from './createBrandedThemeWithAlias';
-import { createAliasTokens, getCurrentAppearance } from '@fluentui-react-native/theming-utils';
 import { createAliasesFromPalette } from './createAliasesFromPalette';
 
 function handlePaletteCall(palette: OfficePalette | CxxException): OfficePalette | undefined {
@@ -33,9 +32,6 @@ export function createOfficeTheme(options: ThemeOptions = {}): ThemeReference {
       const name = paletteName || '';
       const palette = handlePaletteCall(ref.module.getPalette(name));
       return createPartialOfficeTheme(module, ref.themeName, palette);
-    },
-    (theme: Theme) => {
-      return { colors: { ...createAliasTokens(getCurrentAppearance(theme.host.appearance, 'light')) } };
     },
     (theme: Theme) => {
       return createBrandedThemeWithAlias(theme);


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

I noticed that the win32 theme has an extra alias tokens from theme step. The default theme already brings in alias tokens so we don't need that step anymore.

Also patched an issue with appearance being undefined making the default theme fall into dark mode.

### Verification

Verified via Theme tester page.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
