### PR TITLE
Take brand colors from pipeline

### DIFF
--- a/apps/fluent-tester/src/FluentTester/theme/CustomThemes.ts
+++ b/apps/fluent-tester/src/FluentTester/theme/CustomThemes.ts
@@ -39,7 +39,11 @@ export class TesterThemeReference extends ThemeReference {
   private baseTheme: ThemeReference;
 
   constructor() {
-    super(baseTheme, parent => applyTheme(parent, this._themeName, this.options.appearance), () => applyBrand(this._brand));
+    super(
+      baseTheme,
+      parent => applyTheme(parent, this._themeName, this.options.appearance),
+      () => applyBrand(this._themeName, this._brand),
+    );
     this.baseTheme = baseTheme;
     this.options = themeOptions;
   }

--- a/apps/fluent-tester/src/FluentTester/theme/applyBrand.ts
+++ b/apps/fluent-tester/src/FluentTester/theme/applyBrand.ts
@@ -1,4 +1,5 @@
 import { PartialTheme } from '@fluentui-react-native/theme-types';
+import { getCurrentBrandAliasTokens } from '@fluentui-react-native/win32-theme';
 
 export type OfficeBrand = 'Default' | 'Office' | 'Word' | 'Excel' | 'Powerpoint' | 'Outlook';
 type BrandRampKey =
@@ -122,7 +123,7 @@ const brandColors: BrandRamps = {
 
 export const brandOptions = Object.keys(brandColors).map(brand => ({ label: brand, value: brand }));
 
-export const applyBrand = (currentBrand: string): PartialTheme => {
+export const applyBrand = (themeName: string, currentBrand: string): PartialTheme => {
   const ramp = brandColors[currentBrand];
   return ramp
     ? {
@@ -159,36 +160,7 @@ export const applyBrand = (currentBrand: string): PartialTheme => {
           brandedPressedBackground: ramp.App8,
           brandedPressedBorder: ramp.App7,
           defaultCheckedHoveredBackground: ramp.App1,
-          neutralForeground2BrandHover: ramp.AppPrimary,
-          neutralForeground2BrandPressed: ramp.AppShade10,
-          neutralForeground2BrandSelected: ramp.AppPrimary,
-          neutralForeground3BrandHover: ramp.AppPrimary,
-          neutralForeground3BrandPressed: ramp.AppShade10,
-          neutralForeground3BrandSelected: ramp.AppPrimary,
-          brandForegroundLink: ramp.AppShade10,
-          brandForegroundLinkHover: ramp.AppShade20,
-          brandForegroundLinkPressed: ramp.AppShade30,
-          brandForegroundLinkSelected: ramp.AppShade10,
-          compoundBrandForeground1: ramp.AppPrimary,
-          compoundBrandForeground1Hover: ramp.AppShade10,
-          compoundBrandForeground1Pressed: ramp.AppShade20,
-          brandForeground1: ramp.AppPrimary,
-          brandForeground2: ramp.AppShade10,
-          brandBackground: ramp.AppPrimary,
-          brandBackgroundHover: ramp.AppShade10,
-          brandBackgroundPressed: ramp.AppShade30,
-          brandBackgroundSelected: ramp.AppShade20,
-          compoundBrandBackground1: ramp.AppPrimary,
-          compoundBrandBackground1Hover: ramp.AppShade10,
-          compoundBrandBackground1Pressed: ramp.AppShade20,
-          brandBackgroundStatic: ramp.AppPrimary,
-          brandBackground2: ramp.AppTint40,
-          neutralStrokeAccessibleSelected: ramp.AppPrimary,
-          brandStroke1: ramp.AppPrimary,
-          brandStroke2: ramp.AppTint40,
-          compoundBrandStroke1: ramp.AppPrimary,
-          compoundBrandStroke1Hover: ramp.AppShade10,
-          compoundBrandStroke1Pressed: ramp.AppShade20,
+          ...getCurrentBrandAliasTokens(themeName, ramp.AppPrimary),
         },
       }
     : {};

--- a/change/@fluentui-react-native-tester-1c08681e-1c94-4888-959b-c6a447a64083.json
+++ b/change/@fluentui-react-native-tester-1c08681e-1c94-4888-959b-c6a447a64083.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix tester",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-theme-tokens-a0bbe0fb-6cf5-49a1-9c64-7797be824c1f.json
+++ b/change/@fluentui-react-native-theme-tokens-a0bbe0fb-6cf5-49a1-9c64-7797be824c1f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add web versions",
+  "packageName": "@fluentui-react-native/theme-tokens",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-win32-theme-43e3ed13-a893-458a-ad74-89490230b984.json
+++ b/change/@fluentui-react-native-win32-theme-43e3ed13-a893-458a-ad74-89490230b984.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Branding should pull from pipeline",
+  "packageName": "@fluentui-react-native/win32-theme",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/theming/theme-tokens/src/global-win32/reactnative/tokens-global.json
+++ b/packages/theming/theme-tokens/src/global-win32/reactnative/tokens-global.json
@@ -1,15 +1,5 @@
 {
   "color": {
-    "access": {
-      "primary": "#af2031",
-      "shade10": "#9e1d2c",
-      "shade20": "#861825",
-      "shade30": "#63121b",
-      "tint10": "#b93443",
-      "tint20": "#d06975",
-      "tint30": "#e7b0b5",
-      "tint40": "#f2d3d6"
-    },
     "anchor": {
       "primary": "#394146",
       "shade10": "#333a3f",
@@ -299,10 +289,15 @@
       "shade10": "#0f703b",
       "shade20": "#0c5f32",
       "shade30": "#094624",
+      "shade40": "#094624",
+      "shade50": "#052912",
+      "shade60": "#03160a",
       "tint10": "#218d51",
       "tint20": "#55b17e",
       "tint30": "#a0d8b9",
-      "tint40": "#caead8"
+      "tint40": "#caead8",
+      "tint50": "#a0d8b9",
+      "tint60": "#caead8"
     },
     "forest": {
       "primary": "#498205",
@@ -584,20 +579,30 @@
       "shade10": "#c33400",
       "shade20": "#a52c00",
       "shade30": "#792000",
+      "shade40": "#792000",
+      "shade50": "#4d2415",
+      "shade60": "#29130b",
       "tint10": "#dd4f1b",
       "tint20": "#e8825d",
       "tint30": "#f4beaa",
-      "tint40": "#f9dcd1"
+      "tint40": "#f9dcd1",
+      "tint50": "#f4beaa",
+      "tint60": "#f9dcd1"
     },
     "oneNote": {
       "primary": "#80397b",
       "shade10": "#6c2f68",
       "shade20": "#52254f",
       "shade30": "#3c1a3a",
+      "shade40": "#430e60",
+      "shade50": "#430e60",
+      "shade60": "#430e60",
       "tint10": "#9e5499",
       "tint20": "#d4a9d1",
       "tint30": "#e0bfde",
-      "tint40": "#f0daee"
+      "tint40": "#f0daee",
+      "tint50": "#e6d1f2",
+      "tint60": "#e6d1f2"
     },
     "orange": {
       "primary": "#f7630c",
@@ -632,10 +637,15 @@
       "shade10": "#106ebe",
       "shade20": "#1664a7",
       "shade30": "#135995",
+      "shade40": "#004578",
+      "shade50": "#043862",
+      "shade60": "#092c47",
       "tint10": "#2488d8",
       "tint20": "#69afe5",
       "tint30": "#b3d6f2",
-      "tint40": "#cce3f5"
+      "tint40": "#cce3f5",
+      "tint50": "#deecf9",
+      "tint60": "#eff6fc"
     },
     "peach": {
       "primary": "#ff8c00",
@@ -698,20 +708,15 @@
       "shade10": "#b13719",
       "shade20": "#952f15",
       "shade30": "#6e220f",
+      "shade40": "#6e220f",
+      "shade50": "#3c1805",
+      "shade60": "#200d03",
       "tint10": "#cb5031",
       "tint20": "#dc816a",
       "tint30": "#edbcb0",
-      "tint40": "#f6dbd4"
-    },
-    "publisher": {
-      "primary": "#038387",
-      "shade10": "#02767a",
-      "shade20": "#026367",
-      "shade30": "#02494c",
-      "tint10": "#159196",
-      "tint20": "#4bb4b7",
-      "tint30": "#9bd9db",
-      "tint40": "#c7ebec"
+      "tint40": "#f6dbd4",
+      "tint50": "#edbcb0",
+      "tint60": "#f6dbd4"
     },
     "pumpkin": {
       "primary": "#ca5010",
@@ -826,6 +831,21 @@
       "tint60": "#f0fafa"
     },
     "white": "#ffffff",
+    "word": {
+      "primary": "#185abd",
+      "shade10": "#1651aa",
+      "shade20": "#13458f",
+      "shade30": "#0e336a",
+      "shade40": "#0e336a",
+      "shade50": "#0c2145",
+      "shade60": "#071225",
+      "tint10": "#2e6ac5",
+      "tint20": "#6794d7",
+      "tint30": "#aec6eb",
+      "tint40": "#d2e0f4",
+      "tint50": "#aec6eb",
+      "tint60": "#d2e0f4"
+    },
     "yellow": {
       "primary": "#fde300",
       "shade10": "#e4cc00",

--- a/packages/theming/theme-tokens/src/global/reactnative/tokens-global.json
+++ b/packages/theming/theme-tokens/src/global/reactnative/tokens-global.json
@@ -284,6 +284,21 @@
       "tint50": "#c2e7e7",
       "tint60": "#eff9f9"
     },
+    "excel": {
+      "primary": "#107c41",
+      "shade10": "#0f703b",
+      "shade20": "#0c5f32",
+      "shade30": "#0a5325",
+      "shade40": "#094624",
+      "shade50": "#052912",
+      "shade60": "#03160a",
+      "tint10": "#10893c",
+      "tint20": "#1f954a",
+      "tint30": "#60bd82",
+      "tint40": "#55b17e",
+      "tint50": "#a0d8b9",
+      "tint60": "#caead8"
+    },
     "forest": {
       "primary": "#498205",
       "shade10": "#427505",
@@ -559,6 +574,36 @@
     },
     "neutralShadowAmbient": "#0000001f",
     "neutralShadowKey": "#00000024",
+    "office": {
+      "primary": "#d83b01",
+      "shade10": "#c33400",
+      "shade20": "#a52c00",
+      "shade30": "#99482b",
+      "shade40": "#792000",
+      "shade50": "#4d2415",
+      "shade60": "#29130b",
+      "tint10": "#fe7948",
+      "tint20": "#ff865a",
+      "tint30": "#ff9973",
+      "tint40": "#e8825d",
+      "tint50": "#f4beaa",
+      "tint60": "#f9dcd1"
+    },
+    "oneNote": {
+      "primary": "#7719aa",
+      "shade10": "#6c179a",
+      "shade20": "#5b1382",
+      "shade30": "#430e60",
+      "shade40": "#430e60",
+      "shade50": "#430e60",
+      "shade60": "#430e60",
+      "tint10": "#862eb5",
+      "tint20": "#a864cd",
+      "tint30": "#d1abe6",
+      "tint40": "#e6d1f2",
+      "tint50": "#e6d1f2",
+      "tint60": "#e6d1f2"
+    },
     "orange": {
       "primary": "#f7630c",
       "shade10": "#de590b",
@@ -586,6 +631,21 @@
       "tint40": "#d7caea",
       "tint50": "#e9e2f4",
       "tint60": "#f9f8fc"
+    },
+    "outlook": {
+      "primary": "#0078d4",
+      "shade10": "#106ebe",
+      "shade20": "#005a9e",
+      "shade30": "#004c87",
+      "shade40": "#004578",
+      "shade50": "#043862",
+      "shade60": "#092c47",
+      "tint10": "#2899f5",
+      "tint20": "#3aa0f3",
+      "tint30": "#6cb8f6",
+      "tint40": "#c7e0f4",
+      "tint50": "#deecf9",
+      "tint60": "#eff6fc"
     },
     "peach": {
       "primary": "#ff8c00",
@@ -642,6 +702,21 @@
       "tint40": "#d696c0",
       "tint50": "#e9c4dc",
       "tint60": "#faf0f6"
+    },
+    "powerPoint": {
+      "primary": "#c43e1c",
+      "shade10": "#b13719",
+      "shade20": "#952f15",
+      "shade30": "#79310a",
+      "shade40": "#6e220f",
+      "shade50": "#3c1805",
+      "shade60": "#200d03",
+      "tint10": "#ca5010",
+      "tint20": "#cf6024",
+      "tint30": "#e1966d",
+      "tint40": "#dc816a",
+      "tint50": "#edbcb0",
+      "tint60": "#f6dbd4"
     },
     "pumpkin": {
       "primary": "#ca5010",
@@ -756,6 +831,21 @@
       "tint60": "#f0fafa"
     },
     "white": "#ffffff",
+    "word": {
+      "primary": "#185abd",
+      "shade10": "#1651aa",
+      "shade20": "#13458f",
+      "shade30": "#19428a",
+      "shade40": "#0e336a",
+      "shade50": "#0c2145",
+      "shade60": "#071225",
+      "tint10": "#296fe6",
+      "tint20": "#3d7ce8",
+      "tint30": "#82abf1",
+      "tint40": "#6794d7",
+      "tint50": "#aec6eb",
+      "tint60": "#d2e0f4"
+    },
     "yellow": {
       "primary": "#fde300",
       "shade10": "#e4cc00",

--- a/packages/theming/theme-tokens/src/pipeline-input/token-input-brand.win32.json
+++ b/packages/theming/theme-tokens/src/pipeline-input/token-input-brand.win32.json
@@ -5,20 +5,6 @@
   },
   "Global": {
     "Color": {
-      "Access": {
-        "Shade": {
-          "30": { "value": "#63121b" },
-          "20": { "value": "#861825" },
-          "10": { "value": "#9e1d2c" }
-        },
-        "Primary": { "value": "#af2031" },
-        "Tint": {
-          "10": { "value": "#b93443" },
-          "20": { "value": "#d06975" },
-          "30": { "value": "#e7b0b5" },
-          "40": { "value": "#f2d3d6" }
-        }
-      },
       "Brand": {
         "Shade": {
           "30": { "value": "#0e336a" },
@@ -103,18 +89,18 @@
           "40": { "value": "#f6dbd4" }
         }
       },
-      "Publisher": {
+      "Word": {
         "Shade": {
-          "30": { "value": "#02494c" },
-          "20": { "value": "#026367" },
-          "10": { "value": "#02767a" }
+          "30": { "value": "#0e336a" },
+          "20": { "value": "#13458f" },
+          "10": { "value": "#1651aa" }
         },
-        "Primary": { "value": "#038387" },
+        "Primary": { "value": "#185abd" },
         "Tint": {
-          "10": { "value": "#159196" },
-          "20": { "value": "#4bb4b7" },
-          "30": { "value": "#9bd9db" },
-          "40": { "value": "#c7ebec" }
+          "10": { "value": "#2e6ac5" },
+          "20": { "value": "#6794d7" },
+          "30": { "value": "#aec6eb" },
+          "40": { "value": "#d2e0f4" }
         }
       }
     }

--- a/packages/theming/theme-tokens/src/pipeline-input/token-input.json
+++ b/packages/theming/theme-tokens/src/pipeline-input/token-input.json
@@ -89,7 +89,121 @@
       "NeutralShadowAmbient": { "value": "rgba(0,0,0,0.12)" },
       "NeutralShadowKey": { "value": "rgba(0,0,0,0.14)" },
       "BrandShadowAmbient": { "value": "rgba(0,0,0,0.30)" },
-      "BrandShadowKey": { "value": "rgba(0,0,0,0.25)" }
+      "BrandShadowKey": { "value": "rgba(0,0,0,0.25)" },
+      "Excel": {
+        "Shade": {
+          "60": { "value": "#03160a" },
+          "50": { "value": "#052912" },
+          "40": { "value": "#094624" },
+          "30": { "value": "#0a5325" },
+          "20": { "value": "#0c5f32" },
+          "10": { "value": "#0f703b" }
+        },
+        "Primary": { "value": "#107c41" },
+        "Tint": {
+          "10": { "value": "#10893c" },
+          "20": { "value": "#1f954a" },
+          "30": { "value": "#60bd82" },
+          "40": { "value": "#55b17e" },
+          "50": { "value": "#a0d8b9" },
+          "60": { "value": "#caead8" }
+        }
+      },
+      "Office": {
+        "Shade": {
+          "60": { "value": "#29130b" },
+          "50": { "value": "#4d2415" },
+          "40": { "value": "#792000" },
+          "30": { "value": "#99482b" },
+          "20": { "value": "#a52c00" },
+          "10": { "value": "#c33400" }
+        },
+        "Primary": { "value": "#d83b01" },
+        "Tint": {
+          "10": { "value": "#fe7948" },
+          "20": { "value": "#ff865a" },
+          "30": { "value": "#ff9973" },
+          "40": { "value": "#e8825d" },
+          "50": { "value": "#f4beaa" },
+          "60": { "value": "#f9dcd1" }
+        }
+      },
+      "OneNote": {
+        "Shade": {
+          "60": { "value": "#430e60" },
+          "50": { "value": "#430e60" },
+          "40": { "value": "#430e60" },
+          "30": { "value": "#430e60" },
+          "20": { "value": "#5b1382" },
+          "10": { "value": "#6c179a" }
+        },
+        "Primary": { "value": "#7719aa" },
+        "Tint": {
+          "10": { "value": "#862eb5" },
+          "20": { "value": "#a864cd" },
+          "30": { "value": "#d1abe6" },
+          "40": { "value": "#e6d1f2" },
+          "50": { "value": "#e6d1f2" },
+          "60": { "value": "#e6d1f2" }
+        }
+      },
+      "Outlook": {
+        "Shade": {
+          "60": { "value": "#092c47" },
+          "50": { "value": "#043862" },
+          "40": { "value": "#004578" },
+          "30": { "value": "#004c87" },
+          "20": { "value": "#005a9e" },
+          "10": { "value": "#106ebe" }
+        },
+        "Primary": { "value": "#0078d4" },
+        "Tint": {
+          "10": { "value": "#2899f5" },
+          "20": { "value": "#3aa0f3" },
+          "30": { "value": "#6cb8f6" },
+          "40": { "value": "#c7e0f4" },
+          "50": { "value": "#deecf9" },
+          "60": { "value": "#eff6fc" }
+        }
+      },
+      "PowerPoint": {
+        "Shade": {
+          "60": { "value": "#200d03" },
+          "50": { "value": "#3c1805" },
+          "40": { "value": "#6e220f" },
+          "30": { "value": "#79310a" },
+          "20": { "value": "#952f15" },
+          "10": { "value": "#b13719" }
+        },
+        "Primary": { "value": "#c43e1c" },
+        "Tint": {
+          "10": { "value": "#ca5010" },
+          "20": { "value": "#cf6024" },
+          "30": { "value": "#e1966d" },
+          "40": { "value": "#dc816a" },
+          "50": { "value": "#edbcb0" },
+          "60": { "value": "#f6dbd4" }
+        }
+      },
+      "Word": {
+        "Shade": {
+          "60": { "value": "#071225" },
+          "50": { "value": "#0c2145" },
+          "40": { "value": "#0e336a" },
+          "30": { "value": "#19428a" },
+          "20": { "value": "#13458f" },
+          "10": { "value": "#1651aa" }
+        },
+        "Primary": { "value": "#185abd" },
+        "Tint": {
+          "10": { "value": "#296fe6" },
+          "20": { "value": "#3d7ce8" },
+          "30": { "value": "#82abf1" },
+          "40": { "value": "#6794d7" },
+          "50": { "value": "#aec6eb" },
+          "60": { "value": "#d2e0f4" }
+        }
+      }
     },
     "Stroke": {
       "Width": {

--- a/packages/theming/theme-tokens/src/tokens-global.win32.ts
+++ b/packages/theming/theme-tokens/src/tokens-global.win32.ts
@@ -1,0 +1,3 @@
+import globalTokens from './global-win32/reactnative/tokens-global.json';
+
+export default globalTokens;

--- a/packages/theming/win32-theme/src/createBrandedThemeWithAlias.ts
+++ b/packages/theming/win32-theme/src/createBrandedThemeWithAlias.ts
@@ -8,12 +8,12 @@ export function createBrandedThemeWithAlias(themeName: string, theme: Theme): Pa
   }
 
   return {
-    colors: overrideBrandAliasTokensWithOffice(themeName, theme),
+    colors: getCurrentBrandAliasTokens(themeName, theme.host.colors.AppPrimary),
   };
 }
 
-function overrideBrandAliasTokensWithOffice(themeName: string, theme: Theme): Partial<AliasColorTokens> {
-  const appColors = getAppColors(theme.host.colors.AppPrimary);
+export function getCurrentBrandAliasTokens(themeName: string, appPrimary: ColorValue): Partial<AliasColorTokens> {
+  const appColors = getAppColors(appPrimary);
   const isWhiteOrColorfulTheme = themeName === 'White' || themeName === 'Colorful';
 
   return {
@@ -51,18 +51,20 @@ function overrideBrandAliasTokensWithOffice(themeName: string, theme: Theme): Pa
 }
 
 function getAppColors(primaryColor: ColorValue) {
-  if (primaryColor === '#185abd') {
-    return globalTokens.color.word;
-  } else if (primaryColor === '#107c41') {
-    return globalTokens.color.excel;
-  } else if (primaryColor === '#d83b01') {
-    return globalTokens.color.office;
-  } else if (primaryColor === '#80397b') {
-    return globalTokens.color.oneNote;
-  } else if (primaryColor === '#0078d4') {
-    return globalTokens.color.outlook;
-  } else if (primaryColor === '#c43e1c') {
-    return globalTokens.color.powerPoint;
+  if (typeof primaryColor === 'string') {
+    if (primaryColor.toLowerCase() === '#185abd') {
+      return globalTokens.color.word;
+    } else if (primaryColor.toLowerCase() === '#107c41') {
+      return globalTokens.color.excel;
+    } else if (primaryColor.toLowerCase() === '#d83b01') {
+      return globalTokens.color.office;
+    } else if (primaryColor.toLowerCase() === '#80397b') {
+      return globalTokens.color.oneNote;
+    } else if (primaryColor.toLowerCase() === '#0078d4') {
+      return globalTokens.color.outlook;
+    } else if (primaryColor.toLowerCase() === '#c43e1c') {
+      return globalTokens.color.powerPoint;
+    }
   }
 
   return globalTokens.color.brand;

--- a/packages/theming/win32-theme/src/createBrandedThemeWithAlias.ts
+++ b/packages/theming/win32-theme/src/createBrandedThemeWithAlias.ts
@@ -1,4 +1,6 @@
 import { Theme, PartialTheme, AliasColorTokens } from '@fluentui-react-native/theme-types';
+import { globalTokens } from '@fluentui-react-native/theme-tokens';
+import { ColorValue } from 'react-native';
 
 export function createBrandedThemeWithAlias(themeName: string, theme: Theme): PartialTheme {
   if (themeName === 'HighContrast' || !theme.host.colors) {
@@ -11,38 +13,57 @@ export function createBrandedThemeWithAlias(themeName: string, theme: Theme): Pa
 }
 
 function overrideBrandAliasTokensWithOffice(themeName: string, theme: Theme): Partial<AliasColorTokens> {
+  const appColors = getAppColors(theme.host.colors.AppPrimary);
   const isWhiteOrColorfulTheme = themeName === 'White' || themeName === 'Colorful';
 
   return {
-    neutralForeground2BrandHover: isWhiteOrColorfulTheme ? theme.host.colors.AppShade10 : theme.host.colors.AppTint40,
-    neutralForeground2BrandPressed: isWhiteOrColorfulTheme ? theme.host.colors.AppShade30 : theme.host.colors.AppTint10,
-    neutralForeground2BrandSelected: isWhiteOrColorfulTheme ? theme.host.colors.AppShade20 : theme.host.colors.AppTint40,
-    neutralForeground3BrandHover: isWhiteOrColorfulTheme ? theme.host.colors.AppShade10 : theme.host.colors.AppTint40,
-    neutralForeground3BrandPressed: isWhiteOrColorfulTheme ? theme.host.colors.AppShade30 : theme.host.colors.AppTint10,
-    neutralForeground3BrandSelected: isWhiteOrColorfulTheme ? theme.host.colors.AppShade20 : theme.host.colors.AppTint40,
-    brandForegroundLink: isWhiteOrColorfulTheme ? theme.host.colors.AppPrimary : theme.host.colors.AppTint30,
-    brandForegroundLinkHover: isWhiteOrColorfulTheme ? theme.host.colors.AppShade10 : theme.host.colors.AppTint40,
-    brandForegroundLinkPressed: isWhiteOrColorfulTheme ? theme.host.colors.AppShade30 : theme.host.colors.AppTint10,
-    brandForegroundLinkSelected: isWhiteOrColorfulTheme ? theme.host.colors.AppShade20 : theme.host.colors.AppTint40,
-    compoundBrandForeground1: isWhiteOrColorfulTheme ? theme.host.colors.AppPrimary : theme.host.colors.AppTint30,
-    compoundBrandForeground1Hover: isWhiteOrColorfulTheme ? theme.host.colors.AppShade10 : theme.host.colors.AppTint40,
-    compoundBrandForeground1Pressed: isWhiteOrColorfulTheme ? theme.host.colors.AppShade30 : theme.host.colors.AppTint10,
-    brandForeground1: isWhiteOrColorfulTheme ? theme.host.colors.AppPrimary : theme.host.colors.AppTint30,
-    brandForeground2: isWhiteOrColorfulTheme ? theme.host.colors.AppShade10 : theme.host.colors.AppTint40,
-    brandBackground: theme.host.colors.AppPrimary,
-    brandBackgroundHover: theme.host.colors.AppShade10,
-    brandBackgroundPressed: theme.host.colors.AppShade30,
-    brandBackgroundSelected: theme.host.colors.AppShade20,
-    compoundBrandBackground1: theme.host.colors.AppPrimary,
-    compoundBrandBackground1Hover: theme.host.colors.AppShade10,
-    compoundBrandBackground1Pressed: theme.host.colors.AppShade20,
-    brandBackgroundStatic: theme.host.colors.AppPrimary,
-    brandBackground2: theme.host.colors.AppTint40,
-    neutralStrokeAccessibleSelected: theme.host.colors.AppPrimary,
-    brandStroke1: theme.host.colors.AppPrimary,
-    brandStroke2: theme.host.colors.AppTint40,
-    compoundBrandStroke1: theme.host.colors.AppPrimary,
-    compoundBrandStroke1Hover: theme.host.colors.AppShade10,
-    compoundBrandStroke1Pressed: theme.host.colors.AppShade20,
+    neutralForeground2BrandHover: isWhiteOrColorfulTheme ? appColors.shade10 : appColors.tint40,
+    neutralForeground2BrandPressed: isWhiteOrColorfulTheme ? appColors.shade30 : appColors.tint10,
+    neutralForeground2BrandSelected: isWhiteOrColorfulTheme ? appColors.shade20 : appColors.tint40,
+    neutralForeground3BrandHover: isWhiteOrColorfulTheme ? appColors.shade10 : appColors.tint40,
+    neutralForeground3BrandPressed: isWhiteOrColorfulTheme ? appColors.shade30 : appColors.tint10,
+    neutralForeground3BrandSelected: isWhiteOrColorfulTheme ? appColors.shade20 : appColors.tint40,
+    brandForegroundLink: isWhiteOrColorfulTheme ? appColors.primary : appColors.tint30,
+    brandForegroundLinkHover: isWhiteOrColorfulTheme ? appColors.shade10 : appColors.tint40,
+    brandForegroundLinkPressed: isWhiteOrColorfulTheme ? appColors.shade30 : appColors.tint10,
+    brandForegroundLinkSelected: isWhiteOrColorfulTheme ? appColors.shade20 : appColors.tint40,
+    compoundBrandForeground1: isWhiteOrColorfulTheme ? appColors.primary : appColors.tint30,
+    compoundBrandForeground1Hover: isWhiteOrColorfulTheme ? appColors.shade10 : appColors.tint40,
+    compoundBrandForeground1Pressed: isWhiteOrColorfulTheme ? appColors.shade30 : appColors.tint10,
+    brandForeground1: isWhiteOrColorfulTheme ? appColors.primary : appColors.tint30,
+    brandForeground2: isWhiteOrColorfulTheme ? appColors.shade10 : appColors.tint40,
+    brandBackground: appColors.primary,
+    brandBackgroundHover: appColors.shade10,
+    brandBackgroundPressed: appColors.shade30,
+    brandBackgroundSelected: appColors.shade20,
+    compoundBrandBackground1: appColors.primary,
+    compoundBrandBackground1Hover: appColors.shade10,
+    compoundBrandBackground1Pressed: appColors.shade20,
+    brandBackgroundStatic: appColors.primary,
+    brandBackground2: appColors.tint40,
+    neutralStrokeAccessibleSelected: appColors.primary,
+    brandStroke1: appColors.primary,
+    brandStroke2: appColors.tint40,
+    compoundBrandStroke1: appColors.primary,
+    compoundBrandStroke1Hover: appColors.shade10,
+    compoundBrandStroke1Pressed: appColors.shade20,
   };
+}
+
+function getAppColors(primaryColor: ColorValue) {
+  if (primaryColor === '#185abd') {
+    return globalTokens.color.word;
+  } else if (primaryColor === '#107c41') {
+    return globalTokens.color.excel;
+  } else if (primaryColor === '#d83b01') {
+    return globalTokens.color.office;
+  } else if (primaryColor === '#80397b') {
+    return globalTokens.color.oneNote;
+  } else if (primaryColor === '#0078d4') {
+    return globalTokens.color.outlook;
+  } else if (primaryColor === '#c43e1c') {
+    return globalTokens.color.powerPoint;
+  }
+
+  return globalTokens.color.brand;
 }

--- a/packages/theming/win32-theme/src/index.ts
+++ b/packages/theming/win32-theme/src/index.ts
@@ -3,3 +3,4 @@ export * from './createPartialOfficeTheme';
 export * from './NativeModule/index';
 export * from './paletteFromOfficeColors';
 export * from './createOfficeAliasTokens';
+export * from './createBrandedThemeWithAlias';


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This change is a follow up to #976.

This change pulls brand colors from the pipeline instead of the native module, so we are closer to having most things pull from the pipeline tokens as a source of truth.

I added brand colors for the "web" version (the base pipeline input file) so that the schema between the web and win32 versions of the pipeline input would match up. This probably isn't the best solution, however it allows the pipeline output for globals to be in one file as opposed to having brand colors be in separate files. This could be better from a pipeline output perspective so that pulling inputs is more straightforward, but I'm open to suggestions here.

I deleted Access an Publisher as I don't think those will have use cases and they don't have colors specified on web.

We match the correct brand tokens by taking the current AppPrimary off the native module. This is, I think, the best way we have available right now to get the host app. This isn't great - probably we should add a way to query for the host app or have that information available somehow - but at least for the short term it should suffice as a way to get the host app.

We also have the logic run on the tester now so that we have less copied code.

### Verification

Ran the tester on Office theme with various brands and Office themes.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
