### PR TITLE
Rename internal eslint-config-rules package

### DIFF
--- a/apps/android/.eslintrc.js
+++ b/apps/android/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-  extends: ['@uifabricshared/eslint-config-rules']
+  extends: ['@fluentui-react-native/eslint-config-rules'],
 };

--- a/apps/android/package.json
+++ b/apps/android/package.json
@@ -32,10 +32,10 @@
   "devDependencies": {
     "@babel/core": "^7.6.2",
     "@babel/runtime": "^7.6.2",
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@rnx-kit/cli": "^0.5.27",
     "@rnx-kit/metro-config": "^1.2.3",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "metro-react-native-babel-preset": "^0.59.0",
     "react-native-svg-transformer": "^0.14.3",
     "react-native-test-app": "^0.7.0",

--- a/apps/fluent-tester/.eslintrc.js
+++ b/apps/fluent-tester/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-  extends: ['@uifabricshared/eslint-config-rules']
+  extends: ['@fluentui-react-native/eslint-config-rules'],
 };

--- a/apps/fluent-tester/package.json
+++ b/apps/fluent-tester/package.json
@@ -56,12 +56,12 @@
     "tslib": "^1.13.0"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@rnx-kit/cli": "^0.5.27",
     "@types/jasmine": "3.5.10",
     "@types/react": ">=16.9.34 < 16.14.0",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "@wdio/appium-service": "5.18.2",
     "@wdio/cli": "5.23.0",
     "@wdio/jasmine-framework": "5.18.6",

--- a/apps/ios/.eslintrc.js
+++ b/apps/ios/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-  extends: ['@uifabricshared/eslint-config-rules']
+  extends: ['@fluentui-react-native/eslint-config-rules'],
 };

--- a/apps/ios/package.json
+++ b/apps/ios/package.json
@@ -30,10 +30,10 @@
   "devDependencies": {
     "@babel/core": "^7.6.2",
     "@babel/runtime": "^7.6.2",
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@rnx-kit/cli": "^0.5.27",
     "@rnx-kit/metro-config": "^1.2.3",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "metro-config": "^0.59.0",
     "metro-react-native-babel-preset": "^0.59.0",
     "react-native-svg-transformer": "^0.14.3",

--- a/apps/macos/.eslintrc.js
+++ b/apps/macos/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-  extends: ['@uifabricshared/eslint-config-rules']
+  extends: ['@fluentui-react-native/eslint-config-rules'],
 };

--- a/apps/macos/package.json
+++ b/apps/macos/package.json
@@ -29,10 +29,10 @@
   "devDependencies": {
     "@babel/core": "^7.6.2",
     "@babel/runtime": "^7.6.2",
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@rnx-kit/cli": "^0.5.27",
     "@rnx-kit/metro-config": "^1.2.3",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "metro-config": "^0.59.0",
     "metro-react-native-babel-preset": "^0.59.0",
     "react-native-svg-transformer": "^0.14.3",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,13 +23,13 @@
     "react-native-web": "^0.12.3"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/jest": "^26.0.0",
     "@types/node": "^12.0.0",
     "@types/react": ">=16.9.34 < 16.14.0",
     "@types/react-dom": "^16.9.0",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "file-loader": "^6.0.0",
     "html-webpack-plugin": "^4.3.0",
     "ts-loader": "^7.0.5",

--- a/apps/win32/.eslintrc.js
+++ b/apps/win32/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-  extends: ['@uifabricshared/eslint-config-rules']
+  extends: ['@fluentui-react-native/eslint-config-rules'],
 };

--- a/apps/win32/package.json
+++ b/apps/win32/package.json
@@ -43,7 +43,7 @@
     "@types/react": ">=16.9.34 < 16.14.0",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@wdio/allure-reporter": "5.22.4",
     "@wdio/appium-service": "5.18.2",
     "@wdio/cli": "5.23.0",

--- a/apps/windows/.eslintrc.js
+++ b/apps/windows/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ['@uifabricshared/eslint-config-rules'],
+  extends: ['@fluentui-react-native/eslint-config-rules'],
   rules: {
     '@typescript-eslint/no-var-requires': 0,
   },

