### PR TITLE
Fix for unrecognized fonts in Text iOS

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/Text/CustomizeUsage.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Text/CustomizeUsage.tsx
@@ -53,8 +53,13 @@ export const CustomizeUsage: React.FunctionComponent = () => {
   const Wingdings = Text.customize({ tokens: { variant: 'captionStandard', fontFamily: 'Wingdings' } });
 
   // Examples of supported Android fonts.
+  const Casual = Text.customize({ tokens: { variant: 'heroStandard', fontFamily: 'casual' } });
+  const Cursive = Text.customize({ tokens: { variant: 'heroStandard', fontFamily: 'cursive' } });
+  // Examples of iOS fonts.
+  const Papyrus = Text.customize({ tokens: { variant: 'heroLargeStandard', fontFamily: 'Papyrus' } });
+  const Helvetica = Text.customize({ tokens: { variant: 'heroLargeStandard', fontFamily: 'Helvetica' } });
+  // Fonts supported on Android and iOS
   const Arial = Text.customize({ tokens: { variant: 'heroLargeStandard', fontFamily: 'arial' } });
-  const ComingSoon = Text.customize({ tokens: { variant: 'heroStandard', fontFamily: 'casual' } });
 
   const CustomFontStack = () => {
     return (
@@ -72,7 +77,20 @@ export const CustomizeUsage: React.FunctionComponent = () => {
     return (
       <Stack style={stackStyle} gap={5}>
         <Arial>Arial</Arial>
-        <ComingSoon>ComingSoon</ComingSoon>
+        <Casual>Casual</Casual>
+        <Cursive>Cursive</Cursive>
+        <CourierNew>Courier New</CourierNew>
+        <Georgia>Georgia</Georgia>
+        <TimesNewRoman>TimesNewRoman</TimesNewRoman>
+      </Stack>
+    );
+  };
+  const CustomFontStackiOS = () => {
+    return (
+      <Stack style={stackStyle} gap={5}>
+        <Arial>Arial</Arial>
+        <Papyrus>Papyrus</Papyrus>
+        <Helvetica>Helvetica</Helvetica>
         <CourierNew>Courier New</CourierNew>
         <Georgia>Georgia</Georgia>
         <TimesNewRoman>TimesNewRoman</TimesNewRoman>
@@ -80,15 +98,27 @@ export const CustomizeUsage: React.FunctionComponent = () => {
     );
   };
 
-  return Platform.OS == 'android' ? (
-    <View>
-      <CustomUsageStack />
-      <CustomFontStackAndroid />
-    </View>
-  ) : (
-    <View>
-      <CustomUsageStack />
-      <CustomFontStack />
-    </View>
-  );
+  switch (Platform.OS) {
+    case 'android':
+      return (
+        <View>
+          <CustomUsageStack />
+          <CustomFontStackAndroid />
+        </View>
+      );
+    case 'ios':
+      return (
+        <View>
+          <CustomUsageStack />
+          <CustomFontStackiOS />
+        </View>
+      );
+    default:
+      return (
+        <View>
+          <CustomUsageStack />
+          <CustomFontStack />
+        </View>
+      );
+  }
 };

--- a/apps/fluent-tester/src/FluentTester/TestComponents/TextExperimental/CustomizeUsage.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/TextExperimental/CustomizeUsage.tsx
@@ -53,8 +53,13 @@ export const CustomizeUsage: React.FunctionComponent = () => {
   const Wingdings = Text.customize({ variant: 'captionStandard', fontFamily: 'Wingdings' });
 
   // Examples of supported Android fonts.
+  const Casual = Text.customize({ variant: 'heroStandard', fontFamily: 'casual' });
+  const Cursive = Text.customize({ variant: 'heroStandard', fontFamily: 'cursive' });
+  // Examples of iOS fonts.
+  const Papyrus = Text.customize({ variant: 'heroLargeStandard', fontFamily: 'Papyrus' });
+  const Helvetica = Text.customize({ variant: 'heroLargeStandard', fontFamily: 'Helvetica' });
+  // Fonts supported on Android and iOS
   const Arial = Text.customize({ variant: 'heroLargeStandard', fontFamily: 'arial' });
-  const ComingSoon = Text.customize({ variant: 'heroStandard', fontFamily: 'casual' });
 
   const CustomFontStack = () => {
     return (
@@ -72,7 +77,20 @@ export const CustomizeUsage: React.FunctionComponent = () => {
     return (
       <Stack style={stackStyle} gap={5}>
         <Arial>Arial</Arial>
-        <ComingSoon>ComingSoon</ComingSoon>
+        <Casual>Casual</Casual>
+        <Cursive>Cursive</Cursive>
+        <CourierNew>Courier New</CourierNew>
+        <Georgia>Georgia</Georgia>
+        <TimesNewRoman>TimesNewRoman</TimesNewRoman>
+      </Stack>
+    );
+  };
+  const CustomFontStackiOS = () => {
+    return (
+      <Stack style={stackStyle} gap={5}>
+        <Arial>Arial</Arial>
+        <Papyrus>Papyrus</Papyrus>
+        <Helvetica>Helvetica</Helvetica>
         <CourierNew>Courier New</CourierNew>
         <Georgia>Georgia</Georgia>
         <TimesNewRoman>TimesNewRoman</TimesNewRoman>
@@ -80,15 +98,27 @@ export const CustomizeUsage: React.FunctionComponent = () => {
     );
   };
 
-  return Platform.OS == 'android' ? (
-    <View>
-      <CustomUsageStack />
-      <CustomFontStackAndroid />
-    </View>
-  ) : (
-    <View>
-      <CustomUsageStack />
-      <CustomFontStack />
-    </View>
-  );
+  switch (Platform.OS) {
+    case 'android':
+      return (
+        <View>
+          <CustomUsageStack />
+          <CustomFontStackAndroid />
+        </View>
+      );
+    case 'ios':
+      return (
+        <View>
+          <CustomUsageStack />
+          <CustomFontStackiOS />
+        </View>
+      );
+    default:
+      return (
+        <View>
+          <CustomUsageStack />
+          <CustomFontStack />
+        </View>
+      );
+  }
 };

--- a/apps/ios/src/Podfile.lock
+++ b/apps/ios/src/Podfile.lock
@@ -18,14 +18,14 @@ PODS:
     - boost-for-react-native
     - DoubleConversion
     - glog
-  - FRNAvatar (0.11.9):
+  - FRNAvatar (0.12.5):
     - MicrosoftFluentUI (= 0.3.0)
     - MicrosoftFluentUI/Avatar_ios (= 0.3.0)
     - React
-  - FRNButton (0.7.12):
+  - FRNButton (0.7.20):
     - MicrosoftFluentUI (= 0.3.0)
     - React
-  - FRNDatePicker (0.3.4):
+  - FRNDatePicker (0.3.6):
     - MicrosoftFluentUI (= 0.3.0)
     - React
   - glog (0.3.5)
@@ -415,7 +415,7 @@ PODS:
     - React-Core (= 0.63.4)
     - React-cxxreact (= 0.63.4)
     - React-jsi (= 0.63.4)
-  - ReactTestApp-DevSupport (0.7.1)
+  - ReactTestApp-DevSupport (0.7.5)
   - ReactTestApp-Resources (1.0.0-dev)
   - RNSVG (12.1.1):
     - React
@@ -545,9 +545,9 @@ SPEC CHECKSUMS:
   FBLazyVector: 3bb422f41b18121b71783a905c10e58606f7dc3e
   FBReactNativeSpec: f2c97f2529dd79c083355182cc158c9f98f4bd6e
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
-  FRNAvatar: b4a793a07f33294c990bef410a12191ccbe508fc
-  FRNButton: 34aec89b4aad59842203630cbdc470a38743f5b7
-  FRNDatePicker: 1bbfe4bc57507ac69c73d4ddcce0e0d77e493802
+  FRNAvatar: f631c488ceadbf4a3f885bb10275104b1041da82
+  FRNButton: 525525958d2c3083e5c2a213e8d4c78e4d1169cc
+  FRNDatePicker: 28086c1c8092614414b4f8b7b3675f3b2a8c9cfc
   glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
   MicrosoftFluentUI: b98d877a2122804132365aa167944f58ef4adb69
   QRCodeReader.swift: 373a389fe9a22d513c879a32a6f647c58f4ef572
@@ -573,7 +573,7 @@ SPEC CHECKSUMS:
   React-RCTText: 5c51df3f08cb9dedc6e790161195d12bac06101c
   React-RCTVibration: ae4f914cfe8de7d4de95ae1ea6cc8f6315d73d9d
   ReactCommon: 73d79c7039f473b76db6ff7c6b159c478acbbb3b
-  ReactTestApp-DevSupport: 058444bc8d4df209aabc6a5f54a73bfd9a114f94
+  ReactTestApp-DevSupport: 84ab1181efc86b93291e97746b58de70016c5340
   ReactTestApp-Resources: 5950ae44720217c6778ff03fb1d906c8fb3ce483
   RNSVG: 551acb6562324b1d52a4e0758f7ca0ec234e278f
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52

--- a/change/@fluentui-react-native-tester-8906750b-e02e-45aa-ae41-9043a216a1d1.json
+++ b/change/@fluentui-react-native-tester-8906750b-e02e-45aa-ae41-9043a216a1d1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix Font error in Text iOS",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "67026167+chiuam@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [X] android

### Description of changes
This change addresses https://github.com/microsoft/fluentui-react-native/issues/657 where 'Arial Black', 'Brush Script MT', and 'Wingdings' fonts are not supported on iOS. Let's add a custom font stack for iOS like Android did. I also added a few more font examples for android and iOS.

### Verification
![image](https://user-images.githubusercontent.com/67026167/131915861-0a1252bf-df9a-4060-ab0b-cb103e87789a.png)
![image](https://user-images.githubusercontent.com/67026167/131915791-ae0f4380-fa65-4f75-a8aa-cbd538b4a503.png)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [X] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
