### PR TITLE
Added new Button props - shape and icon-position

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonIconTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonIconTestSection.tsx
@@ -28,6 +28,12 @@ export const ButtonIconTest: React.FunctionComponent = () => {
         content="Font icon"
         style={commonTestStyles.vmargin}
       />
+      <Button
+        icon={{ fontSource: { ...fontBuiltInProps, fontSize: 32 }, color: '#060' }}
+        content="Icon after"
+        style={commonTestStyles.vmargin}
+        iconPosition="after"
+      />
       <Button icon={{ fontSource: fontBuiltInProps }} content="Font icon" style={commonTestStyles.vmargin} />
       <Button appearance="primary" icon={{ fontSource: fontBuiltInProps }} content="Font icon" style={commonTestStyles.vmargin} />
       {svgIconsEnabled && (

--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonShapeTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonShapeTestSection.tsx
@@ -1,0 +1,17 @@
+import { Button } from '@fluentui-react-native/experimental-button';
+import * as React from 'react';
+import { View } from 'react-native';
+import { commonTestStyles, stackStyle } from '../Common/styles';
+
+export const ButtonShapeTest: React.FunctionComponent = () => {
+  return (
+    <View style={[stackStyle, commonTestStyles.view]}>
+      <Button shape="rounded" content="Default Rounded Button" />
+      <Button shape="square" content="Square Button" />
+      <Button shape="circular" content="Circular Button" />
+      <Button appearance="primary" shape="rounded" content="Default Rounded Button" />
+      <Button appearance="primary" shape="square" content="Square Button" />
+      <Button appearance="primary" shape="circular" content="Circular Button" />
+    </View>
+  );
+};

--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonShapeTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonShapeTestSection.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@fluentui-react-native/experimental-button';
+import { Button, CompoundButton } from '@fluentui-react-native/experimental-button';
 import * as React from 'react';
 import { View } from 'react-native';
 import { commonTestStyles, stackStyle } from '../Common/styles';
@@ -6,12 +6,15 @@ import { commonTestStyles, stackStyle } from '../Common/styles';
 export const ButtonShapeTest: React.FunctionComponent = () => {
   return (
     <View style={[stackStyle, commonTestStyles.view]}>
-      <Button shape="rounded" content="Default Rounded Button" />
-      <Button shape="square" content="Square Button" />
-      <Button shape="circular" content="Circular Button" />
-      <Button appearance="primary" shape="rounded" content="Default Rounded Button" />
-      <Button appearance="primary" shape="square" content="Square Button" />
-      <Button appearance="primary" shape="circular" content="Circular Button" />
+      <Button shape="rounded" content="Default Rounded Button" style={commonTestStyles.vmargin} />
+      <Button shape="square" content="Square Button" style={commonTestStyles.vmargin} />
+      <Button shape="circular" content="Circular Button" style={commonTestStyles.vmargin} />
+      <Button appearance="primary" shape="rounded" content="Primary Rounded Button" style={commonTestStyles.vmargin} />
+      <Button appearance="primary" shape="square" content="Square Button" style={commonTestStyles.vmargin} />
+      <Button appearance="primary" shape="circular" content="Circular Button" style={commonTestStyles.vmargin} />
+      <CompoundButton content="Compound Button" secondaryContent="rounded" shape="rounded" style={commonTestStyles.vmargin} />
+      <CompoundButton content="Compound Button" secondaryContent="square" shape="square" style={commonTestStyles.vmargin} />
+      <CompoundButton content="Compound Button" secondaryContent="circular" shape="circular" style={commonTestStyles.vmargin} />
     </View>
   );
 };

--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonTest.tsx
@@ -5,12 +5,17 @@ import { ExperimentalButtonTestPageId } from './consts';
 import { Test, TestSection, PlatformStatus } from '../Test';
 import { ButtonIconTest } from './ButtonIconTestSection';
 import { ButtonSizeTest } from './ButtonSizeTestSection';
+import { ButtonShapeTest } from './ButtonShapeTestSection';
 
 const buttonSections: TestSection[] = [
   {
     name: 'Button Variants',
     testID: ExperimentalButtonTestPageId,
     component: ButtonVariantTest,
+  },
+  {
+    name: 'Button Shape',
+    component: ButtonShapeTest,
   },
   {
     name: 'Icon Button',

--- a/change/@fluentui-react-native-experimental-button-3c50aeaf-cac2-4dd8-8254-2d625d285429.json
+++ b/change/@fluentui-react-native-experimental-button-3c50aeaf-cac2-4dd8-8254-2d625d285429.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added new props for Button (shape, icon-position)",
+  "packageName": "@fluentui-react-native/experimental-button",
+  "email": "v.kozlova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-40c82c05-5ab3-4b78-b686-da4cc57c876a.json
+++ b/change/@fluentui-react-native-tester-40c82c05-5ab3-4b78-b686-da4cc57c876a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added new props for Button (shape, icon-position)",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "v.kozlova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Button/src/Button.styling.ts
+++ b/packages/experimental/Button/src/Button.styling.ts
@@ -21,6 +21,9 @@ export const buttonStates: (keyof ButtonTokens)[] = [
   'large',
   'hasContent',
   'hasIcon',
+  'rounded',
+  'circular',
+  'square',
 ];
 
 export const stylingSettings: UseStylingOptions<ButtonProps, ButtonSlotProps, ButtonTokens> = {

--- a/packages/experimental/Button/src/Button.tsx
+++ b/packages/experimental/Button/src/Button.tsx
@@ -24,6 +24,8 @@ export const buttonLookup = (layer: string, state: IPressableState, userProps: B
     layer === userProps['appearance'] ||
     layer === userProps['size'] ||
     (!userProps['size'] && layer === getDefaultSize()) ||
+    layer === userProps['shape'] ||
+    (!userProps['shape'] && layer === 'rounded') ||
     (layer === 'hasContent' && userProps.content) ||
     (layer === 'hasIcon' && userProps.icon)
   );

--- a/packages/experimental/Button/src/Button.tsx
+++ b/packages/experimental/Button/src/Button.tsx
@@ -47,12 +47,13 @@ export const Button = compose<ButtonType>({
 
     // now return the handler for finishing render
     return (final: ButtonProps, ...children: React.ReactNode[]) => {
-      const { icon, content, ...mergedProps } = mergeProps(button.props, final);
+      const { icon, iconPosition, content, ...mergedProps } = mergeProps(button.props, final);
       return (
         <Slots.root {...mergedProps}>
-          {icon && <Slots.icon {...iconProps} />}
+          {icon && iconPosition === 'before' && <Slots.icon {...iconProps} />}
           {content && <Slots.content key="content">{content}</Slots.content>}
           {children}
+          {icon && iconPosition === 'after' && <Slots.icon {...iconProps} />}
         </Slots.root>
       );
     };

--- a/packages/experimental/Button/src/Button.types.ts
+++ b/packages/experimental/Button/src/Button.types.ts
@@ -9,6 +9,7 @@ import { IconProps, IconSourcesType } from '@fluentui-react-native/icon';
 export const buttonName = 'Button';
 export type ButtonSize = 'small' | 'medium' | 'large';
 export type ButtonAppearance = 'primary' | 'subtle';
+export type ButtonShape = 'rounded' | 'circular' | 'square';
 
 export interface ButtonCoreTokens extends LayoutTokens, FontTokens, IBorderTokens, IShadowTokens, IColorTokens {
   /**
@@ -67,6 +68,9 @@ export interface ButtonTokens extends ButtonCoreTokens {
   small?: ButtonTokens;
   medium?: ButtonTokens;
   large?: ButtonTokens;
+  rounded?: ButtonTokens;
+  circular?: ButtonTokens;
+  square?: ButtonTokens;
 }
 
 export interface ButtonCoreProps extends Omit<IWithPressableOptions<ViewProps>, 'onPress'> {
@@ -106,6 +110,12 @@ export interface ButtonProps extends ButtonCoreProps {
 
   /** Sets style of button to a preset size style  */
   size?: ButtonSize;
+
+  /**
+   * Button shape: 'rounded' | 'circular' | 'square'
+   * @defaultvalue rounded
+   */
+  shape?: ButtonShape;
 }
 
 export type ButtonState = IPressableHooks<ButtonProps & React.ComponentPropsWithRef<any>>;

--- a/packages/experimental/Button/src/Button.types.ts
+++ b/packages/experimental/Button/src/Button.types.ts
@@ -47,9 +47,6 @@ export interface ButtonCoreTokens extends LayoutTokens, FontTokens, IBorderToken
    */
   spacingIconContent?: number;
 
-  rightIcon?: ButtonTokens;
-  leftIcon?: ButtonTokens;
-
   /**
    * States that can be applied to a button
    */
@@ -122,7 +119,7 @@ export interface ButtonProps extends ButtonCoreProps {
 
   /**
    * Icon can be placed before or after Button's content.
-   * @default 'before'
+   * @default before
    */
   iconPosition?: 'before' | 'after';
 }

--- a/packages/experimental/Button/src/Button.types.ts
+++ b/packages/experimental/Button/src/Button.types.ts
@@ -47,6 +47,9 @@ export interface ButtonCoreTokens extends LayoutTokens, FontTokens, IBorderToken
    */
   spacingIconContent?: number;
 
+  rightIcon?: ButtonTokens;
+  leftIcon?: ButtonTokens;
+
   /**
    * States that can be applied to a button
    */
@@ -116,6 +119,12 @@ export interface ButtonProps extends ButtonCoreProps {
    * @defaultvalue rounded
    */
   shape?: ButtonShape;
+
+  /**
+   * Icon can be placed before or after Button's content.
+   * @default 'before'
+   */
+  iconPosition?: 'before' | 'after';
 }
 
 export type ButtonState = IPressableHooks<ButtonProps & React.ComponentPropsWithRef<any>>;

--- a/packages/experimental/Button/src/ButtonTokens.ts
+++ b/packages/experimental/Button/src/ButtonTokens.ts
@@ -11,7 +11,6 @@ export const defaultButtonTokens: TokenSettings<ButtonTokens, Theme> = () =>
     medium: {
       padding: globalTokens.spacing.sNudge - globalTokens.stroke.width.thin,
       borderWidth: globalTokens.stroke.width.thin,
-      borderRadius: globalTokens.corner.radius.medium,
       iconSize: 16,
       hasContent: {
         minWidth: 96,
@@ -25,7 +24,6 @@ export const defaultButtonTokens: TokenSettings<ButtonTokens, Theme> = () =>
     small: {
       padding: globalTokens.spacing.xs - globalTokens.stroke.width.thin,
       borderWidth: globalTokens.stroke.width.thin,
-      borderRadius: globalTokens.corner.radius.medium,
       iconSize: 16,
       hasContent: {
         minWidth: 64,
@@ -39,7 +37,6 @@ export const defaultButtonTokens: TokenSettings<ButtonTokens, Theme> = () =>
     large: {
       padding: globalTokens.spacing.s - globalTokens.stroke.width.thin,
       borderWidth: globalTokens.stroke.width.thin,
-      borderRadius: globalTokens.corner.radius.medium,
       iconSize: 20,
       hasContent: {
         minWidth: 96,
@@ -49,5 +46,14 @@ export const defaultButtonTokens: TokenSettings<ButtonTokens, Theme> = () =>
           spacingIconContent: globalTokens.spacing.sNudge,
         },
       },
+    },
+    rounded: {
+      borderRadius: globalTokens.corner.radius.medium,
+    },
+    circular: {
+      borderRadius: globalTokens.corner.radius.circle,
+    },
+    square: {
+      borderRadius: globalTokens.corner.radius.none,
     },
   } as ButtonTokens);

--- a/packages/experimental/Button/src/CompoundButton/CompoundButtonTokens.ts
+++ b/packages/experimental/Button/src/CompoundButton/CompoundButtonTokens.ts
@@ -6,7 +6,6 @@ import { CompoundButtonTokens } from './CompoundButton.types';
 export const defaultCompoundButtonTokens: TokenSettings<CompoundButtonTokens, Theme> = (): CompoundButtonTokens => ({
   small: {
     padding: globalTokens.spacing.s - globalTokens.stroke.width.thin,
-    borderRadius: globalTokens.corner.radius.medium,
     hasContent: {
       paddingHorizontal: globalTokens.spacing.s - globalTokens.stroke.width.thin,
       minWidth: 64,

--- a/packages/experimental/Button/src/CompoundButton/__snapshots__/CompoundButton.test.tsx.snap
+++ b/packages/experimental/Button/src/CompoundButton/__snapshots__/CompoundButton.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`CompoundButton default 1`] = `
   }
   accessible={true}
   focusable={true}
+  iconPosition="before"
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}

--- a/packages/experimental/Button/src/ToggleButton/__snapshots__/ToggleButton.test.tsx.snap
+++ b/packages/experimental/Button/src/ToggleButton/__snapshots__/ToggleButton.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`ToggleButton default 1`] = `
   }
   accessible={true}
   focusable={true}
+  iconPosition="before"
   onAccessibilityTap={[Function]}
   onBlur={[Function]}
   onClick={[Function]}

--- a/packages/experimental/Button/src/useButton.ts
+++ b/packages/experimental/Button/src/useButton.ts
@@ -22,6 +22,7 @@ export const useButton = (props: ButtonProps): ButtonState => {
       focusable: true,
       ref: useViewCommandFocus(componentRef),
       onKeyUp: onKeyUp,
+      iconPosition: props.iconPosition || 'before',
     },
     state: pressable.state,
   };


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
Added shape and icon-position props.

TODO: style icon for 'right' position. I'll do it when remove 'content'prop because currently spacingIconContent prop depends on hasContent prop.

### Verification
Checked manually.
![image](https://user-images.githubusercontent.com/11574680/143134725-bd920799-e815-4e26-9817-f6815db904cd.png)
![image](https://user-images.githubusercontent.com/11574680/143090759-32693c7d-17a1-4063-b2bc-228cd0f4d6eb.png)


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
