### PR TITLE
Allow theming module to be implemented as a turbo module

### DIFF
--- a/change/@fluentui-react-native-interactive-hooks-2f7d94a7-bcb5-4ac3-8f98-0ab3b9856d49.json
+++ b/change/@fluentui-react-native-interactive-hooks-2f7d94a7-bcb5-4ac3-8f98-0ab3b9856d49.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Use UIManager from react-native instead of from NativeModules",
+  "packageName": "@fluentui-react-native/interactive-hooks",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-win32-theme-17ae96da-8c02-42df-bc52-d82cafe974d1.json
+++ b/change/@fluentui-react-native-win32-theme-17ae96da-8c02-42df-bc52-d82cafe974d1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Allow theming module to be implemented as a turbomanager",
+  "packageName": "@fluentui-react-native/win32-theme",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/theming/win32-theme/src/NativeModule/getThemingModule.native.ts
+++ b/packages/theming/win32-theme/src/NativeModule/getThemingModule.native.ts
@@ -1,12 +1,15 @@
 import { OfficeThemingModule } from './officeThemingModule';
-import { NativeEventEmitter, NativeModules } from 'react-native';
+import { NativeEventEmitter } from 'react-native';
 import { fallbackGetPalette, fallbackOfficeModule } from './fallbackOfficeModule';
 
 declare module 'react-native' {
-  interface NativeModulesStatic {
-    Theming: OfficeThemingModule & EventSubscriptionVendor;
+  interface ITurboModuleRegistry {
+    get: (name: 'Theming') => OfficeThemingModule & EventSubscriptionVendor;
   }
+  const TurboModuleRegistry: ITurboModuleRegistry;
 }
+
+import { TurboModuleRegistry } from 'react-native';
 
 /**
  *  If we have a userAgent string, let's assume we're web debugging.  __DEV__ is for developer bundles.  Currently,
@@ -19,7 +22,7 @@ function disableGetPalette(): boolean {
 }
 
 export function getThemingModule(): [OfficeThemingModule, NativeEventEmitter | undefined] {
-  const module = NativeModules && NativeModules.Theming;
+  const module = TurboModuleRegistry.get('Theming');
   // if the native module exists return the module + an emitter for it
   if (module) {
     // mock getPalette if it should be disabled, otherwise return the module directly

--- a/packages/utils/interactive-hooks/src/useViewCommandFocus.macos.ts
+++ b/packages/utils/interactive-hooks/src/useViewCommandFocus.macos.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { findNodeHandle, NativeModules, View } from 'react-native';
+import { findNodeHandle, UIManager, View } from 'react-native';
 
 const setAndForwardRef = require('./setAndForwardRef');
 
@@ -22,7 +22,7 @@ export function useViewCommandFocus(
 
   const _setNativeRef = setAndForwardRef({
     getForwardedRef: () => forwardedRef,
-    setLocalRef: localRef => {
+    setLocalRef: (localRef) => {
       focusRef.current = localRef;
 
       /**
@@ -30,11 +30,7 @@ export function useViewCommandFocus(
        */
       if (localRef) {
         localRef.focus = () => {
-          NativeModules.UIManager.dispatchViewManagerCommand(
-            findNodeHandle(localRef),
-            NativeModules.UIManager.getViewManagerConfig('RCTView').Commands.focus,
-            null,
-          );
+          UIManager.dispatchViewManagerCommand(findNodeHandle(localRef), UIManager.getViewManagerConfig('RCTView').Commands.focus, null);
         };
       }
     },

--- a/packages/utils/interactive-hooks/src/useViewCommandFocus.win32.ts
+++ b/packages/utils/interactive-hooks/src/useViewCommandFocus.win32.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { findNodeHandle, NativeModules } from 'react-native';
+import { findNodeHandle, UIManager } from 'react-native';
 import { IViewWin32 } from '@office-iss/react-native-win32';
 
 const setAndForwardRef = require('./setAndForwardRef');
@@ -31,11 +31,7 @@ export function useViewCommandFocus(
        */
       if (localRef) {
         localRef.focus = () => {
-          NativeModules.UIManager.dispatchViewManagerCommand(
-            findNodeHandle(localRef),
-            NativeModules.UIManager.getViewManagerConfig('RCTView').Commands.focus,
-            null,
-          );
+          UIManager.dispatchViewManagerCommand(findNodeHandle(localRef), UIManager.getViewManagerConfig('RCTView').Commands.focus, null);
         };
       }
     },


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Using `TurboModuleRegistry.get('Theming')` instead of `NativeModules.Theming`, which will allow the theming module to be implemented as either a NativeModule, or a TurboModule.

Also changed a couple of uses of `NativeModule.UIManager`, to instead use the exported UIManger object, which has better type information, and will allow UIManager to be implemented as a TurboManager in the future too. 

### Verification

Booted the test app on win32 and went to the theming page.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
