### PR TITLE
Fix default theme failing when appearance not passed in

### DIFF
--- a/change/@fluentui-react-native-theming-utils-b3f54cd3-30a1-4646-af97-ab85e5d27546.json
+++ b/change/@fluentui-react-native-theming-utils-b3f54cd3-30a1-4646-af97-ab85e5d27546.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add check for undefined",
+  "packageName": "@fluentui-react-native/theming-utils",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/theming/theming-utils/src/getCurrentAppearance.ts
+++ b/packages/theming/theming-utils/src/getCurrentAppearance.ts
@@ -2,5 +2,9 @@ import { Appearance } from 'react-native';
 import { AppearanceOptions, ThemeOptions } from '@fluentui-react-native/theme-types';
 
 export function getCurrentAppearance(appearance: ThemeOptions['appearance'], fallback: AppearanceOptions): AppearanceOptions {
+  if (appearance === undefined) {
+    return fallback;
+  }
+
   return appearance === 'dynamic' ? (Appearance && Appearance.getColorScheme()) || fallback : appearance;
 }


### PR DESCRIPTION
Fixes #1004 

### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [x] windows
- [ ] android

### Description of changes

If a defined appearance is not passed in to getCurrentAppearance, it currently returns undefined.

Give a fallback if there's no appearance passed in as part of options.

### Verification

Tested change with Tester.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