--- a/change/@fluentui-react-native-adapters-bbf428c3-61fd-4b5e-8483-841f2a552399.json
+++ b/change/@fluentui-react-native-adapters-bbf428c3-61fd-4b5e-8483-841f2a552399.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/adapters",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-android-theme-611bcb02-158b-42a2-8a70-f408b46d40dc.json
+++ b/change/@fluentui-react-native-android-theme-611bcb02-158b-42a2-8a70-f408b46d40dc.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/android-theme",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-apple-theme-febd275f-57d8-4e54-993e-e774f26f225c.json
+++ b/change/@fluentui-react-native-apple-theme-febd275f-57d8-4e54-993e-e774f26f225c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/apple-theme",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-button-f62b2c3c-4b5d-43a5-8fb3-009fe9e7dca4.json
+++ b/change/@fluentui-react-native-button-f62b2c3c-4b5d-43a5-8fb3-009fe9e7dca4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/button",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-callout-7da11ad0-0d5a-4608-9de7-bd646dbeb61c.json
+++ b/change/@fluentui-react-native-callout-7da11ad0-0d5a-4608-9de7-bd646dbeb61c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/callout",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-checkbox-01f727a2-b33c-49f8-87a9-f0a9ba0992eb.json
+++ b/change/@fluentui-react-native-checkbox-01f727a2-b33c-49f8-87a9-f0a9ba0992eb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/checkbox",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-component-cache-17591bfa-7841-40f4-b4d7-b7ee26110003.json
+++ b/change/@fluentui-react-native-component-cache-17591bfa-7841-40f4-b4d7-b7ee26110003.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/component-cache",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-contextual-menu-3b4f70f0-89fc-4a59-b56c-c3f9ad1b8edb.json
+++ b/change/@fluentui-react-native-contextual-menu-3b4f70f0-89fc-4a59-b56c-c3f9ad1b8edb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/contextual-menu",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-dc9fe6a1-8863-45b5-9c3a-d0893c34ce43.json
+++ b/change/@fluentui-react-native-dc9fe6a1-8863-45b5-9c3a-d0893c34ce43.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui/react-native",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-default-theme-77e8e2e6-a520-4cea-a112-acb37d88eeb2.json
+++ b/change/@fluentui-react-native-default-theme-77e8e2e6-a520-4cea-a112-acb37d88eeb2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/default-theme",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-activity-indicator-3c1e450d-15a8-4dcb-bed9-7686322d914a.json
+++ b/change/@fluentui-react-native-experimental-activity-indicator-3c1e450d-15a8-4dcb-bed9-7686322d914a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/experimental-activity-indicator",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-avatar-008c23b3-9836-4245-a74e-15ce679321c5.json
+++ b/change/@fluentui-react-native-experimental-avatar-008c23b3-9836-4245-a74e-15ce679321c5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/experimental-avatar",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-button-4d66be6b-f7e7-4bc3-a4e5-33f26174aa5f.json
+++ b/change/@fluentui-react-native-experimental-button-4d66be6b-f7e7-4bc3-a4e5-33f26174aa5f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/experimental-button",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-checkbox-2786113e-1d06-4feb-a3b5-d8f6e692400e.json
+++ b/change/@fluentui-react-native-experimental-checkbox-2786113e-1d06-4feb-a3b5-d8f6e692400e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/experimental-checkbox",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-expander-a07e590b-21b8-4b1f-aa4b-bc54eea8517c.json
+++ b/change/@fluentui-react-native-experimental-expander-a07e590b-21b8-4b1f-aa4b-bc54eea8517c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/experimental-expander",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-menu-button-09007fb1-e6f4-4a12-8829-06ea158a212b.json
+++ b/change/@fluentui-react-native-experimental-menu-button-09007fb1-e6f4-4a12-8829-06ea158a212b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/experimental-menu-button",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-native-date-picker-53aa6ed8-57d6-47e6-bd75-9c7c2d9cf524.json
+++ b/change/@fluentui-react-native-experimental-native-date-picker-53aa6ed8-57d6-47e6-bd75-9c7c2d9cf524.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/experimental-native-date-picker",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-shimmer-c82d3ce7-c694-4d61-93ab-4cf21c6b4ff3.json
+++ b/change/@fluentui-react-native-experimental-shimmer-c82d3ce7-c694-4d61-93ab-4cf21c6b4ff3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/experimental-shimmer",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-tabs-48e19289-c3b4-409f-bd2d-321889178c1f.json
+++ b/change/@fluentui-react-native-experimental-tabs-48e19289-c3b4-409f-bd2d-321889178c1f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/experimental-tabs",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-text-d6e8d3a5-ec83-4b1a-afbd-7194b5eaae21.json
+++ b/change/@fluentui-react-native-experimental-text-d6e8d3a5-ec83-4b1a-afbd-7194b5eaae21.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/experimental-text",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-focus-trap-zone-872c2c7a-155a-4f38-9f05-9e17a98fa8f5.json
+++ b/change/@fluentui-react-native-focus-trap-zone-872c2c7a-155a-4f38-9f05-9e17a98fa8f5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/focus-trap-zone",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-focus-zone-38cba036-fd5a-4e55-888e-f367e0feb3f1.json
+++ b/change/@fluentui-react-native-focus-zone-38cba036-fd5a-4e55-888e-f367e0feb3f1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/focus-zone",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-framework-9cbff5d1-3b6b-4581-ae0f-6f34792d7ca6.json
+++ b/change/@fluentui-react-native-framework-9cbff5d1-3b6b-4581-ae0f-6f34792d7ca6.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/framework",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-icon-7884cfd1-605a-4f16-984e-4ff241f5f18e.json
+++ b/change/@fluentui-react-native-icon-7884cfd1-605a-4f16-984e-4ff241f5f18e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/icon",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-immutable-merge-67baaef5-efd8-4239-a511-8c0f54df4a11.json
+++ b/change/@fluentui-react-native-immutable-merge-67baaef5-efd8-4239-a511-8c0f54df4a11.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/immutable-merge",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-interactive-hooks-3fe5bde9-a75b-4ded-b175-4038c88748ac.json
+++ b/change/@fluentui-react-native-interactive-hooks-3fe5bde9-a75b-4ded-b175-4038c88748ac.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/interactive-hooks",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-link-0ffb0175-3ebe-4f8e-8fc4-b26606f59cc8.json
+++ b/change/@fluentui-react-native-link-0ffb0175-3ebe-4f8e-8fc4-b26606f59cc8.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/link",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-memo-cache-fc73328f-5a0c-4416-9c78-40a982b0640e.json
+++ b/change/@fluentui-react-native-memo-cache-fc73328f-5a0c-4416-9c78-40a982b0640e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/memo-cache",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-menu-button-3b121086-91ea-4a15-97c3-a24e08f7a0d3.json
+++ b/change/@fluentui-react-native-menu-button-3b121086-91ea-4a15-97c3-a24e08f7a0d3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/menu-button",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-merge-props-addc1c0d-7b74-4e14-b9f7-1977278c2783.json
+++ b/change/@fluentui-react-native-merge-props-addc1c0d-7b74-4e14-b9f7-1977278c2783.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/merge-props",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-persona-702de8d4-6947-44d4-9d99-04d191dacd08.json
+++ b/change/@fluentui-react-native-persona-702de8d4-6947-44d4-9d99-04d191dacd08.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/persona",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-persona-coin-f4ac8901-2f2e-4248-8aeb-f92e797c3a5b.json
+++ b/change/@fluentui-react-native-persona-coin-f4ac8901-2f2e-4248-8aeb-f92e797c3a5b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/persona-coin",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-pressable-9aa6ac32-0f81-40f3-8d52-fd082d17d037.json
+++ b/change/@fluentui-react-native-pressable-9aa6ac32-0f81-40f3-8d52-fd082d17d037.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/pressable",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-radio-group-c7ac32b6-fc88-46cc-a770-a4b7e18c6f07.json
+++ b/change/@fluentui-react-native-radio-group-c7ac32b6-fc88-46cc-a770-a4b7e18c6f07.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/radio-group",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-separator-1cd8f447-2956-4fe1-841e-b7d8158d29db.json
+++ b/change/@fluentui-react-native-separator-1cd8f447-2956-4fe1-841e-b7d8158d29db.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/separator",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-stack-b602a7e0-70ed-4355-a999-71624bd427c9.json
+++ b/change/@fluentui-react-native-stack-b602a7e0-70ed-4355-a999-71624bd427c9.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/stack",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-styling-utils-8aa5e75b-935e-43b1-87c6-6a864116caec.json
+++ b/change/@fluentui-react-native-styling-utils-8aa5e75b-935e-43b1-87c6-6a864116caec.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/styling-utils",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-tabs-8f90f28c-85bb-4155-8ae6-55640d55925a.json
+++ b/change/@fluentui-react-native-tabs-8f90f28c-85bb-4155-8ae6-55640d55925a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/tabs",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-tester-3b6e42ef-eac3-4920-8899-a9aba24c5058.json
+++ b/change/@fluentui-react-native-tester-3b6e42ef-eac3-4920-8899-a9aba24c5058.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-tester-win32-d8685c51-b4fe-44ab-9cba-c5178c41198f.json
+++ b/change/@fluentui-react-native-tester-win32-d8685c51-b4fe-44ab-9cba-c5178c41198f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/tester-win32",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-text-f9ea5508-f8a1-49ad-be45-c8c3d8951489.json
+++ b/change/@fluentui-react-native-text-f9ea5508-f8a1-49ad-be45-c8c3d8951489.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/text",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-theme-tokens-2d1aa81b-8187-487c-82e2-756d6fbf51dc.json
+++ b/change/@fluentui-react-native-theme-tokens-2d1aa81b-8187-487c-82e2-756d6fbf51dc.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/theme-tokens",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-theme-types-9ae97e65-5ca2-45f6-ba9e-fba3eb71ad99.json
+++ b/change/@fluentui-react-native-theme-types-9ae97e65-5ca2-45f6-ba9e-fba3eb71ad99.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/theme-types",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-themed-stylesheet-c0779807-d557-48af-af12-e772e575970b.json
+++ b/change/@fluentui-react-native-themed-stylesheet-c0779807-d557-48af-af12-e772e575970b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/themed-stylesheet",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-theming-utils-b13bc570-8fa9-435a-8dd0-1d64854d33c9.json
+++ b/change/@fluentui-react-native-theming-utils-b13bc570-8fa9-435a-8dd0-1d64854d33c9.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/theming-utils",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-tokens-fbfaef8f-19bc-427b-8571-14dc67b5a61d.json
+++ b/change/@fluentui-react-native-tokens-fbfaef8f-19bc-427b-8571-14dc67b5a61d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/tokens",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-win32-theme-0f2d14bd-1ba8-482f-a812-bb7b125e311a.json
+++ b/change/@fluentui-react-native-win32-theme-0f2d14bd-1ba8-482f-a812-bb7b125e311a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@fluentui-react-native/win32-theme",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@uifabricshared-foundation-composable-97f00de5-794c-4ecd-9306-b68cdb43bca0.json
+++ b/change/@uifabricshared-foundation-composable-97f00de5-794c-4ecd-9306-b68cdb43bca0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@uifabricshared/foundation-composable",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@uifabricshared-foundation-compose-c5185619-0bfc-46ba-b4c2-8e8c017801a3.json
+++ b/change/@uifabricshared-foundation-compose-c5185619-0bfc-46ba-b4c2-8e8c017801a3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@uifabricshared/foundation-compose",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@uifabricshared-foundation-settings-56effb73-6a74-4f0d-ba81-dd7b0031cda1.json
+++ b/change/@uifabricshared-foundation-settings-56effb73-6a74-4f0d-ba81-dd7b0031cda1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@uifabricshared/foundation-settings",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@uifabricshared-theme-registry-feb79a87-6afb-446a-a36c-4c4843bd0fad.json
+++ b/change/@uifabricshared-theme-registry-feb79a87-6afb-446a-a36c-4c4843bd0fad.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@uifabricshared/theme-registry",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@uifabricshared-themed-settings-5f2f4aa3-e275-44cc-b81b-601eec555c5a.json
+++ b/change/@uifabricshared-themed-settings-5f2f4aa3-e275-44cc-b81b-601eec555c5a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@uifabricshared/themed-settings",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@uifabricshared-theming-ramp-c74331a4-0476-483c-8193-59ba50f96f08.json
+++ b/change/@uifabricshared-theming-ramp-c74331a4-0476-483c-8193-59ba50f96f08.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@uifabricshared/theming-ramp",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@uifabricshared-theming-react-native-9024b0dc-7d01-439d-bb26-88aeb22c0969.json
+++ b/change/@uifabricshared-theming-react-native-9024b0dc-7d01-439d-bb26-88aeb22c0969.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Rename uifabricshared/eslint-config-rules to fluentui-react-native/eslint-config-rules",
+  "packageName": "@uifabricshared/theming-react-native",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/components/Button/.eslintrc.js
+++ b/packages/components/Button/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/components/Button/package.json
+++ b/packages/components/Button/package.json
@@ -32,10 +32,10 @@
     "@uifabricshared/foundation-settings": ">=0.10.3 <1.0.0"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@office-iss/react-native-win32": "^0.63.7",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react-native": "^0.63.4"
   },
   "peerDependencies": {

--- a/packages/components/Callout/.eslintrc.js
+++ b/packages/components/Callout/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/components/Callout/package.json
+++ b/packages/components/Callout/package.json
@@ -32,9 +32,9 @@
     "@uifabricshared/foundation-settings": ">=0.10.3 <1.0.0"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react-native": "^0.63.4"
   },
   "peerDependencies": {

--- a/packages/components/Checkbox/.eslintrc.js
+++ b/packages/components/Checkbox/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-  extends: ['@uifabricshared/eslint-config-rules']
+  extends: ['@fluentui-react-native/eslint-config-rules'],
 };

