### PR TITLE
Removed content prop from the Button component

### DIFF
--- a/apps/fluent-tester/src/FluentTester/FluentTester.tsx
+++ b/apps/fluent-tester/src/FluentTester/FluentTester.tsx
@@ -116,11 +116,12 @@ export const FluentTester: React.FunctionComponent<FluentTesterProps> = (props: 
           {/* on iOS, display a back Button */}
           <Button
             appearance="subtle"
-            content="‹ Back"
             style={{ alignSelf: 'flex-start', display: Platform.OS === 'ios' ? 'flex' : 'none' }}
             onClick={onBackPress}
             disabled={onTestListView}
-          />
+          >
+            ‹ Back
+          </Button>
           <ThemePickers />
         </View>
       </View>
@@ -140,11 +141,12 @@ export const FluentTester: React.FunctionComponent<FluentTesterProps> = (props: 
                 appearance="subtle"
                 key={index}
                 disabled={index == selectedTestIndex}
-                content={description.name}
                 onClick={() => setSelectedTestIndex(index)}
                 style={fluentTesterStyles.testListItem}
                 testID={description.testPage}
-              />
+              >
+                {description.name}
+              </Button>
             );
           })}
         </ScrollView>

--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonIconTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonIconTestSection.tsx
@@ -4,6 +4,7 @@ import { Platform, View } from 'react-native';
 import { commonTestStyles, stackStyle } from '../Common/styles';
 import { SvgIconProps } from '@fluentui-react-native/icon';
 import TestSvg from './test.svg';
