### PR TITLE
Fix yarn warning

### DIFF
--- a/change/@fluentui-react-native-experimental-drawer-b4b4c3ca-f6f4-4468-950a-bea14568c3cb.json
+++ b/change/@fluentui-react-native-experimental-drawer-b4b4c3ca-f6f4-4468-950a-bea14568c3cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix react version",
+  "packageName": "@fluentui-react-native/experimental-drawer",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Drawer/package.json
+++ b/packages/experimental/Drawer/package.json
@@ -30,9 +30,9 @@
     "@types/react-native": "^0.64.0",
     "@uifabricshared/build-native": "^0.1.1",
     "immediate": "~3.0.5",
-    "lie" : "~3.3.0",
-    "pako" : "~1.0.2",
-    "react": "16.13.1",
+    "lie": "~3.3.0",
+    "pako": "~1.0.2",
+    "react": "17.0.1",
     "react-native": "^0.64.3",
     "readable-stream": "~2.3.6",
     "set-immediate-shim": "~1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14824,7 +14824,7 @@ react-test-renderer@^17.0.0:
     react-shallow-renderer "^16.13.1"
     scheduler "^0.20.2"
 
-react@16.13.1, react@17.0.1:
+react@17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.1.tgz#6e0600416bd57574e3f86d92edba3d9008726127"
   integrity sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Saw a warning when running yarn on the latest commit:
warning Resolution field "react@17.0.1" is incompatible with requested version "react@16.13.1"

Fixing the dependency to match peer dependency.

### Verification

yarn --force doesn't show the error

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