--- a/packages/components/Checkbox/package.json
+++ b/packages/components/Checkbox/package.json
@@ -31,10 +31,10 @@
     "@uifabricshared/foundation-settings": ">=0.10.3 <1.0.0"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@office-iss/react-native-win32": "^0.63.7",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react-native": "^0.63.4"
   },
   "peerDependencies": {

--- a/packages/components/ContextualMenu/.eslintrc.js
+++ b/packages/components/ContextualMenu/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/components/ContextualMenu/package.json
+++ b/packages/components/ContextualMenu/package.json
@@ -34,10 +34,10 @@
     "@uifabricshared/foundation-settings": ">=0.10.3 <1.0.0"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/pressable": ">=0.7.30 <1.0.0",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react-native": "^0.63.4"
   },
   "peerDependencies": {

--- a/packages/components/FocusTrapZone/.eslintrc.js
+++ b/packages/components/FocusTrapZone/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/components/FocusTrapZone/package.json
+++ b/packages/components/FocusTrapZone/package.json
@@ -28,9 +28,9 @@
     "@uifabricshared/foundation-settings": ">=0.10.3 <1.0.0"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react-native": "^0.63.4"
   },
   "peerDependencies": {

--- a/packages/components/FocusZone/.eslintrc.js
+++ b/packages/components/FocusZone/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/components/FocusZone/package.json
+++ b/packages/components/FocusZone/package.json
@@ -27,10 +27,10 @@
     "@uifabricshared/foundation-settings": ">=0.10.3 <1.0.0"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@office-iss/react-native-win32": "^0.63.7",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react-native": "^0.63.4"
   },
   "peerDependencies": {

--- a/packages/components/Link/.eslintrc.js
+++ b/packages/components/Link/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/components/Link/package.json
+++ b/packages/components/Link/package.json
@@ -30,9 +30,9 @@
     "@uifabricshared/foundation-settings": ">=0.10.3 <1.0.0"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react-native": "^0.63.4"
   },
   "peerDependencies": {

--- a/packages/components/MenuButton/.eslintrc.js
+++ b/packages/components/MenuButton/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/components/MenuButton/package.json
+++ b/packages/components/MenuButton/package.json
@@ -36,9 +36,9 @@
     "react-native-svg": "^12.1.1"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react-native": "^0.63.4"
   },
   "peerDependencies": {

--- a/packages/components/Persona/.eslintrc.js
+++ b/packages/components/Persona/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/components/Persona/package.json
+++ b/packages/components/Persona/package.json
@@ -31,9 +31,9 @@
     "@uifabricshared/foundation-tokens": ">=0.10.3 <1.0.0"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react-native": "^0.63.4"
   },
   "peerDependencies": {

--- a/packages/components/PersonaCoin/.eslintrc.js
+++ b/packages/components/PersonaCoin/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/components/PersonaCoin/package.json
+++ b/packages/components/PersonaCoin/package.json
@@ -31,10 +31,10 @@
     "@uifabricshared/foundation-tokens": ">=0.10.3 <1.0.0"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@office-iss/react-native-win32": "^0.63.7",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react-native": "^0.63.4"
   },
   "peerDependencies": {

--- a/packages/components/Pressable/.eslintrc.js
+++ b/packages/components/Pressable/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/components/Pressable/package.json
+++ b/packages/components/Pressable/package.json
@@ -27,9 +27,9 @@
     "@uifabricshared/foundation-settings": ">=0.10.3 <1.0.0"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react-native": "^0.63.4"
   },
   "peerDependencies": {

--- a/packages/components/RadioGroup/.eslintrc.js
+++ b/packages/components/RadioGroup/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/components/RadioGroup/package.json
+++ b/packages/components/RadioGroup/package.json
@@ -33,11 +33,11 @@
     "@uifabricshared/foundation-settings": ">=0.10.3 <1.0.0"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/test-tools": ">=0.1.1 <1.0.0",
     "@office-iss/react-native-win32": "^0.63.7",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react-native": "^0.63.4"
   },
   "peerDependencies": {

--- a/packages/components/Separator/.eslintrc.js
+++ b/packages/components/Separator/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/components/Separator/package.json
+++ b/packages/components/Separator/package.json
@@ -24,10 +24,10 @@
     "@fluentui-react-native/framework": ">=0.6.6 <1.0.0"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@office-iss/react-native-win32": "^0.63.7",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react-native": "^0.63.4"
   },
   "peerDependencies": {

--- a/packages/components/Stack/.eslintrc.js
+++ b/packages/components/Stack/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/components/Stack/package.json
+++ b/packages/components/Stack/package.json
@@ -30,10 +30,10 @@
     "@uifabricshared/foundation-tokens": ">=0.10.3 <1.0.0"
   },
   "devDependencies": {
-    "@types/react-native": "^0.63.0",
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/text": ">=0.10.25 <1.0.0",
+    "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react-native": "^0.63.4"
   },
   "peerDependencies": {

--- a/packages/components/Tabs/.eslintrc.js
+++ b/packages/components/Tabs/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/components/Tabs/package.json
+++ b/packages/components/Tabs/package.json
@@ -35,11 +35,11 @@
     "@uifabricshared/foundation-settings": ">=0.10.3 <1.0.0"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/test-tools": ">=0.1.1 <1.0.0",
     "@office-iss/react-native-win32": "^0.63.7",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react-native": "^0.63.4"
   },
   "peerDependencies": {

--- a/packages/components/text/.eslintrc.js
+++ b/packages/components/text/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/components/text/package.json
+++ b/packages/components/text/package.json
@@ -26,10 +26,10 @@
     "@fluentui-react-native/tokens": ">=0.10.3 <1.0.0"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/test-tools": ">=0.1.1 <1.0.0",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react-native": "^0.63.4"
   },
   "peerDependencies": {

--- a/packages/deprecated/foundation-composable/.eslintrc.js
+++ b/packages/deprecated/foundation-composable/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/deprecated/foundation-composable/package.json
+++ b/packages/deprecated/foundation-composable/package.json
@@ -36,10 +36,10 @@
     "@uifabricshared/foundation-settings": ">=0.10.3 <1.0.0"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/jest": "^26.0.0",
     "@types/react": ">=16.9.34 < 16.14.0",
-    "react": "16.13.1",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1"
+    "react": "16.13.1"
   }
 }

