### PR TITLE
Fixed Height of the Button and Link components increases with adding borderWidth

### DIFF
--- a/change/@fluentui-react-native-button-96e007e5-d0c7-4f82-975f-82b3127425b4.json
+++ b/change/@fluentui-react-native-button-96e007e5-d0c7-4f82-975f-82b3127425b4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed \"Height of the Button and Link components increases with adding borderWidth\"",
+  "packageName": "@fluentui-react-native/button",
+  "email": "v.kozlova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Button/src/Button.settings.win32.ts
+++ b/packages/components/Button/src/Button.settings.win32.ts
@@ -49,6 +49,8 @@ export const settings: IComposeSettings<IButtonType> = [
         minHeight: 24,
         minWidth: 32,
         justifyContent: 'center',
+        borderWidth: 1,
+        borderColor: 'transparent'
       },
     },
     _precedence: ['hovered', 'focused', 'pressed', 'disabled'],
@@ -78,9 +80,14 @@ export const settings: IComposeSettings<IButtonType> = [
         tokens: {
           backgroundColor: 'neutralBackground1Hover',
           color: 'neutralForeground1',
-          borderColor: 'strokeFocus2',
-          borderWidth: 2,
+          borderColor: 'strokeFocus2'
         },
+        stack: {
+          style: {
+            borderColor: '#000',
+            borderWidth: 1
+          }
+        }
       },
     },
   },

--- a/packages/components/Button/src/Button.settings.win32.ts
+++ b/packages/components/Button/src/Button.settings.win32.ts
@@ -10,6 +10,7 @@ export const settings: IComposeSettings<IButtonType> = [
       borderColor: 'neutralStroke1',
       borderWidth: 1,
       borderRadius: 4,
+      wrapperBorderColor: 'transparent'
     },
     root: {
       accessible: true,
@@ -22,6 +23,13 @@ export const settings: IComposeSettings<IButtonType> = [
         alignSelf: 'flex-start',
       },
     } as IViewProps,
+    borderWrapper: {
+      style: {
+        display: 'flex',
+        flexGrow: 1,
+        borderWidth: 1,
+      }
+    },
     endIcon: {
       style: {
         marginStart: 2,
@@ -49,8 +57,6 @@ export const settings: IComposeSettings<IButtonType> = [
         minHeight: 24,
         minWidth: 32,
         justifyContent: 'center',
-        borderWidth: 1,
-        borderColor: 'transparent'
       },
     },
     _precedence: ['hovered', 'focused', 'pressed', 'disabled'],
@@ -80,14 +86,9 @@ export const settings: IComposeSettings<IButtonType> = [
         tokens: {
           backgroundColor: 'neutralBackground1Hover',
           color: 'neutralForeground1',
-          borderColor: 'strokeFocus2'
+          borderColor: 'strokeFocus2',
+          wrapperBorderColor: 'strokeFocus2',
         },
-        stack: {
-          style: {
-            borderColor: '#000',
-            borderWidth: 1
-          }
-        }
       },
     },
   },

--- a/packages/components/Button/src/Button.tsx
+++ b/packages/components/Button/src/Button.tsx
@@ -79,18 +79,21 @@ export const Button = compose<IButtonType>({
 
     return (
       <Slots.root>
-        <Slots.stack>
-          {info.startIcon && <Slots.startIcon />}
-          {info.content && <Slots.content />}
-          {children}
-          {info.endIcon && <Slots.endIcon />}
-        </Slots.stack>
+        <Slots.borderWrapper>
+          <Slots.stack>
+            {info.startIcon && <Slots.startIcon />}
+            {info.content && <Slots.content />}
+            {children}
+            {info.endIcon && <Slots.endIcon />}
+          </Slots.stack>
+        </Slots.borderWrapper>
       </Slots.root>
     );
   },
   slots: {
     root: View,
     stack: { slotType: View, filter: filterViewProps },
+    borderWrapper: { slotType: View, filter: filterViewProps },
     startIcon: { slotType: Icon as React.ComponentType },
     content: Text,
     endIcon: { slotType: Icon as React.ComponentType },
@@ -98,6 +101,7 @@ export const Button = compose<IButtonType>({
   styles: {
     root: [backgroundColorTokens, borderTokens],
     stack: [],
+    borderWrapper: [{ source: 'wrapperBorderColor', lookup: getPaletteFromTheme, target: 'borderColor' }],
     startIcon: [{ source: 'iconColor', lookup: getPaletteFromTheme, target: 'color' }],
     content: [textTokens, foregroundColorTokens],
     endIcon: [{ source: 'iconColor', lookup: getPaletteFromTheme, target: 'color' }],

--- a/packages/components/Button/src/Button.types.ts
+++ b/packages/components/Button/src/Button.types.ts
@@ -88,6 +88,7 @@ export interface IButtonTokens extends FontTokens, IForegroundColorTokens, IBack
    */
   startIcon?: IconSourcesType;
   endIcon?: IconSourcesType;
+  wrapperBorderColor?: ColorValue;
 }
 
 export interface IButtonProps extends Omit<IPressableProps, 'onPress'> {
@@ -120,6 +121,7 @@ export interface IButtonSlotProps {
   root: React.PropsWithRef<IViewProps>;
   ripple?: PressableProps; // This slot exists to enable ripple-effect in android. It does not affect other platforms.
   stack: ViewProps;
+  borderWrapper: ViewProps;
   startIcon: IconProps;
   content: ITextProps;
   endIcon: IconProps;


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
Fixed JS side of the defect where Button size increases with adding border.
Couldn't use token in focused state for stack, had to use hex color.

### Verification
Before:
![image](https://user-images.githubusercontent.com/11574680/133499593-3efb251a-fd46-48e6-b5e4-2e3806ed2d9f.png)

After:
![image](https://user-images.githubusercontent.com/11574680/133499111-badfe43f-47fc-4ff4-8d7f-1f04dbfdedf2.png)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
