### PR TITLE
Removed content prop from Toggle, Compound Buttons and FAB

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonShapeTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonShapeTestSection.tsx
@@ -24,9 +24,15 @@ export const ButtonShapeTest: React.FunctionComponent = () => {
       <Button appearance="primary" shape="circular" style={commonTestStyles.vmargin}>
         Circular Button
       </Button>
-      <CompoundButton content="Compound Button" secondaryContent="rounded" shape="rounded" style={commonTestStyles.vmargin} />
-      <CompoundButton content="Compound Button" secondaryContent="square" shape="square" style={commonTestStyles.vmargin} />
-      <CompoundButton content="Compound Button" secondaryContent="circular" shape="circular" style={commonTestStyles.vmargin} />
+      <CompoundButton secondaryContent="rounded" shape="rounded" style={commonTestStyles.vmargin}>
+        Compound Button
+      </CompoundButton>
+      <CompoundButton secondaryContent="square" shape="square" style={commonTestStyles.vmargin}>
+        Compound Button
+      </CompoundButton>
+      <CompoundButton secondaryContent="circular" shape="circular" style={commonTestStyles.vmargin}>
+        Compound Button
+      </CompoundButton>
     </View>
   );
 };

--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonSizeTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonSizeTestSection.tsx
@@ -39,12 +39,24 @@ export const ButtonSizeTest: React.FunctionComponent = () => {
       <Button size="large" style={commonTestStyles.vmargin}>
         Large
       </Button>
-      <Button loading size="small" style={commonTestStyles.vmargin}>Loading Button Small</Button>
-      <Button loading size="medium" style={commonTestStyles.vmargin}>Loading Button Medium</Button>
-      <Button loading size="large" style={commonTestStyles.vmargin}>Loading Button Large</Button>
-      <CompoundButton content="Compound Button" secondaryContent="rounded" shape="rounded" style={commonTestStyles.vmargin} />
-      <CompoundButton content="Compound Button" secondaryContent="square" shape="square" style={commonTestStyles.vmargin} />
-      <CompoundButton content="Compound Button" secondaryContent="circular" shape="circular" style={commonTestStyles.vmargin} />
+      <Button loading size="small" style={commonTestStyles.vmargin}>
+        Loading Button Small
+      </Button>
+      <Button loading size="medium" style={commonTestStyles.vmargin}>
+        Loading Button Medium
+      </Button>
+      <Button loading size="large" style={commonTestStyles.vmargin}>
+        Loading Button Large
+      </Button>
+      <CompoundButton secondaryContent="rounded" shape="rounded" style={commonTestStyles.vmargin}>
+        Compound Button
+      </CompoundButton>
+      <CompoundButton secondaryContent="square" shape="square" style={commonTestStyles.vmargin}>
+        Compound Button
+      </CompoundButton>
+      <CompoundButton secondaryContent="circular" shape="circular" style={commonTestStyles.vmargin}>
+        Compound Button
+      </CompoundButton>
     </View>
   );
 };

--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonVariantTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonVariantTestSection.tsx
@@ -23,9 +23,7 @@ export const ButtonVariantTest: React.FunctionComponent = () => {
       <Button appearance="subtle" style={commonTestStyles.vmargin}>
         Subtle
       </Button>
-      <Button loading>
-        Loading Button
-      </Button>
+      <Button loading>Loading Button</Button>
       <Button block style={commonTestStyles.vmargin}>
         Block
       </Button>
@@ -35,11 +33,19 @@ export const ButtonVariantTest: React.FunctionComponent = () => {
       <Button appearance="subtle" block style={commonTestStyles.vmargin}>
         Block Subtle
       </Button>
-      <CompoundButton content="Default" secondaryContent="Compound" style={commonTestStyles.vmargin} />
-      <CompoundButton appearance="primary" content="Primary" secondaryContent="Compound" style={commonTestStyles.vmargin} />
-      <CompoundButton appearance="subtle" content="Subtle" secondaryContent="Compound" style={commonTestStyles.vmargin} />
+      <CompoundButton secondaryContent="Compound" style={commonTestStyles.vmargin}>
+        Default
+      </CompoundButton>
+      <CompoundButton appearance="primary" secondaryContent="Compound" style={commonTestStyles.vmargin}>
+        Primary
+      </CompoundButton>
+      <CompoundButton appearance="subtle" secondaryContent="Compound" style={commonTestStyles.vmargin}>
+        Subtle
+      </CompoundButton>
       <FAB icon={{ svgSource: svgProps, width: 20, height: 20 }} style={commonTestStyles.vmargin} />
-      <FAB icon={{ svgSource: svgProps, width: 20, height: 20 }} content="FAB" style={commonTestStyles.vmargin} />
+      <FAB icon={{ svgSource: svgProps, width: 20, height: 20 }} style={commonTestStyles.vmargin}>
+        FAB
+      </FAB>
     </View>
   );
 };

