### PR TITLE
Don't pass code point as a style prop to Icon's inner Text component

### DIFF
--- a/apps/ios/src/Podfile.lock
+++ b/apps/ios/src/Podfile.lock
@@ -18,14 +18,11 @@ PODS:
     - boost-for-react-native
     - DoubleConversion
     - glog
-  - FRNAvatar (0.12.5):
+  - FRNAvatar (0.12.12):
     - MicrosoftFluentUI (= 0.3.0)
     - MicrosoftFluentUI/Avatar_ios (= 0.3.0)
     - React
-  - FRNButton (0.7.20):
-    - MicrosoftFluentUI (= 0.3.0)
-    - React
-  - FRNDatePicker (0.3.6):
+  - FRNDatePicker (0.3.7):
     - MicrosoftFluentUI (= 0.3.0)
     - React
   - glog (0.3.5)
@@ -428,7 +425,6 @@ DEPENDENCIES:
   - FBReactNativeSpec (from `../../../node_modules/react-native/Libraries/FBReactNativeSpec`)
   - Folly (from `../../../node_modules/react-native/third-party-podspecs/Folly.podspec`)
   - FRNAvatar (from `../../../packages/experimental/Avatar/FRNAvatar.podspec`)
-  - FRNButton (from `../../../packages/experimental/NativeButton/FRNButton.podspec`)
   - FRNDatePicker (from `../../../packages/experimental/NativeDatePicker/FRNDatePicker.podspec`)
   - glog (from `../../../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - QRCodeReader.swift
@@ -480,8 +476,6 @@ EXTERNAL SOURCES:
     :podspec: "../../../node_modules/react-native/third-party-podspecs/Folly.podspec"
   FRNAvatar:
     :path: "../../../packages/experimental/Avatar/FRNAvatar.podspec"
-  FRNButton:
-    :path: "../../../packages/experimental/NativeButton/FRNButton.podspec"
   FRNDatePicker:
     :path: "../../../packages/experimental/NativeDatePicker/FRNDatePicker.podspec"
   glog:
@@ -545,9 +539,8 @@ SPEC CHECKSUMS:
   FBLazyVector: 3bb422f41b18121b71783a905c10e58606f7dc3e
   FBReactNativeSpec: f2c97f2529dd79c083355182cc158c9f98f4bd6e
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
-  FRNAvatar: f631c488ceadbf4a3f885bb10275104b1041da82
-  FRNButton: 525525958d2c3083e5c2a213e8d4c78e4d1169cc
-  FRNDatePicker: 28086c1c8092614414b4f8b7b3675f3b2a8c9cfc
+  FRNAvatar: 2687926489d4e58fd8f68b0cb4297ce1c179e742
+  FRNDatePicker: 3b0ee573936065b2de86ec61ab5f6407ba8163c8
   glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
   MicrosoftFluentUI: b98d877a2122804132365aa167944f58ef4adb69
   QRCodeReader.swift: 373a389fe9a22d513c879a32a6f647c58f4ef572
@@ -579,6 +572,6 @@ SPEC CHECKSUMS:
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
   Yoga: 4bd86afe9883422a7c4028c00e34790f560923d6
 
-PODFILE CHECKSUM: bcebab1599979f3beb71af26698524d24cb9f19e
+PODFILE CHECKSUM: 61f64d2e918386255ef0609310cb922b5e1c51b3
 
-COCOAPODS: 1.10.2
+COCOAPODS: 1.11.0

--- a/apps/macos/src/Podfile.lock
+++ b/apps/macos/src/Podfile.lock
@@ -1,24 +1,21 @@
 PODS:
   - boost-for-react-native (1.63.0)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.63.37)
-  - FBReactNativeSpec (0.63.37):
+  - FBLazyVector (0.63.38)
+  - FBReactNativeSpec (0.63.38):
     - RCT-Folly (= 2020.01.13.00)
-    - RCTRequired (= 0.63.37)
-    - RCTTypeSafety (= 0.63.37)
-    - React-Core (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - ReactCommon/turbomodule/core (= 0.63.37)
-  - FRNAvatar (0.12.9):
+    - RCTRequired (= 0.63.38)
+    - RCTTypeSafety (= 0.63.38)
+    - React-Core (= 0.63.38)
+    - React-jsi (= 0.63.38)
+    - ReactCommon/turbomodule/core (= 0.63.38)
+  - FRNAvatar (0.12.12):
     - MicrosoftFluentUI (= 0.3.0)
     - MicrosoftFluentUI/Avatar_ios (= 0.3.0)
     - React
-  - FRNButton (0.7.24):
-    - MicrosoftFluentUI (= 0.3.0)
+  - FRNMenuButton (0.6.11):
     - React
-  - FRNMenuButton (0.6.8):
-    - React
-  - FRNRadioButton (0.13.9):
+  - FRNRadioButton (0.13.12):
     - React
   - glog (0.3.5)
   - MicrosoftFluentUI (0.3.0):
@@ -93,237 +90,237 @@ PODS:
     - boost-for-react-native
     - DoubleConversion
     - glog
-  - RCTFocusZone (0.7.24):
+  - RCTFocusZone (0.7.27):
     - React
-  - RCTRequired (0.63.37)
-  - RCTTypeSafety (0.63.37):
-    - FBLazyVector (= 0.63.37)
+  - RCTRequired (0.63.38)
+  - RCTTypeSafety (0.63.38):
+    - FBLazyVector (= 0.63.38)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTRequired (= 0.63.37)
-    - React-Core (= 0.63.37)
-  - React (0.63.37):
-    - React-Core (= 0.63.37)
-    - React-Core/DevSupport (= 0.63.37)
-    - React-Core/RCTWebSocket (= 0.63.37)
-    - React-RCTActionSheet (= 0.63.37)
-    - React-RCTAnimation (= 0.63.37)
-    - React-RCTBlob (= 0.63.37)
-    - React-RCTImage (= 0.63.37)
-    - React-RCTLinking (= 0.63.37)
-    - React-RCTNetwork (= 0.63.37)
-    - React-RCTSettings (= 0.63.37)
-    - React-RCTText (= 0.63.37)
-    - React-RCTVibration (= 0.63.37)
-  - React-callinvoker (0.63.37)
-  - React-Core (0.63.37):
+    - RCTRequired (= 0.63.38)
+    - React-Core (= 0.63.38)
+  - React (0.63.38):
+    - React-Core (= 0.63.38)
+    - React-Core/DevSupport (= 0.63.38)
+    - React-Core/RCTWebSocket (= 0.63.38)
+    - React-RCTActionSheet (= 0.63.38)
+    - React-RCTAnimation (= 0.63.38)
+    - React-RCTBlob (= 0.63.38)
+    - React-RCTImage (= 0.63.38)
+    - React-RCTLinking (= 0.63.38)
+    - React-RCTNetwork (= 0.63.38)
+    - React-RCTSettings (= 0.63.38)
+    - React-RCTText (= 0.63.38)
+    - React-RCTVibration (= 0.63.38)
+  - React-callinvoker (0.63.38)
+  - React-Core (0.63.38):
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.63.37)
-    - React-cxxreact (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - React-jsiexecutor (= 0.63.37)
+    - React-Core/Default (= 0.63.38)
+    - React-cxxreact (= 0.63.38)
+    - React-jsi (= 0.63.38)
+    - React-jsiexecutor (= 0.63.38)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.63.37):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default
-    - React-cxxreact (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - React-jsiexecutor (= 0.63.37)
-    - Yoga
-  - React-Core/Default (0.63.37):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-cxxreact (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - React-jsiexecutor (= 0.63.37)
-    - Yoga
-  - React-Core/DevSupport (0.63.37):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.63.37)
-    - React-Core/RCTWebSocket (= 0.63.37)
-    - React-cxxreact (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - React-jsiexecutor (= 0.63.37)
-    - React-jsinspector (= 0.63.37)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.63.37):
+  - React-Core/CoreModulesHeaders (0.63.38):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - React-jsiexecutor (= 0.63.37)
+    - React-cxxreact (= 0.63.38)
+    - React-jsi (= 0.63.38)
+    - React-jsiexecutor (= 0.63.38)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.63.37):
+  - React-Core/Default (0.63.38):
+    - glog
+    - RCT-Folly (= 2020.01.13.00)
+    - React-cxxreact (= 0.63.38)
+    - React-jsi (= 0.63.38)
+    - React-jsiexecutor (= 0.63.38)
+    - Yoga
+  - React-Core/DevSupport (0.63.38):
+    - glog
+    - RCT-Folly (= 2020.01.13.00)
+    - React-Core/Default (= 0.63.38)
+    - React-Core/RCTWebSocket (= 0.63.38)
+    - React-cxxreact (= 0.63.38)
+    - React-jsi (= 0.63.38)
+    - React-jsiexecutor (= 0.63.38)
+    - React-jsinspector (= 0.63.38)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.63.38):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - React-jsiexecutor (= 0.63.37)
+    - React-cxxreact (= 0.63.38)
+    - React-jsi (= 0.63.38)
+    - React-jsiexecutor (= 0.63.38)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.63.37):
+  - React-Core/RCTAnimationHeaders (0.63.38):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - React-jsiexecutor (= 0.63.37)
+    - React-cxxreact (= 0.63.38)
+    - React-jsi (= 0.63.38)
+    - React-jsiexecutor (= 0.63.38)
     - Yoga
-  - React-Core/RCTImageHeaders (0.63.37):
+  - React-Core/RCTBlobHeaders (0.63.38):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - React-jsiexecutor (= 0.63.37)
+    - React-cxxreact (= 0.63.38)
+    - React-jsi (= 0.63.38)
+    - React-jsiexecutor (= 0.63.38)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.63.37):
+  - React-Core/RCTImageHeaders (0.63.38):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - React-jsiexecutor (= 0.63.37)
+    - React-cxxreact (= 0.63.38)
+    - React-jsi (= 0.63.38)
+    - React-jsiexecutor (= 0.63.38)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.63.37):
+  - React-Core/RCTLinkingHeaders (0.63.38):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - React-jsiexecutor (= 0.63.37)
+    - React-cxxreact (= 0.63.38)
+    - React-jsi (= 0.63.38)
+    - React-jsiexecutor (= 0.63.38)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.63.37):
+  - React-Core/RCTNetworkHeaders (0.63.38):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - React-jsiexecutor (= 0.63.37)
+    - React-cxxreact (= 0.63.38)
+    - React-jsi (= 0.63.38)
+    - React-jsiexecutor (= 0.63.38)
     - Yoga
-  - React-Core/RCTTextHeaders (0.63.37):
+  - React-Core/RCTSettingsHeaders (0.63.38):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - React-jsiexecutor (= 0.63.37)
+    - React-cxxreact (= 0.63.38)
+    - React-jsi (= 0.63.38)
+    - React-jsiexecutor (= 0.63.38)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.63.37):
+  - React-Core/RCTTextHeaders (0.63.38):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - React-jsiexecutor (= 0.63.37)
+    - React-cxxreact (= 0.63.38)
+    - React-jsi (= 0.63.38)
+    - React-jsiexecutor (= 0.63.38)
     - Yoga
-  - React-Core/RCTWebSocket (0.63.37):
+  - React-Core/RCTVibrationHeaders (0.63.38):
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.63.37)
-    - React-cxxreact (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - React-jsiexecutor (= 0.63.37)
+    - React-Core/Default
+    - React-cxxreact (= 0.63.38)
+    - React-jsi (= 0.63.38)
+    - React-jsiexecutor (= 0.63.38)
     - Yoga
-  - React-CoreModules (0.63.37):
-    - FBReactNativeSpec (= 0.63.37)
+  - React-Core/RCTWebSocket (0.63.38):
+    - glog
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.37)
-    - React-Core/CoreModulesHeaders (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - React-RCTImage (= 0.63.37)
-    - ReactCommon/turbomodule/core (= 0.63.37)
-  - React-cxxreact (0.63.37):
+    - React-Core/Default (= 0.63.38)
+    - React-cxxreact (= 0.63.38)
+    - React-jsi (= 0.63.38)
+    - React-jsiexecutor (= 0.63.38)
+    - Yoga
+  - React-CoreModules (0.63.38):
+    - FBReactNativeSpec (= 0.63.38)
+    - RCT-Folly (= 2020.01.13.00)
+    - RCTTypeSafety (= 0.63.38)
+    - React-Core/CoreModulesHeaders (= 0.63.38)
+    - React-jsi (= 0.63.38)
+    - React-RCTImage (= 0.63.38)
+    - ReactCommon/turbomodule/core (= 0.63.38)
+  - React-cxxreact (0.63.38):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.63.37)
-    - React-jsinspector (= 0.63.37)
-  - React-jsi (0.63.37):
+    - React-callinvoker (= 0.63.38)
+    - React-jsinspector (= 0.63.38)
+  - React-jsi (0.63.38):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-jsi/Default (= 0.63.37)
-  - React-jsi/Default (0.63.37):
+    - React-jsi/Default (= 0.63.38)
+  - React-jsi/Default (0.63.38):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-  - React-jsiexecutor (0.63.37):
+  - React-jsiexecutor (0.63.38):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-cxxreact (= 0.63.37)
-    - React-jsi (= 0.63.37)
-  - React-jsinspector (0.63.37)
-  - React-RCTActionSheet (0.63.37):
-    - React-Core/RCTActionSheetHeaders (= 0.63.37)
-  - React-RCTAnimation (0.63.37):
-    - FBReactNativeSpec (= 0.63.37)
+    - React-cxxreact (= 0.63.38)
+    - React-jsi (= 0.63.38)
+  - React-jsinspector (0.63.38)
+  - React-RCTActionSheet (0.63.38):
+    - React-Core/RCTActionSheetHeaders (= 0.63.38)
+  - React-RCTAnimation (0.63.38):
+    - FBReactNativeSpec (= 0.63.38)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.37)
-    - React-Core/RCTAnimationHeaders (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - ReactCommon/turbomodule/core (= 0.63.37)
-  - React-RCTBlob (0.63.37):
-    - FBReactNativeSpec (= 0.63.37)
+    - RCTTypeSafety (= 0.63.38)
+    - React-Core/RCTAnimationHeaders (= 0.63.38)
+    - React-jsi (= 0.63.38)
+    - ReactCommon/turbomodule/core (= 0.63.38)
+  - React-RCTBlob (0.63.38):
+    - FBReactNativeSpec (= 0.63.38)
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/RCTBlobHeaders (= 0.63.37)
-    - React-Core/RCTWebSocket (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - React-RCTNetwork (= 0.63.37)
-    - ReactCommon/turbomodule/core (= 0.63.37)
-  - React-RCTImage (0.63.37):
-    - FBReactNativeSpec (= 0.63.37)
+    - React-Core/RCTBlobHeaders (= 0.63.38)
+    - React-Core/RCTWebSocket (= 0.63.38)
+    - React-jsi (= 0.63.38)
+    - React-RCTNetwork (= 0.63.38)
+    - ReactCommon/turbomodule/core (= 0.63.38)
+  - React-RCTImage (0.63.38):
+    - FBReactNativeSpec (= 0.63.38)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.37)
-    - React-Core/RCTImageHeaders (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - React-RCTNetwork (= 0.63.37)
-    - ReactCommon/turbomodule/core (= 0.63.37)
-  - React-RCTLinking (0.63.37):
-    - FBReactNativeSpec (= 0.63.37)
-    - React-Core/RCTLinkingHeaders (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - ReactCommon/turbomodule/core (= 0.63.37)
-  - React-RCTNetwork (0.63.37):
-    - FBReactNativeSpec (= 0.63.37)
+    - RCTTypeSafety (= 0.63.38)
+    - React-Core/RCTImageHeaders (= 0.63.38)
+    - React-jsi (= 0.63.38)
+    - React-RCTNetwork (= 0.63.38)
+    - ReactCommon/turbomodule/core (= 0.63.38)
+  - React-RCTLinking (0.63.38):
+    - FBReactNativeSpec (= 0.63.38)
+    - React-Core/RCTLinkingHeaders (= 0.63.38)
+    - React-jsi (= 0.63.38)
+    - ReactCommon/turbomodule/core (= 0.63.38)
+  - React-RCTNetwork (0.63.38):
+    - FBReactNativeSpec (= 0.63.38)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.37)
-    - React-Core/RCTNetworkHeaders (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - ReactCommon/turbomodule/core (= 0.63.37)
-  - React-RCTSettings (0.63.37):
-    - FBReactNativeSpec (= 0.63.37)
+    - RCTTypeSafety (= 0.63.38)
+    - React-Core/RCTNetworkHeaders (= 0.63.38)
+    - React-jsi (= 0.63.38)
+    - ReactCommon/turbomodule/core (= 0.63.38)
+  - React-RCTSettings (0.63.38):
+    - FBReactNativeSpec (= 0.63.38)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.37)
-    - React-Core/RCTSettingsHeaders (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - ReactCommon/turbomodule/core (= 0.63.37)
-  - React-RCTText (0.63.37):
-    - React-Core/RCTTextHeaders (= 0.63.37)
-  - React-RCTVibration (0.63.37):
-    - FBReactNativeSpec (= 0.63.37)
+    - RCTTypeSafety (= 0.63.38)
+    - React-Core/RCTSettingsHeaders (= 0.63.38)
+    - React-jsi (= 0.63.38)
+    - ReactCommon/turbomodule/core (= 0.63.38)
+  - React-RCTText (0.63.38):
+    - React-Core/RCTTextHeaders (= 0.63.38)
+  - React-RCTVibration (0.63.38):
+    - FBReactNativeSpec (= 0.63.38)
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/RCTVibrationHeaders (= 0.63.37)
-    - React-jsi (= 0.63.37)
-    - ReactCommon/turbomodule/core (= 0.63.37)
-  - ReactCommon/turbomodule/core (0.63.37):
+    - React-Core/RCTVibrationHeaders (= 0.63.38)
+    - React-jsi (= 0.63.38)
+    - ReactCommon/turbomodule/core (= 0.63.38)
+  - ReactCommon/turbomodule/core (0.63.38):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.63.37)
-    - React-Core (= 0.63.37)
-    - React-cxxreact (= 0.63.37)
-    - React-jsi (= 0.63.37)
+    - React-callinvoker (= 0.63.38)
+    - React-Core (= 0.63.38)
+    - React-cxxreact (= 0.63.38)
+    - React-jsi (= 0.63.38)
   - ReactTestApp-DevSupport (0.7.5)
   - ReactTestApp-Resources (1.0.0-dev)
-  - RNCPicker (1.16.7):
+  - RNCPicker (1.16.8):
     - React-Core
   - RNSVG (12.1.1):
     - React
@@ -336,7 +333,6 @@ DEPENDENCIES:
   - FBLazyVector (from `../../../node_modules/react-native-macos/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../../../node_modules/react-native-macos/Libraries/FBReactNativeSpec`)
   - FRNAvatar (from `../../../packages/experimental/Avatar/FRNAvatar.podspec`)
-  - FRNButton (from `../../../packages/experimental/NativeButton/FRNButton.podspec`)
   - FRNMenuButton (from `../../../packages/components/MenuButton/FRNMenuButton.podspec`)
   - FRNRadioButton (from `../../../packages/components/RadioGroup/FRNRadioButton.podspec`)
   - glog (from `../../../node_modules/react-native-macos/third-party-podspecs/glog.podspec`)
@@ -387,8 +383,6 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native-macos/Libraries/FBReactNativeSpec"
   FRNAvatar:
     :path: "../../../packages/experimental/Avatar/FRNAvatar.podspec"
-  FRNButton:
-    :path: "../../../packages/experimental/NativeButton/FRNButton.podspec"
   FRNMenuButton:
     :path: "../../../packages/components/MenuButton/FRNMenuButton.podspec"
   FRNRadioButton:
@@ -453,43 +447,42 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost-for-react-native: dabda8622e76020607c2ae1e65cc0cda8b61479d
   DoubleConversion: 56a44bcfd14ab2ff66f5a146b2e875eb4b69b19b
-  FBLazyVector: 9d69690b3a1ca272ca0c0cee76ffcb6cf36d77af
-  FBReactNativeSpec: 8b671febd2393669947b56e8d8f53a54185dd0b7
-  FRNAvatar: 4b7a4ffdbda34d61c2242ce5aed73dd6bbfd4a71
-  FRNButton: 7d2bff3a960b28f855dde8b4b8782e747a252367
-  FRNMenuButton: d281a1475723dbece8ac1124e2e58eebc3400b05
-  FRNRadioButton: 44067b2b4d3c7b022c9d94da888c0b6433a41098
+  FBLazyVector: 6f26a5d3b481c40c520b319ab2919994ab28e51d
+  FBReactNativeSpec: a364112f45d4c007ab0a375296bd2b5bc171cd72
+  FRNAvatar: 2687926489d4e58fd8f68b0cb4297ce1c179e742
+  FRNMenuButton: d586b0020fac8dd5860c132030bf5db65f6e3184
+  FRNRadioButton: 8dd7bdc2d360b6747c04bec836bff26ebeeafdf3
   glog: 1cb7c408c781ae8f35bbababe459b45e3dee4ec1
   MicrosoftFluentUI: b98d877a2122804132365aa167944f58ef4adb69
   RCT-Folly: 1347093ffe75e152d846f7e45a3ef901b60021aa
-  RCTFocusZone: 4a776092b0875822772e4d1adda7a508aac01187
-  RCTRequired: 34869e88152b553afc0c7bde31b7b95f626ae367
-  RCTTypeSafety: a7e07dddefa291537fa86c996b19bbbeda9db88e
-  React: 4b1d4533300d5ffecadd5966efad43aae87d0dcb
-  React-callinvoker: f6cc4222b47cfbea310047e92fec23d454029595
-  React-Core: bf15e114c68922342fa1c77a7582458086931f50
-  React-CoreModules: 00bbdffe53f364828dcf56c0c8ed58502a67757a
-  React-cxxreact: a6ae61aee087fb51956642ec9e45f0f5cc50e488
-  React-jsi: 95337001f7c137cb7aa17b39a05b654b54ddcccb
-  React-jsiexecutor: 6dcf6fb045190e13ab29d5a3eed010aaecd934be
-  React-jsinspector: df2c5f97e26ffc68bea06c4aae11e4ce09e53e3e
-  React-RCTActionSheet: faf3d96046a0fa2b40c3c1bd0c36be860b42f2a1
-  React-RCTAnimation: 7e62b31253f45c752f7593cff24a8845557b4d13
-  React-RCTBlob: 8a1c648f7887d850972233f742589e67d52357bb
-  React-RCTImage: d40614e39fc3186a0b406ceb13fd1903880dec96
-  React-RCTLinking: a0906eb0f0169f881a0637cbb9999fb4881ee200
-  React-RCTNetwork: b1baf2d42aa5dc7157c57c7cc7ca548b9eeadaee
-  React-RCTSettings: a21555584a097f61277b9ed97c00091da9beaa61
-  React-RCTText: 2f9504b1157ccce317774eb3ca935a923ddc95d7
-  React-RCTVibration: db89493e2520ad419eeb59e40059e246d9e71607
-  ReactCommon: 014dd1ff02eab367fa6676b7b408d1a08893a98d
+  RCTFocusZone: 337ea97ab5015b5d3e82778329d985afb2c1f449
+  RCTRequired: 2d4cfa605a65bdd56802eaa8fdbc3310f7136edf
+  RCTTypeSafety: 4b3cf5ccb0859341fcb2521ae5d9623582b327e3
+  React: dbb7cca926a22af3437d1b584fb25dd539827834
+  React-callinvoker: c4559694e7feb44e23bea3146d80ba2115275fc7
+  React-Core: c8f2cd77754ecdf30189e161030dd3b124dcfc5e
+  React-CoreModules: e0848d9020df774dc6ccbd463b1e479340b5f87e
+  React-cxxreact: 9fd4a0bfd568b17b5b443458abd811b88f953058
+  React-jsi: 44fbe6321b975bcf197bd2e755bf4bbfcdefc71c
+  React-jsiexecutor: fdc300cddea55c8c4cdd35ef7a4ca79d901a008f
+  React-jsinspector: fcd5f97a8417f35190dddef8320eca519bcb99d2
+  React-RCTActionSheet: cb548b3e6e2469a7a2e35d415a6c202e426d3382
+  React-RCTAnimation: 526a79643ef10d3c8682572f10da9e3c37f2bd11
+  React-RCTBlob: cd713a51bc0050e2dcac184be7aa3de73712ac46
+  React-RCTImage: afe0b37c99dbaed0dc1365166b7002a98d9a1bae
+  React-RCTLinking: 3ab416d68e320234c575667a05e8c985f0658135
+  React-RCTNetwork: e4c44e037526453d14ab5af49fb29a420e61bf15
+  React-RCTSettings: 08fe9de5aa4077191464382070f236079de0922f
+  React-RCTText: bc82c1865820b8d07b64b75041b040cff3152a7a
+  React-RCTVibration: ab72db1b238f49246d7b7663ce8fa4d57bc29c5b
+  ReactCommon: 8164c9d3cd8c956f2fc432b667e964e38ba8e16c
   ReactTestApp-DevSupport: 84ab1181efc86b93291e97746b58de70016c5340
   ReactTestApp-Resources: 5950ae44720217c6778ff03fb1d906c8fb3ce483
-  RNCPicker: 9865e85857650bbc553c660acc580ff86abd056a
+  RNCPicker: 0991c56da7815c0cf946d6f63cf920b25296e5f6
   RNSVG: 551acb6562324b1d52a4e0758f7ca0ec234e278f
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
-  Yoga: 77d9987384e26b4aaf3e7a01808838cc2d4304f2
+  Yoga: a68ce967f49a478e85b0642fd33aee46187ab6f8
 
-PODFILE CHECKSUM: d23a9935aa1847f95c01edb06af76ae66811c13e
+PODFILE CHECKSUM: 46f3269bae3054aad680d2884e21a267ff647aa4
 
-COCOAPODS: 1.10.2
+COCOAPODS: 1.11.0

--- a/change/@fluentui-react-native-icon-5dfd39ea-2892-45b1-ae5a-0f2b759d66eb.json
+++ b/change/@fluentui-react-native-icon-5dfd39ea-2892-45b1-ae5a-0f2b759d66eb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix bug where codepoint was passed as style prop",
+  "packageName": "@fluentui-react-native/icon",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Icon/src/Icon.tsx
+++ b/packages/experimental/Icon/src/Icon.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { IconProps, SvgIconProps, FontIconProps } from './Icon.types';
-import { Image, ImageStyle, Platform, View, ColorValue } from 'react-native';
+import { Image, ImageStyle, Platform, View, ColorValue, TextStyle } from 'react-native';
 import { Text } from '@fluentui-react-native/text';
 import { mergeStyles, useFluentTheme } from '@fluentui-react-native/framework';
 import { stagedComponent, mergeProps, getMemoCache } from '@fluentui-react-native/framework';
@@ -34,18 +34,17 @@ const fontStyleMemoCache = getMemoCache();
 function renderFontIcon(iconProps: IconProps) {
   const fontSource: FontIconProps = iconProps.fontSource;
 
-  const style = fontStyleMemoCache(
+  const style: TextStyle = fontStyleMemoCache(
     {
       fontSrcFile: fontSource.fontSrcFile,
       fontFamily:
         fontSource.fontSrcFile != undefined
           ? fontFamilyFromFontSrcFile(fontSource.fontSrcFile, fontSource.fontFamily)
           : fontSource.fontFamily,
-      codepoint: fontSource.codepoint,
       fontSize: fontSource.fontSize,
       color: iconProps.color,
     },
-    [iconProps.color, fontSource.fontSrcFile, fontSource.fontFamily, fontSource.codepoint, fontSource.codepoint],
+    [iconProps.color, fontSource.fontSrcFile, fontSource.fontFamily],
   )[0];
 
   const char = String.fromCharCode(fontSource.codepoint);


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

Resolves #1050 

I consistently got this error every time we rendered a Font Icon:
```
[Tue Oct 05 2021 12:16:18.715] LOG Running "FluentTester" with {"rootTag":11,"initialProps":{}}
[Tue Oct 05 2021 12:21:40.395] ERROR Warning: Failed prop type: Invalid props.style key `codepoint` supplied to `Text`.
Bad object: {
"margin": 0,
"color": "#060",
"fontFamily": "Arial",
"fontSize": 32,
"fontWeight": "400",
"codepoint": 9827
}
```
The code point prop is used to extract a single character, and render it inside a <Text> component. It is not supposed to be a style prop as far as I can tell. Looking into the code, it looks like we are indeed unnecessarily passing the "codepoint" prop as a style prop. This should be a simple fix.

### Verification

Ran the macOS and iOS test apps, went to the icon test page, and I no longer got an error. 

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
