### PR TITLE
chore: allow passing args to eslint

### DIFF
--- a/scripts/src/tasks/eslint.js
+++ b/scripts/src/tasks/eslint.js
@@ -1,6 +1,7 @@
 // @ts-check
 
-const { eslintTask } = require('just-scripts');
+const { argv, eslintTask } = require('just-scripts');
 exports.eslint = eslintTask({
   files: ['src/'],
+  ...argv(),
 });


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This allows one to run ESLint with the `--fix` option.

### Verification

Tested locally that running `yarn lint --fix` applies fixes suggested by ESLint.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
