### PR TITLE
Update our pipeline to use macOS 11 and Xcode 12.5

### DIFF
--- a/.ado/azure-pipelines.publish.yml
+++ b/.ado/azure-pipelines.publish.yml
@@ -41,7 +41,7 @@ jobs:
   - job: NuGetPublish
     displayName: NuGet Publish
     pool:
-      vmImage: 'macos-10.15'
+      vmImage: 'macos-11'
       demands: ['xcode', 'sh', 'npm']
     timeoutInMinutes: 90 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them

--- a/.ado/azure-pipelines.yml
+++ b/.ado/azure-pipelines.yml
@@ -73,7 +73,7 @@ jobs:
   - job: ApplePR
     displayName: Apple PR
     pool:
-      vmImage: 'macos-10.15'
+      vmImage: 'macos-11'
       demands: ['xcode', 'sh', 'npm']
     timeoutInMinutes: 60 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
@@ -115,7 +115,7 @@ jobs:
   - job: AndroidPR
     displayName: Android PR
     pool:
-      vmImage: 'macos-10.15'
+      vmImage: 'macos-11'
     variables:
       relative_directory: 'android'
     timeoutInMinutes: 60 # how long to run the job before automatically cancelling
@@ -151,7 +151,7 @@ jobs:
   # - job: NuGetPublish
   #   displayName: NuGet Publish
   #   pool:
-  #     vmImage: 'macos-10.15'
+  #     vmImage: 'macos-11'
   #     demands: ['xcode', 'sh', 'npm']
   #   timeoutInMinutes: 90 # how long to run the job before automatically cancelling
   #   cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them

--- a/.ado/scripts/xcode_select_current_version.sh
+++ b/.ado/scripts/xcode_select_current_version.sh
@@ -3,7 +3,7 @@
 if [ -n "$XCODE_PATH_OVERRIDE" ]; then # If someone calls this with the XCODE_PATH_OVERRIDE variable set to a path to a developer dir, use it instead
     XCODE_PATH="$XCODE_PATH_OVERRIDE"
 else
-    XCODE_PATH='/Applications/Xcode_12.4.app/Contents/Developer'
+    XCODE_PATH='/Applications/Xcode_12.5.app/Contents/Developer'
 fi
 
 echo "Running command: sudo xcode-select --switch $XCODE_PATH"


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Following the changes in FluentUI Apple (https://github.com/microsoft/fluentui-apple/pull/700) let's update our version of macOS and Xcode in our pipeline to align with what we use downstream in office code. Specifically:
- macOS 11
- Xcode 12.5

### Verification

PR passing should prove that our code still builds

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