--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ToggleButtonTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ToggleButtonTestSection.tsx
@@ -22,24 +22,30 @@ export const ToggleButtonTest: React.FunctionComponent = () => {
   return (
     <View style={[stackStyle, commonTestStyles.view]}>
       <View style={styles.row}>
-        <ToggleButton onClick={onDefaultClicked} checked={defaultChecked} content="Default Toggle" style={commonTestStyles.vmargin} />
+        <ToggleButton onClick={onDefaultClicked} checked={defaultChecked} style={commonTestStyles.vmargin}>
+          Default Toggle
+        </ToggleButton>
         <Checkbox checked={defaultChecked} label="Default Toggle is Checked" style={[commonTestStyles.vmargin, styles.hmargin]} />
       </View>
-      <ToggleButton checked content="Checked Default Toggle" style={commonTestStyles.vmargin} />
-      <ToggleButton checked={false} content="Unchecked Default Toggle" style={commonTestStyles.vmargin} />
-      {/* <ToggleButton primary content="Primary Toggle" /> */}
+      <ToggleButton checked style={commonTestStyles.vmargin}>
+        Checked Default Toggle
+      </ToggleButton>
+      <ToggleButton checked={false} style={commonTestStyles.vmargin}>
+        Unchecked Default Toggle
+      </ToggleButton>
+      <ToggleButton appearance="primary">Primary Toggle</ToggleButton>
       <View style={styles.row}>
-        <ToggleButton
-          appearance="subtle"
-          onClick={onGhostClicked}
-          checked={subtleChecked}
-          content="Subtle Toggle"
-          style={commonTestStyles.vmargin}
-        />
+        <ToggleButton appearance="subtle" onClick={onGhostClicked} checked={subtleChecked} style={commonTestStyles.vmargin}>
+          Subtle Toggle
+        </ToggleButton>
         <Checkbox checked={subtleChecked} label="Subtle Toggle is Checked" style={[commonTestStyles.vmargin, styles.hmargin]} />
       </View>
-      <ToggleButton appearance="subtle" checked content="Checked Subtle Toggle" style={commonTestStyles.vmargin} />
-      <ToggleButton appearance="subtle" checked={false} content="Unchecked Subtle Toggle" style={commonTestStyles.vmargin} />
+      <ToggleButton appearance="subtle" checked style={commonTestStyles.vmargin}>
+        Checked Subtle Toggle
+      </ToggleButton>
+      <ToggleButton appearance="subtle" checked={false} style={commonTestStyles.vmargin}>
+        Unchecked Subtle Toggle
+      </ToggleButton>
     </View>
   );
 };

