### PR TITLE
Fixed bug with changing height of Button on focus

### DIFF
--- a/change/@fluentui-react-native-button-79f27a9a-c807-407e-a9fe-e8dd02de3018.json
+++ b/change/@fluentui-react-native-button-79f27a9a-c807-407e-a9fe-e8dd02de3018.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed bug with changing height of Button on focus",
+  "packageName": "@fluentui-react-native/button",
+  "email": "v.kozlova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Button/src/Button.settings.win32.ts
+++ b/packages/components/Button/src/Button.settings.win32.ts
@@ -82,6 +82,7 @@ export const settings: IComposeSettings<IButtonType> = [
           borderWidth: 2,
         },
         stack: {
+          // TODO - #984: temp solution to remove extra space for the focused button
           style: {
             height: 22
           }

--- a/packages/components/Button/src/Button.settings.win32.ts
+++ b/packages/components/Button/src/Button.settings.win32.ts
@@ -82,7 +82,7 @@ export const settings: IComposeSettings<IButtonType> = [
           borderWidth: 2,
         },
         stack: {
-          // TODO - #984: temp solution to remove extra space for the focused button
+          // GH #986: temp solution to remove extra space for the focused button
           style: {
             height: 22
           }

--- a/packages/components/Button/src/Button.settings.win32.ts
+++ b/packages/components/Button/src/Button.settings.win32.ts
@@ -46,7 +46,7 @@ export const settings: IComposeSettings<IButtonType> = [
         alignItems: 'center',
         flexDirection: 'row',
         alignSelf: 'flex-start',
-        minHeight: 24,
+        height: 24,
         minWidth: 32,
         justifyContent: 'center',
       },
@@ -81,6 +81,11 @@ export const settings: IComposeSettings<IButtonType> = [
           borderColor: 'strokeFocus2',
           borderWidth: 2,
         },
+        stack: {
+          style: {
+            height: 22
+          }
+        }
       },
     },
   },

--- a/packages/components/Button/src/PrimaryButton/PrimaryButton.settings.win32.ts
+++ b/packages/components/Button/src/PrimaryButton/PrimaryButton.settings.win32.ts
@@ -8,7 +8,7 @@ export const settings: IComposeSettings<IButtonType> = [
       color: 'neutralForegroundInverted',
       borderColor: 'brandBackground',
     },
-    // TODO - #728: neutralForegroundInverted is not working for icon color.
+    // GH #728: neutralForegroundInverted is not working for icon color.
     endIcon: {
       color: '#ffffff',
     },


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
Border-width of focused button is 2px. Because of that focused button had different height.

### Verification
![image](https://user-images.githubusercontent.com/11574680/132244476-4a2b9a1d-eea8-4546-bec5-12a12b94b45b.png)![image](https://user-images.githubusercontent.com/11574680/132244488-d642e7f4-06ad-4acf-a60b-7698f3ced7d6.png)


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
