### PR TITLE
Fix disabled state for button

### DIFF
--- a/change/@fluentui-react-native-experimental-button-0dda92d8-fc36-4c79-b57d-6e00ee32637c.json
+++ b/change/@fluentui-react-native-experimental-button-0dda92d8-fc36-4c79-b57d-6e00ee32637c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix disabled state not working properly",
+  "packageName": "@fluentui-react-native/experimental-button",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-menu-button-1305326d-7706-4ba4-b0cd-d0ba2fd8088f.json
+++ b/change/@fluentui-react-native-experimental-menu-button-1305326d-7706-4ba4-b0cd-d0ba2fd8088f.json
@@ -1,7 +1,7 @@
 {
-  "type": "none",
+  "type": "patch",
   "comment": "Fix tests",
   "packageName": "@fluentui-react-native/experimental-menu-button",
   "email": "ruaraki@microsoft.com",
-  "dependentChangeType": "none"
+  "dependentChangeType": "patch"
 }

--- a/change/@fluentui-react-native-experimental-menu-button-1305326d-7706-4ba4-b0cd-d0ba2fd8088f.json
+++ b/change/@fluentui-react-native-experimental-menu-button-1305326d-7706-4ba4-b0cd-d0ba2fd8088f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix tests",
+  "packageName": "@fluentui-react-native/experimental-menu-button",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/experimental/Button/src/CompoundButton/__snapshots__/CompoundButton.test.tsx.snap
+++ b/packages/experimental/Button/src/CompoundButton/__snapshots__/CompoundButton.test.tsx.snap
@@ -4,6 +4,11 @@ exports[`CompoundButton default 1`] = `
 <View
   accessibilityLabel="Default Button"
   accessibilityRole="button"
+  accessibilityState={
+    Object {
+      "disabled": false,
+    }
+  }
   accessible={true}
   focusable={true}
   onBlur={[Function]}

--- a/packages/experimental/Button/src/ToggleButton/__snapshots__/ToggleButton.test.tsx.snap
+++ b/packages/experimental/Button/src/ToggleButton/__snapshots__/ToggleButton.test.tsx.snap
@@ -3,6 +3,11 @@
 exports[`ToggleButton default 1`] = `
 <View
   accessibilityRole="button"
+  accessibilityState={
+    Object {
+      "disabled": false,
+    }
+  }
   accessible={true}
   focusable={true}
   onAccessibilityTap={[Function]}

--- a/packages/experimental/Button/src/__snapshots__/Button.test.tsx.snap
+++ b/packages/experimental/Button/src/__snapshots__/Button.test.tsx.snap
@@ -4,6 +4,11 @@ exports[`Button component tests Button default 1`] = `
 <View
   accessibilityLabel="Default Button"
   accessibilityRole="button"
+  accessibilityState={
+    Object {
+      "disabled": false,
+    }
+  }
   accessible={true}
   focusable={true}
   onBlur={[Function]}

--- a/packages/experimental/Button/src/useButton.ts
+++ b/packages/experimental/Button/src/useButton.ts
@@ -17,6 +17,7 @@ export const useButton = (props: ButtonProps): ButtonState => {
       accessibilityRole: 'button',
       onAccessibilityTap: props.onAccessibilityTap || props.onClick,
       accessibilityLabel: props.accessibilityLabel || props.content,
+      accessibilityState: { disabled: props.disabled },
       focusable: true,
       ref: useViewCommandFocus(componentRef),
       onKeyUp: onKeyUp,

--- a/packages/experimental/Button/src/useButton.ts
+++ b/packages/experimental/Button/src/useButton.ts
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { useAsPressable, useKeyCallback, useOnPressWithFocus, useViewCommandFocus } from '@fluentui-react-native/interactive-hooks';
 import { ButtonProps, ButtonState } from './Button.types';
+import { memoize } from '@fluentui-react-native/framework';
 
 export const useButton = (props: ButtonProps): ButtonState => {
   // attach the pressable state handlers
   const defaultComponentRef = React.useRef(null);
-  const { onClick, componentRef = defaultComponentRef, ...rest } = props;
+  const { onClick, componentRef = defaultComponentRef, disabled, ...rest } = props;
   const onClickWithFocus = useOnPressWithFocus(componentRef, onClick);
   const pressable = useAsPressable({ ...rest, onPress: onClickWithFocus });
   const onKeyUp = useKeyCallback(onClick, ' ', 'Enter');
@@ -17,7 +18,7 @@ export const useButton = (props: ButtonProps): ButtonState => {
       accessibilityRole: 'button',
       onAccessibilityTap: props.onAccessibilityTap || props.onClick,
       accessibilityLabel: props.accessibilityLabel || props.content,
-      accessibilityState: { disabled: props.disabled },
+      accessibilityState: getAccessibilityState(!!disabled),
       focusable: true,
       ref: useViewCommandFocus(componentRef),
       onKeyUp: onKeyUp,
@@ -25,3 +26,8 @@ export const useButton = (props: ButtonProps): ButtonState => {
     state: pressable.state,
   };
 };
+
+const getAccessibilityState = memoize(getAccessibilityStateWorker);
+function getAccessibilityStateWorker(disabled: boolean) {
+  return { disabled: disabled };
+}

--- a/packages/experimental/MenuButton/src/__tests__/__snapshots__/MenuButton.test.win32.tsx.snap
+++ b/packages/experimental/MenuButton/src/__tests__/__snapshots__/MenuButton.test.win32.tsx.snap
@@ -4,6 +4,11 @@ exports[`ContextualMenu default 1`] = `
 <View
   accessibilityLabel="Press for Nested MenuButton"
   accessibilityRole="button"
+  accessibilityState={
+    Object {
+      "disabled": false,
+    }
+  }
   accessible={true}
   focusable={true}
   onAccessibilityTap={[Function]}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

Seems that the migration to the new framework dropped defining accessibilityState for the Button. Putting it back to ensure that the button announces the right state and acts properly. Focus now skips disabled experimental buttons.

### Verification
Played around with keyboarding. Keyboard focusable is off according to accessibility checker

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [x] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