--- a/packages/deprecated/foundation-compose/.eslintrc.js
+++ b/packages/deprecated/foundation-compose/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/deprecated/foundation-compose/package.json
+++ b/packages/deprecated/foundation-compose/package.json
@@ -42,7 +42,7 @@
     "@uifabricshared/theming-ramp": ">=0.15.11 <1.0.0"
   },
   "devDependencies": {
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "react": "16.13.1"
   },
   "peerDependencies": {

--- a/packages/deprecated/foundation-settings/.eslintrc.js
+++ b/packages/deprecated/foundation-settings/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/deprecated/foundation-settings/package.json
+++ b/packages/deprecated/foundation-settings/package.json
@@ -36,10 +36,10 @@
     "@fluentui-react-native/merge-props": ">=0.3.5 <1.0.0"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/jest": "^26.0.0",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react-native": "^0.63.4"
   },
   "peerDependencies": {

--- a/packages/deprecated/theme-registry/.eslintrc.js
+++ b/packages/deprecated/theme-registry/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/deprecated/theme-registry/package.json
+++ b/packages/deprecated/theme-registry/package.json
@@ -33,11 +33,11 @@
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/immutable-merge": "^1.1.4",
     "@types/jest": "^26.0.0",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react-native": "^0.63.4"
   }
 }

