### PR TITLE
E2E tests for V1 Button

### DIFF
--- a/apps/fluent-tester/src/E2E/ButtonExperimental/pages/ButtonExperimentalPageObject.ts
+++ b/apps/fluent-tester/src/E2E/ButtonExperimental/pages/ButtonExperimentalPageObject.ts
@@ -1,0 +1,34 @@
+import {
+  EXPERIMENTAL_BUTTON_TEST_PAGE,
+  BUTTONEXPERIMENTAL_TEST_COMPONENT,
+  BUTTONEXPERIMENTAL_NO_A11Y_LABEL_COMPONENT,
+  HOMEPAGE_BUTTON_BUTTONEXPERIMENTAL,
+} from '../../../FluentTester/TestComponents/ButtonExperimental/consts';
+import { BasePage, By } from '../../common/BasePage';
+
+class ButtonExperimentalPageObject extends BasePage {
+  /*****************************************/
+  /**************** Getters ****************/
+  /*****************************************/
+  get _testPage() {
+    return By(EXPERIMENTAL_BUTTON_TEST_PAGE);
+  }
+
+  get _pageName() {
+    return EXPERIMENTAL_BUTTON_TEST_PAGE;
+  }
+
+  get _primaryComponent() {
+    return By(BUTTONEXPERIMENTAL_TEST_COMPONENT);
+  }
+
+  get _secondaryComponent() {
+    return By(BUTTONEXPERIMENTAL_NO_A11Y_LABEL_COMPONENT);
+  }
+
+  get _pageButton() {
+    return By(HOMEPAGE_BUTTON_BUTTONEXPERIMENTAL);
+  }
+}
+
+export default new ButtonExperimentalPageObject();

