### PR TITLE
Add global and alias tokens for Android

### DIFF
--- a/packages/theming/theme-tokens/src/global-android/reactnative/tokens-global.json
+++ b/packages/theming/theme-tokens/src/global-android/reactnative/tokens-global.json
@@ -1,0 +1,1099 @@
+{
+	"color": {
+		"anchor": {
+			"primary": "#394146",
+			"shade10": "#333a3f",
+			"shade20": "#2b3135",
+			"shade30": "#202427",
+			"shade40": "#111315",
+			"shade50": "#090a0b",
+			"tint10": "#4d565c",
+			"tint20": "#626c72",
+			"tint30": "#808a90",
+			"tint40": "#bcc3c7",
+			"tint50": "#dbdfe1",
+			"tint60": "#f6f7f8"
+		},
+		"beige": {
+			"primary": "#7a7574",
+			"shade10": "#6e6968",
+			"shade20": "#5d5958",
+			"shade30": "#444241",
+			"shade40": "#252323",
+			"shade50": "#141313",
+			"tint10": "#8a8584",
+			"tint20": "#9a9594",
+			"tint30": "#afabaa",
+			"tint40": "#d7d4d4",
+			"tint50": "#eae8e8",
+			"tint60": "#faf9f9"
+		},
+		"berry": {
+			"primary": "#c239b3",
+			"shade10": "#af33a1",
+			"shade20": "#932b88",
+			"shade30": "#6d2064",
+			"shade40": "#3a1136",
+			"shade50": "#1f091d",
+			"tint10": "#c94cbc",
+			"tint20": "#d161c4",
+			"tint30": "#da7ed0",
+			"tint40": "#edbbe7",
+			"tint50": "#f5daf2",
+			"tint60": "#fdf5fc"
+		},
+		"black": "#000000",
+		"blue": {
+			"primary": "#0078d4",
+			"shade10": "#006cbf",
+			"shade20": "#005ba1",
+			"shade30": "#004377",
+			"shade40": "#002440",
+			"shade50": "#001322",
+			"tint10": "#1a86d9",
+			"tint20": "#3595de",
+			"tint30": "#5caae5",
+			"tint40": "#a9d3f2",
+			"tint50": "#d0e7f8",
+			"tint60": "#f3f9fd"
+		},
+		"brand": {
+			"primary": "#0078d4",
+			"shade10": "#106ebe",
+			"shade20": "#005a9e",
+			"shade30": "#004578",
+			"shade40": "#004578",
+			"shade50": "#043862",
+			"shade60": "#092c47",
+			"tint10": "#2b88d8",
+			"tint20": "#c7e0f4",
+			"tint30": "#deecf9",
+			"tint40": "#eff6fc",
+			"tint50": "#deecf9",
+			"tint60": "#eff6fc"
+		},
+		"brandShadowAmbient": "#0000004d",
+		"brandShadowKey": "#00000040",
+		"brass": {
+			"primary": "#986f0b",
+			"shade10": "#89640a",
+			"shade20": "#745408",
+			"shade30": "#553e06",
+			"shade40": "#2e2103",
+			"shade50": "#181202",
+			"tint10": "#a47d1e",
+			"tint20": "#b18c34",
+			"tint30": "#c1a256",
+			"tint40": "#e0cea2",
+			"tint50": "#efe4cb",
+			"tint60": "#fbf8f2"
+		},
+		"bronze": {
+			"primary": "#a74109",
+			"shade10": "#963a08",
+			"shade20": "#7f3107",
+			"shade30": "#5e2405",
+			"shade40": "#321303",
+			"shade50": "#1b0a01",
+			"tint10": "#b2521e",
+			"tint20": "#bc6535",
+			"tint30": "#ca8057",
+			"tint40": "#e5bba4",
+			"tint50": "#f1d9cc",
+			"tint60": "#fbf5f2"
+		},
+		"brown": {
+			"primary": "#8e562e",
+			"shade10": "#804d29",
+			"shade20": "#6c4123",
+			"shade30": "#50301a",
+			"shade40": "#2b1a0e",
+			"shade50": "#170e07",
+			"tint10": "#9c663f",
+			"tint20": "#a97652",
+			"tint30": "#bb8f6f",
+			"tint40": "#ddc3b0",
+			"tint50": "#edded3",
+			"tint60": "#faf7f4"
+		},
+		"burgundy": {
+			"primary": "#a4262c",
+			"shade10": "#942228",
+			"shade20": "#7d1d21",
+			"shade30": "#5c1519",
+			"shade40": "#310b0d",
+			"shade50": "#1a0607",
+			"tint10": "#af393e",
+			"tint20": "#ba4d52",
+			"tint30": "#c86c70",
+			"tint40": "#e4afb2",
+			"tint50": "#f0d3d4",
+			"tint60": "#fbf4f4"
+		},
+		"charcoal": {
+			"primary": "#393939",
+			"shade10": "#333333",
+			"shade20": "#2b2b2b",
+			"shade30": "#202020",
+			"shade40": "#111111",
+			"shade50": "#090909",
+			"tint10": "#515151",
+			"tint20": "#686868",
+			"tint30": "#888888",
+			"tint40": "#c4c4c4",
+			"tint50": "#dfdfdf",
+			"tint60": "#f7f7f7"
+		},
+		"cornflower": {
+			"primary": "#4f6bed",
+			"shade10": "#4760d5",
+			"shade20": "#3c51b4",
+			"shade30": "#2c3c85",
+			"shade40": "#182047",
+			"shade50": "#0d1126",
+			"tint10": "#637cef",
+			"tint20": "#778df1",
+			"tint30": "#93a4f4",
+			"tint40": "#c8d1fa",
+			"tint50": "#e1e6fc",
+			"tint60": "#f7f9fe"
+		},
+		"cranberry": {
+			"primary": "#c50f1f",
+			"shade10": "#b10e1c",
+			"shade20": "#960b18",
+			"shade30": "#6e0811",
+			"shade40": "#3b0509",
+			"shade50": "#200205",
+			"tint10": "#cc2635",
+			"tint20": "#d33f4c",
+			"tint30": "#dc626d",
+			"tint40": "#eeacb2",
+			"tint50": "#f6d1d5",
+			"tint60": "#fdf3f4"
+		},
+		"cyan": {
+			"primary": "#0099bc",
+			"shade10": "#008aa9",
+			"shade20": "#00748f",
+			"shade30": "#005669",
+			"shade40": "#002e38",
+			"shade50": "#00181e",
+			"tint10": "#18a4c4",
+			"tint20": "#31afcc",
+			"tint30": "#56bfd7",
+			"tint40": "#a4deeb",
+			"tint50": "#cdedf4",
+			"tint60": "#f2fafc"
+		},
+		"darkBlue": {
+			"primary": "#003966",
+			"shade10": "#00335c",
+			"shade20": "#002b4e",
+			"shade30": "#002039",
+			"shade40": "#00111f",
+			"shade50": "#000910",
+			"tint10": "#0e4a78",
+			"tint20": "#215c8b",
+			"tint30": "#4178a3",
+			"tint40": "#92b5d1",
+			"tint50": "#c2d6e7",
+			"tint60": "#eff4f9"
+		},
+		"darkBrown": {
+			"primary": "#4d291c",
+			"shade10": "#452519",
+			"shade20": "#3a1f15",
+			"shade30": "#2b1710",
+			"shade40": "#170c08",
+			"shade50": "#0c0704",
+			"tint10": "#623a2b",
+			"tint20": "#784d3e",
+			"tint30": "#946b5c",
+			"tint40": "#caada3",
+			"tint50": "#e3d2cb",
+			"tint60": "#f8f3f2"
+		},
+		"darkGreen": {
+			"primary": "#0b6a0b",
+			"shade10": "#0a5f0a",
+			"shade20": "#085108",
+			"shade30": "#063b06",
+			"shade40": "#032003",
+			"shade50": "#021102",
+			"tint10": "#1a7c1a",
+			"tint20": "#2d8e2d",
+			"tint30": "#4da64d",
+			"tint40": "#9ad29a",
+			"tint50": "#c6e7c6",
+			"tint60": "#f0f9f0"
+		},
+		"darkOrange": {
+			"primary": "#da3b01",
+			"shade10": "#c43501",
+			"shade20": "#a62d01",
+			"shade30": "#7a2101",
+			"shade40": "#411200",
+			"shade50": "#230900",
+			"tint10": "#de501c",
+			"tint20": "#e36537",
+			"tint30": "#e9835e",
+			"tint40": "#f4bfab",
+			"tint50": "#f9dcd1",
+			"tint60": "#fdf6f3"
+		},
+		"darkPurple": {
+			"primary": "#401b6c",
+			"shade10": "#3a1861",
+			"shade20": "#311552",
+			"shade30": "#240f3c",
+			"shade40": "#130820",
+			"shade50": "#0a0411",
+			"tint10": "#512b7e",
+			"tint20": "#633e8f",
+			"tint30": "#7e5ca7",
+			"tint40": "#b9a3d3",
+			"tint50": "#d8cce7",
+			"tint60": "#f5f2f9"
+		},
+		"darkRed": {
+			"primary": "#750b1c",
+			"shade10": "#690a19",
+			"shade20": "#590815",
+			"shade30": "#420610",
+			"shade40": "#230308",
+			"shade50": "#130204",
+			"tint10": "#861b2c",
+			"tint20": "#962f3f",
+			"tint30": "#ac4f5e",
+			"tint40": "#d69ca5",
+			"tint50": "#e9c7cd",
+			"tint60": "#f9f0f2"
+		},
+		"darkTeal": {
+			"primary": "#006666",
+			"shade10": "#005c5c",
+			"shade20": "#004e4e",
+			"shade30": "#003939",
+			"shade40": "#001f1f",
+			"shade50": "#001010",
+			"tint10": "#0e7878",
+			"tint20": "#218b8b",
+			"tint30": "#41a3a3",
+			"tint40": "#92d1d1",
+			"tint50": "#c2e7e7",
+			"tint60": "#eff9f9"
+		},
+		"excel": {
+			"primary": "#107c41",
+			"shade10": "#0f703b",
+			"shade20": "#0c5f32",
+			"shade30": "#0a5325",
+			"shade40": "#094624",
+			"shade50": "#052912",
+			"shade60": "#03160a",
+			"tint10": "#10893c",
+			"tint20": "#1f954a",
+			"tint30": "#60bd82",
+			"tint40": "#55b17e",
+			"tint50": "#a0d8b9",
+			"tint60": "#caead8"
+		},
+		"forest": {
+			"primary": "#498205",
+			"shade10": "#427505",
+			"shade20": "#376304",
+			"shade30": "#294903",
+			"shade40": "#162702",
+			"shade50": "#0c1501",
+			"tint10": "#599116",
+			"tint20": "#6ba02b",
+			"tint30": "#85b44c",
+			"tint40": "#bdd99b",
+			"tint50": "#dbebc7",
+			"tint60": "#f6faf0"
+		},
+		"gold": {
+			"primary": "#c19c00",
+			"shade10": "#ae8c00",
+			"shade20": "#937700",
+			"shade30": "#6c5700",
+			"shade40": "#3a2f00",
+			"shade50": "#1f1900",
+			"tint10": "#c8a718",
+			"tint20": "#d0b232",
+			"tint30": "#dac157",
+			"tint40": "#ecdfa5",
+			"tint50": "#f5eece",
+			"tint60": "#fdfbf2"
+		},
+		"grape": {
+			"primary": "#881798",
+			"shade10": "#7a1589",
+			"shade20": "#671174",
+			"shade30": "#4c0d55",
+			"shade40": "#29072e",
+			"shade50": "#160418",
+			"tint10": "#952aa4",
+			"tint20": "#a33fb1",
+			"tint30": "#b55fc1",
+			"tint40": "#d9a7e0",
+			"tint50": "#eaceef",
+			"tint60": "#faf2fb"
+		},
+		"green": {
+			"primary": "#107c10",
+			"shade10": "#0e700e",
+			"shade20": "#0c5e0c",
+			"shade30": "#094509",
+			"shade40": "#052505",
+			"shade50": "#031403",
+			"tint10": "#218c21",
+			"tint20": "#359b35",
+			"tint30": "#54b054",
+			"tint40": "#9fd89f",
+			"tint50": "#c9eac9",
+			"tint60": "#f1faf1"
+		},
+		"grey": {
+			"0": "#000000",
+			"2": "#050505",
+			"4": "#0a0a0a",
+			"6": "#0f0f0f",
+			"8": "#141414",
+			"10": "#1a1a1a",
+			"12": "#1f1f1f",
+			"14": "#242424",
+			"16": "#292929",
+			"18": "#2e2e2e",
+			"20": "#333333",
+			"22": "#383838",
+			"24": "#3d3d3d",
+			"26": "#424242",
+			"28": "#474747",
+			"30": "#4d4d4d",
+			"32": "#525252",
+			"34": "#575757",
+			"36": "#5c5c5c",
+			"38": "#616161",
+			"40": "#666666",
+			"42": "#6b6b6b",
+			"44": "#707070",
+			"46": "#757575",
+			"48": "#7a7a7a",
+			"50": "#808080",
+			"52": "#858585",
+			"54": "#8a8a8a",
+			"56": "#8f8f8f",
+			"58": "#949494",
+			"60": "#999999",
+			"62": "#9e9e9e",
+			"64": "#a3a3a3",
+			"66": "#a8a8a8",
+			"68": "#adadad",
+			"70": "#b3b3b3",
+			"72": "#b8b8b8",
+			"74": "#bdbdbd",
+			"76": "#c2c2c2",
+			"78": "#c7c7c7",
+			"80": "#cccccc",
+			"82": "#d1d1d1",
+			"84": "#d6d6d6",
+			"86": "#dbdbdb",
+			"88": "#e0e0e0",
+			"90": "#e6e6e6",
+			"92": "#ebebeb",
+			"94": "#f0f0f0",
+			"96": "#f5f5f5",
+			"98": "#fafafa",
+			"100": "#ffffff"
+		},
+		"hc": {
+			"disabled": "PlatformColor(GrayText)",
+			"buttonFace": "PlatformColor(ButtonFace)",
+			"buttonText": "PlatformColor(ButtonText)",
+			"canvas": "PlatformColor(Window)",
+			"canvasText": "PlatformColor(WindowText)",
+			"highlight": "PlatformColor(Highlight)",
+			"highlightText": "PlatformColor(HighlightText)",
+			"hyperlink": "PlatformColor(Hotlight)"
+		},
+		"hotPink": {
+			"primary": "#e3008c",
+			"shade10": "#cc007e",
+			"shade20": "#ad006a",
+			"shade30": "#7f004e",
+			"shade40": "#44002a",
+			"shade50": "#240016",
+			"tint10": "#e61c99",
+			"tint20": "#ea38a6",
+			"tint30": "#ee5fb7",
+			"tint40": "#f7adda",
+			"tint50": "#fbd2eb",
+			"tint60": "#fef4fa"
+		},
+		"lavender": {
+			"primary": "#7160e8",
+			"shade10": "#6656d1",
+			"shade20": "#5649b0",
+			"shade30": "#3f3682",
+			"shade40": "#221d46",
+			"shade50": "#120f25",
+			"tint10": "#8172eb",
+			"tint20": "#9184ee",
+			"tint30": "#a79cf1",
+			"tint40": "#d2ccf8",
+			"tint50": "#e7e4fb",
+			"tint60": "#f9f8fe"
+		},
+		"lightBlue": {
+			"primary": "#3a96dd",
+			"shade10": "#3487c7",
+			"shade20": "#2c72a8",
+			"shade30": "#20547c",
+			"shade40": "#112d42",
+			"shade50": "#091823",
+			"tint10": "#4fa1e1",
+			"tint20": "#65ade5",
+			"tint30": "#83bdeb",
+			"tint40": "#bfddf5",
+			"tint50": "#dcedfa",
+			"tint60": "#f6fafe"
+		},
+		"lightGreen": {
+			"primary": "#13a10e",
+			"shade10": "#11910d",
+			"shade20": "#0e7a0b",
+			"shade30": "#0b5a08",
+			"shade40": "#063004",
+			"shade50": "#031a02",
+			"tint10": "#27ac22",
+			"tint20": "#3db838",
+			"tint30": "#5ec75a",
+			"tint40": "#a7e3a5",
+			"tint50": "#cef0cd",
+			"tint60": "#f2fbf2"
+		},
+		"lightTeal": {
+			"primary": "#00b7c3",
+			"shade10": "#00a5af",
+			"shade20": "#008b94",
+			"shade30": "#00666d",
+			"shade40": "#00373a",
+			"shade50": "#001d1f",
+			"tint10": "#18bfca",
+			"tint20": "#32c8d1",
+			"tint30": "#58d3db",
+			"tint40": "#a6e9ed",
+			"tint50": "#cef3f5",
+			"tint60": "#f2fcfd"
+		},
+		"lilac": {
+			"primary": "#b146c2",
+			"shade10": "#9f3faf",
+			"shade20": "#863593",
+			"shade30": "#63276d",
+			"shade40": "#35153a",
+			"shade50": "#1c0b1f",
+			"tint10": "#ba58c9",
+			"tint20": "#c36bd1",
+			"tint30": "#cf87da",
+			"tint40": "#e6bfed",
+			"tint50": "#f2dcf5",
+			"tint60": "#fcf6fd"
+		},
+		"lime": {
+			"primary": "#73aa24",
+			"shade10": "#689920",
+			"shade20": "#57811b",
+			"shade30": "#405f14",
+			"shade40": "#23330b",
+			"shade50": "#121b06",
+			"tint10": "#81b437",
+			"tint20": "#90be4c",
+			"tint30": "#a4cc6c",
+			"tint40": "#cfe5af",
+			"tint50": "#e5f1d3",
+			"tint60": "#f8fcf4"
+		},
+		"magenta": {
+			"primary": "#bf0077",
+			"shade10": "#ac006b",
+			"shade20": "#91005a",
+			"shade30": "#6b0043",
+			"shade40": "#390024",
+			"shade50": "#1f0013",
+			"tint10": "#c71885",
+			"tint20": "#ce3293",
+			"tint30": "#d957a8",
+			"tint40": "#eca5d1",
+			"tint50": "#f5cee6",
+			"tint60": "#fcf2f9"
+		},
+		"marigold": {
+			"primary": "#eaa300",
+			"shade10": "#d39300",
+			"shade20": "#b27c00",
+			"shade30": "#835b00",
+			"shade40": "#463100",
+			"shade50": "#251a00",
+			"tint10": "#edad1c",
+			"tint20": "#efb839",
+			"tint30": "#f2c661",
+			"tint40": "#f9e2ae",
+			"tint50": "#fcefd3",
+			"tint60": "#fefbf4"
+		},
+		"mink": {
+			"primary": "#5d5a58",
+			"shade10": "#54514f",
+			"shade20": "#474443",
+			"shade30": "#343231",
+			"shade40": "#1c1b1a",
+			"shade50": "#0f0e0e",
+			"tint10": "#706d6b",
+			"tint20": "#84817e",
+			"tint30": "#9e9b99",
+			"tint40": "#cecccb",
+			"tint50": "#e5e4e3",
+			"tint60": "#f8f8f8"
+		},
+		"navy": {
+			"primary": "#0027b4",
+			"shade10": "#0023a2",
+			"shade20": "#001e89",
+			"shade30": "#001665",
+			"shade40": "#000c36",
+			"shade50": "#00061d",
+			"tint10": "#173bbd",
+			"tint20": "#3050c6",
+			"tint30": "#546fd2",
+			"tint40": "#a3b2e8",
+			"tint50": "#ccd5f3",
+			"tint60": "#f2f4fc"
+		},
+		"neutralShadowAmbient": "#0000001f",
+		"neutralShadowKey": "#00000024",
+		"office": {
+			"primary": "#d83b01",
+			"shade10": "#c33400",
+			"shade20": "#a52c00",
+			"shade30": "#99482b",
+			"shade40": "#792000",
+			"shade50": "#4d2415",
+			"shade60": "#29130b",
+			"tint10": "#fe7948",
+			"tint20": "#ff865a",
+			"tint30": "#ff9973",
+			"tint40": "#e8825d",
+			"tint50": "#f4beaa",
+			"tint60": "#f9dcd1"
+		},
+		"oneNote": {
+			"primary": "#7719aa",
+			"shade10": "#6c179a",
+			"shade20": "#5b1382",
+			"shade30": "#430e60",
+			"shade40": "#430e60",
+			"shade50": "#430e60",
+			"shade60": "#430e60",
+			"tint10": "#862eb5",
+			"tint20": "#a864cd",
+			"tint30": "#d1abe6",
+			"tint40": "#e6d1f2",
+			"tint50": "#e6d1f2",
+			"tint60": "#e6d1f2"
+		},
+		"orange": {
+			"primary": "#f7630c",
+			"shade10": "#de590b",
+			"shade20": "#bc4b09",
+			"shade30": "#8a3707",
+			"shade40": "#4a1e04",
+			"shade50": "#271002",
+			"tint10": "#f87528",
+			"tint20": "#f98845",
+			"tint30": "#faa06b",
+			"tint40": "#fdcfb4",
+			"tint50": "#fee5d7",
+			"tint60": "#fff9f5"
+		},
+		"orchid": {
+			"primary": "#8764b8",
+			"shade10": "#795aa6",
+			"shade20": "#674c8c",
+			"shade30": "#4c3867",
+			"shade40": "#281e37",
+			"shade50": "#16101d",
+			"tint10": "#9373c0",
+			"tint20": "#a083c9",
+			"tint30": "#b29ad4",
+			"tint40": "#d7caea",
+			"tint50": "#e9e2f4",
+			"tint60": "#f9f8fc"
+		},
+		"outlook": {
+			"primary": "#0078d4",
+			"shade10": "#106ebe",
+			"shade20": "#005a9e",
+			"shade30": "#004c87",
+			"shade40": "#004578",
+			"shade50": "#043862",
+			"shade60": "#092c47",
+			"tint10": "#2899f5",
+			"tint20": "#3aa0f3",
+			"tint30": "#6cb8f6",
+			"tint40": "#c7e0f4",
+			"tint50": "#deecf9",
+			"tint60": "#eff6fc"
+		},
+		"peach": {
+			"primary": "#ff8c00",
+			"shade10": "#e67e00",
+			"shade20": "#c26a00",
+			"shade30": "#8f4e00",
+			"shade40": "#4d2a00",
+			"shade50": "#291600",
+			"tint10": "#ff9a1f",
+			"tint20": "#ffa83d",
+			"tint30": "#ffba66",
+			"tint40": "#ffddb3",
+			"tint50": "#ffedd6",
+			"tint60": "#fffaf5"
+		},
+		"pink": {
+			"primary": "#e43ba6",
+			"shade10": "#cd3595",
+			"shade20": "#ad2d7e",
+			"shade30": "#80215d",
+			"shade40": "#441232",
+			"shade50": "#24091b",
+			"tint10": "#e750b0",
+			"tint20": "#ea66ba",
+			"tint30": "#ef85c8",
+			"tint40": "#f7c0e3",
+			"tint50": "#fbddf0",
+			"tint60": "#fef6fb"
+		},
+		"platinum": {
+			"primary": "#69797e",
+			"shade10": "#5f6d71",
+			"shade20": "#505c60",
+			"shade30": "#3b4447",
+			"shade40": "#1f2426",
+			"shade50": "#111314",
+			"tint10": "#79898d",
+			"tint20": "#89989d",
+			"tint30": "#a0adb2",
+			"tint40": "#cdd6d8",
+			"tint50": "#e4e9ea",
+			"tint60": "#f8f9fa"
+		},
+		"plum": {
+			"primary": "#77004d",
+			"shade10": "#6b0045",
+			"shade20": "#5a003b",
+			"shade30": "#43002b",
+			"shade40": "#240017",
+			"shade50": "#13000c",
+			"tint10": "#87105d",
+			"tint20": "#98246f",
+			"tint30": "#ad4589",
+			"tint40": "#d696c0",
+			"tint50": "#e9c4dc",
+			"tint60": "#faf0f6"
+		},
+		"powerPoint": {
+			"primary": "#c43e1c",
+			"shade10": "#b13719",
+			"shade20": "#952f15",
+			"shade30": "#79310a",
+			"shade40": "#6e220f",
+			"shade50": "#3c1805",
+			"shade60": "#200d03",
+			"tint10": "#ca5010",
+			"tint20": "#cf6024",
+			"tint30": "#e1966d",
+			"tint40": "#dc816a",
+			"tint50": "#edbcb0",
+			"tint60": "#f6dbd4"
+		},
+		"pumpkin": {
+			"primary": "#ca5010",
+			"shade10": "#b6480e",
+			"shade20": "#9a3d0c",
+			"shade30": "#712d09",
+			"shade40": "#3d1805",
+			"shade50": "#200d03",
+			"tint10": "#d06228",
+			"tint20": "#d77440",
+			"tint30": "#df8e64",
+			"tint40": "#efc4ad",
+			"tint50": "#f7dfd2",
+			"tint60": "#fdf7f4"
+		},
+		"purple": {
+			"primary": "#5c2e91",
+			"shade10": "#532982",
+			"shade20": "#46236e",
+			"shade30": "#341a51",
+			"shade40": "#1c0e2b",
+			"shade50": "#0f0717",
+			"tint10": "#6b3f9e",
+			"tint20": "#7c52ab",
+			"tint30": "#9470bd",
+			"tint40": "#c6b1de",
+			"tint50": "#e0d3ed",
+			"tint60": "#f7f4fb"
+		},
+		"red": {
+			"primary": "#d13438",
+			"shade10": "#bc2f32",
+			"shade20": "#9f282b",
+			"shade30": "#751d1f",
+			"shade40": "#3f1011",
+			"shade50": "#210809",
+			"tint10": "#d7494c",
+			"tint20": "#dc5e62",
+			"tint30": "#e37d80",
+			"tint40": "#f1bbbc",
+			"tint50": "#f8dadb",
+			"tint60": "#fdf6f6"
+		},
+		"royalBlue": {
+			"primary": "#004e8c",
+			"shade10": "#00467e",
+			"shade20": "#003b6a",
+			"shade30": "#002c4e",
+			"shade40": "#00172a",
+			"shade50": "#000c16",
+			"tint10": "#125e9a",
+			"tint20": "#286fa8",
+			"tint30": "#4a89ba",
+			"tint40": "#9abfdc",
+			"tint50": "#c7dced",
+			"tint60": "#f0f6fa"
+		},
+		"seafoam": {
+			"primary": "#00cc6a",
+			"shade10": "#00b85f",
+			"shade20": "#009b51",
+			"shade30": "#00723b",
+			"shade40": "#003d20",
+			"shade50": "#002111",
+			"tint10": "#19d279",
+			"tint20": "#34d889",
+			"tint30": "#5ae0a0",
+			"tint40": "#a8f0cd",
+			"tint50": "#cff7e4",
+			"tint60": "#f3fdf8"
+		},
+		"silver": {
+			"primary": "#859599",
+			"shade10": "#78868a",
+			"shade20": "#657174",
+			"shade30": "#4a5356",
+			"shade40": "#282d2e",
+			"shade50": "#151818",
+			"tint10": "#92a1a5",
+			"tint20": "#a0aeb1",
+			"tint30": "#b3bfc2",
+			"tint40": "#d8dfe0",
+			"tint50": "#eaeeef",
+			"tint60": "#fafbfb"
+		},
+		"steel": {
+			"primary": "#005b70",
+			"shade10": "#005265",
+			"shade20": "#004555",
+			"shade30": "#00333f",
+			"shade40": "#001b22",
+			"shade50": "#000f12",
+			"tint10": "#0f6c81",
+			"tint20": "#237d92",
+			"tint30": "#4496a9",
+			"tint40": "#94c8d4",
+			"tint50": "#c3e1e8",
+			"tint60": "#eff7f9"
+		},
+		"teal": {
+			"primary": "#038387",
+			"shade10": "#037679",
+			"shade20": "#026467",
+			"shade30": "#02494c",
+			"shade40": "#012728",
+			"shade50": "#001516",
+			"tint10": "#159195",
+			"tint20": "#2aa0a4",
+			"tint30": "#4cb4b7",
+			"tint40": "#9bd9db",
+			"tint50": "#c7ebec",
+			"tint60": "#f0fafa"
+		},
+		"white": "#ffffff",
+		"word": {
+			"primary": "#185abd",
+			"shade10": "#1651aa",
+			"shade20": "#13458f",
+			"shade30": "#19428a",
+			"shade40": "#0e336a",
+			"shade50": "#0c2145",
+			"shade60": "#071225",
+			"tint10": "#296fe6",
+			"tint20": "#3d7ce8",
+			"tint30": "#82abf1",
+			"tint40": "#6794d7",
+			"tint50": "#aec6eb",
+			"tint60": "#d2e0f4"
+		},
+		"yellow": {
+			"primary": "#fde300",
+			"shade10": "#e4cc00",
+			"shade20": "#c0ad00",
+			"shade30": "#8e7f00",
+			"shade40": "#4c4400",
+			"shade50": "#282400",
+			"tint10": "#fde61e",
+			"tint20": "#fdea3d",
+			"tint30": "#feee66",
+			"tint40": "#fef7b2",
+			"tint50": "#fffad6",
+			"tint60": "#fffef5"
+		}
+	},
+	"corner": {
+		"radius": {
+			"circle": 9999,
+			"extraLarge": 8,
+			"large": 6,
+			"medium": 4,
+			"none": 0,
+			"small": 2
+		}
+	},
+	"font": {
+		"family": {
+			"default": "\"Segoe UI\", Roboto, \"SF Pro Text\", \"Helvetica Neue\", Helvetica, Arial, sans-serif",
+			"monospace": "Consolas, \"Courier New\", monospace",
+			"numeric": "\"Bahnschrift\", \"Segoe UI\", Roboto, \"SF Pro Text\", \"Helvetica Neue\", Helvetica, Arial, sans-serif"
+		},
+		"lineHeight": {
+			"100": 14,
+			"200": 16,
+			"300": 20,
+			"400": 22,
+			"500": 28,
+			"600": 32,
+			"700": 36,
+			"800": 40,
+			"900": 52,
+			"1000": 92
+		},
+		"size": {
+			"100": 10,
+			"200": 12,
+			"300": 14,
+			"400": 16,
+			"500": 20,
+			"600": 24,
+			"700": 28,
+			"800": 32,
+			"900": 40,
+			"1000": 68
+		},
+		"weight": {
+			"bold": "700",
+			"medium": "500",
+			"regular": "400",
+			"semibold": "600"
+		}
+	},
+	"padding": {
+		"400": [
+			7,
+			15,
+			7,
+			15
+		]
+	},
+	"shadow": {
+		"2": [
+			{
+				"x": 0,
+				"y": 0,
+				"blur": 2,
+				"color": "#0000001f"
+			},
+			{
+				"x": 0,
+				"y": 1,
+				"blur": 2,
+				"color": "#00000024"
+			}
+		],
+		"4": [
+			{
+				"x": 0,
+				"y": 0,
+				"blur": 2,
+				"color": "#0000001f"
+			},
+			{
+				"x": 0,
+				"y": 2,
+				"blur": 4,
+				"color": "#00000024"
+			}
+		],
+		"8": [
+			{
+				"x": 0,
+				"y": 0,
+				"blur": 2,
+				"color": "#0000001f"
+			},
+			{
+				"x": 0,
+				"y": 4,
+				"blur": 8,
+				"color": "#00000024"
+			}
+		],
+		"16": [
+			{
+				"x": 0,
+				"y": 0,
+				"blur": 2,
+				"color": "#0000001f"
+			},
+			{
+				"x": 0,
+				"y": 8,
+				"blur": 16,
+				"color": "#00000024"
+			}
+		],
+		"28": [
+			{
+				"x": 0,
+				"y": 0,
+				"blur": 8,
+				"color": "#0000001f"
+			},
+			{
+				"x": 0,
+				"y": 14,
+				"blur": 28,
+				"color": "#00000024"
+			}
+		],
+		"64": [
+			{
+				"x": 0,
+				"y": 0,
+				"blur": 8,
+				"color": "#0000001f"
+			},
+			{
+				"x": 0,
+				"y": 32,
+				"blur": 64,
+				"color": "#00000024"
+			}
+		],
+		"brand": {
+			"2": [
+				{
+					"x": 0,
+					"y": 0,
+					"blur": 2,
+					"color": "#0000004d"
+				},
+				{
+					"x": 0,
+					"y": 1,
+					"blur": 2,
+					"color": "#00000040"
+				}
+			],
+			"4": [
+				{
+					"x": 0,
+					"y": 0,
+					"blur": 2,
+					"color": "#0000004d"
+				},
+				{
+					"x": 0,
+					"y": 2,
+					"blur": 4,
+					"color": "#00000040"
+				}
+			],
+			"8": [
+				{
+					"x": 0,
+					"y": 0,
+					"blur": 2,
+					"color": "#0000004d"
+				},
+				{
+					"x": 0,
+					"y": 4,
+					"blur": 8,
+					"color": "#00000040"
+				}
+			],
+			"16": [
+				{
+					"x": 0,
+					"y": 0,
+					"blur": 2,
+					"color": "#0000004d"
+				},
+				{
+					"x": 0,
+					"y": 8,
+					"blur": 16,
+					"color": "#00000040"
+				}
+			],
+			"28": [
+				{
+					"x": 0,
+					"y": 0,
+					"blur": 8,
+					"color": "#0000004d"
+				},
+				{
+					"x": 0,
+					"y": 14,
+					"blur": 28,
+					"color": "#00000040"
+				}
+			],
+			"64": [
+				{
+					"x": 0,
+					"y": 0,
+					"blur": 8,
+					"color": "#0000004d"
+				},
+				{
+					"x": 0,
+					"y": 32,
+					"blur": 64,
+					"color": "#00000040"
+				}
+			]
+		}
+	},
+	"stroke": {
+		"width": {
+			"thick": 2,
+			"thicker": 3,
+			"thickest": 4,
+			"thin": 1
+		}
+	}
+}