--- a/packages/deprecated/themed-settings/.eslintrc.js
+++ b/packages/deprecated/themed-settings/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/deprecated/themed-settings/package.json
+++ b/packages/deprecated/themed-settings/package.json
@@ -35,12 +35,12 @@
     "@uifabricshared/foundation-settings": ">=0.10.3 <1.0.0"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
+    "@fluentui-react-native/memo-cache": "^1.1.5",
     "@types/jest": "^26.0.0",
     "@types/node": "^10.3.5",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
-    "@fluentui-react-native/memo-cache": "^1.1.5",
     "react-native": "^0.63.4"
   },
   "peerDependencies": {

--- a/packages/deprecated/theming-ramp/.eslintrc.js
+++ b/packages/deprecated/theming-ramp/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/deprecated/theming-ramp/package.json
+++ b/packages/deprecated/theming-ramp/package.json
@@ -37,12 +37,12 @@
     "@fluentui-react-native/theme-types": ">=0.12.4 <1.0.0"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/test-tools": ">=0.1.1 <1.0.0",
     "@types/jest": "^26.0.0",
     "@types/react": ">=16.9.34 < 16.14.0",
-    "react": "16.13.1",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1"
+    "react": "16.13.1"
   },
   "peerDependencies": {
     "react": ">=16.13.1"

--- a/packages/deprecated/theming-react-native/.eslintrc.js
+++ b/packages/deprecated/theming-react-native/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/deprecated/theming-react-native/package.json
+++ b/packages/deprecated/theming-react-native/package.json
@@ -34,13 +34,13 @@
     "@uifabricshared/theming-ramp": ">=0.15.11 <1.0.0"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/jest": "^26.0.0",
     "@types/react": ">=16.9.34 < 16.14.0",
+    "@uifabricshared/build-native": "^0.1.1",
     "react": "16.13.1",
     "react-native": "^0.63.4",
-    "typescript": "3.8.3",
-    "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1"
+    "typescript": "3.8.3"
   },
   "peerDependencies": {
     "react": ">=16.13.1",

--- a/packages/experimental/ActivityIndicator/package.json
+++ b/packages/experimental/ActivityIndicator/package.json
@@ -25,9 +25,9 @@
     "react-native-svg": "^12.1.1"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react-native": "^0.63.4"
   },
   "peerDependencies": {

--- a/packages/experimental/Avatar/package.json
+++ b/packages/experimental/Avatar/package.json
@@ -28,9 +28,9 @@
     "@fluentui-react-native/framework": "0.6.6"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react-native": "^0.63.4",
     "react": "16.13.1"
   },

