### PR TITLE
Align picker versions

### DIFF
--- a/apps/android/package.json
+++ b/apps/android/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@fluentui-react-native/tester": "^0.40.0",
     "@react-native-community/slider": "^3.0.3",
-    "@react-native-picker/picker": "^1.9.11",
+    "@react-native-picker/picker": "^1.16.7",
     "hermes-engine": "~0.5.0",
     "react": "16.13.1",
     "react-native": "^0.63.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2556,11 +2556,6 @@
   resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-1.16.7.tgz#2c943572efcd21c218ee03f23ba1475544b24cf1"
   integrity sha512-/QJxL4JniloFvdPDufQTiMQQbpucCQ0w7wvGhZQt0x3KVxvI1f/vzDO+669r/1yipcFZbSLcYIiQSMSpZtkqiQ==
 
-"@react-native-picker/picker@^1.9.11":
-  version "1.16.6"
-  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-1.16.6.tgz#6af7e69e4bf2b70ca713392c467c9e52477a6289"
-  integrity sha512-Vc/SRqKp/TWG6dcmKAbvTknS35L9/qhfinGkDzpOeephxiTOdUwKw8G0KEwuwvJyE0KwgglH5AeNHNS+4uYR8w==
-
 "@react-native-windows/cli@0.63.12":
   version "0.63.12"
   resolved "https://registry.yarnpkg.com/@react-native-windows/cli/-/cli-0.63.12.tgz#fff41cb8e0e039e133a8e3a29a25927fe77d5856"


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [x] android

### Description of changes

Forgot to change the picker version in the fluent tester package.json

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