--- a/packages/theming/theme-tokens/src/light-android/reactnative/tokens-aliases.json
+++ b/packages/theming/theme-tokens/src/light-android/reactnative/tokens-aliases.json
@@ -1,0 +1,159 @@
+{
+	"body": {
+		"fontFamily": "\"Segoe UI\", Roboto, \"SF Pro Text\", \"Helvetica Neue\", Helvetica, Arial, sans-serif",
+		"fontLineHeight": 20,
+		"fontSize": 14,
+		"fontWeight": "400"
+	},
+	"borderless": {
+		"strokeAlignment": "inner",
+		"strokeColorRest": "transparent",
+		"strokeColorHover": "transparent",
+		"strokeColorPressed": "transparent",
+		"strokeColorDisabled": "transparent",
+		"strokeWidth": 1
+	},
+	"brandBackground": {
+		"fillColorRest": "#185abd",
+		"fillColorHover": "#1651aa",
+		"fillColorPressed": "#0e336a",
+		"fillColorDisabled": "#e0e0e0",
+		"fillColorSelected": "#13458f"
+	},
+	"brandForeground": {
+		"fillColorRest": "#185abd",
+		"fillColorHover": "#1651aa",
+		"fillColorPressed": "#0e336a",
+		"fillColorDisabled": "#bdbdbd",
+		"fillColorSelected": "#13458f"
+	},
+	"brandStroke": {
+		"strokeColorRest": "#185abd",
+		"strokeColorHover": "#1651aa",
+		"strokeColorPressed": "#0e336a",
+		"strokeColorDisabled": "#e0e0e0",
+		"strokeColorSelected": "#13458f"
+	},
+	"caption": {
+		"fontFamily": "\"Segoe UI\", Roboto, \"SF Pro Text\", \"Helvetica Neue\", Helvetica, Arial, sans-serif",
+		"fontLineHeight": 16,
+		"fontSize": 12,
+		"fontWeight": "400"
+	},
+	"control": {
+		"cornerRadius": 4,
+		"fontFamily": "\"Segoe UI\", Roboto, \"SF Pro Text\", \"Helvetica Neue\", Helvetica, Arial, sans-serif",
+		"fontLineHeight": 20,
+		"fontSize": 14,
+		"fontWeight": "600"
+	},
+	"display": {
+		"fontFamily": "\"Segoe UI\", Roboto, \"SF Pro Text\", \"Helvetica Neue\", Helvetica, Arial, sans-serif",
+		"fontLineHeight": 92,
+		"fontSize": 68,
+		"fontWeight": "600"
+	},
+	"headline": {
+		"fontFamily": "\"Segoe UI\", Roboto, \"SF Pro Text\", \"Helvetica Neue\", Helvetica, Arial, sans-serif",
+		"fontLineHeight": 28,
+		"fontSize": 20,
+		"fontWeight": "600"
+	},
+	"icon": {
+		"cornerRadius": 4
+	},
+	"illustration": {
+		"cornerRadius": 8
+	},
+	"largeTitle": {
+		"fontFamily": "\"Segoe UI\", Roboto, \"SF Pro Text\", \"Helvetica Neue\", Helvetica, Arial, sans-serif",
+		"fontLineHeight": 52,
+		"fontSize": 40,
+		"fontWeight": "600"
+	},
+	"neutralBackground1": {
+		"fillColorRest": "#ffffff",
+		"fillColorPressed": "#ebebeb"
+	},
+	"neutralBackground2": {
+		"fillColorRest": "#fafafa"
+	},
+	"neutralBackground3": {
+		"fillColorRest": "#f5f5f5"
+	},
+	"neutralBackground4": {
+		"fillColorRest": "#f0f0f0"
+	},
+	"neutralBackground5": {
+		"fillColorRest": "#ebebeb"
+	},
+	"neutralBackgroundDisabled": {
+		"fillColorRest": "#e0e0e0"
+	},
+	"neutralForeground1": {
+		"fillColorRest": "#242424"
+	},
+	"neutralForeground2": {
+		"fillColorRest": "#424242"
+	},
+	"neutralForeground3": {
+		"fillColorRest": "#616161"
+	},
+	"neutralForeground4": {
+		"fillColorRest": "#808080"
+	},
+	"neutralForegroundDisabled": {
+		"fillColorRest": "#bdbdbd"
+	},
+	"neutralForegroundInverted": {
+		"fillColorRest": "#ffffff"
+	},
+	"neutralStroke1": {
+		"strokeColorRest": "#f0f0f0"
+	},
+	"neutralStroke2": {
+		"strokeColorRest": "#e0e0e0"
+	},
+	"neutralStroke3": {
+		"strokeColorRest": "#d1d1d1"
+	},
+	"round": {
+		"cornerRadius": 9999
+	},
+	"square": {
+		"cornerRadius": 0
+	},
+	"subheadline": {
+		"fontFamily": "\"Segoe UI\", Roboto, \"SF Pro Text\", \"Helvetica Neue\", Helvetica, Arial, sans-serif",
+		"fontLineHeight": 22,
+		"fontSize": 16,
+		"fontWeight": "600"
+	},
+	"surface": {
+		"cornerRadius": 4
+	},
+	"title1": {
+		"fontFamily": "\"Segoe UI\", Roboto, \"SF Pro Text\", \"Helvetica Neue\", Helvetica, Arial, sans-serif",
+		"fontLineHeight": 40,
+		"fontSize": 32,
+		"fontWeight": "600"
+	},
+	"title2": {
+		"fontFamily": "\"Segoe UI\", Roboto, \"SF Pro Text\", \"Helvetica Neue\", Helvetica, Arial, sans-serif",
+		"fontLineHeight": 36,
+		"fontSize": 28,
+		"fontWeight": "600"
+	},
+	"title3": {
+		"fontFamily": "\"Segoe UI\", Roboto, \"SF Pro Text\", \"Helvetica Neue\", Helvetica, Arial, sans-serif",
+		"fontLineHeight": 32,
+		"fontSize": 24,
+		"fontWeight": "600"
+	},
+	"transparentBackground": {
+		"fillColorRest": "transparent",
+		"fillColorHover": "transparent",
+		"fillColorPressed": "transparent",
+		"fillColorSelected": "transparent"
+	}
+}