--- a/packages/experimental/Button/.eslintrc.js
+++ b/packages/experimental/Button/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/experimental/Button/package.json
+++ b/packages/experimental/Button/package.json
@@ -32,11 +32,11 @@
     "tslib": "^1.13.0"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/test-tools": ">=0.1.1 <1.0.0",
     "@office-iss/react-native-win32": "^0.63.7",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react": "16.13.1",
     "react-native": "^0.63.4"
   },

--- a/packages/experimental/Checkbox/package.json
+++ b/packages/experimental/Checkbox/package.json
@@ -34,10 +34,10 @@
     "tslib": "^1.13.0"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@office-iss/react-native-win32": "^0.63.7",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react": "16.13.1",
     "react-native": "^0.63.4"
   },

--- a/packages/experimental/Expander/package.json
+++ b/packages/experimental/Expander/package.json
@@ -29,9 +29,9 @@
     "@fluentui-react-native/framework": "0.6.6"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react": "16.13.1",
     "react-native": "^0.63.4",
     "react-native-windows": "^0.63.0"

--- a/packages/experimental/Icon/package.json
+++ b/packages/experimental/Icon/package.json
@@ -28,10 +28,10 @@
     "react-native-svg": "^12.1.1"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@office-iss/react-native-win32": "^0.63.7",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react-native": "^0.63.4",
     "react-native-svg-transformer": "^0.14.3"
   },

--- a/packages/experimental/MenuButton/.eslintrc.js
+++ b/packages/experimental/MenuButton/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/experimental/MenuButton/package.json
+++ b/packages/experimental/MenuButton/package.json
@@ -28,9 +28,9 @@
     "react-native-svg": "^12.1.1"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react": "16.13.1",
     "react-native": "^0.63.4"
   },

--- a/packages/experimental/NativeDatePicker/package.json
+++ b/packages/experimental/NativeDatePicker/package.json
@@ -24,9 +24,9 @@
     "prettier-fix": "fluentui-scripts prettier --fix true"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react-native": "^0.63.4",
     "react": "16.13.1"
   },

--- a/packages/experimental/Shimmer/package.json
+++ b/packages/experimental/Shimmer/package.json
@@ -23,9 +23,9 @@
     "react-native-svg": "^12.1.1"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "assert-never": "^1.2.1",
     "react-native": "^0.63.4"
   },

--- a/packages/experimental/Stack/.eslintrc.js
+++ b/packages/experimental/Stack/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/experimental/Stack/package.json
+++ b/packages/experimental/Stack/package.json
@@ -27,10 +27,10 @@
     "@fluentui-react-native/tokens": ">=0.10.3 <1.0.0"
   },
   "devDependencies": {
-    "@types/react-native": "^0.63.0",
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/text": ">=0.10.25 <1.0.0",
+    "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react": "16.13.1",
     "react-native": "^0.63.4",
     "tslib": "^1.13.0"

--- a/packages/experimental/Tabs/.eslintrc.js
+++ b/packages/experimental/Tabs/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/experimental/Tabs/package.json
+++ b/packages/experimental/Tabs/package.json
@@ -32,11 +32,11 @@
     "tslib": "^1.13.0"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/test-tools": ">=0.1.1 <1.0.0",
     "@office-iss/react-native-win32": "^0.63.7",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react": "16.13.1",
     "react-native": "^0.63.4"
   },

--- a/packages/experimental/Text/.eslintrc.js
+++ b/packages/experimental/Text/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/experimental/Text/package.json
+++ b/packages/experimental/Text/package.json
@@ -26,10 +26,10 @@
     "tslib": "^1.13.0"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/test-tools": ">=0.1.1 <1.0.0",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react-native": "^0.63.4"
   },
   "peerDependencies": {

--- a/packages/framework/component-cache/.eslintrc.js
+++ b/packages/framework/component-cache/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/framework/component-cache/package.json
+++ b/packages/framework/component-cache/package.json
@@ -35,7 +35,7 @@
     "@types/jest": "^26.0.0",
     "@types/node": "^10.3.5",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "react": "16.13.1",
     "react-native": "^0.63.4"
   },

