### PR TITLE
chore: enable no-export-all rule

### DIFF
--- a/change/@fluentui-react-native-52e4c067-3c10-45af-b1c6-12a9c26b4d43.json
+++ b/change/@fluentui-react-native-52e4c067-3c10-45af-b1c6-12a9c26b4d43.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Don't `export *` from external packages",
+  "packageName": "@fluentui/react-native",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-framework-9c7b1125-b35f-4aee-b85c-e4e24e07dcc2.json
+++ b/change/@fluentui-react-native-framework-9c7b1125-b35f-4aee-b85c-e4e24e07dcc2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Don't `export *` from external packages",
+  "packageName": "@fluentui-react-native/framework",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/framework/eslint-config-rules/eslintrc.js
+++ b/packages/framework/eslint-config-rules/eslintrc.js
@@ -1,6 +1,7 @@
 module.exports = {
   extends: ['plugin:@rnx-kit/recommended'],
   rules: {
+    '@rnx-kit/no-export-all': ['error', { expand: "external-only" }],
     '@typescript-eslint/consistent-type-assertions': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/interface-name-prefix': 'off',

--- a/packages/framework/framework/src/index.ts
+++ b/packages/framework/framework/src/index.ts
@@ -1,10 +1,84 @@
-export * from '@fluentui-react-native/memo-cache';
-export * from '@fluentui-react-native/merge-props';
-export * from '@fluentui-react-native/tokens';
-export * from '@fluentui-react-native/use-slot';
-export * from '@fluentui-react-native/use-slots';
-export * from '@fluentui-react-native/immutable-merge';
-export * from '@fluentui-react-native/theme-types';
+export { GetMemoValue, getMemoCache, memoize } from '@fluentui-react-native/memo-cache';
+
+export { StyleProp, mergeProps, mergeStyles } from '@fluentui-react-native/merge-props';
+
+export {
+  backgroundColorTokens,
+  borderStyles,
+  borderTokens,
+  colorTokens,
+  fontStyles,
+  foregroundColorTokens,
+  getPaletteFromTheme,
+  layoutStyles,
+  layoutTokens,
+  shadowStyles,
+  shadowTokens,
+  textTokens,
+  tokenBuilder,
+} from '@fluentui-react-native/tokens';
+export type {
+  FontStyleTokens,
+  FontTokens,
+  FontVariantTokens,
+  IBackgroundColorTokens,
+  IBorderTokens,
+  IColorTokens,
+  IForegroundColorTokens,
+  IShadowTokens,
+  LayoutTokens,
+  TokenBuilder,
+} from '@fluentui-react-native/tokens';
+
+export { renderSlot, stagedComponent, useSlot, withSlots } from '@fluentui-react-native/use-slot';
+export type { ComposableFunction, FinalRender, NativeReactType, SlotFn, StagedRender } from '@fluentui-react-native/use-slot';
+
+export { buildUseSlots } from '@fluentui-react-native/use-slots';
+export type { GetSlotProps, Slots, UseSlotOptions, UseSlotsBase } from '@fluentui-react-native/use-slots';
+
+export { immutableMerge, immutableMergeCore, processImmutable } from '@fluentui-react-native/immutable-merge';
+export type {
+  BuiltinRecursionHandlers,
+  CustomRecursionHandler,
+  MergeOptions,
+  RecursionHandler,
+  RecursionOption,
+} from '@fluentui-react-native/immutable-merge';
+
+export { ThemeContext, useTheme } from '@fluentui-react-native/theme-types';
+export type {
+  AliasColorTokens,
+  AppearanceOptions,
+  Color,
+  ControlColorTokens,
+  FabricWebPalette,
+  FontFamilies,
+  FontFamily,
+  FontFamilyValue,
+  FontSize,
+  FontSizeValuePoints,
+  FontSizes,
+  FontWeight,
+  FontWeightValue,
+  FontWeights,
+  OfficePalette,
+  Palette,
+  PaletteBackgroundColors,
+  PaletteTextColors,
+  PartialPalette,
+  PartialTheme,
+  PartialTypography,
+  Spacing,
+  TextStyling,
+  Theme,
+  ThemeColorDefinition,
+  ThemeOptions,
+  Typography,
+  Variant,
+  VariantValue,
+  Variants,
+} from '@fluentui-react-native/theme-types';
+
 export * from './compose';
 export * from './compressible';
 export * from './useFluentTheme';

--- a/packages/libraries/core/src/index.ts
+++ b/packages/libraries/core/src/index.ts
@@ -1,16 +1,246 @@
-export * from '@fluentui-react-native/button';
-export * from '@fluentui-react-native/callout';
-export * from '@fluentui-react-native/checkbox';
-export * from '@fluentui-react-native/contextual-menu';
-export * from '@fluentui-react-native/focus-trap-zone';
-export * from '@fluentui-react-native/focus-zone';
-export * from '@fluentui-react-native/link';
-export * from '@fluentui-react-native/persona';
-export * from '@fluentui-react-native/persona-coin';
-export * from '@fluentui-react-native/pressable';
-export * from '@fluentui-react-native/radio-group';
-export * from '@fluentui-react-native/separator';
-export * from '@fluentui-react-native/text';
-export * from '@fluentui-react-native/interactive-hooks';
-export * from '@fluentui-react-native/menu-button';
-export * from '@fluentui-react-native/tabs';
+export { Button, PrimaryButton, StealthButton, buttonName } from '@fluentui-react-native/button';
+export type {
+  IButtonInfo,
+  IButtonProps,
+  IButtonRenderData,
+  IButtonSlotProps,
+  IButtonState,
+  IButtonTokens,
+  IButtonType,
+} from '@fluentui-react-native/button';
+
+export { Callout, calloutName } from '@fluentui-react-native/callout';
+export type {
+  DirectionalHint,
+  DismissBehaviors,
+  ICalloutProps,
+  ICalloutRenderData,
+  ICalloutSlotProps,
+  ICalloutTokens,
+  ICalloutType,
+  RestoreFocusEvent,
+} from '@fluentui-react-native/callout';
+
+export { Checkbox, checkboxName } from '@fluentui-react-native/checkbox';
+export type {
+  ICheckboxProps,
+  ICheckboxRenderData,
+  ICheckboxSlotProps,
+  ICheckboxState,
+  ICheckboxTokens,
+  ICheckboxType,
+} from '@fluentui-react-native/checkbox';
+
+export {
+  CMContext,
+  ContextualMenu,
+  ContextualMenuItem,
+  Submenu,
+  SubmenuItem,
+  contextualMenuItemName,
+  contextualMenuName,
+  submenuItemName,
+  submenuName,
+} from '@fluentui-react-native/contextual-menu';
+export type {
+  ContextualMenuContext,
+  ContextualMenuItemProps,
+  ContextualMenuItemRenderData,
+  ContextualMenuItemSlotProps,
+  ContextualMenuItemState,
+  ContextualMenuItemTokens,
+  ContextualMenuItemType,
+  ContextualMenuProps,
+  ContextualMenuRenderData,
+  ContextualMenuSlotProps,
+  ContextualMenuState,
+  ContextualMenuTokens,
+  ContextualMenuType,
+  SubmenuItemProps,
+  SubmenuItemRenderData,
+  SubmenuItemSlotProps,
+  SubmenuItemState,
+  SubmenuItemTokens,
+  SubmenuItemType,
+  SubmenuProps,
+  SubmenuRenderData,
+  SubmenuSlotProps,
+  SubmenuState,
+  SubmenuTokens,
+  SubmenuType,
+} from '@fluentui-react-native/contextual-menu';
+
+export { FocusTrapZone, filterOutComponentRef } from '@fluentui-react-native/focus-trap-zone';
+export type { IFocusTrapZoneProps, IFocusTrapZoneSlotProps, IFocusTrapZoneType } from '@fluentui-react-native/focus-trap-zone';
+
+export { FocusZone, focusZoneName } from '@fluentui-react-native/focus-zone';
+export type {
+  FocusZoneDirection,
+  FocusZoneProps,
+  FocusZoneRenderData,
+  FocusZoneSlotProps,
+  FocusZoneState,
+  FocusZoneTokens,
+  FocusZoneType,
+  NativeProps,
+  NavigateAtEnd,
+} from '@fluentui-react-native/focus-zone';
+
+export { Link, linkName, useAsLink } from '@fluentui-react-native/link';
+export type {
+  ILinkHooks,
+  ILinkInfo,
+  ILinkOptions,
+  ILinkProps,
+  ILinkRenderData,
+  ILinkSlotProps,
+  ILinkState,
+  ILinkTokens,
+  ILinkType,
+  IWithLinkOptions,
+} from '@fluentui-react-native/link';
+
+export { Persona, personaName } from '@fluentui-react-native/persona';
+export type {
+  IPersonaProps,
+  IPersonaRenderData,
+  IPersonaSlotProps,
+  IPersonaState,
+  IPersonaTokens,
+  IPersonaType,
+} from '@fluentui-react-native/persona';
+
+export { PersonaCoin, buildRootStyles, personaCoinName } from '@fluentui-react-native/persona-coin';
+export type {
+  IPersonaCoinProps,
+  IPersonaCoinRenderData,
+  IPersonaCoinSlotProps,
+  IPersonaCoinState,
+  IPersonaCoinTokens,
+  IPersonaCoinType,
+  IPersonaConfigurableProps,
+  IconAlignment,
+  PersonaCoinColor,
+  PersonaCoinFluentColor,
+  PersonaPresence,
+  PersonaSize,
+  RingConfig,
+  RingThickness,
+} from '@fluentui-react-native/persona-coin';
+
+export { Pressable } from '@fluentui-react-native/pressable';
+export type { IChildAsFunction, IPressableProps, IPressableType, IRenderChild, IRenderStyle } from '@fluentui-react-native/pressable';
+
+export { RadioButton, RadioGroup, RadioGroupContext, radioButtonName, radioGroupName } from '@fluentui-react-native/radio-group';
+export type {
+  IRadioButtonProps,
+  IRadioButtonRenderData,
+  IRadioButtonSlotProps,
+  IRadioButtonTokens,
+  IRadioButtonType,
+  IRadioGroupContext,
+  IRadioGroupProps,
+  IRadioGroupRenderData,
+  IRadioGroupSlotProps,
+  IRadioGroupState,
+  IRadioGroupTokens,
+  IRadioGroupType,
+} from '@fluentui-react-native/radio-group';
+
+export { Separator, separatorName } from '@fluentui-react-native/separator';
+export type { SeparatorProps, SeparatorTokens, SeparatorType } from '@fluentui-react-native/separator';
+
+export { Text, textName } from '@fluentui-react-native/text';
+export type { ITextProps, ITextType } from '@fluentui-react-native/text';
+
+export {
+  createIconProps,
+  normalizeRect,
+  useAsPressable,
+  useAsToggle,
+  useFocusState,
+  useHoverState,
+  useKeyCallback,
+  useOnPressWithFocus,
+  usePressState,
+  usePressability,
+  usePressableState,
+  useSelectedKey,
+  useViewCommandFocus,
+} from '@fluentui-react-native/interactive-hooks';
+export type {
+  AbstractComponent,
+  BlurEvent,
+  ComponentMethods,
+  FocusEvent,
+  HostComponent,
+  IFocusState,
+  IFocusable,
+  IHoverState,
+  IPressState,
+  IPressableHooks,
+  IPressableOptions,
+  IPressableState,
+  IWithPressableEvents,
+  IWithPressableOptions,
+  KeyPressEvent,
+  KeyUpCallback,
+  Layout,
+  LayoutEvent,
+  MeasureInWindowOnSuccessCallback,
+  MeasureLayoutOnSuccessCallback,
+  MeasureOnSuccessCallback,
+  MouseEvent,
+  NativeMethods,
+  OnChangeCallback,
+  OnPressCallback,
+  OnPressWithFocusCallback,
+  OnToggleCallback,
+  PressEvent,
+  PressabilityConfig,
+  PressabilityEventHandlers,
+  PressableFocusProps,
+  PressableHoverEventProps,
+  PressableHoverProps,
+  PressablePressProps,
+  PressablePropsExtended,
+  Rect,
+  RectOrSize,
+  ResponderSyntheticEvent,
+  ScrollEvent,
+  SyntheticEvent,
+  TextLayout,
+  TextLayoutEvent,
+  onKeySelectCallback,
+} from '@fluentui-react-native/interactive-hooks';
+
+export { MenuButton, MenuButtonName } from '@fluentui-react-native/menu-button';
+export type {
+  MenuButtonContext,
+  MenuButtonItemProps,
+  MenuButtonProps,
+  MenuButtonRenderData,
+  MenuButtonSlotProps,
+  MenuButtonState,
+  MenuButtonTokens,
+  MenuButtonType,
+} from '@fluentui-react-native/menu-button';
+
+export { Tabs, TabsContext, TabsItem, tabsItemName, tabsName } from '@fluentui-react-native/tabs';
+export type {
+  TabsContextData,
+  TabsInfo,
+  TabsItemInfo,
+  TabsItemProps,
+  TabsItemRenderData,
+  TabsItemSlotProps,
+  TabsItemState,
+  TabsItemTokens,
+  TabsItemType,
+  TabsProps,
+  TabsRenderData,
+  TabsSlotProps,
+  TabsState,
+  TabsTokens,
+  TabsType,
+} from '@fluentui-react-native/tabs';


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Enables the no-export-all rule for exports from external packages.

More on why `export *` is bad here: https://hackmd.io/Z021hgSGStKlYLwsqNMOcg

### Verification

Build should succeed.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