+import { SvgXml } from 'react-native-svg';
 
 export const ButtonIconTest: React.FunctionComponent = () => {
   const fontBuiltInProps = {
@@ -21,29 +22,49 @@ export const ButtonIconTest: React.FunctionComponent = () => {
   };
   const svgIconsEnabled = ['ios', 'macos', 'win32', 'android'].includes(Platform.OS as string);
 
+  const chevronXml = `
+          <svg width="12" height="16" viewBox="0 0 11 6" color="#000">
+            <path fill='currentColor' d='M0.646447 0.646447C0.841709 0.451184 1.15829 0.451184 1.35355 0.646447L5.5 4.79289L9.64645 0.646447C9.84171 0.451185 10.1583 0.451185 10.3536 0.646447C10.5488 0.841709 10.5488 1.15829 10.3536 1.35355L5.85355 5.85355C5.65829 6.04882 5.34171 6.04882 5.14645 5.85355L0.646447 1.35355C0.451184 1.15829 0.451184 0.841709 0.646447 0.646447Z' />
+          </svg>`;
+
   return (
     <View style={[stackStyle, commonTestStyles.view]}>
+      <Button icon={{ fontSource: { ...fontBuiltInProps, fontSize: 32 }, color: '#060' }} style={commonTestStyles.vmargin}>
+        Font icon
+      </Button>
       <Button
         icon={{ fontSource: { ...fontBuiltInProps, fontSize: 32 }, color: '#060' }}
-        content="Font icon"
-        style={commonTestStyles.vmargin}
-      />
-      <Button
-        icon={{ fontSource: { ...fontBuiltInProps, fontSize: 32 }, color: '#060' }}
-        content="Icon after"
         style={commonTestStyles.vmargin}
         iconPosition="after"
-      />
-      <Button icon={{ fontSource: fontBuiltInProps }} content="Font icon" style={commonTestStyles.vmargin} />
-      <Button appearance="primary" icon={{ fontSource: fontBuiltInProps }} content="Font icon" style={commonTestStyles.vmargin} />
+      >
+        Icon after
+      </Button>
+      <Button style={commonTestStyles.vmargin} icon={{ svgSource: svgProps }}>
+        Icon Button and Chevron
+        <SvgXml xml={chevronXml} style={{ marginLeft: 4 }} />
+      </Button>
+      <Button icon={{ fontSource: fontBuiltInProps }} style={commonTestStyles.vmargin}>
+        Font icon
+      </Button>
+      <Button appearance="primary" icon={{ fontSource: fontBuiltInProps }} style={commonTestStyles.vmargin}>
+        Font icon
+      </Button>
       {svgIconsEnabled && (
         <>
-          <Button appearance="primary" icon={{ svgSource: svgProps, color: 'red' }} content="SVG" style={commonTestStyles.vmargin} />
-          <Button icon={{ svgSource: svgProps }} content="SVG" style={commonTestStyles.vmargin} />
+          <Button appearance="primary" icon={{ svgSource: svgProps, color: 'red' }} style={commonTestStyles.vmargin}>
+            SVG
+          </Button>
+          <Button icon={{ svgSource: svgProps }} style={commonTestStyles.vmargin}>
+            SVG
+          </Button>
         </>
       )}
-      <Button appearance="primary" icon={testImage} content="PNG" style={commonTestStyles.vmargin} />
-      <Button icon={testImage} content="PNG" style={commonTestStyles.vmargin} />
+      <Button appearance="primary" icon={testImage} style={commonTestStyles.vmargin}>
+        PNG
+      </Button>
+      <Button icon={testImage} style={commonTestStyles.vmargin}>
+        PNG
+      </Button>
     </View>
   );
 };

--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonIconTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonIconTestSection.tsx
@@ -41,7 +41,7 @@ export const ButtonIconTest: React.FunctionComponent = () => {
       </Button>
       <Button style={commonTestStyles.vmargin} icon={{ svgSource: svgProps }}>
         Icon Button and Chevron
-        <SvgXml xml={chevronXml} style={{ marginLeft: 4 }} />
+        <SvgXml xml={chevronXml} />
       </Button>
       <Button icon={{ fontSource: fontBuiltInProps }} style={commonTestStyles.vmargin}>
         Font icon

--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonShapeTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonShapeTestSection.tsx
@@ -6,12 +6,24 @@ import { commonTestStyles, stackStyle } from '../Common/styles';
 export const ButtonShapeTest: React.FunctionComponent = () => {
   return (
     <View style={[stackStyle, commonTestStyles.view]}>
-      <Button shape="rounded" content="Default Rounded Button" style={commonTestStyles.vmargin} />
-      <Button shape="square" content="Square Button" style={commonTestStyles.vmargin} />
-      <Button shape="circular" content="Circular Button" style={commonTestStyles.vmargin} />
-      <Button appearance="primary" shape="rounded" content="Primary Rounded Button" style={commonTestStyles.vmargin} />
-      <Button appearance="primary" shape="square" content="Square Button" style={commonTestStyles.vmargin} />
-      <Button appearance="primary" shape="circular" content="Circular Button" style={commonTestStyles.vmargin} />
+      <Button shape="rounded" style={commonTestStyles.vmargin}>
+        Default Rounded Button
+      </Button>
+      <Button shape="square" style={commonTestStyles.vmargin}>
+        Square Button
+      </Button>
+      <Button shape="circular" style={commonTestStyles.vmargin}>
+        Circular Button
+      </Button>
+      <Button appearance="primary" shape="rounded" style={commonTestStyles.vmargin}>
+        Primary Rounded Button
+      </Button>
+      <Button appearance="primary" shape="square" style={commonTestStyles.vmargin}>
+        Square Button
+      </Button>
+      <Button appearance="primary" shape="circular" style={commonTestStyles.vmargin}>
+        Circular Button
+      </Button>
       <CompoundButton content="Compound Button" secondaryContent="rounded" shape="rounded" style={commonTestStyles.vmargin} />
       <CompoundButton content="Compound Button" secondaryContent="square" shape="square" style={commonTestStyles.vmargin} />
       <CompoundButton content="Compound Button" secondaryContent="circular" shape="circular" style={commonTestStyles.vmargin} />

--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonSizeTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonSizeTestSection.tsx
@@ -16,17 +16,32 @@ export const ButtonSizeTest: React.FunctionComponent = () => {
     <View style={[stackStyle, commonTestStyles.view]}>
       {svgIconsEnabled && (
         <>
-          <Button size="small" icon={{ svgSource: svgProps }} style={commonTestStyles.vmargin} />
-          <Button size="medium" icon={{ svgSource: svgProps }} style={commonTestStyles.vmargin} />
-          <Button size="large" icon={{ svgSource: svgProps }} style={commonTestStyles.vmargin} />
+          <Button iconOnly size="small" icon={{ svgSource: svgProps }} style={commonTestStyles.vmargin} />
+          <Button iconOnly size="medium" icon={{ svgSource: svgProps }} style={commonTestStyles.vmargin} />
+          <Button iconOnly size="large" icon={{ svgSource: svgProps }} style={commonTestStyles.vmargin} />
+          <Button size="small" icon={{ svgSource: svgProps }} style={commonTestStyles.vmargin}>
+            Small Button with icon
+          </Button>
+          <Button size="medium" icon={{ svgSource: svgProps }} style={commonTestStyles.vmargin}>
+            Medium Button with icon
+          </Button>
+          <Button size="large" icon={{ svgSource: svgProps }} style={commonTestStyles.vmargin}>
+            Large Button with icon
+          </Button>
         </>
       )}
-      <Button size="small" content="Small" style={commonTestStyles.vmargin} />
-      <Button size="medium" content="Medium" style={commonTestStyles.vmargin} />
-      <Button size="large" content="Large" style={commonTestStyles.vmargin} />
-      <CompoundButton size="small" content="Small" secondaryContent="Compound" style={commonTestStyles.vmargin} />
-      <CompoundButton size="medium" content="Medium" secondaryContent="Compound" style={commonTestStyles.vmargin} />
-      <CompoundButton size="large" content="Large" secondaryContent="Compound" style={commonTestStyles.vmargin} />
+      <Button size="small" style={commonTestStyles.vmargin}>
+        Small
+      </Button>
+      <Button size="medium" style={commonTestStyles.vmargin}>
+        Medium
+      </Button>
+      <Button size="large" style={commonTestStyles.vmargin}>
+        Large
+      </Button>
+      <CompoundButton content="Compound Button" secondaryContent="rounded" shape="rounded" style={commonTestStyles.vmargin} />
+      <CompoundButton content="Compound Button" secondaryContent="square" shape="square" style={commonTestStyles.vmargin} />
+      <CompoundButton content="Compound Button" secondaryContent="circular" shape="circular" style={commonTestStyles.vmargin} />
     </View>
   );
 };

--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonVariantTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonVariantTestSection.tsx
@@ -13,12 +13,22 @@ export const ButtonVariantTest: React.FunctionComponent = () => {
 
   return (
     <View style={[stackStyle, commonTestStyles.view]}>
-      <Button content="Default" style={commonTestStyles.vmargin} />
-      <Button appearance="primary" content="Primary" style={commonTestStyles.vmargin} />
-      <Button appearance="subtle" content="Subtle" style={commonTestStyles.vmargin} />
-      <Button block content="Block" style={commonTestStyles.vmargin} />
-      <Button appearance="primary" block content="Block Primary" style={commonTestStyles.vmargin} />
-      <Button appearance="subtle" block content="Block Subtle" style={commonTestStyles.vmargin} />
+      <Button style={commonTestStyles.vmargin}>Default</Button>
+      <Button appearance="primary" style={commonTestStyles.vmargin}>
+        Primary
+      </Button>
+      <Button appearance="subtle" style={commonTestStyles.vmargin}>
+        Subtle
+      </Button>
+      <Button block style={commonTestStyles.vmargin}>
+        Block
+      </Button>
+      <Button appearance="primary" block style={commonTestStyles.vmargin}>
+        Block Primary
+      </Button>
+      <Button appearance="subtle" block style={commonTestStyles.vmargin}>
+        Block Subtle
+      </Button>
       <CompoundButton content="Default" secondaryContent="Compound" style={commonTestStyles.vmargin} />
       <CompoundButton appearance="primary" content="Primary" secondaryContent="Compound" style={commonTestStyles.vmargin} />
       <CompoundButton appearance="subtle" content="Subtle" secondaryContent="Compound" style={commonTestStyles.vmargin} />

--- a/apps/fluent-tester/src/FluentTester/TestComponents/TabsExperimental/TabsTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/TabsExperimental/TabsTest.tsx
@@ -184,7 +184,7 @@ const tabsSettingSelectedKey: React.FunctionComponent = () => {
           <Text>Tabs #3</Text>
         </TabsItem>
       </Tabs>
-      <Button content="View Next Tab" onClick={goToNextTab} />
+      <Button onClick={goToNextTab}>View Next Tab</Button>
     </View>
   );
 };
@@ -216,7 +216,7 @@ const tabsWithFlexibility: React.FunctionComponent = () => {
           <Text>Tabs #3</Text>
         </TabsItem>
       </Tabs>
-      <Button content="View Home Tab" onClick={goHomeTab} />
+      <Button onClick={goHomeTab}>View Home Tab</Button>
     </View>
   );
 };

--- a/apps/fluent-tester/src/FluentTester/theme/ThemePickers.ios.tsx
+++ b/apps/fluent-tester/src/FluentTester/theme/ThemePickers.ios.tsx
@@ -63,7 +63,7 @@ export const ThemePickers: React.FunctionComponent = () => {
         }}
         actions={themeMenuOptions}
       >
-        <Button appearance="subtle" content="Theme" />
+        <Button appearance="subtle">Theme</Button>
       </MenuView>
       <MenuView
         title="Brand"
@@ -72,7 +72,7 @@ export const ThemePickers: React.FunctionComponent = () => {
         }}
         actions={brandMenuOptions}
       >
-        <Button appearance="subtle" content="Brand" />
+        <Button appearance="subtle">Brand</Button>
       </MenuView>
     </View>
   );

