### PR TITLE
Downgrade Text component

### DIFF
--- a/apps/fluent-tester/src/FluentTester/FluentTester.tsx
+++ b/apps/fluent-tester/src/FluentTester/FluentTester.tsx
@@ -1,7 +1,7 @@
 import { Theme } from '@fluentui-react-native/framework';
 import { FocusTrapZone, Separator, StealthButton } from '@fluentui/react-native';
 import { Button } from '@fluentui-react-native/experimental-button';
-import { Text } from '@fluentui-react-native/experimental-text';
+import { Text } from '@fluentui-react-native/text';
 import { themedStyleSheet } from '@fluentui-react-native/themed-stylesheet';
 import * as React from 'react';
 import { ScrollView, View, Text as RNText, Platform, SafeAreaView, BackHandler } from 'react-native';


### PR DESCRIPTION
Fixes #1028

### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [x] windows
- [ ] android

### Description of changes

When clicking on a test page in the tester, an error pops up from RN that tells us that we're changing the value of a prop at a time when we shouldn't be in the rendering phase. This is an issue that is specific to the UWP platform, because we're still using Chakra. It seems to be a timing issue - it's not something that we see causing issues with other engines on other platforms.

This error also occurs in the Separator component, but we worked around that by skipping the prop that was causing problems. But unfortunately since the style is integral to the Text component, we can't really do that for the Text component.

To unblock the Tester I'm going to downgrade the Text component to the non-experimental version.

### Verification

Tester works fine when I downgrade the Text component

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