--- a/packages/framework/eslint-config-rules/package.json
+++ b/packages/framework/eslint-config-rules/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "@uifabricshared/eslint-config-rules",
+  "name": "@fluentui-react-native/eslint-config-rules",
   "version": "0.1.1",
   "description": "ESLint ruleset for UI Fabric React Native",
+  "private": "true",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/ui-fabric-react-native",

--- a/packages/framework/framework/.eslintrc.js
+++ b/packages/framework/framework/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-  extends: ['@uifabricshared/eslint-config-rules']
+  extends: ['@fluentui-react-native/eslint-config-rules'],
 };

--- a/packages/framework/framework/package.json
+++ b/packages/framework/framework/package.json
@@ -39,10 +39,10 @@
     "tslib": "^1.13.0"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react": ">=16.9.34 < 16.14.0",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-native": "^0.63.4",

--- a/packages/framework/immutable-merge/.eslintrc.js
+++ b/packages/framework/immutable-merge/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/framework/immutable-merge/package.json
+++ b/packages/framework/immutable-merge/package.json
@@ -35,9 +35,9 @@
     "tslib": "^1.13.0"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/jest": "^26.0.0",
     "@types/node": "^10.3.5",
-    "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1"
+    "@uifabricshared/build-native": "^0.1.1"
   }
 }

--- a/packages/framework/memo-cache/.eslintrc.js
+++ b/packages/framework/memo-cache/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/framework/memo-cache/package.json
+++ b/packages/framework/memo-cache/package.json
@@ -32,10 +32,10 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/jest": "^26.0.0",
     "@types/node": "^10.3.5",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "tslib": "^1.13.0"
   }
 }

--- a/packages/framework/merge-props/.eslintrc.js
+++ b/packages/framework/merge-props/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/framework/merge-props/package.json
+++ b/packages/framework/merge-props/package.json
@@ -37,10 +37,10 @@
     "tslib": "^1.13.0"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/jest": "^26.0.0",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react-native": "^0.63.4"
   },
   "peerDependencies": {

--- a/packages/framework/themed-stylesheet/.eslintrc.js
+++ b/packages/framework/themed-stylesheet/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/framework/themed-stylesheet/package.json
+++ b/packages/framework/themed-stylesheet/package.json
@@ -35,9 +35,9 @@
     "@fluentui-react-native/memo-cache": "^1.1.5"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react-native": "^0.63.4"
   },
   "peerDependencies": {

--- a/packages/libraries/core/.eslintrc.js
+++ b/packages/libraries/core/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-  extends: ['@uifabricshared/eslint-config-rules']
+  extends: ['@fluentui-react-native/eslint-config-rules'],
 };

--- a/packages/libraries/core/package.json
+++ b/packages/libraries/core/package.json
@@ -48,9 +48,9 @@
     "@fluentui-react-native/text": ">=0.10.25 <1.0.0"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react": "16.13.1",
     "react-native": "^0.63.4"
   },

--- a/packages/theming/android-theme/.eslintrc.js
+++ b/packages/theming/android-theme/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/theming/android-theme/package.json
+++ b/packages/theming/android-theme/package.json
@@ -36,9 +36,9 @@
     "@fluentui-react-native/theme": ">=0.5.23 <1.0.0"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react-native": "^0.63.4"
   },
   "peerDependencies": {

--- a/packages/theming/apple-theme/.eslintrc.js
+++ b/packages/theming/apple-theme/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/theming/apple-theme/package.json
+++ b/packages/theming/apple-theme/package.json
@@ -34,10 +34,10 @@
     "@fluentui-react-native/theming-utils": "^0.7.9"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react": ">=16.9.34 < 16.14.0",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react-native": "^0.63.4"
   },
   "peerDependencies": {

--- a/packages/theming/default-theme/.eslintrc.js
+++ b/packages/theming/default-theme/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/theming/default-theme/package.json
+++ b/packages/theming/default-theme/package.json
@@ -39,10 +39,10 @@
     "assert-never": "^1.2.1"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react": ">=16.9.34 < 16.14.0",
-    "react": "16.13.1",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
+    "react": "16.13.1",
     "react-native": "^0.63.4"
   },
   "peerDependencies": {

--- a/packages/theming/theme-tokens/.eslintrc.js
+++ b/packages/theming/theme-tokens/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/theming/theme-tokens/package.json
+++ b/packages/theming/theme-tokens/package.json
@@ -36,9 +36,9 @@
     "assert-never": "^1.2.1"
   },
   "devDependencies": {
-    "react-native": "^0.63.4",
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1"
+    "react-native": "^0.63.4"
   },
   "peerDependencies": {
     "react": "^16.13.1",

--- a/packages/theming/theme-types/.eslintrc.js
+++ b/packages/theming/theme-types/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/theming/theme-types/package.json
+++ b/packages/theming/theme-types/package.json
@@ -33,12 +33,12 @@
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react": ">=16.9.34 < 16.14.0",
     "@types/react-native": "^0.63.0",
-    "react": "16.13.1",
-    "react-native": "^0.63.4",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1"
+    "react": "16.13.1",
+    "react-native": "^0.63.4"
   },
   "peerDependencies": {
     "react": ">=16.13.1",

--- a/packages/theming/theming-utils/.eslintrc.js
+++ b/packages/theming/theming-utils/.eslintrc.js
@@ -1,8 +1,6 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ],
+  extends: ['@fluentui-react-native/eslint-config-rules'],
   rules: {
     '@typescript-eslint/no-var-requires': 0,
-  }
-}
+  },
+};

