### PR TITLE
Secondary content rename

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonShapeTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonShapeTestSection.tsx
@@ -24,13 +24,13 @@ export const ButtonShapeTest: React.FunctionComponent = () => {
       <Button appearance="primary" shape="circular" style={commonTestStyles.vmargin}>
         Circular Button
       </Button>
-      <CompoundButton secondaryContent="rounded" shape="rounded" style={commonTestStyles.vmargin}>
+      <CompoundButton secondaryText="rounded" shape="rounded" style={commonTestStyles.vmargin}>
         Compound Button
       </CompoundButton>
-      <CompoundButton secondaryContent="square" shape="square" style={commonTestStyles.vmargin}>
+      <CompoundButton secondaryText="square" shape="square" style={commonTestStyles.vmargin}>
         Compound Button
       </CompoundButton>
-      <CompoundButton secondaryContent="circular" shape="circular" style={commonTestStyles.vmargin}>
+      <CompoundButton secondaryText="circular" shape="circular" style={commonTestStyles.vmargin}>
         Compound Button
       </CompoundButton>
     </View>

--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonSizeTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonSizeTestSection.tsx
@@ -48,13 +48,13 @@ export const ButtonSizeTest: React.FunctionComponent = () => {
       <Button loading size="large" style={commonTestStyles.vmargin}>
         Loading Button Large
       </Button>
-      <CompoundButton secondaryContent="rounded" shape="rounded" style={commonTestStyles.vmargin}>
+      <CompoundButton secondaryText="rounded" shape="rounded" style={commonTestStyles.vmargin}>
         Compound Button
       </CompoundButton>
-      <CompoundButton secondaryContent="square" shape="square" style={commonTestStyles.vmargin}>
+      <CompoundButton secondaryText="square" shape="square" style={commonTestStyles.vmargin}>
         Compound Button
       </CompoundButton>
-      <CompoundButton secondaryContent="circular" shape="circular" style={commonTestStyles.vmargin}>
+      <CompoundButton secondaryText="circular" shape="circular" style={commonTestStyles.vmargin}>
         Compound Button
       </CompoundButton>
     </View>

--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonVariantTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonVariantTestSection.tsx
@@ -33,13 +33,13 @@ export const ButtonVariantTest: React.FunctionComponent = () => {
       <Button appearance="subtle" block style={commonTestStyles.vmargin}>
         Block Subtle
       </Button>
-      <CompoundButton secondaryContent="Compound" style={commonTestStyles.vmargin}>
+      <CompoundButton secondaryText="Compound" style={commonTestStyles.vmargin}>
         Default
       </CompoundButton>
-      <CompoundButton appearance="primary" secondaryContent="Compound" style={commonTestStyles.vmargin}>
+      <CompoundButton appearance="primary" secondaryText="Compound" style={commonTestStyles.vmargin}>
         Primary
       </CompoundButton>
-      <CompoundButton appearance="subtle" secondaryContent="Compound" style={commonTestStyles.vmargin}>
+      <CompoundButton appearance="subtle" secondaryText="Compound" style={commonTestStyles.vmargin}>
         Subtle
       </CompoundButton>
       <FAB icon={{ svgSource: svgProps, width: 20, height: 20 }} style={commonTestStyles.vmargin} />

--- a/change/@fluentui-react-native-experimental-button-3a8e4ad5-6405-48d7-8c33-aad7fd12061e.json
+++ b/change/@fluentui-react-native-experimental-button-3a8e4ad5-6405-48d7-8c33-aad7fd12061e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Button - Renamed secondaryContent to secondaryText",
+  "packageName": "@fluentui-react-native/experimental-button",
+  "email": "v.kozlova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-b12757b5-c698-463e-a062-0e9d73ade9b3.json
+++ b/change/@fluentui-react-native-tester-b12757b5-c698-463e-a062-0e9d73ade9b3.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Button - Renamed secondaryContent to secondaryText",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "v.kozlova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Button/src/CompoundButton/CompoundButton.styling.ts
+++ b/packages/experimental/Button/src/CompoundButton/CompoundButton.styling.ts
@@ -49,7 +49,7 @@ export const stylingSettings: UseStylingOptions<CompoundButtonProps, CompoundBut
       }),
       ['color', ...fontStyles.keys],
     ),
