### PR TITLE
Fix regression in useHoverState

### DIFF
--- a/change/@fluentui-react-native-interactive-hooks-0567a5fa-fff2-4605-a218-9a8cdb917651.json
+++ b/change/@fluentui-react-native-interactive-hooks-0567a5fa-fff2-4605-a218-9a8cdb917651.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix a regression in useHoverState",
+  "packageName": "@fluentui-react-native/interactive-hooks",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/utils/interactive-hooks/src/useAsPressable.ts
+++ b/packages/utils/interactive-hooks/src/useAsPressable.ts
@@ -132,10 +132,10 @@ export function usePressState<T extends object>(props: IWithPressableOptions<T>)
  */
 // eslint-disable-next-line @typescript-eslint/ban-types
 export function useHoverState<T extends object>(props: IWithPressableOptions<T>): [IWithPressableEvents<T>, IHoverState] {
-  const [hoverProps, hoverState] = useHoverHelper(props);
   // https://github.com/facebook/react-native/issues/32406
-  // Pressability exposes onHoverIn & onHoverOut, while useHoverHelper returns onMouseEnter & onMouseLeave.
+  // Pressability takes in onHoverIn & onHoverOut, while useHoverHelper returns onMouseEnter & onMouseLeave.
   // Lets be sure to pass these props properly into usePressability.
+  const [hoverProps, hoverState] = useHoverHelper(props);
   const { onMouseEnter, onMouseLeave, ...restHoverProps } = hoverProps;
   return [{ ...props, ...usePressability({ ...props, onHoverIn: onMouseEnter, onHoverOut: onMouseLeave, ...restHoverProps }) }, hoverState];
 }

--- a/packages/utils/interactive-hooks/src/useAsPressable.ts
+++ b/packages/utils/interactive-hooks/src/useAsPressable.ts
@@ -18,6 +18,13 @@ import { usePressability } from './usePressability';
  */
 function useHoverHelper(props: PressableHoverProps): [PressableHoverEventProps, IHoverState] {
   const [hoverState, setHoverState] = React.useState({ hovered: false });
+
+  // https://github.com/facebook/react-native/issues/32406
+  // Pressability exposes onHoverIn & onHoverOut, and converts them into onMouseEnter/onMouseLeave event handlers
+  // passed into an inner <View> component. However,Pressable does not expose onHoverIn/onHoverOut as props. Our
+  // desktop ports do expose onMouseEnter & onMouseLeave as event handlers on View though. As a workaround, let's
+  // have our public API take in onHoverIn & onHoverOut as props, but pass them as onMouseEnter/onMouseLeave
+
   const onMouseEnter = React.useCallback(
     (e) => {
       setHoverState({ hovered: true });
@@ -126,7 +133,11 @@ export function usePressState<T extends object>(props: IWithPressableOptions<T>)
 // eslint-disable-next-line @typescript-eslint/ban-types
 export function useHoverState<T extends object>(props: IWithPressableOptions<T>): [IWithPressableEvents<T>, IHoverState] {
   const [hoverProps, hoverState] = useHoverHelper(props);
-  return [{ ...props, ...usePressability({ ...props, ...hoverProps }) }, hoverState];
+  // https://github.com/facebook/react-native/issues/32406
+  // Pressability exposes onHoverIn & onHoverOut, while useHoverHelper returns onMouseEnter & onMouseLeave.
+  // Lets be sure to pass these props properly into usePressability.
+  const { onMouseEnter, onMouseLeave, ...restHoverProps } = hoverProps;
+  return [{ ...props, ...usePressability({ ...props, onHoverIn: onMouseEnter, onHoverOut: onMouseLeave, ...restHoverProps }) }, hoverState];
 }
 
 /**


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

PR #1063 introduced a regression where the hook `useHoverState` was not working properly. Thankfully this is only really used in test code, but we should fix it in case any clients use it. I also took the time to add some code comments + a link to the upstream Facebook issue of why we need to route onHoverIn & onHover out to onMouseEnter & onMouseLeave

### Verification

Pressable Test works again

https://user-images.githubusercontent.com/6722175/137403438-1134978e-7ae6-425a-9282-3c9328cf2679.mov

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