--- a/packages/theming/theming-utils/package.json
+++ b/packages/theming/theming-utils/package.json
@@ -30,9 +30,9 @@
     "@fluentui-react-native/theme-types": ">=0.12.4 <1.0.0"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react-native": "^0.63.4",
     "react-native-windows": "^0.64.0"
   },

--- a/packages/theming/win32-theme/.eslintrc.js
+++ b/packages/theming/win32-theme/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/theming/win32-theme/package.json
+++ b/packages/theming/win32-theme/package.json
@@ -41,11 +41,11 @@
     "tslib": "^1.13.0"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react": ">=16.9.34 < 16.14.0",
     "@types/react-native": "^0.63.0",
-    "react": "16.13.1",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
+    "react": "16.13.1",
     "react-native": "^0.63.4"
   },
   "peerDependencies": {

--- a/packages/utils/adapters/.eslintrc.js
+++ b/packages/utils/adapters/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/utils/adapters/package.json
+++ b/packages/utils/adapters/package.json
@@ -22,10 +22,10 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/jest": "^26.0.0",
     "@types/react-native": "^0.63.0",
-    "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1"
+    "@uifabricshared/build-native": "^0.1.1"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": ">=0.63.7",

--- a/packages/utils/interactive-hooks/.eslintrc.js
+++ b/packages/utils/interactive-hooks/.eslintrc.js
@@ -1,8 +1,6 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ],
+  extends: ['@fluentui-react-native/eslint-config-rules'],
   rules: {
     '@typescript-eslint/no-var-requires': 0,
-  }
-}
+  },
+};

--- a/packages/utils/interactive-hooks/package.json
+++ b/packages/utils/interactive-hooks/package.json
@@ -25,12 +25,12 @@
     "tslib": "^1.13.0"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
+    "@fluentui-react-native/icon": "0.8.30",
     "@office-iss/react-native-win32": "^0.63.7",
     "@types/react": ">=16.9.34 < 16.14.0",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
-    "@fluentui-react-native/icon": "0.8.30",
     "react": "16.13.1",
     "react-native": "^0.63.4"
   },

--- a/packages/utils/styling/.eslintrc.js
+++ b/packages/utils/styling/.eslintrc.js
@@ -1,8 +1,6 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ],
+  extends: ['@fluentui-react-native/eslint-config-rules'],
   rules: {
     '@typescript-eslint/no-var-requires': 0,
-  }
-}
+  },
+};

--- a/packages/utils/styling/package.json
+++ b/packages/utils/styling/package.json
@@ -21,8 +21,8 @@
     "prettier-fix": "fluentui-scripts prettier --fix true"
   },
   "devDependencies": {
-    "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1"
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
+    "@uifabricshared/build-native": "^0.1.1"
   },
   "peerDependencies": {
     "react": "^16.13.1",

--- a/packages/utils/test-tools/.eslintrc.js
+++ b/packages/utils/test-tools/.eslintrc.js
@@ -1,8 +1,6 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ],
+  extends: ['@fluentui-react-native/eslint-config-rules'],
   rules: {
     '@typescript-eslint/no-var-requires': 0,
-  }
-}
+  },
+};

--- a/packages/utils/test-tools/package.json
+++ b/packages/utils/test-tools/package.json
@@ -21,10 +21,10 @@
     "@fluentui-react-native/theme-types": ">=0.12.4 <1.0.0"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react": ">=16.9.34 < 16.14.0",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react": "16.13.1",
     "react-native": "^0.63.4"
   },

--- a/packages/utils/tokens/.eslintrc.js
+++ b/packages/utils/tokens/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: [
-    "@uifabricshared/eslint-config-rules"
-  ]
-}
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/utils/tokens/package.json
+++ b/packages/utils/tokens/package.json
@@ -28,9 +28,9 @@
     "tslib": "^1.13.0"
   },
   "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react-native": "^0.63.0",
     "@uifabricshared/build-native": "^0.1.1",
-    "@uifabricshared/eslint-config-rules": "^0.1.1",
     "react-native": "^0.63.4"
   },
   "peerDependencies": {

--- a/scripts/src/tasks/depcheck.js
+++ b/scripts/src/tasks/depcheck.js
@@ -22,7 +22,7 @@ function depcheckTask() {
     const options = mergeOneLevel(
       {
         ignorePatterns: ['*eslint*', '/lib/*', '/lib-commonjs/*'],
-        ignoreMatches: ['@uifabricshared/build-native', '@uifabricshared/eslint-config-rules', 'tslib', ...scriptsDevDeps()],
+        ignoreMatches: ['@uifabricshared/build-native', '@fluentui-react-native/eslint-config-rules', 'tslib', ...scriptsDevDeps()],
         specials: [depcheck.special.eslint, depcheck.special.webpack, depcheck.special.jest],
       },
       config.depcheck,


### PR DESCRIPTION
Fixes #1109

### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Rename internal eslint-config-rules package to use fluentui-react-native instead of uifabricshared prefix.

Package was not published based on the beachball configs, but I added the private flag for the package as an extra precaution.

### Verification

Ran linting/test, and depcheck. Both pass. Build also passes.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