--- a/change/@fluentui-react-native-experimental-button-3491d36e-bbec-41a1-9766-1e3ae0ed35e1.json
+++ b/change/@fluentui-react-native-experimental-button-3491d36e-bbec-41a1-9766-1e3ae0ed35e1.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Removed content prop from Button component.",
+  "packageName": "@fluentui-react-native/experimental-button",
+  "email": "v.kozlova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-menu-button-72e75713-3892-4265-9698-26f31139cb89.json
+++ b/change/@fluentui-react-native-experimental-menu-button-72e75713-3892-4265-9698-26f31139cb89.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Removed content prop from Button component.",
+  "packageName": "@fluentui-react-native/experimental-menu-button",
+  "email": "v.kozlova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-e63a5813-a280-4bd8-953e-614ea99c1b15.json
+++ b/change/@fluentui-react-native-tester-e63a5813-a280-4bd8-953e-614ea99c1b15.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Removed content prop from Button component.",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "v.kozlova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Button/src/Button.styling.ts
+++ b/packages/experimental/Button/src/Button.styling.ts
@@ -48,16 +48,23 @@ export const stylingSettings: UseStylingOptions<ButtonProps, ButtonSlotProps, Bu
       ['backgroundColor', 'width', ...borderStyles.keys, ...layoutStyles.keys, ...shadowStyles.keys],
     ),
     content: buildProps(
-      (tokens: ButtonTokens, theme: Theme) => ({
-        style: {
-          color: tokens.color,
-          ...getTextMarginAdjustment(),
-          ...(tokens.spacingIconContent && { marginLeft: tokens.spacingIconContent }),
-          ...(tokens.afterIconSpacing && { marginRight: tokens.afterIconSpacing }),
-          ...fontStyles.from(tokens, theme),
-        },
-      }),
-      ['color', 'spacingIconContent', 'afterIconSpacing', ...fontStyles.keys],
+      (tokens: ButtonTokens, theme: Theme) => {
+        const spacingIconContent = tokens.spacingIconContent
+          ? {
+              marginLeft: tokens.spacingIconContent,
+              marginRight: tokens.spacingIconContent,
+            }
+          : {};
+        return {
+          style: {
+            color: tokens.color,
+            ...getTextMarginAdjustment(),
+            ...spacingIconContent,
+            ...fontStyles.from(tokens, theme),
+          },
+        };
+      },
+      ['color', 'spacingIconContent', ...fontStyles.keys],
     ),
     icon: buildProps(
       (tokens: ButtonTokens) => ({

--- a/packages/experimental/Button/src/Button.styling.ts
+++ b/packages/experimental/Button/src/Button.styling.ts
@@ -53,10 +53,11 @@ export const stylingSettings: UseStylingOptions<ButtonProps, ButtonSlotProps, Bu
           color: tokens.color,
           ...getTextMarginAdjustment(),
           ...(tokens.spacingIconContent && { marginLeft: tokens.spacingIconContent }),
+          ...(tokens.afterIconSpacing && { marginRight: tokens.afterIconSpacing }),
           ...fontStyles.from(tokens, theme),
         },
       }),