--- a/packages/theming/theme-tokens/src/pipeline-input/token-input-brand.android.json
+++ b/packages/theming/theme-tokens/src/pipeline-input/token-input-brand.android.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/fluentui-token-pipeline/main/docs/token.schema.json",
+  "Meta": {
+    "FluentUITokensVersion": 0
+  },
+  "Global": {
+    "Color": {
+      "Brand": {
+        "Shade": {
+          "30": { "value": "#004578" },
+          "20": { "value": "#005A9E" },
+          "10": { "value": "#106EBE" }
+        },
+        "Primary": { "value": "#0078D4" },
+        "Tint": {
+          "10": { "value": "#2B88D8" },
+          "20": { "value": "#C7E0F4" },
+          "30": { "value": "#DEECF9" },
+          "40": { "value": "#EFF6FC" }
+        }
+      }
+    }
+  }
+}

--- a/packages/theming/theme-tokens/src/pipeline-input/token-input-light.android.json
+++ b/packages/theming/theme-tokens/src/pipeline-input/token-input-light.android.json
@@ -1,0 +1,149 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/fluentui-token-pipeline/main/docs/token.schema.json",
+  "Meta": {
+    "FluentUITokensVersion": 0
+  },
+  "Set": {
+    "NeutralForeground1": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.Grey.14" }
+        }
+      }
+    },
+    "NeutralForeground2": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.Grey.26" }
+        }
+      }
+    },
+    "NeutralForeground3": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.Grey.38" }
+        }
+      }
+    },
+    "NeutralForeground4": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.Grey.50" }
+        }
+      }
+    },
+    "NeutralForegroundDisabled": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.Grey.74" }
+        }
+      }
+    },
+    "BrandForeground": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.Brand.Primary" },
+          "Hover": { "aliasOf": "Global.Color.Brand.Shade.10" },
+          "Pressed": { "aliasOf": "Global.Color.Brand.Shade.30" },
+          "Selected": { "aliasOf": "Global.Color.Brand.Shade.20" },
+          "Disabled": { "aliasOf": "Global.Color.Grey.74" }
+        }
+      }
+    },
+
+    "NeutralForegroundInverted": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.White" }
+        }
+      }
+    },
+    "NeutralBackground1": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.White" },
+          "Pressed": { "aliasOf": "Global.Color.Grey.92" }
+        }
+      }
+    },
+    "NeutralBackground2": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.Grey.98" }
+        }
+      }
+    },
+    "NeutralBackground3": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.Grey.96" }
+        }
+      }
+    },
+    "NeutralBackground4": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.Grey.94" }
+        }
+      }
+    },
+    "NeutralBackground5": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.Grey.92" }
+        }
+      }
+    },
+    "NeutralBackgroundDisabled": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.Grey.88" }
+        }
+      }
+    },
+    "BrandBackground": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.Brand.Primary" },
+          "Hover": { "aliasOf": "Global.Color.Brand.Shade.10" },
+          "Pressed": { "aliasOf": "Global.Color.Brand.Shade.30" },
+          "Selected": { "aliasOf": "Global.Color.Brand.Shade.20" },
+          "Disabled": { "aliasOf": "Global.Color.Grey.88"}
+        }
+      }
+    },
+
+    "NeutralStroke1": {
+      "Stroke": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.Grey.94" }
+        }
+      }
+    },
+    "NeutralStroke2": {
+      "Stroke": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.Grey.88" }
+        }
+      }
+    },
+    "NeutralStroke3": {
+      "Stroke": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.Grey.82" }
+        }
+      }
+    },
+    "BrandStroke": {
+      "Stroke": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.Brand.Primary" },
+          "Hover": { "aliasOf": "Global.Color.Brand.Shade.10" },
+          "Pressed": { "aliasOf": "Global.Color.Brand.Shade.30" },
+          "Selected": { "aliasOf": "Global.Color.Brand.Shade.20" },
+          "Disabled": { "aliasOf": "Global.Color.Grey.88" }
+        }
+      }
+    }
+  }
+}

