### PR TITLE
Update README.md

### DIFF
--- a/apps/windows/README.md
+++ b/apps/windows/README.md
@@ -5,22 +5,13 @@
 ## Prerequisites
 
 - [Node.js](https://nodejs.org/en/download/)
+  - You can quickly see if Node.js is installed by running "node -v" in a command prompt. If it's installed, you will see the version number. If not, it will not recognize the command.
 - [React Native Windows Development Dependencies](https://microsoft.github.io/react-native-windows/docs/rnw-dependencies)
   - **NOTE:** Please make sure you grab all of the items listed there and the appropriate versions.
-    ![this picture](../../assets/VSDeps.png)
-- [Azure Credentials Plugin for NuGet](https://github.com/microsoft/artifacts-credprovider#manual-installation-on-windows)
+  - You can check or install these dependencies by running the command mentioned in the link above in an elevated PowerShell window.
+  - If you're installing or verifying Visual Studio 2019 dependencies manually, you can check your tool options under Tools > Get Tools and Features...
+- [Azure Credentials Plugin for NuGet](https://github.com/microsoft/artifacts-credprovider#installation-on-windows)
   - We're currently on an expermental version of react-native-windows which is being published to a private NPM feed hosted on Azure DevOps.
-
-### Add the App Signing Certificate to your Personal Certificate Store
-
-As with normal UWP app development, the UWP test harness that loads the JS bundle must have a developer-signed certificate present to install the APPX package.
-
-1. Windows+R to open the Run Dialog and type in `certmgr.msc`. **NOTE:** For some reason this takes some time on my machine.
-2. Expand `Personal` and right click on `Certificates`
-3. Under `All tasks` click `Import`
-4. For the Current User, `Browse` to find `FluentTester_TemporaryKey.pfx` in your local clone of the repo.
-5. On the next page, type in 'password' for the password.
-   ![Certificate Manager Browse Window](./../../assets/CertFile.png)
 
 ## Running the App
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [x] windows
- [ ] android

### Description of changes

- Adds additional bullet points to help verify if right dependencies are installed
- Remove dated screenshot under RNW Development Dependencies (screenshot featured older versions of required tools)
- Remove section referencing adding the App Signing Certificate to your Personal Certificate Store since this is no longer required (or even possible to do) after change #755 was merged

### Verification

Ran through the steps on clean machine (cloning repo and downloading dependencies from scratch)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
