### PR TITLE
Changed chevron icon to SVGXML in MenuButton

### DIFF
--- a/change/@fluentui-react-native-menu-button-e69c3ea6-000c-4cba-89c9-e07458b8bf52.json
+++ b/change/@fluentui-react-native-menu-button-e69c3ea6-000c-4cba-89c9-e07458b8bf52.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Changed chevron icon to SVGXML in MenuButton",
+  "packageName": "@fluentui-react-native/menu-button",
+  "email": "v.kozlova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/MenuButton/src/MenuButton.tsx
+++ b/packages/components/MenuButton/src/MenuButton.tsx
@@ -6,7 +6,7 @@ import { IUseComposeStyling, compose } from '@uifabricshared/foundation-compose'
 import { mergeSettings } from '@uifabricshared/foundation-settings';
 import { ISlots, withSlots } from '@uifabricshared/foundation-composable';
 import { backgroundColorTokens, borderTokens } from '@fluentui-react-native/tokens';
-import { Svg, Path } from 'react-native-svg';
+import { SvgXml } from 'react-native-svg';
 import { defaultIconColor, primaryIconColor } from './MenuButton.style';
 
 import {
@@ -88,12 +88,6 @@ export const MenuButton = compose<MenuButtonType>({
       contextualMenuItems: {
         menuItems: menuItemsUpdated,
       },
-      chevronSvg: {
-        width: '12',
-        height: '16',
-        viewBox: '0 0 11 6',
-        color: primary ? primaryIconColor : defaultIconColor,
-      },
     });
 
     return { slotProps, state };
@@ -104,7 +98,7 @@ export const MenuButton = compose<MenuButtonType>({
     primaryButton: { slotType: PrimaryButton as React.ComponentType },
     contextualMenu: { slotType: ContextualMenu as React.ComponentType },
     contextualMenuItems: React.Fragment,
-    chevronSvg: Svg,
+    chevronSvg: SvgXml,
   },
   styles: {
     contextualMenu: [backgroundColorTokens, borderTokens],
@@ -117,17 +111,23 @@ export const MenuButton = compose<MenuButtonType>({
     const context = renderData.state!.context;
     const menuItems = renderData.slotProps!.contextualMenuItems ? renderData.slotProps!.contextualMenuItems.menuItems : [];
 
-    const chevronIcon = () => {
-      const chevronPath = `M0.646447 0.646447C0.841709 0.451184 1.15829 0.451184 1.35355 0.646447L5.5 4.79289L9.64645 0.646447C9.84171 0.451185 10.1583 0.451185 10.3536 0.646447C10.5488 0.841709 10.5488 1.15829 10.3536 1.35355L5.85355 5.85355C5.65829 6.04882 5.34171 6.04882 5.14645 5.85355L0.646447 1.35355C0.451184 1.15829 0.451184 0.841709 0.646447 0.646447Z`;
-      return (
-        <Slots.chevronSvg>
-          <Path fill="currentColor" d={chevronPath} />
-        </Slots.chevronSvg>
-      );
-    };
+    const chevronColor = context.primary ? primaryIconColor : defaultIconColor;
+    const chevronXml = `
+    <svg width="12" height="16" viewBox="0 0 11 6" color=${chevronColor}>
+      <path fill='currentColor' d='M0.646447 0.646447C0.841709 0.451184 1.15829 0.451184 1.35355 0.646447L5.5 4.79289L9.64645 0.646447C9.84171 0.451185 10.1583 0.451185 10.3536 0.646447C10.5488 0.841709 10.5488 1.15829 10.3536 1.35355L5.85355 5.85355C5.65829 6.04882 5.34171 6.04882 5.14645 5.85355L0.646447 1.35355C0.451184 1.15829 0.451184 0.841709 0.646447 0.646447Z' />
+    </svg>`;
+
     return (
       <Slots.root>
-        {context.primary ? <Slots.primaryButton>{chevronIcon()}</Slots.primaryButton> : <Slots.button>{chevronIcon()}</Slots.button>}
+        {context.primary ? (
+          <Slots.primaryButton>
+            <Slots.chevronSvg xml={chevronXml} />
+          </Slots.primaryButton>
+        ) : (
+          <Slots.button>
+            <Slots.chevronSvg xml={chevronXml} />
+          </Slots.button>
+        )}
         {context.showContextualMenu && (
           <Slots.contextualMenu>
             {menuItems.map((menuItem) => {

--- a/packages/components/MenuButton/src/MenuButton.types.ts
+++ b/packages/components/MenuButton/src/MenuButton.types.ts
@@ -2,7 +2,7 @@ import { ContextualMenuItemProps, ContextualMenuProps, SubmenuProps } from '@flu
 import { FontTokens, IForegroundColorTokens, IBackgroundColorTokens, IBorderTokens } from '@fluentui-react-native/tokens';
 import { IButtonProps } from '@fluentui-react-native/button';
 import { IRenderData } from '@uifabricshared/foundation-composable';
-import { SvgProps } from 'react-native-svg';
+import { XmlProps } from 'react-native-svg';
 
 export const MenuButtonName = 'MenuButton';
 
@@ -38,7 +38,7 @@ export type MenuButtonSlotProps = {
   contextualMenu: React.PropsWithRef<ContextualMenuProps>;
   contextualMenuItems: Pick<MenuButtonProps, 'menuItems'>;
   contextualMenuItem: MenuButtonItemProps;
-  chevronSvg: SvgProps;
+  chevronSvg: XmlProps;
 };
 
 export type MenuButtonRenderData = IRenderData<MenuButtonSlotProps, MenuButtonState>;

--- a/packages/components/MenuButton/src/__tests__/__snapshots__/MenuButton.test.win32.tsx.snap
+++ b/packages/components/MenuButton/src/__tests__/__snapshots__/MenuButton.test.win32.tsx.snap
@@ -73,11 +73,11 @@ exports[`ContextualMenu default 1`] = `
       </Text>
       <RNSVGSvgView
         align="xMidYMid"
-        bbHeight="16"
-        bbWidth="12"
+        bbHeight={16}
+        bbWidth={12}
         color={-10395295}
         focusable={false}
-        height="16"
+        height={16}
         meetOrSlice={0}
         minX={0}
         minY={0}
@@ -97,7 +97,11 @@ exports[`ContextualMenu default 1`] = `
         tintColor={-10395295}
         vbHeight={6}
         vbWidth={11}
-        width="12"
+        width={12}
+        xml="
+    <svg width=\\"12\\" height=\\"16\\" viewBox=\\"0 0 11 6\\" color=#616161>
+      <path fill='currentColor' d='M0.646447 0.646447C0.841709 0.451184 1.15829 0.451184 1.35355 0.646447L5.5 4.79289L9.64645 0.646447C9.84171 0.451185 10.1583 0.451185 10.3536 0.646447C10.5488 0.841709 10.5488 1.15829 10.3536 1.35355L5.85355 5.85355C5.65829 6.04882 5.34171 6.04882 5.14645 5.85355L0.646447 1.35355C0.451184 1.15829 0.451184 0.841709 0.646447 0.646447Z' />
+    </svg>"
       >
         <RNSVGGroup>
           <RNSVGPath


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
Fix for "Follow up on using SVGXML in MenuButton #1000"
I used SvgXML. I tried to use xml as slot prop but it didn't work so I had to add it as a prop in the render method.
Also, I tried to use it as endIcon but it doesn't work with SVGXML.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
