### PR TITLE
Fix dependabot labeling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,11 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-    time: '13:00'
-  labels:
-  - dependencies
-  version_requirement_updates: off
-  versioning-strategy: lockfile-only
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: daily
+      time: '13:00'
+    labels:
+      - 'Type: Dependencies'
+    version_requirement_updates: off
+    versioning-strategy: lockfile-only


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Changing the labels broke the auto-labeling that dependabot does for its PRs. Fixing by updating the .yml file.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
