### PR TITLE
Add props to buildProps

### DIFF
--- a/change/@fluentui-react-native-framework-8d280009-d6bf-4d13-935f-c60be74ca8bb.json
+++ b/change/@fluentui-react-native-framework-8d280009-d6bf-4d13-935f-c60be74ca8bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add props to build props",
+  "packageName": "@fluentui-react-native/framework",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-use-styling-cd3f2f14-92ff-44b1-a0e8-6cfd43967bce.json
+++ b/change/@fluentui-react-native-use-styling-cd3f2f14-92ff-44b1-a0e8-6cfd43967bce.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add props to build props",
+  "packageName": "@fluentui-react-native/use-styling",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Stack/src/Stack.styling.ts
+++ b/packages/experimental/Stack/src/Stack.styling.ts
@@ -40,7 +40,7 @@ const tokensThatAreAlsoProps: (keyof StackTokenProps)[] = [
 
 const nowrapProps: ViewProps = {};
 
-const buildInnerProps = (tokenProps: StackTokens, theme: Theme, cache: GetMemoValue<ViewProps>) => {
+const buildInnerProps = (tokenProps: StackTokens, theme: Theme, _props: unknown, cache: GetMemoValue<ViewProps>) => {
   // if wrapping is disabled just return a fixed empty object without doing any additional work
   if (!tokenProps.wrap) {
     return nowrapProps;

--- a/packages/framework/framework/src/useStyling.ts
+++ b/packages/framework/framework/src/useStyling.ts
@@ -25,7 +25,7 @@ export type BuildProps<TProps, TTokens, TOuterProps = unknown> = BuildPropsBase<
  */
 export function buildProps<TProps, TTokens, TOuterProps = unknown>(
   fn: (tokens: TTokens, theme: Theme, props?: TOuterProps) => TProps,
-  keys?: (keyof TTokens)[],
+  keys?: (keyof TTokens | keyof TOuterProps)[],
 ): BuildProps<TProps, TTokens, TOuterProps> {
   return buildPropsBase<TProps, TTokens, Theme, TOuterProps>(fn, keys);
 }

--- a/packages/framework/framework/src/useStyling.ts
+++ b/packages/framework/framework/src/useStyling.ts
@@ -15,13 +15,19 @@ import {
 import { Theme } from '@fluentui-react-native/theme-types';
 import { themeHelper } from './themeHelper';
 
-export type BuildProps<TProps, TTokens> = BuildPropsBase<TProps, TTokens, Theme>;
+export type BuildProps<TProps, TTokens, TOuterProps = unknown> = BuildPropsBase<TProps, TTokens, Theme, TOuterProps>;
 
-export function buildProps<TProps, TTokens>(
-  fn: (tokens: TTokens, theme: Theme) => TProps,
+/**
+ * Test
+ * @param fn
+ * @param keys
+ * @returns
+ */
+export function buildProps<TProps, TTokens, TOuterProps = unknown>(
+  fn: (tokens: TTokens, theme: Theme, props?: TOuterProps) => TProps,
   keys?: (keyof TTokens)[],
-): BuildProps<TProps, TTokens> {
-  return buildPropsBase<TProps, TTokens, Theme>(fn, keys);
+): BuildProps<TProps, TTokens, TOuterProps> {
+  return buildPropsBase<TProps, TTokens, Theme, TOuterProps>(fn, keys);
 }
 
 export type TokensFromTheme<TTokens> = TokensFromThemeBase<TTokens, Theme>;

--- a/packages/framework/framework/src/useStyling.ts
+++ b/packages/framework/framework/src/useStyling.ts
@@ -17,12 +17,6 @@ import { themeHelper } from './themeHelper';
 
 export type BuildProps<TProps, TTokens, TOuterProps = unknown> = BuildPropsBase<TProps, TTokens, Theme, TOuterProps>;
 
-/**
- * Test
- * @param fn
- * @param keys
- * @returns
- */
 export function buildProps<TProps, TTokens, TOuterProps = unknown>(
   fn: (tokens: TTokens, theme: Theme, props?: TOuterProps) => TProps,
   keys?: (keyof TTokens | keyof TOuterProps)[],

--- a/packages/framework/use-styling/README.md
+++ b/packages/framework/use-styling/README.md
@@ -14,7 +14,7 @@ An extremely simple example might look like:
 const useSyling = buildUseStyling(myComponentOptions, themeHelper);
 
 // component implementation, consuming the styling hook
-const MyComponent = (props) => {
+const MyComponent = props => {
   // get some default/styled props for the container and content child components
   const { container, content } = useStyling(props);
   // render as normal but mixin those values to pass the props to the sub-components
@@ -205,7 +205,7 @@ const Button = (props: ButtonProps) => {
   // get some state value that figures out whether the button is pressed and/or hovered
   const buttonState: ButtonState = useButtonState(props);
   // get styling values based on props and the current state
-  const { container, icon, label } = useStyling(props, (stateName) => buttonState[stateName]);
+  const { container, icon, label } = useStyling(props, stateName => buttonState[stateName]);
 
   const buttonProps = useButtonMagic(props, container);
   return (
@@ -257,38 +257,36 @@ const useStyling = buildUseStyling({
 The functions are assumed to have the following signature:
 
 ```ts
-function propBuilder(tokens: Tokens, theme: Theme, cache: GetMemoValue<Props>): Props;
+function propBuilder(tokens: Tokens, theme: Theme, props: OuterProps, cache: GetMemoValue<Props>): Props;
 ```
 
 While tokens and theme have been discussed at length above, the cache will be a cache instance keyed on:
 
 - The theme
 - The tokens coming from the theme
+- The props that are being passed through from the outer component
 - This slot
 
 If there are no tokens which are also props, i.e. if `tokensProps` is falsy, this is sufficient and the function could be written as:
 
 ```ts
-const slotFn = (tokens: Tokens, theme: Theme, cache: GetMemoValue<Props>) =>
-  cache(
-    () => {
-      return {
-        style: {
-          backgroundColor: tokens.backgroundColor,
-          // etc.
-        },
-      };
-    },
-    [
-      /* no keys, just direct cache the function result*/
-    ],
-  )[0];
+const slotFn = (tokens: Tokens, theme: Theme, props: OuterProps, cache: GetMemoValue<Props>) =>
+  cache(() => {
+    return {
+      style: {
+        backgroundColor: tokens.backgroundColor,
+        // etc.
+      },
+    };
+  }, [
+    /* no keys, just direct cache the function result*/
+  ])[0];
 ```
 
 If some all props are tokens then those keys should be considered in the caching. This would then turn into:
 
 ```ts
-const slotFn = (tokens: Tokens, theme: Theme, cache: GetMemoValue<Props>) => {
+const slotFn = (tokens: Tokens, theme: Theme, props: OuterProps, cache: GetMemoValue<Props>) => {
   const { backgroundColor, color, borderRadius } = tokens;
   return cache(
     () => ({
@@ -305,7 +303,7 @@ The library provides a helper called buildProps to make this more ergonomic. It 
 
 ```ts
 const slotFn = buildProps(
-  (tokens: Tokens, theme: Theme) => ({
+  (tokens: Tokens, theme: Theme, props: OuterProps) => ({
     style: {
       backgroundColor: tokens.backgroundColor,
       color: tokens.color,

--- a/packages/framework/use-styling/src/buildProps.test.ts
+++ b/packages/framework/use-styling/src/buildProps.test.ts
@@ -21,11 +21,11 @@ describe('props function tests', () => {
   test('basic build props function caches as expected', () => {
     const cache = getMemoCache();
     const styleFn = buildProps(munge, ['a', 'b']);
-    const p1 = styleFn({ a: 'a', b: 'b', c: 'c' }, theme, cache);
-    expect(styleFn({ a: 'a', b: 'b', c: 'foo' }, theme, cache)).toBe(p1);
-    const p2 = styleFn({ a: 'b', b: 'b' }, theme, cache);
+    const p1 = styleFn({ a: 'a', b: 'b', c: 'c' }, theme, undefined, cache);
+    expect(styleFn({ a: 'a', b: 'b', c: 'foo' }, theme, undefined, cache)).toBe(p1);
+    const p2 = styleFn({ a: 'b', b: 'b' }, theme, undefined, cache);
     expect(p2).not.toBe(p1);
-    expect(styleFn({ a: 'b', b: 'b', c: 'bar' }, theme, cache)).toBe(p2);
+    expect(styleFn({ a: 'b', b: 'b', c: 'bar' }, theme, undefined, cache)).toBe(p2);
   });
 
   test('build props function refinement works with explicit keys', () => {
@@ -35,12 +35,12 @@ describe('props function tests', () => {
     const t1 = { a: 'a', b: 'b', c: 'c', d: 'd' };
     const t2 = { a: 'a', b: 'b', c: 'foo', d: 'bar' };
 
-    const p1 = styleFn(t1, theme, cache);
-    const p2 = styleFn(t2, theme, cache);
+    const p1 = styleFn(t1, theme, undefined, cache);
+    const p2 = styleFn(t2, theme, undefined, cache);
     expect(p2).not.toBe(p1);
 
-    const rp1 = refinedFn(t1, theme, cache);
-    const rp2 = refinedFn(t2, theme, cache);
+    const rp1 = refinedFn(t1, theme, undefined, cache);
+    const rp2 = refinedFn(t2, theme, undefined, cache);
     expect(rp2).toBe(rp1);
   });
 });

--- a/packages/framework/use-styling/src/buildProps.ts
+++ b/packages/framework/use-styling/src/buildProps.ts
@@ -47,6 +47,13 @@ export type BuildSlotProps<TSlotProps, TTokens, TTheme, TOuterProps> = {
   [K in keyof TSlotProps]?: RefinableBuildPropsBase<TSlotProps[K], TTokens, TTheme, TOuterProps> | TSlotProps[K]
 };
 
+/**
+ * Caches and returns the function based on the current keys.
+ *
+ * @param fn Function which does the work of producing props for the tokens, theme, and props provided
+ * @param keys Set of input values the function is dependent on
+ * @returns Cached function
+ */
 function cacheStyleClosure<TProps, TTokens, TTheme, TOuterProps>(
   fn: (tokens: TTokens, theme: TTheme, props: TOuterProps) => TProps,
   keys?: (keyof TTokens | keyof TOuterProps)[],
@@ -66,7 +73,8 @@ function cacheStyleClosure<TProps, TTokens, TTheme, TOuterProps>(
 
 /**
  * Reduce keys to the set that are also part of the mask.
- * @param keys - which token properties are used by this style, this determines the keys to use for caching
+ *
+ * @param keys - which token and prop properties are used by this style, this determines the keys to use for caching
  * @param mask - the set of tokens that are also props
  * @returns An array of keys that are part of the mask to be used as a caching key
  */
@@ -80,8 +88,8 @@ function refineKeys<TTokens, TOuterProps = unknown>(
 /**
  * Standard wrapper for a function that provides props for a component based on tokens and theme.
  *
- * @param fn - function which does the work of producing props for the tokens and theme provided
- * @param keys - which token properties are used by this style, this determines the keys to use for caching
+ * @param fn - function which does the work of producing props for the tokens, theme, and props provided
+ * @param keys - which token and prop properties are used by this style, this determines the keys to use for caching
  */
 export function buildProps<TProps, TTokens, TTheme, TOuterProps = unknown>(
   fn: (tokens: TTokens, theme: TTheme, props?: TOuterProps) => TProps,

--- a/packages/framework/use-styling/src/buildProps.ts
+++ b/packages/framework/use-styling/src/buildProps.ts
@@ -18,47 +18,45 @@ export type TokensThatAreAlsoProps<TTokens> = (keyof TTokens)[] | 'all' | 'none'
  * The provided
  * cache will be scoped to the theme, slot, and tokens that are coming out of the theme.
  */
-export type BuildPropsBase<TProps, TTokens, TTheme> = (tokens: TTokens, theme: TTheme, cache: GetMemoValue<any>) => Partial<TProps>;
+export type BuildPropsBase<TProps, TTokens, TTheme, TOuterProps> = (
+  tokens: TTokens,
+  theme: TTheme,
+  props: TOuterProps,
+  cache: GetMemoValue<any>,
+) => Partial<TProps>;
 
 /**
  * A refine function allows style functions to be updated based on tokens that are also props. Only those tokens that are also
  * props need to be considered as a key for caching
  */
-export type RefineFunctionBase<TProps, TTokens, TTheme> = (
+export type RefineFunctionBase<TProps, TTokens, TTheme, TOuterProps> = (
   mask?: TokensThatAreAlsoProps<TTokens>,
-) => BuildPropsBase<TProps, TTokens, TTheme>;
+) => BuildPropsBase<TProps, TTokens, TTheme, TOuterProps>;
 
 /**
  * Signature for a style function which can be optionally refined by the styling hook if prop masks are provided
  */
-export type RefinableBuildPropsBase<TProps, TTokens, TTheme> = BuildPropsBase<TProps, TTokens, TTheme> & {
-  refine?: RefineFunctionBase<TProps, TTokens, TTheme>;
+export type RefinableBuildPropsBase<TProps, TTokens, TTheme, TOuterProps> = BuildPropsBase<TProps, TTokens, TTheme, TOuterProps> & {
+  refine?: RefineFunctionBase<TProps, TTokens, TTheme, TOuterProps>;
 };
 
 /**
  * Style functions can be plain functions, refinable functions, or just raw props
  */
-export type BuildSlotProps<TSlotProps, TTokens, TTheme> = {
-  [K in keyof TSlotProps]?: RefinableBuildPropsBase<TSlotProps[K], TTokens, TTheme> | TSlotProps[K];
+export type BuildSlotProps<TSlotProps, TTokens, TTheme, TOuterProps> = {
+  [K in keyof TSlotProps]?: RefinableBuildPropsBase<TSlotProps[K], TTokens, TTheme, TOuterProps> | TSlotProps[K]
 };
 
-function cacheStyleClosure<TProps, TTokens, TTheme>(
-  fn: (tokens: TTokens, theme: TTheme) => TProps,
+function cacheStyleClosure<TProps, TTokens, TTheme, TOuterProps>(
+  fn: (tokens: TTokens, theme: TTheme, props: TOuterProps) => TProps,
   keys?: (keyof TTokens)[],
-): RefinableBuildPropsBase<TProps, TTokens, TTheme> {
-  return (tokens: TTokens, theme: TTheme, cache: GetMemoValue<TProps>) =>
-    cache(
-      () => fn(tokens, theme),
-      (keys || []).map((key) => tokens[key]),
-    )[0];
+): RefinableBuildPropsBase<TProps, TTokens, TTheme, TOuterProps> {
+  return (tokens: TTokens, theme: TTheme, props: TOuterProps, cache: GetMemoValue<TProps>) =>
+    cache(() => fn(tokens, theme, props), (keys || []).map(key => tokens[key]))[0];
 }
 
 function refineKeys<TTokens>(keys: (keyof TTokens)[], mask?: TokensThatAreAlsoProps<TTokens>): (keyof TTokens)[] {
-  return typeof mask === 'object' && Array.isArray(mask)
-    ? keys.filter((key) => mask.findIndex((val) => val === key) !== -1)
-    : mask
-    ? keys
-    : [];
+  return typeof mask === 'object' && Array.isArray(mask) ? keys.filter(key => mask.findIndex(val => val === key) !== -1) : mask ? keys : [];
 }
 
 /**
@@ -67,10 +65,10 @@ function refineKeys<TTokens>(keys: (keyof TTokens)[], mask?: TokensThatAreAlsoPr
  * @param fn - function which does the work of producing props for the tokens and theme provided
  * @param keys - which token properties are used by this style, this determines the keys to use for caching
  */
-export function buildProps<TProps, TTokens, TTheme>(
-  fn: (tokens: TTokens, theme: TTheme) => TProps,
+export function buildProps<TProps, TTokens, TTheme, TOuterProps = unknown>(
+  fn: (tokens: TTokens, theme: TTheme, props?: TOuterProps) => TProps,
   keys?: (keyof TTokens)[],
-): RefinableBuildPropsBase<TProps, TTokens, TTheme> {
+): RefinableBuildPropsBase<TProps, TTokens, TTheme, TOuterProps> {
   // wrap the provided function in the standard caching layer, basing it upon the provided keys
   const result = cacheStyleClosure(fn, keys);
 
@@ -92,14 +90,15 @@ export function buildProps<TProps, TTokens, TTheme>(
  * @param fn - function or props to potentially refine
  * @param mask - prop mask to use for refinement
  */
-export function refinePropsFunctions<TSlotProps, TTokens, TTheme>(
-  styles: BuildSlotProps<TSlotProps, TTokens, TTheme>,
+export function refinePropsFunctions<TSlotProps, TTokens, TTheme, TOuterProps>(
+  styles: BuildSlotProps<TSlotProps, TTokens, TTheme, TOuterProps>,
   mask: TokensThatAreAlsoProps<TTokens>,
-): BuildSlotProps<TSlotProps, TTokens, TTheme> {
+): BuildSlotProps<TSlotProps, TTokens, TTheme, TOuterProps> {
   const result = {};
-  Object.keys(styles).forEach((key) => {
+  Object.keys(styles).forEach(key => {
     const refine =
-      typeof styles[key] === 'function' && (styles[key] as RefinableBuildPropsBase<TSlotProps[keyof TSlotProps], TTokens, TTheme>).refine;
+      typeof styles[key] === 'function' &&
+      (styles[key] as RefinableBuildPropsBase<TSlotProps[keyof TSlotProps], TTokens, TTheme, TOuterProps>).refine;
     result[key] = refine ? refine(mask) : styles[key];
   });
   return result;

--- a/packages/framework/use-styling/src/buildUseStyling.ts
+++ b/packages/framework/use-styling/src/buildUseStyling.ts
@@ -20,7 +20,7 @@ export type UseStylingOptions<TProps, TSlotProps, TTokens, TTheme> = {
   /**
    * Functions which build up the props for each slot
    */
-  slotProps?: BuildSlotProps<TSlotProps, TTokens, TTheme>;
+  slotProps?: BuildSlotProps<TSlotProps, TTokens, TTheme, TProps>;
 
   /**
    * Which props should be considered to be tokens.
@@ -55,18 +55,20 @@ export type ThemeHelper<TTheme> = {
  * @param styles - refined style functions or props to use for processing
  * @param tokens - token inputs for the style functions
  * @param theme - theme to resolve against
+ * @param props - props from outer component
  * @param cache - cache to use for the base of slot caching
  */
-function resolveToSlotProps<TSlotProps, TTokens, TTheme>(
-  styles: BuildSlotProps<TSlotProps, TTokens, TTheme>,
+function resolveToSlotProps<TSlotProps, TTokens, TTheme, TProps>(
+  styles: BuildSlotProps<TSlotProps, TTokens, TTheme, TProps>,
   tokens: TTokens,
   theme: TTheme,
+  props: TProps,
   cache: GetMemoValue<TTokens>,
 ): TSlotProps {
   const slotProps = {};
-  Object.keys(styles).forEach((key) => {
+  Object.keys(styles).forEach(key => {
     const style = styles[key];
-    slotProps[key] = typeof style === 'function' ? style(tokens, theme, cache(null, [key])[1]) : style;
+    slotProps[key] = typeof style === 'function' ? style(tokens, theme, props, cache(null, [key])[1]) : style;
   });
   return slotProps as TSlotProps;
 }
@@ -96,7 +98,7 @@ export function buildUseStyling<TProps, TSlotProps, TTokens, TTheme>(
 
     // resolve overrides as appropriate
     if (options.states) {
-      [mergedTokens, cache] = applyTokenLayers(mergedTokens, options.states as string[], cache, lookup || ((val) => props[val]));
+      [mergedTokens, cache] = applyTokenLayers(mergedTokens, options.states as string[], cache, lookup || (val => props[val]));
     }
 
     // now resolve tokens
@@ -107,6 +109,6 @@ export function buildUseStyling<TProps, TSlotProps, TTokens, TTheme>(
     }
 
     // finally produce slotProps from calling the style functions on each entry
-    return resolveToSlotProps(styles, mergedTokens, theme, cache);
+    return resolveToSlotProps(styles, mergedTokens, theme, props, cache);
   };
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

We've been running into issues with slotProps/buildProps in compose v2. Specifically, it doesn't really allow for us to take the outer component's props into account when building slot props. This makes cases where we want to nest slots harder to do, since much of the outer portions of the render functions of nested slots rely on props that we wouldn't be able to pass along until we get to the inner portion of the render function of the outer component, thus making them unavailable for the inner slot.

Although tokensThatAreAlsoProps exists, for some of the props, like passing onClick along from an outer component to a slot that's a FURN Button, it didn't really make sense to make that a token. So I think the "right" change is to allow props to be passed into buildProps and be used to create slotProps, so that certain props are available for outer render time.

### Verification

Tests have been run and a new test has been added. Verified with the menu button changes that Valentyna is working on that this seems to resolve the issues we've been running into with onClick, and should work for propagating primary/ghost.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests - working on it, getting this out to make sure that there's no large issue with this change.
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