--- a/apps/fluent-tester/src/E2E/ButtonExperimental/specs/ButtonExperimental.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/ButtonExperimental/specs/ButtonExperimental.spec.win.ts
@@ -20,7 +20,7 @@ describe('Button Testing Initialization', function () {
     ButtonExperimentalPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */
-    NavigateAppPage.clickAndGoToButtonPage();
+    NavigateAppPage.clickAndGoToExperimentalButtonPage();
     ButtonExperimentalPageObject.waitForPageDisplayed(PAGE_TIMEOUT);
 
     expect(ButtonExperimentalPageObject.isPageLoaded()).toBeTruthy();

--- a/apps/fluent-tester/src/E2E/ButtonExperimental/specs/ButtonExperimental.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/ButtonExperimental/specs/ButtonExperimental.spec.win.ts
@@ -1,0 +1,50 @@
+import NavigateAppPage from '../../common/NavigateAppPage';
+import ButtonExperimentalPageObject from '../pages/ButtonExperimentalPageObject';
+import { ComponentSelector } from '../../common/BasePage';
+import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT, BUTTON_A11Y_ROLE } from '../../common/consts';
+import {
+  BUTTONEXPERIMENTAL_ACCESSIBILITY_LABEL,
+  BUTTONEXPERIMENTAL_TEST_COMPONENT_LABEL,
+} from '../../../FluentTester/TestComponents/ButtonExperimental/consts';
+
+// Before testing begins, allow up to 60 seconds for app to open
+describe('Button Testing Initialization', function () {
+  it('Wait for app load', () => {
+    NavigateAppPage.waitForPageDisplayed(BOOT_APP_TIMEOUT);
+    expect(NavigateAppPage.isPageLoaded()).toBeTruthy();
+  });
+
+  it('Click and navigate to Button test page', () => {
+    /* Scroll to component test page button in scrollview if not already visible*/
+    ButtonExperimentalPageObject.scrollToComponentButton();
+    ButtonExperimentalPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
+
+    /* Click on component button to navigate to test page */
+    NavigateAppPage.clickAndGoToButtonPage();
+    ButtonExperimentalPageObject.waitForPageDisplayed(PAGE_TIMEOUT);
+
+    expect(ButtonExperimentalPageObject.isPageLoaded()).toBeTruthy();
+  });
+});
+
+describe('Button Accessibility Testing', () => {
+  it('Button - Validate accessibilityRole is correct', () => {
+    ButtonExperimentalPageObject.scrollToTestElement();
+    ButtonExperimentalPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
+    expect(ButtonExperimentalPageObject.getAccessibilityRole()).toEqual(BUTTON_A11Y_ROLE);
+  });
+
+  it('Button - Set accessibilityLabel', () => {
+    ButtonExperimentalPageObject.scrollToTestElement();
+    ButtonExperimentalPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
+    expect(ButtonExperimentalPageObject.getAccessibilityLabel(ComponentSelector.Primary)).toEqual(BUTTONEXPERIMENTAL_ACCESSIBILITY_LABEL);
+  });
+
+  it('Button - Do not set accessibilityLabel -> Default to Button label', () => {
+    ButtonExperimentalPageObject.scrollToTestElement();
+    ButtonExperimentalPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
+    expect(ButtonExperimentalPageObject.getAccessibilityLabel(ComponentSelector.Secondary)).toEqual(
+      BUTTONEXPERIMENTAL_TEST_COMPONENT_LABEL,
+    );
+  });
+});

--- a/apps/fluent-tester/src/E2E/common/NavigateAppPage.ts
+++ b/apps/fluent-tester/src/E2E/common/NavigateAppPage.ts
@@ -1,5 +1,6 @@
 import { HOMEPAGE_CHECKBOX_BUTTON } from '../../FluentTester/TestComponents/Checkbox/consts';
 import { HOMEPAGE_BUTTON_BUTTON } from '../../FluentTester/TestComponents/Button/consts';
+import { HOMEPAGE_BUTTON_BUTTONEXPERIMENTAL } from '../../FluentTester/TestComponents/ButtonExperimental/consts';
 import { HOMEPAGE_CALLOUT_BUTTON } from '../../FluentTester/TestComponents/Callout/consts';
 import { HOMEPAGE_CONTEXTUALMENU_BUTTON } from '../../FluentTester/TestComponents/ContextualMenu/consts';
 import { HOMEPAGE_EXPERIMENTAL_TABS_BUTTON } from '../../FluentTester/TestComponents/TabsExperimental/consts';
@@ -93,6 +94,10 @@ class NavigateAppPage extends BasePage {
     this.themePage.click();
   }
 
+  clickAndGoToExperimentalButtonPage() {
+    this.experimentalButtonPage.click();
+  }
+
   clickAndGoToExperimentalTabsPage() {
     this.experimentalTabsPage.click();
   }
@@ -175,6 +180,10 @@ class NavigateAppPage extends BasePage {
 
   private get themePage() {
     return By(HOMEPAGE_THEME_BUTTON);
+  }
+
+  private get experimentalButtonPage() {
+    return By(HOMEPAGE_BUTTON_BUTTONEXPERIMENTAL);
   }
 
   private get experimentalTabsPage() {

--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonTest.tsx
@@ -6,6 +6,7 @@ import { Test, TestSection, PlatformStatus } from '../Test';
 import { ButtonIconTest } from './ButtonIconTestSection';
 import { ButtonSizeTest } from './ButtonSizeTestSection';
 import { ButtonShapeTest } from './ButtonShapeTestSection';
+import { E2EButtonExperimentalTest } from './E2EButtonTest';
 
 const buttonSections: TestSection[] = [
   {
@@ -28,6 +29,10 @@ const buttonSections: TestSection[] = [
   {
     name: 'Sizes',
     component: ButtonSizeTest,
+  },
+  {
+    name: 'E2E Button Testing',
+    component: E2EButtonExperimentalTest,
   },
 ];
 

--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonTest.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ButtonVariantTest } from './ButtonVariantTestSection';
 import { ToggleButtonTest } from './ToggleButtonTestSection';
-import { ExperimentalButtonTestPageId } from './consts';
+import { EXPERIMENTAL_BUTTON_TEST_PAGE } from './consts';
 import { Test, TestSection, PlatformStatus } from '../Test';
 import { ButtonIconTest } from './ButtonIconTestSection';
 import { ButtonSizeTest } from './ButtonSizeTestSection';
@@ -10,7 +10,7 @@ import { ButtonShapeTest } from './ButtonShapeTestSection';
 const buttonSections: TestSection[] = [
   {
     name: 'Button Variants',
-    testID: ExperimentalButtonTestPageId,
+    testID: EXPERIMENTAL_BUTTON_TEST_PAGE,
     component: ButtonVariantTest,
   },
   {

--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/E2EButtonTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/E2EButtonTest.tsx
@@ -1,0 +1,37 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+import { Text } from '@fluentui/react-native';
+import { Button } from '@fluentui-react-native/experimental-button';
+import { Stack } from '@fluentui-react-native/stack';
+import * as React from 'react';
+import { View } from 'react-native';
+import { stackStyle } from '../Common/styles';
+import {
+  BUTTONEXPERIMENTAL_TEST_COMPONENT,
+  BUTTONEXPERIMENTAL_ON_PRESS,
+  BUTTONEXPERIMENTAL_NO_A11Y_LABEL_COMPONENT,
+  BUTTONEXPERIMENTAL_ACCESSIBILITY_LABEL,
+  BUTTONEXPERIMENTAL_TEST_COMPONENT_LABEL,
+} from './consts';
+
+export const E2EButtonTest: React.FunctionComponent = () => {
+  const [buttonPressed, setButtonPressed] = React.useState(false);
+
+  const onClick = React.useCallback(() => {
+    setButtonPressed(!buttonPressed);
+  }, [buttonPressed]);
+
+  return (
+    <View>
+      <Stack style={stackStyle}>
+        <Button
+          content="This is a button for E2E testing"
+          testID={BUTTONEXPERIMENTAL_TEST_COMPONENT}
+          onClick={onClick}
+          accessibilityLabel={BUTTONEXPERIMENTAL_ACCESSIBILITY_LABEL}
+        />
+        <Button content={BUTTONEXPERIMENTAL_TEST_COMPONENT_LABEL} testID={BUTTONEXPERIMENTAL_NO_A11Y_LABEL_COMPONENT} onClick={onClick} />
+        {buttonPressed ? <Text testID={BUTTONEXPERIMENTAL_ON_PRESS}>Button Pressed</Text> : null}
+      </Stack>
+    </View>
+  );
+};

--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/E2EButtonTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/E2EButtonTest.tsx
@@ -13,7 +13,7 @@ import {
   BUTTONEXPERIMENTAL_TEST_COMPONENT_LABEL,
 } from './consts';
 
-export const E2EButtonTest: React.FunctionComponent = () => {
+export const E2EButtonExperimentalTest: React.FunctionComponent = () => {
   const [buttonPressed, setButtonPressed] = React.useState(false);
 
   const onClick = React.useCallback(() => {

--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/consts.ts
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/consts.ts
@@ -1,2 +1,12 @@
 export const HOMEPAGE_BUTTON_BUTTONEXPERIMENTAL = 'Homepage_Button_ButtonExperimental'; // Button on the homepage that navigates to the selected test page
-export const ExperimentalButtonTestPageId = 'ButtonExperimental_TestPage'; // A component on each specific test page.
+export const EXPERIMENTAL_BUTTON_TEST_PAGE = 'ButtonExperimental_TestPage'; // A component on each specific test page.
+
+/* Test Button 1 */
+export const BUTTONEXPERIMENTAL_TEST_COMPONENT = 'Button_Test_Component'; // A component on each specific test page
+export const BUTTONEXPERIMENTAL_ACCESSIBILITY_LABEL = 'E2E testing Button accessibility label';
+
+/* Test Button 2 */
+export const BUTTONEXPERIMENTAL_NO_A11Y_LABEL_COMPONENT = 'Button_No_A11y_label_Component';
+export const BUTTONEXPERIMENTAL_TEST_COMPONENT_LABEL = 'Test Button2 - No Accessibility Label'; // A component on each specific test page
+
+export const BUTTONEXPERIMENTAL_ON_PRESS = 'Button_On_Press'; // For testing the press functionality on a button

--- a/change/@fluentui-react-native-tester-c9ff1c09-4380-4647-8fc8-1ff02956cd66.json
+++ b/change/@fluentui-react-native-tester-c9ff1c09-4380-4647-8fc8-1ff02956cd66.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add e2e tests for experimental button",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Adding E2E tests & E2E automation test for the V1 Button. The structure is copied from the existing Button component.

### Verification

I'm having trouble running these locally so I'm hoping the CI can validate that they're running properly for me.

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
