### PR TITLE
Add palette fallback to new win32 theme code

### DIFF
--- a/apps/fluent-tester/src/FluentTester/theme/applyTheme.ts
+++ b/apps/fluent-tester/src/FluentTester/theme/applyTheme.ts
@@ -55,7 +55,7 @@ const themingModule = getThemingModule()[0];
 export function applyTheme(parent: Theme, name: ThemeNames, appearance: ThemeOptions['appearance']): PartialTheme {
   switch (name) {
     case 'Office':
-      return themingModule ? createOfficeTheme({ appearance, paletteName: 'WhiteColors' }).theme : {};
+      return themingModule ? createOfficeTheme({ appearance, paletteName: 'Menus_FluentSV' }).theme : {};
     case 'Caterpillar':
       return applyCaterpillarTheme(parent);
     default:

--- a/change/@fluentui-react-native-tester-51dc8b75-0a0a-43f5-ae72-5b5db72988b7.json
+++ b/change/@fluentui-react-native-tester-51dc8b75-0a0a-43f5-ae72-5b5db72988b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add fallback palette and update test palette",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-win32-theme-d33edc26-7ed3-4f6d-ae43-6d6709bdbc41.json
+++ b/change/@fluentui-react-native-win32-theme-d33edc26-7ed3-4f6d-ae43-6d6709bdbc41.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add fallback palette and update test palette",
+  "packageName": "@fluentui-react-native/win32-theme",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/docs/pages/Theming/DefaultThemes.md
+++ b/docs/pages/Theming/DefaultThemes.md
@@ -16,7 +16,7 @@ On win32, we allow for better integration with an Office host.
 
 On win32, we allow for integration with Office theming via an `OfficeThemingModule`. Office has a native module which provides information about the queried palette based on the current Office theme. FURN uses the information to populate `theme.colors`, but the palette is available as well under `theme.host.palette`.
 
-You can create a theme using information from Office by calling `createOfficeTheme()`. By default, we use the `WhiteColors` palette. You can also ask for a specific palette's values by passing in a `paletteName` as part of the `ThemeOptions` passed into `createOfficeTheme()`:
+You can create a theme using information from Office by calling `createOfficeTheme()`. By default, we use the `Menus_FluentSV` palette. You can also ask for a specific palette's values by passing in a `paletteName` as part of the `ThemeOptions` passed into `createOfficeTheme()`:
 
 ```tsx
 import { ThemeProvider } from '@fluentui-react-native/theme';

--- a/packages/theming/win32-theme/src/createOfficeTheme.ts
+++ b/packages/theming/win32-theme/src/createOfficeTheme.ts
@@ -30,7 +30,7 @@ export function createOfficeTheme(options: ThemeOptions = {}): ThemeReference {
   const themeRef = new ThemeReference(
     createDefaultTheme(options),
     () => {
-      const name = paletteName || '';
+      const name = paletteName || 'Menus_FluentSV';
       const palette = handlePaletteCall(ref.module.getPalette(name));
       return createPartialOfficeTheme(module, ref.themeName, palette);
     },


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Apparently the fallback code to default to a palette when none is provided wasn't ported to the new theme code.

Adding code to fall back to Menus_FluentSV palette by default, which aligns with the newest visuals. Also updating tester to use new theme.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