--- a/packages/theming/theme-tokens/src/tokens-global.android.ts
+++ b/packages/theming/theme-tokens/src/tokens-global.android.ts
@@ -1,0 +1,3 @@
+import globalTokens from './global-android/reactnative/tokens-global.json';
+
+export default globalTokens;

--- a/scripts/build-tokens.js
+++ b/scripts/build-tokens.js
@@ -33,12 +33,26 @@ async function run() {
   fs.unlinkSync(path.join(process.cwd(), 'packages/theming/theme-tokens/src/global-win32/reactnative/tokens-aliases.json'));
   fs.unlinkSync(path.join(process.cwd(), 'packages/theming/theme-tokens/src/global-win32/reactnative/tokens-controls.json'));
 
+  console.log('Generating android global tokens...');
+  child_process.execSync(
+    'yarn transform-tokens --in ./packages/theming/theme-tokens/src/pipeline-input/token-input.json --in ./packages/theming/theme-tokens/src/pipeline-input/token-input-brand.android.json --out ./packages/theming/theme-tokens/src/global-android --p reactnative',
+  );
+  fs.unlinkSync(path.join(process.cwd(), 'packages/theming/theme-tokens/src/global-android/reactnative/tokens-aliases.json'));
+  fs.unlinkSync(path.join(process.cwd(), 'packages/theming/theme-tokens/src/global-android/reactnative/tokens-controls.json'));
+
   console.log('Generating light mode tokens...');
   child_process.execSync(
     'yarn transform-tokens --in ./packages/theming/theme-tokens/src/pipeline-input/token-input.json --in ./packages/theming/theme-tokens/src/pipeline-input/token-input-light.json --out ./packages/theming/theme-tokens/src/light --p reactnative',
   );
   fs.unlinkSync(path.join(process.cwd(), 'packages/theming/theme-tokens/src/light/reactnative/tokens-global.json'));
   fs.unlinkSync(path.join(process.cwd(), 'packages/theming/theme-tokens/src/light/reactnative/tokens-controls.json'));
+
+  console.log('Generating android light mode tokens...');
+  child_process.execSync(
+    'yarn transform-tokens --in ./packages/theming/theme-tokens/src/pipeline-input/token-input.json --in ./packages/theming/theme-tokens/src/pipeline-input/token-input-brand.win32.json --in ./packages/theming/theme-tokens/src/pipeline-input/token-input-light.android.json --out ./packages/theming/theme-tokens/src/light-android --p reactnative',
+  );
+  fs.unlinkSync(path.join(process.cwd(), 'packages/theming/theme-tokens/src/light-android/reactnative/tokens-global.json'));
+  fs.unlinkSync(path.join(process.cwd(), 'packages/theming/theme-tokens/src/light-android/reactnative/tokens-controls.json'));
 
   console.log('Generating dark mode tokens...');
   child_process.execSync(


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [X] android

### Description of changes
- Added a pipeline-input file and a new script in build-tokens.js that adds brand tokens to global-android tokens
- Added a pipeline-input file and a new script in build-tokens.js that adds brand tokens to light-android alias tokens

### Verification
No intended visual change yet. Will do a visual pass and update tests later.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
