### PR TITLE
Add appearance prop on v1 button

### DIFF
--- a/apps/fluent-tester/src/FluentTester/FluentTester.tsx
+++ b/apps/fluent-tester/src/FluentTester/FluentTester.tsx
@@ -115,7 +115,7 @@ export const FluentTester: React.FunctionComponent<FluentTesterProps> = (props: 
         <View style={fluentTesterStyles.header}>
           {/* on iOS, display a back Button */}
           <Button
-            subtle
+            appearance="subtle"
             content="‹ Back"
             style={{ alignSelf: 'flex-start', display: Platform.OS === 'ios' ? 'flex' : 'none' }}
             onClick={onBackPress}
@@ -137,7 +137,7 @@ export const FluentTester: React.FunctionComponent<FluentTesterProps> = (props: 
           {sortedTestComponents.map((description, index) => {
             return (
               <Button
-                subtle
+                appearance="subtle"
                 key={index}
                 disabled={index == selectedTestIndex}
                 content={description.name}

--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonIconTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonIconTestSection.tsx
@@ -29,14 +29,14 @@ export const ButtonIconTest: React.FunctionComponent = () => {
         style={commonTestStyles.vmargin}
       />
       <Button icon={{ fontSource: fontBuiltInProps }} content="Font icon" style={commonTestStyles.vmargin} />
-      <Button primary icon={{ fontSource: fontBuiltInProps }} content="Font icon" style={commonTestStyles.vmargin} />
+      <Button appearance="primary" icon={{ fontSource: fontBuiltInProps }} content="Font icon" style={commonTestStyles.vmargin} />
       {svgIconsEnabled && (
         <>
-          <Button primary icon={{ svgSource: svgProps, color: 'red' }} content="SVG" style={commonTestStyles.vmargin} />
+          <Button appearance="primary" icon={{ svgSource: svgProps, color: 'red' }} content="SVG" style={commonTestStyles.vmargin} />
           <Button icon={{ svgSource: svgProps }} content="SVG" style={commonTestStyles.vmargin} />
         </>
       )}
-      <Button primary icon={testImage} content="PNG" style={commonTestStyles.vmargin} />
+      <Button appearance="primary" icon={testImage} content="PNG" style={commonTestStyles.vmargin} />
       <Button icon={testImage} content="PNG" style={commonTestStyles.vmargin} />
     </View>
   );

--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonVariantTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonVariantTestSection.tsx
@@ -14,14 +14,14 @@ export const ButtonVariantTest: React.FunctionComponent = () => {
   return (
     <View style={[stackStyle, commonTestStyles.view]}>
       <Button content="Default" style={commonTestStyles.vmargin} />
-      <Button primary content="Primary" style={commonTestStyles.vmargin} />
-      <Button subtle content="Subtle" style={commonTestStyles.vmargin} />
+      <Button appearance="primary" content="Primary" style={commonTestStyles.vmargin} />
+      <Button appearance="subtle" content="Subtle" style={commonTestStyles.vmargin} />
       <Button fluid content="Fluid" style={commonTestStyles.vmargin} />
-      <Button primary fluid content="Fluid Primary" style={commonTestStyles.vmargin} />
-      <Button subtle fluid content="Fluid Subtle" style={commonTestStyles.vmargin} />
+      <Button appearance="primary" fluid content="Fluid Primary" style={commonTestStyles.vmargin} />
+      <Button appearance="subtle" fluid content="Fluid Subtle" style={commonTestStyles.vmargin} />
       <CompoundButton content="Default" secondaryContent="Compound" style={commonTestStyles.vmargin} />
-      <CompoundButton primary content="Primary" secondaryContent="Compound" style={commonTestStyles.vmargin} />
-      <CompoundButton subtle content="Subtle" secondaryContent="Compound" style={commonTestStyles.vmargin} />
+      <CompoundButton appearance="primary" content="Primary" secondaryContent="Compound" style={commonTestStyles.vmargin} />
+      <CompoundButton appearance="subtle" content="Subtle" secondaryContent="Compound" style={commonTestStyles.vmargin} />
       {Platform.OS !== 'windows' && (
         <>
           <Button fab icon={{ svgSource: svgProps, width: 20, height: 20 }} style={commonTestStyles.vmargin} />

--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ToggleButtonTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ToggleButtonTestSection.tsx
@@ -29,11 +29,17 @@ export const ToggleButtonTest: React.FunctionComponent = () => {
       <ToggleButton checked={false} content="Unchecked Default Toggle" style={commonTestStyles.vmargin} />
       {/* <ToggleButton primary content="Primary Toggle" /> */}
       <View style={styles.row}>
-        <ToggleButton subtle onClick={onGhostClicked} checked={subtleChecked} content="Subtle Toggle" style={commonTestStyles.vmargin} />
+        <ToggleButton
+          appearance="subtle"
+          onClick={onGhostClicked}
+          checked={subtleChecked}
+          content="Subtle Toggle"
+          style={commonTestStyles.vmargin}
+        />
         <Checkbox checked={subtleChecked} label="Subtle Toggle is Checked" style={[commonTestStyles.vmargin, styles.hmargin]} />
       </View>
-      <ToggleButton subtle checked content="Checked Subtle Toggle" style={commonTestStyles.vmargin} />
-      <ToggleButton subtle checked={false} content="Unchecked Subtle Toggle" style={commonTestStyles.vmargin} />
+      <ToggleButton appearance="subtle" checked content="Checked Subtle Toggle" style={commonTestStyles.vmargin} />
+      <ToggleButton appearance="subtle" checked={false} content="Unchecked Subtle Toggle" style={commonTestStyles.vmargin} />
     </View>
   );
 };

--- a/apps/fluent-tester/src/FluentTester/TestComponents/MenuButtonExperimental/StandardMenuButtonTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/MenuButtonExperimental/StandardMenuButtonTest.tsx
@@ -79,7 +79,7 @@ export const StandardMenuButton: React.FunctionComponent = () => {
             <Separator vertical />
             <View style={columnStyle}>
               <MenuButton
-                primary
+                appearance="primary"
                 content="Primary MenuButton"
                 menuItems={menuItems}
                 onItemClick={onItemClick}
@@ -87,7 +87,7 @@ export const StandardMenuButton: React.FunctionComponent = () => {
               />
               <Text>Primary MenuButton with icon</Text>
               <MenuButton
-                primary
+                appearance="primary"
                 icon={iconToShow}
                 content="Primary MenuButton"
                 menuItems={menuItems}
@@ -95,9 +95,15 @@ export const StandardMenuButton: React.FunctionComponent = () => {
                 contextualMenu={contextualMenuProps}
               />
               <Text>Primary MenuButton with only icon</Text>
-              <MenuButton primary icon={iconToShow} menuItems={menuItems} onItemClick={onItemClick} contextualMenu={contextualMenuProps} />
+              <MenuButton
+                appearance="primary"
+                icon={iconToShow}
+                menuItems={menuItems}
+                onItemClick={onItemClick}
+                contextualMenu={contextualMenuProps}
+              />
               <Text>Primary Disabled MenuButton</Text>
-              <MenuButton primary disabled content="Disabled Primary MenuButton" menuItems={menuItems} />
+              <MenuButton appearance="primary" disabled content="Disabled Primary MenuButton" menuItems={menuItems} />
             </View>
           </View>
         </View>

--- a/apps/fluent-tester/src/FluentTester/theme/ThemePickers.ios.tsx
+++ b/apps/fluent-tester/src/FluentTester/theme/ThemePickers.ios.tsx
@@ -63,7 +63,7 @@ export const ThemePickers: React.FunctionComponent = () => {
         }}
         actions={themeMenuOptions}
       >
-        <Button subtle content="Theme" />
+        <Button appearance="subtle" content="Theme" />
       </MenuView>
       <MenuView
         title="Brand"
@@ -72,7 +72,7 @@ export const ThemePickers: React.FunctionComponent = () => {
         }}
         actions={brandMenuOptions}
       >
-        <Button subtle content="Brand" />
+        <Button appearance="subtle" content="Brand" />
       </MenuView>
     </View>
   );

--- a/change/@fluentui-react-native-experimental-button-5dd6fd84-933d-4a65-9abc-0b97a830999b.json
+++ b/change/@fluentui-react-native-experimental-button-5dd6fd84-933d-4a65-9abc-0b97a830999b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Change button props to add appearance",
+  "packageName": "@fluentui-react-native/experimental-button",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-menu-button-49e724fb-9b47-4edb-b9d8-237c1c6948c2.json
+++ b/change/@fluentui-react-native-experimental-menu-button-49e724fb-9b47-4edb-b9d8-237c1c6948c2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Change button props to add appearance",
+  "packageName": "@fluentui-react-native/experimental-menu-button",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-22b0d74b-8040-4436-a32f-6613c262256c.json
+++ b/change/@fluentui-react-native-tester-22b0d74b-8040-4436-a32f-6613c262256c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Change button props to add appearance",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Button/src/Button.tsx
+++ b/packages/experimental/Button/src/Button.tsx
@@ -21,6 +21,7 @@ export const buttonLookup = (layer: string, state: IPressableState, userProps: B
   return (
     state[layer] ||
     userProps[layer] ||
+    layer === userProps['appearance'] ||
     (!userProps.fab && (layer === userProps['size'] || (!userProps['size'] && layer === getDefaultSize()))) ||
     (layer === 'hasContent' && userProps.content) ||
     (layer === 'hasIcon' && userProps.icon)

--- a/packages/experimental/Button/src/Button.types.ts
+++ b/packages/experimental/Button/src/Button.types.ts
@@ -8,6 +8,7 @@ import { IconProps, IconSourcesType } from '@fluentui-react-native/icon';
 
 export const buttonName = 'Button';
 export type ButtonSize = 'small' | 'medium' | 'large';
+export type ButtonAppearance = 'primary' | 'outline' | 'subtle' | 'transparent';
 
 export interface ButtonTokens extends LayoutTokens, FontTokens, IBorderTokens, IShadowTokens, IColorTokens {
   /**
@@ -64,6 +65,14 @@ export interface ButtonTokens extends LayoutTokens, FontTokens, IBorderTokens, I
 }
 
 export interface ButtonProps extends Omit<IWithPressableOptions<ViewProps>, 'onPress'> {
+  /**
+   * A button can have its content and borders styled for greater emphasis or to be subtle.
+   * - 'primary': Emphasizes the button as a primary action.
+   * - 'subtle': Minimizes emphasis to blend into the background until hovered or focused.
+   * - 'transparent': NYI. Removes background and border styling.
+   */
+  appearance?: ButtonAppearance;
+
   /*
    * Text to show on the Button.
    */
@@ -87,12 +96,6 @@ export interface ButtonProps extends Omit<IWithPressableOptions<ViewProps>, 'onP
   testID?: string;
   tooltip?: string;
 
-  /** A button can emphasize that it represents the primary action. */
-  primary?: boolean;
-
-  /** A button can blend into its background to become less emphasized. */
-  subtle?: boolean;
-
   /** A button can fill the width of its container. */
   fluid?: boolean;
 
@@ -100,7 +103,7 @@ export interface ButtonProps extends Omit<IWithPressableOptions<ViewProps>, 'onP
   fab?: boolean;
 
   /** Sets style of button to a preset size style  */
-  size?: ButtonSize
+  size?: ButtonSize;
 }
 
 export type ButtonState = IPressableHooks<ButtonProps & React.ComponentPropsWithRef<any>>;

--- a/packages/experimental/MenuButton/src/MenuButton.tsx
+++ b/packages/experimental/MenuButton/src/MenuButton.tsx
@@ -22,7 +22,7 @@ export const MenuButton = compose<MenuButtonType>({
     root: {},
   },
   render: (props: MenuButtonProps, useSlots: UseSlots<MenuButtonType>) => {
-    const { menuItems, content, icon, disabled, onItemClick, contextualMenu, primary, style, ...rest } = props;
+    const { menuItems, content, icon, disabled, onItemClick, contextualMenu, style, appearance, ...rest } = props;
 
     const stdBtnRef = useRef(null);
     const [showContextualMenu, setShowContextualMenu] = useState(false);
@@ -36,7 +36,7 @@ export const MenuButton = compose<MenuButtonType>({
     const buttonProps = {
       content,
       disabled,
-      primary,
+      appearance,
       icon,
       style,
       componentRef: stdBtnRef,
@@ -77,7 +77,7 @@ export const MenuButton = compose<MenuButtonType>({
     const Slots = useSlots(props);
 
     return () => {
-      const chevronColor = primary ? primaryIconColor : defaultIconColor;
+      const chevronColor = appearance === 'primary' ? primaryIconColor : defaultIconColor;
       const chevronXml = `
           <svg width="12" height="16" viewBox="0 0 11 6" color=${chevronColor}>
             <path fill='currentColor' d='M0.646447 0.646447C0.841709 0.451184 1.15829 0.451184 1.35355 0.646447L5.5 4.79289L9.64645 0.646447C9.84171 0.451185 10.1583 0.451185 10.3536 0.646447C10.5488 0.841709 10.5488 1.15829 10.3536 1.35355L5.85355 5.85355C5.65829 6.04882 5.34171 6.04882 5.14645 5.85355L0.646447 1.35355C0.451184 1.15829 0.451184 0.841709 0.646447 0.646447Z' />


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

In the push to move to a settled API, we are aligning props to be closer to those of web. [Web is moving to use an `appearance` prop](https://github.com/microsoft/fluentui/blob/master/packages/react-button/src/components/Button/Button.types.ts) to control states like primary/subtle/etc. Making the change here to align props with web. This means removing the `primary` and `subtle` props and using `appearance` instead.

Fixed up tests as well to use the new prop.

### Verification

Booted up win32 tester and ensured that the look of the tests has not changed.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
