### PR TITLE
Prototyping focus borders through JS

### DIFF
--- a/packages/experimental/Button/src/Button.styling.ts
+++ b/packages/experimental/Button/src/Button.styling.ts
@@ -12,12 +12,12 @@ export const buttonStates: (keyof ButtonTokens)[] = [
   'primary',
   'subtle',
   'hovered',
-  'focused',
   'pressed',
   'disabled',
   'small',
   'medium',
   'large',
+  'focused',
   'hasContent',
   'hasIcon',
 ];

--- a/packages/experimental/Button/src/ButtonTokens.ts
+++ b/packages/experimental/Button/src/ButtonTokens.ts
@@ -33,6 +33,13 @@ export const defaultButtonTokens: TokenSettings<ButtonTokens, Theme> = () =>
           spacingIconContent: globalTokens.spacing.sNudge,
         },
       },
+      focused: {
+        padding: globalTokens.spacing.sNudge - globalTokens.stroke.width.thick,
+        borderWidth: globalTokens.stroke.width.thick,
+        hasContent: {
+          paddingHorizontal: globalTokens.spacing.l - globalTokens.stroke.width.thick,
+        },
+      },
     },
     small: {
       padding: globalTokens.spacing.xs - globalTokens.stroke.width.thin,
@@ -45,6 +52,13 @@ export const defaultButtonTokens: TokenSettings<ButtonTokens, Theme> = () =>
         variant: 'secondaryStandard',
         hasIcon: {
           spacingIconContent: globalTokens.spacing.xs,
+        },
+      },
+      focused: {
+        padding: globalTokens.spacing.xs - globalTokens.stroke.width.thick,
+        borderWidth: globalTokens.stroke.width.thick,
+        hasContent: {
+          paddingHorizontal: globalTokens.spacing.m - globalTokens.stroke.width.thick,
         },
       },
     },

--- a/packages/experimental/Button/src/CompoundButton/CompoundButtonTokens.ts
+++ b/packages/experimental/Button/src/CompoundButton/CompoundButtonTokens.ts
@@ -13,6 +13,12 @@ export const defaultCompoundButtonTokens: TokenSettings<CompoundButtonTokens, Th
       variant: 'bodyStandard',
       secondaryContentFont: { variant: 'secondaryStandard' },
     },
+    focused: {
+      padding: globalTokens.spacing.s - globalTokens.stroke.width.thick,
+      hasContent: {
+        paddingHorizontal: globalTokens.spacing.s - globalTokens.stroke.width.thick,
+      },
+    },
   },
   medium: {
     padding: globalTokens.spacing.m - globalTokens.stroke.width.thin,
@@ -21,6 +27,12 @@ export const defaultCompoundButtonTokens: TokenSettings<CompoundButtonTokens, Th
       minWidth: 96,
       variant: 'bodySemibold',
       secondaryContentFont: { variant: 'secondaryStandard' },
+    },
+    focused: {
+      padding: globalTokens.spacing.m - globalTokens.stroke.width.thick,
+      hasContent: {
+        paddingHorizontal: globalTokens.spacing.m - globalTokens.stroke.width.thick,
+      },
     },
   },
   large: {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This is a prototype of implementing the focus borders design wants through JS.

Web uses zIndex to solve this problem, but unfortunately that isn't available to us in win32.
Also this does not fix the focus border in windows, at least on win10 (win11 may have curved borders by default). We will need to figure out how to either turn off the focus border on UWP or change the system focus brush in order for this to work there.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
