### PR TITLE
Primary button color

### DIFF
--- a/change/@fluentui-react-native-button-e1b227b9-2998-44cc-a950-8fc4ae365f2e.json
+++ b/change/@fluentui-react-native-button-e1b227b9-2998-44cc-a950-8fc4ae365f2e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated color for Primary button according to the design",
+  "packageName": "@fluentui-react-native/button",
+  "email": "v.kozlova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Button/src/PrimaryButton/PrimaryButton.settings.win32.ts
+++ b/packages/components/Button/src/PrimaryButton/PrimaryButton.settings.win32.ts
@@ -5,10 +5,10 @@ export const settings: IComposeSettings<IButtonType> = [
   {
     tokens: {
       backgroundColor: 'brandBackground',
-      color: 'neutralForegroundInverted',
+      color: 'neutralForegroundOnBrand',
       borderColor: 'brandBackground',
     },
-    // TODO - #728: neutralForegroundInverted is not working for icon color.
+    // TODO - #728: neutralForegroundOnBrand is not working for icon color.
     endIcon: {
       color: '#ffffff',
     },
@@ -26,14 +26,14 @@ export const settings: IComposeSettings<IButtonType> = [
       hovered: {
         tokens: {
           backgroundColor: 'brandBackgroundHover',
-          color: 'neutralForegroundInverted',
+          color: 'neutralForegroundOnBrand',
           borderColor: 'brandBackgroundHover',
         },
       },
       pressed: {
         tokens: {
           backgroundColor: 'brandBackgroundPressed',
-          color: 'neutralForegroundInverted',
+          color: 'neutralForegroundOnBrand',
           borderColor: 'brandBackgroundPressed',
         },
       },
@@ -41,7 +41,7 @@ export const settings: IComposeSettings<IButtonType> = [
         tokens: {
           backgroundColor: 'brandBackgroundHover',
           borderColor: 'strokeFocus2',
-          color: 'neutralForegroundInvertedHover',
+          color: 'neutralForegroundInvertedLinkHover',
         },
       },
     },


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
Fixed bug with color of Primary button in Dark mode.

### Verification
Before:
![image](https://user-images.githubusercontent.com/11574680/132408394-107ea7a8-9691-4624-b2fa-6447c4f34c01.png)

After:
![image](https://user-images.githubusercontent.com/11574680/132408309-b55e6260-9f54-453e-8de2-5bb5bc5beba8.png)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
