### PR TITLE
Fix uwp button test

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonIconTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonIconTestSection.tsx
@@ -39,10 +39,12 @@ export const ButtonIconTest: React.FunctionComponent = () => {
       >
         Icon after
       </Button>
-      <Button style={commonTestStyles.vmargin} icon={{ svgSource: svgProps }}>
-        Icon Button and Chevron
-        <SvgXml xml={chevronXml} />
-      </Button>
+      {svgIconsEnabled && (
+        <Button style={commonTestStyles.vmargin} icon={{ svgSource: svgProps }}>
+          Icon Button and Chevron
+          <SvgXml xml={chevronXml} />
+        </Button>
+      )}
       <Button icon={{ fontSource: fontBuiltInProps }} style={commonTestStyles.vmargin}>
         Font icon
       </Button>

--- a/change/@fluentui-react-native-tester-ea550de0-1cb2-4f62-a88b-d6d662c34514.json
+++ b/change/@fluentui-react-native-tester-ea550de0-1cb2-4f62-a88b-d6d662c34514.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Only show chevron test when SVGs are supported",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [x] windows
- [ ] android

### Description of changes

Button test page stopped loading in UWP. A test was added that uses an SVG, which isn't supported on UWP.
Fix is to not show that version of the button when we're on UWP

### Verification
Test page loads on UWP
Test page loads and shows the button with the SVG on win32.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
