### PR TITLE
Removed non-working Controls Test Pages from the windows Tester App

### DIFF
--- a/apps/fluent-tester/src/FluentTester/testPages.windows.ts
+++ b/apps/fluent-tester/src/FluentTester/testPages.windows.ts
@@ -1,18 +1,15 @@
 import { ButtonTest, HOMEPAGE_BUTTON_BUTTON } from './TestComponents/Button';
 import { CalloutTest, HOMEPAGE_CALLOUT_BUTTON } from './TestComponents/Callout';
 import { CheckboxTest, HOMEPAGE_CHECKBOX_BUTTON } from './TestComponents/Checkbox';
-import { ContextualMenuTest, HOMEPAGE_CONTEXTUALMENU_BUTTON } from './TestComponents/ContextualMenu';
 import { HOMEPAGE_LINK_BUTTON, LinkTest } from './TestComponents/Link';
 import { HOMEPAGE_PERSONA_BUTTON, PersonaTest } from './TestComponents/Persona';
 import { HOMEPAGE_PERSONACOIN_BUTTON, PersonaCoinTest } from './TestComponents/PersonaCoin';
 import { HOMEPAGE_PRESSABLE_BUTTON, PressableTest } from './TestComponents/Pressable';
-import { HOMEPAGE_RADIOGROUP_BUTTON, RadioGroupTest } from './TestComponents/RadioGroup';
 import { HOMEPAGE_SEPARATOR_BUTTON, SeparatorTest } from './TestComponents/Separator';
 import { HOMEPAGE_TEXT_BUTTON, TextTest } from './TestComponents/Text';
 import { HOMEPAGE_THEME_BUTTON, ThemeTest } from './TestComponents/Theme';
 import { HOMEPAGE_TABS_BUTTON, TabsTest } from './TestComponents/Tabs';
 import { HOMEPAGE_TOKEN_BUTTON, TokenTest } from './TestComponents/Tokens';
-import { ExpanderTest, HOMEPAGE_EXPANDER_BUTTON } from './TestComponents/Expander';
 import { HOMEPAGE_EXPERIMENTAL_TEXT_BUTTON, TextExperimentalTest } from './TestComponents/TextExperimental';
 
 export const tests = [
@@ -25,11 +22,6 @@ export const tests = [
     name: 'Callout Test',
     component: CalloutTest,
     testPage: HOMEPAGE_CALLOUT_BUTTON,
-  },
-  {
-    name: 'ContextualMenu Test',
-    component: ContextualMenuTest,
-    testPage: HOMEPAGE_CONTEXTUALMENU_BUTTON,
   },
   {
     name: 'Pressable Test',
@@ -55,11 +47,6 @@ export const tests = [
     testPage: HOMEPAGE_PERSONACOIN_BUTTON,
   },
   {
-    name: 'RadioGroup Test',
-    component: RadioGroupTest,
-    testPage: HOMEPAGE_RADIOGROUP_BUTTON,
-  },
-  {
     name: 'Persona Test',
     component: PersonaTest,
     testPage: HOMEPAGE_PERSONA_BUTTON,
@@ -78,10 +65,5 @@ export const tests = [
     name: 'Tokens Test',
     component: TokenTest,
     testPage: HOMEPAGE_TOKEN_BUTTON,
-  },
-  {
-    name: 'Expander Test',
-    component: ExpanderTest,
-    testPage: HOMEPAGE_EXPANDER_BUTTON,
   },
 ];

--- a/apps/fluent-tester/src/FluentTester/testPages.windows.ts
+++ b/apps/fluent-tester/src/FluentTester/testPages.windows.ts
@@ -10,6 +10,7 @@ import { HOMEPAGE_TEXT_BUTTON, TextTest } from './TestComponents/Text';
 import { HOMEPAGE_THEME_BUTTON, ThemeTest } from './TestComponents/Theme';
 import { HOMEPAGE_TABS_BUTTON, TabsTest } from './TestComponents/Tabs';
 import { HOMEPAGE_TOKEN_BUTTON, TokenTest } from './TestComponents/Tokens';
+import { ExpanderTest, HOMEPAGE_EXPANDER_BUTTON } from './TestComponents/Expander';
 import { HOMEPAGE_EXPERIMENTAL_TEXT_BUTTON, TextExperimentalTest } from './TestComponents/TextExperimental';
 
 export const tests = [
@@ -65,5 +66,10 @@ export const tests = [
     name: 'Tokens Test',
     component: TokenTest,
     testPage: HOMEPAGE_TOKEN_BUTTON,
+  },
+  {
+    name: 'Expander Test',
+    component: ExpanderTest,
+    testPage: HOMEPAGE_EXPANDER_BUTTON,
   },
 ];

--- a/change/@fluentui-react-native-tester-3a600d2f-c52b-4f4b-933d-aacb8d0de8ba.json
+++ b/change/@fluentui-react-native-tester-3a600d2f-c52b-4f4b-933d-aacb8d0de8ba.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Removed non-working components from the tester app",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "dake.3601@gmail.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [x] windows
- [ ] android

### Description of changes

Removed the following Test Pages from the windows Tester App:
- ContextualMenu Test
- RadioGroup Test

### Verification

**Before**

ContextualMenu Test
![image](https://user-images.githubusercontent.com/57121448/132073172-14c386e1-9631-451a-90f0-9b169782f544.png)

<!--
Expander Test
![image](https://user-images.githubusercontent.com/57121448/132073177-cf008d40-c3a9-4fb9-9cee-f21676312981.png)
-->
 
RadioGroup Test
![image](https://user-images.githubusercontent.com/57121448/132073185-664ed50b-b584-464c-b3b2-d7e542c371af.png)


**After**

![image](https://user-images.githubusercontent.com/57121448/132073044-9c5617fc-0686-4355-916c-5187f4b42cb1.png)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