-    secondaryContent: buildProps(
+    secondaryText: buildProps(
       (tokens: CompoundButtonTokens, theme: Theme) => ({
         style: {
           ...getTextMarginAdjustment(),

--- a/packages/experimental/Button/src/CompoundButton/CompoundButton.test.tsx
+++ b/packages/experimental/Button/src/CompoundButton/CompoundButton.test.tsx
@@ -3,6 +3,6 @@ import { CompoundButton } from './CompoundButton';
 import * as renderer from 'react-test-renderer';
 
 it('CompoundButton default', () => {
-  const tree = renderer.create(<CompoundButton secondaryContent="sublabel">Default Button</CompoundButton>).toJSON();
+  const tree = renderer.create(<CompoundButton secondaryText="sublabel">Default Button</CompoundButton>).toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/packages/experimental/Button/src/CompoundButton/CompoundButton.tsx
+++ b/packages/experimental/Button/src/CompoundButton/CompoundButton.tsx
@@ -17,7 +17,7 @@ export const CompoundButton = compose<CompoundButtonType>({
     root: View,
     icon: Icon,
     content: Text,
-    secondaryContent: Text,
+    secondaryText: Text,
     contentContainer: View,
   },
   render: (userProps: CompoundButtonProps, useSlots: UseSlots<CompoundButtonType>) => {
@@ -25,11 +25,11 @@ export const CompoundButton = compose<CompoundButtonType>({
     const iconProps = createIconProps(userProps.icon);
 
     // grab the styled slots
-    const Slots = useSlots(userProps, layer => buttonLookup(layer, button.state, userProps));
+    const Slots = useSlots(userProps, (layer) => buttonLookup(layer, button.state, userProps));
 
     // now return the handler for finishing render
     return (final: CompoundButtonProps, ...children: React.ReactNode[]) => {
-      const { icon, secondaryContent, iconPosition, ...mergedProps } = mergeProps(button.props, final);
+      const { icon, secondaryText, iconPosition, ...mergedProps } = mergeProps(button.props, final);
 
       return (
         <Slots.root {...mergedProps}>
@@ -37,7 +37,7 @@ export const CompoundButton = compose<CompoundButtonType>({
           {React.Children.map(children, (child) => (
             <Slots.contentContainer>
               {typeof child === 'string' ? <Slots.content key="content">{child}</Slots.content> : child}
-              {secondaryContent && <Slots.secondaryContent key="secondaryContent">{secondaryContent}</Slots.secondaryContent>}
+              {secondaryText && <Slots.secondaryText key="secondaryText">{secondaryText}</Slots.secondaryText>}
             </Slots.contentContainer>
           ))}
           {icon && iconPosition === 'after' && <Slots.icon {...iconProps} />}

--- a/packages/experimental/Button/src/CompoundButton/CompoundButton.types.ts
+++ b/packages/experimental/Button/src/CompoundButton/CompoundButton.types.ts
@@ -28,12 +28,12 @@ export interface CompoundButtonProps extends ButtonProps {
   /**
    * Second line of text that describes the action this button takes.
    */
-  secondaryContent?: string;
+  secondaryText?: string;
 }
 
 export interface CompoundButtonSlotProps extends ButtonSlotProps {
   contentContainer: ViewProps;
-  secondaryContent: TextProps;
+  secondaryText: TextProps;
 }
 
 export interface CompoundButtonType {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
Renamed secondaryContent to secondaryText to aling with Web.
I didn't rename tokens.

### Verification
Checked manually

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