-      ['color', 'spacingIconContent', ...fontStyles.keys],
+      ['color', 'spacingIconContent', 'afterIconSpacing', ...fontStyles.keys],
     ),
     icon: buildProps(
       (tokens: ButtonTokens) => ({

--- a/packages/experimental/Button/src/Button.test.tsx
+++ b/packages/experimental/Button/src/Button.test.tsx
@@ -5,25 +5,25 @@ import { checkRenderConsistency, checkReRender } from '@fluentui-react-native/te
 
 describe('Button component tests', () => {
   it('Button default', () => {
-    const tree = renderer.create(<Button content="Default Button" />).toJSON();
+    const tree = renderer.create(<Button>Default Button</Button>).toJSON();
     expect(tree).toMatchSnapshot();
   });
 
   it('Button simple rendering does not invalidate styling', () => {
-    checkRenderConsistency(() => <Button content="Default button" />, 2);
+    checkRenderConsistency(() => <Button>Default button</Button>, 2);
   });
 
   it('Button re-renders correctly', () => {
-    checkReRender(() => <Button content="Render twice" />, 2);
+    checkReRender(() => <Button>Render twice</Button>, 2);
   });
 
   it('Button shares produced styles across multiple renders', () => {
     const style = { backgroundColor: 'black' };
-    checkRenderConsistency(() => <Button content="Shared styles" style={style} />, 2);
+    checkRenderConsistency(() => <Button style={style}>Shared styles</Button>, 2);
   });
 
   it('Button re-renders correctly with style', () => {
     const style = { borderColor: 'blue' };
-    checkReRender(() => <Button content="Shared Style Render" style={style} />, 2);
+    checkReRender(() => <Button style={style}>Shared Style Render</Button>, 2);
   });
 });

--- a/packages/experimental/Button/src/Button.tsx
+++ b/packages/experimental/Button/src/Button.tsx
@@ -51,8 +51,8 @@ export const Button = compose<ButtonType>({
       return (
         <Slots.root {...mergedProps}>
           {icon && iconPosition === 'before' && <Slots.icon {...iconProps} />}
-          {Object.keys(children).map((key) =>
-            typeof children[key] === 'string' ? <Slots.content key="content">{children[key]}</Slots.content> : children[key],
+          {React.Children.map(children, (child) =>
+            typeof child === 'string' ? <Slots.content key="content">{child}</Slots.content> : child,
           )}
           {icon && iconPosition === 'after' && <Slots.icon {...iconProps} />}
         </Slots.root>

--- a/packages/experimental/Button/src/Button.tsx
+++ b/packages/experimental/Button/src/Button.tsx
@@ -26,7 +26,7 @@ export const buttonLookup = (layer: string, state: IPressableState, userProps: B
     (!userProps['size'] && layer === getDefaultSize()) ||
     layer === userProps['shape'] ||
     (!userProps['shape'] && layer === 'rounded') ||
-    (layer === 'hasContent' && userProps.content) ||
+    (layer === 'hasContent' && !userProps.iconOnly) ||
     (layer === 'hasIcon' && userProps.icon)
   );
 };
@@ -47,12 +47,13 @@ export const Button = compose<ButtonType>({
 
     // now return the handler for finishing render
     return (final: ButtonProps, ...children: React.ReactNode[]) => {
-      const { icon, iconPosition, content, ...mergedProps } = mergeProps(button.props, final);
+      const { icon, iconPosition, ...mergedProps } = mergeProps(button.props, final);
       return (
         <Slots.root {...mergedProps}>
           {icon && iconPosition === 'before' && <Slots.icon {...iconProps} />}
-          {content && <Slots.content key="content">{content}</Slots.content>}
-          {children}
+          {Object.keys(children).map((key) =>
+            typeof children[key] === 'string' ? <Slots.content key="content">{children[key]}</Slots.content> : children[key],
+          )}
           {icon && iconPosition === 'after' && <Slots.icon {...iconProps} />}
         </Slots.root>
       );

--- a/packages/experimental/Button/src/Button.types.ts
+++ b/packages/experimental/Button/src/Button.types.ts
@@ -48,11 +48,6 @@ export interface ButtonCoreTokens extends LayoutTokens, FontTokens, IBorderToken
   spacingIconContent?: number;
 
   /**
-   * The amount of spacing between "after" icon and the content
-   */
-  afterIconSpacing?: number;
-
-  /**
    * States that can be applied to a button
    */
   hovered?: ButtonTokens;
@@ -130,7 +125,7 @@ export interface ButtonProps extends ButtonCoreProps {
   iconPosition?: 'before' | 'after';
 
   /**
-   * Button contains only icon
+   * Button contains only icon, there's no text content
    */
   iconOnly?: boolean;
 }

--- a/packages/experimental/Button/src/Button.types.ts
+++ b/packages/experimental/Button/src/Button.types.ts
@@ -48,6 +48,11 @@ export interface ButtonCoreTokens extends LayoutTokens, FontTokens, IBorderToken
   spacingIconContent?: number;
 
   /**
+   * The amount of spacing between "after" icon and the content
+   */
+  afterIconSpacing?: number;
+
+  /**
    * States that can be applied to a button
    */
   hovered?: ButtonTokens;
@@ -105,6 +110,7 @@ export interface ButtonProps extends ButtonCoreProps {
    * - 'subtle': Minimizes emphasis to blend into the background until hovered or focused.
    */
   appearance?: ButtonAppearance;
+
   /** A button can fill the width of its container. */
   block?: boolean;
 
@@ -122,6 +128,11 @@ export interface ButtonProps extends ButtonCoreProps {
    * @default before
    */
   iconPosition?: 'before' | 'after';
+
+  /**
+   * Button contains only icon
+   */
+  iconOnly?: boolean;
 }
 
 export type ButtonState = IPressableHooks<ButtonProps & React.ComponentPropsWithRef<any>>;

--- a/packages/experimental/Button/src/ButtonTokens.ts
+++ b/packages/experimental/Button/src/ButtonTokens.ts
@@ -18,6 +18,7 @@ export const defaultButtonTokens: TokenSettings<ButtonTokens, Theme> = () =>
         variant: 'bodySemibold',
         hasIcon: {
           spacingIconContent: globalTokens.spacing.sNudge,
+          afterIconSpacing: globalTokens.spacing.sNudge,
         },
       },
     },
@@ -31,6 +32,7 @@ export const defaultButtonTokens: TokenSettings<ButtonTokens, Theme> = () =>
         variant: 'secondaryStandard',
         hasIcon: {
           spacingIconContent: globalTokens.spacing.xs,
+          afterIconSpacing: globalTokens.spacing.xs,
         },
       },
     },
@@ -44,6 +46,7 @@ export const defaultButtonTokens: TokenSettings<ButtonTokens, Theme> = () =>
         variant: 'subheaderSemibold',
         hasIcon: {
           spacingIconContent: globalTokens.spacing.sNudge,
+          afterIconSpacing: globalTokens.spacing.sNudge,
         },
       },
     },

--- a/packages/experimental/Button/src/ButtonTokens.ts
+++ b/packages/experimental/Button/src/ButtonTokens.ts
@@ -18,7 +18,6 @@ export const defaultButtonTokens: TokenSettings<ButtonTokens, Theme> = () =>
         variant: 'bodySemibold',
         hasIcon: {
           spacingIconContent: globalTokens.spacing.sNudge,
-          afterIconSpacing: globalTokens.spacing.sNudge,
         },
       },
     },
@@ -32,7 +31,6 @@ export const defaultButtonTokens: TokenSettings<ButtonTokens, Theme> = () =>
         variant: 'secondaryStandard',
         hasIcon: {
           spacingIconContent: globalTokens.spacing.xs,
-          afterIconSpacing: globalTokens.spacing.xs,
         },
       },
     },
@@ -46,7 +44,6 @@ export const defaultButtonTokens: TokenSettings<ButtonTokens, Theme> = () =>
         variant: 'subheaderSemibold',
         hasIcon: {
           spacingIconContent: globalTokens.spacing.sNudge,
-          afterIconSpacing: globalTokens.spacing.sNudge,
         },
       },
     },

