### PR TITLE
Get changelog for main fluentui/react-native package to have more detail

### DIFF
--- a/beachball.config.js
+++ b/beachball.config.js
@@ -4,7 +4,7 @@ const path = require('path');
 module.exports = {
   disallowedChangeTypes: ['major'],
   hooks: {
-    prepublish: packagePath => {
+    prepublish: (packagePath) => {
       const packageJsonPath = path.join(packagePath, 'package.json');
       const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
       if (packageJson.onPublish) {
@@ -12,6 +12,32 @@ module.exports = {
         delete packageJson.onPublish;
         fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + '\n');
       }
-    }
-  }
+    },
+  },
+  changelog: {
+    groups: [
+      {
+        masterPackageName: '@fluentui/react-native',
+        include: [
+          '@fluentui-react-native/button',
+          '@fluentui-react-native/callout',
+          '@fluentui-react-native/checkbox',
+          '@fluentui-react-native/contextual-menu',
+          '@fluentui-react-native/focus-trap-zone',
+          '@fluentui-react-native/focus-zone',
+          '@fluentui-react-native/link',
+          '@fluentui-react-native/persona',
+          '@fluentui-react-native/persona-coin',
+          '@fluentui-react-native/pressable',
+          '@fluentui-react-native/radio-group',
+          '@fluentui-react-native/separator',
+          '@fluentui-react-native/text',
+          '@fluentui-react-native/interactive-hooks',
+          '@fluentui-react-native/menu-button',
+          '@fluentui-react-native/tabs',
+        ],
+        changelogPath: path.resolve('packages/libraries/core/'),
+      },
+    ],
+  },
 };

--- a/change/@fluentui-react-native-fc67a6de-3237-4988-b541-8441c6cff3af.json
+++ b/change/@fluentui-react-native-fc67a6de-3237-4988-b541-8441c6cff3af.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add to beachball config so that changelog includes individual changes that influence larger package",
+  "packageName": "@fluentui/react-native",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/libraries/core/src/index.ts
+++ b/packages/libraries/core/src/index.ts
@@ -1,3 +1,6 @@
+// Please make sure to update beachball config to include new package if you add to this list
+// so that changelogs are generated properly
+
 export * from '@fluentui-react-native/button';
 export * from '@fluentui-react-native/callout';
 export * from '@fluentui-react-native/checkbox';


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This change changes the beachball config to treat the fluentui/react-native package as a group of packages of the packages it re-exports. This will hopefully make it so that there's more detail in the changelog for the changes that cause the package to bump in version, which we can then use to create release notes.

The main challenge with release notes with FURN has been how to make the release notes fairly accessible (i.e. don't make users run around to individual packages to piece together what changes are included in a version bump of @fluentui/react-native) without including changes that aren't included in the package (ex. theming or framework changes don't directly affect the @fluentui/react-native package).

The beachball grouping config seems to be the solution here as it will include the changes of the packages that I list as part of the group into the larger package's changelog. Then I can use code similar to RNW to read out changes that affect the larger package from the changelog to generate release notes.

### Verification

Used `yarn beachball bump` which is the local version of `beachball publish` to test the output. The output of the @fluentui/react-native changelog was more verbose with these settings.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