--- a/change/@fluentui-react-native-experimental-button-d947c167-f725-4564-be33-c2e900e12842.json
+++ b/change/@fluentui-react-native-experimental-button-d947c167-f725-4564-be33-c2e900e12842.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Removed content prop from Toggle, Compound Buttons and FAB",
+  "packageName": "@fluentui-react-native/experimental-button",
+  "email": "v.kozlova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-48323a40-2a06-4421-85b5-87871ba32608.json
+++ b/change/@fluentui-react-native-tester-48323a40-2a06-4421-85b5-87871ba32608.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Removed content prop from Toggle, Compound Buttons and FAB",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "v.kozlova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Button/src/CompoundButton/CompoundButton.test.tsx
+++ b/packages/experimental/Button/src/CompoundButton/CompoundButton.test.tsx
@@ -3,6 +3,6 @@ import { CompoundButton } from './CompoundButton';
 import * as renderer from 'react-test-renderer';
 
 it('CompoundButton default', () => {
-  const tree = renderer.create(<CompoundButton content="Default Button" secondaryContent="sublabel" />).toJSON();
+  const tree = renderer.create(<CompoundButton secondaryContent="sublabel">Default Button</CompoundButton>).toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/packages/experimental/Button/src/CompoundButton/CompoundButton.tsx
+++ b/packages/experimental/Button/src/CompoundButton/CompoundButton.tsx
@@ -29,18 +29,18 @@ export const CompoundButton = compose<CompoundButtonType>({
 
     // now return the handler for finishing render
     return (final: CompoundButtonProps, ...children: React.ReactNode[]) => {
-      const { icon, content, secondaryContent, ...mergedProps } = mergeProps(button.props, final);
+      const { icon, secondaryContent, iconPosition, ...mergedProps } = mergeProps(button.props, final);
 
       return (
         <Slots.root {...mergedProps}>
-          {icon && <Slots.icon {...iconProps} />}
-          {(content || secondaryContent) && (
+          {icon && iconPosition === 'before' && <Slots.icon {...iconProps} />}
+          {React.Children.map(children, (child) => (
             <Slots.contentContainer>
-              {content && <Slots.content key="content">{content}</Slots.content>}
+              {typeof child === 'string' ? <Slots.content key="content">{child}</Slots.content> : child}
               {secondaryContent && <Slots.secondaryContent key="secondaryContent">{secondaryContent}</Slots.secondaryContent>}
             </Slots.contentContainer>
-          )}
-          {children}
+          ))}
+          {icon && iconPosition === 'after' && <Slots.icon {...iconProps} />}
         </Slots.root>
       );
     };

--- a/packages/experimental/Button/src/CompoundButton/__snapshots__/CompoundButton.test.tsx.snap
+++ b/packages/experimental/Button/src/CompoundButton/__snapshots__/CompoundButton.test.tsx.snap
@@ -2,7 +2,6 @@
 
 exports[`CompoundButton default 1`] = `
 <View
-  accessibilityLabel="Default Button"
   accessibilityRole="button"
   accessibilityState={
     Object {
@@ -11,7 +10,6 @@ exports[`CompoundButton default 1`] = `
   }
   accessible={true}
   focusable={true}
-  iconPosition="before"
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}

--- a/packages/experimental/Button/src/FAB/FABCore.tsx
+++ b/packages/experimental/Button/src/FAB/FABCore.tsx
@@ -31,7 +31,7 @@ export const FAB = compose<FABType>({
     content: Text,
   },
   render: (userProps: ButtonCoreProps, useSlots: UseSlots<FABType>) => {
-    const { icon, content, onClick, ...rest } = userProps;
+    const { icon, onClick, ...rest } = userProps;
     const iconProps = createIconProps(userProps.icon);
 
     const button = useButton(rest);
@@ -46,8 +46,9 @@ export const FAB = compose<FABType>({
       return (
         <Slots.root {...mergedProps}>
           {icon && <Slots.icon {...iconProps} />}
-          {content && <Slots.content key="content">{content}</Slots.content>}
-          {children}
+          {React.Children.map(children, (child) =>
+            typeof child === 'string' ? <Slots.content key="content">{child}</Slots.content> : child,
+          )}
         </Slots.root>
       );
     };

--- a/packages/experimental/Button/src/ToggleButton/ToggleButton.test.tsx
+++ b/packages/experimental/Button/src/ToggleButton/ToggleButton.test.tsx
@@ -3,6 +3,6 @@ import { ToggleButton } from './ToggleButton';
 import * as renderer from 'react-test-renderer';
 
 it('ToggleButton default', () => {
-  const tree = renderer.create(<ToggleButton content="Default Button" />).toJSON();
+  const tree = renderer.create(<ToggleButton>Default Button</ToggleButton>).toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/packages/experimental/Button/src/ToggleButton/ToggleButton.tsx
+++ b/packages/experimental/Button/src/ToggleButton/ToggleButton.tsx
@@ -20,7 +20,7 @@ export const ToggleButton = compose<ToggleButtonType>({
     content: Text,
   },
   render: (userProps: ToggleButtonProps, useSlots: UseSlots<ToggleButtonType>) => {
-    const { icon, content, defaultChecked, checked, onClick, ...rest } = userProps;
+    const { icon, defaultChecked, checked, onClick, iconPosition, ...rest } = userProps;
     const iconProps = createIconProps(userProps.icon);
 
     // Warns defaultChecked and checked being mutually exclusive.
@@ -31,7 +31,7 @@ export const ToggleButton = compose<ToggleButtonType>({
     const button = useButton({ onClick: toggle, ...rest });
 
     // grab the styled slots
-    const Slots = useSlots(userProps, layer => (layer === 'checked' && checkedValue) || buttonLookup(layer, button.state, userProps));
+    const Slots = useSlots(userProps, (layer) => (layer === 'checked' && checkedValue) || buttonLookup(layer, button.state, userProps));
 
     // now return the handler for finishing render
     return (final: ToggleButtonProps, ...children: React.ReactNode[]) => {
@@ -39,9 +39,11 @@ export const ToggleButton = compose<ToggleButtonType>({
 
       return (
         <Slots.root {...mergedProps}>
-          {icon && <Slots.icon {...iconProps} />}
-          {content && <Slots.content key="content">{content}</Slots.content>}
-          {children}
+          {icon && iconPosition === 'before' && <Slots.icon {...iconProps} />}
+          {React.Children.map(children, (child) =>
+            typeof child === 'string' ? <Slots.content key="content">{child}</Slots.content> : child,
+          )}
+          {icon && iconPosition === 'after' && <Slots.icon {...iconProps} />}
         </Slots.root>
       );
     };


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
Removed content prop from Toggle, Compound buttons and FAB.

### Verification
Checked manually
![image](https://user-images.githubusercontent.com/11574680/145060368-cf0146e4-2456-4861-809f-e14497311405.png)
![image](https://user-images.githubusercontent.com/11574680/145060396-b72e3187-f6e3-4232-bd21-c915e9b6b5a1.png)
![image](https://user-images.githubusercontent.com/11574680/145060487-7eeb8a7c-c0f1-4974-b138-a664cab564aa.png)
![image](https://user-images.githubusercontent.com/11574680/145060528-eebbdf41-d732-4eb8-9277-6fd15e219aa0.png)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