--- a/packages/experimental/Button/src/__snapshots__/Button.test.tsx.snap
+++ b/packages/experimental/Button/src/__snapshots__/Button.test.tsx.snap
@@ -2,7 +2,6 @@
 
 exports[`Button component tests Button default 1`] = `
 <View
-  accessibilityLabel="Default Button"
   accessibilityRole="button"
   accessibilityState={
     Object {

--- a/packages/experimental/MenuButton/src/MenuButton.tsx
+++ b/packages/experimental/MenuButton/src/MenuButton.tsx
@@ -82,10 +82,12 @@ export const MenuButton = compose<MenuButtonType>({
           <svg width="12" height="16" viewBox="0 0 11 6" color=${chevronColor}>
             <path fill='currentColor' d='M0.646447 0.646447C0.841709 0.451184 1.15829 0.451184 1.35355 0.646447L5.5 4.79289L9.64645 0.646447C9.84171 0.451185 10.1583 0.451185 10.3536 0.646447C10.5488 0.841709 10.5488 1.15829 10.3536 1.35355L5.85355 5.85355C5.65829 6.04882 5.34171 6.04882 5.14645 5.85355L0.646447 1.35355C0.451184 1.15829 0.451184 0.841709 0.646447 0.646447Z' />
           </svg>`;
+      const { content, ...restButtonProps } = buttonProps;
 
       return (
         <Slots.root>
-          <Button {...buttonProps}>
+          <Button {...restButtonProps}>
+            {content}
             <Slots.chevronIcon xml={chevronXml} />
           </Button>
           {showContextualMenu && renderContextualMenu(contextualMenuProps, menuItemsUpdated)}

--- a/packages/experimental/MenuButton/src/__tests__/__snapshots__/MenuButton.test.win32.tsx.snap
+++ b/packages/experimental/MenuButton/src/__tests__/__snapshots__/MenuButton.test.win32.tsx.snap
@@ -2,7 +2,6 @@
 
 exports[`ContextualMenu default 1`] = `
 <View
-  accessibilityLabel="Press for Nested MenuButton"
   accessibilityRole="button"
   accessibilityState={
     Object {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
- Removed "content" prop from the Button component. Content is used as part of children prop
- Fixed padding for an "after" icon

TODO:
- If this solution is good, I'll do the same for Compound, FAB and Toggle buttons.
- spacingIconContent can be renamed to beforeIconSpacing. But this prop is used in other Buttons so if this solution is good, I'll rename it when I fix other buttons.

### Verification
Checked manually
![image](https://user-images.githubusercontent.com/11574680/144057799-e9b6b887-1e3e-4d26-bc31-b113d7a0e51d.png)
![image](https://user-images.githubusercontent.com/11574680/144057827-2e132da3-95a9-4026-b7d6-db00289bed9f.png)
![image](https://user-images.githubusercontent.com/11574680/144057857-3ae4a986-6f9b-4d02-b127-f5d97d1d42f5.png)
![image](https://user-images.githubusercontent.com/11574680/144057878-731fac73-5bbe-4f6b-affc-5dcccfda5820.png)


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
