### PR TITLE
Fixed icon and duplicated secondaryContent for Compound button

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonSizeTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonSizeTestSection.tsx
@@ -48,10 +48,10 @@ export const ButtonSizeTest: React.FunctionComponent = () => {
       <Button loading size="large" style={commonTestStyles.vmargin}>
         Loading Button Large
       </Button>
-      <CompoundButton secondaryContent="Small compound button" size="small" style={commonTestStyles.vmargin}>
+      <CompoundButton secondaryContent="Small compound button" style={commonTestStyles.vmargin}>
         Compound Button
       </CompoundButton>
-      <CompoundButton secondaryContent="Medium compound button" style={commonTestStyles.vmargin}>
+      <CompoundButton secondaryContent="Medium compound button" size="medium" style={commonTestStyles.vmargin}>
         Compound Button
       </CompoundButton>
       <CompoundButton secondaryContent="Large compound button" size="large" style={commonTestStyles.vmargin}>

--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonSizeTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonSizeTestSection.tsx
@@ -57,7 +57,7 @@ export const ButtonSizeTest: React.FunctionComponent = () => {
       <CompoundButton secondaryContent="Large compound button" size="large" style={commonTestStyles.vmargin}>
         Compound Button
       </CompoundButton>
-      <CompoundButton icon={{ svgSource: svgProps }} secondaryContent="SecondaryContent" style={commonTestStyles.vmargin}>
+      <CompoundButton icon={{ svgSource: svgProps }} secondaryContent="SecondaryContent" size="small" style={commonTestStyles.vmargin}>
         Content
       </CompoundButton>
       <CompoundButton icon={{ svgSource: svgProps }} secondaryContent="SecondaryContent" size="medium" style={commonTestStyles.vmargin}>

--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonSizeTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonSizeTestSection.tsx
@@ -48,7 +48,7 @@ export const ButtonSizeTest: React.FunctionComponent = () => {
       <Button loading size="large" style={commonTestStyles.vmargin}>
         Loading Button Large
       </Button>
-      <CompoundButton secondaryContent="Small compound button" style={commonTestStyles.vmargin}>
+      <CompoundButton secondaryContent="Small compound button" size="small" style={commonTestStyles.vmargin}>
         Compound Button
       </CompoundButton>
       <CompoundButton secondaryContent="Medium compound button" size="medium" style={commonTestStyles.vmargin}>

--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonSizeTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonSizeTestSection.tsx
@@ -48,14 +48,23 @@ export const ButtonSizeTest: React.FunctionComponent = () => {
       <Button loading size="large" style={commonTestStyles.vmargin}>
         Loading Button Large
       </Button>
-      <CompoundButton secondaryContent="rounded" shape="rounded" style={commonTestStyles.vmargin}>
+      <CompoundButton secondaryContent="Small compound button" size="small" style={commonTestStyles.vmargin}>
         Compound Button
       </CompoundButton>
-      <CompoundButton secondaryContent="square" shape="square" style={commonTestStyles.vmargin}>
+      <CompoundButton secondaryContent="Medium compound button" style={commonTestStyles.vmargin}>
         Compound Button
       </CompoundButton>
-      <CompoundButton secondaryContent="circular" shape="circular" style={commonTestStyles.vmargin}>
+      <CompoundButton secondaryContent="Large compound button" size="large" style={commonTestStyles.vmargin}>
         Compound Button
+      </CompoundButton>
+      <CompoundButton icon={{ svgSource: svgProps }} secondaryContent="SecondaryContent" style={commonTestStyles.vmargin}>
+        Content
+      </CompoundButton>
+      <CompoundButton icon={{ svgSource: svgProps }} secondaryContent="SecondaryContent" size="medium" style={commonTestStyles.vmargin}>
+        Content
+      </CompoundButton>
+      <CompoundButton icon={{ svgSource: svgProps }} secondaryContent="SecondaryContent" size="large" style={commonTestStyles.vmargin}>
+        Content
       </CompoundButton>
     </View>
   );

--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonVariantTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonVariantTestSection.tsx
@@ -1,6 +1,6 @@
 import { Button, CompoundButton, FAB } from '@fluentui-react-native/experimental-button';
 import * as React from 'react';
-import { View, Text } from 'react-native';
+import { View } from 'react-native';
 import { commonTestStyles, stackStyle } from '../Common/styles';
 import { SvgIconProps } from '@fluentui-react-native/icon';
 import TestSvg from './test.svg';

--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonVariantTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonVariantTestSection.tsx
@@ -1,6 +1,6 @@
 import { Button, CompoundButton, FAB } from '@fluentui-react-native/experimental-button';
 import * as React from 'react';
-import { View } from 'react-native';
+import { View, Text } from 'react-native';
 import { commonTestStyles, stackStyle } from '../Common/styles';
 import { SvgIconProps } from '@fluentui-react-native/icon';
 import TestSvg from './test.svg';
@@ -41,6 +41,10 @@ export const ButtonVariantTest: React.FunctionComponent = () => {
       </CompoundButton>
       <CompoundButton appearance="subtle" secondaryContent="Compound" style={commonTestStyles.vmargin}>
         Subtle
+      </CompoundButton>
+      <CompoundButton secondaryContent="secondaryContent" size="large" style={commonTestStyles.vmargin}>
+        Compound Button
+        <Text>Child element</Text>
       </CompoundButton>
       <FAB icon={{ svgSource: svgProps, width: 20, height: 20 }} style={commonTestStyles.vmargin} />
       <FAB icon={{ svgSource: svgProps, width: 20, height: 20 }} style={commonTestStyles.vmargin}>

--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonVariantTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonVariantTestSection.tsx
@@ -42,10 +42,6 @@ export const ButtonVariantTest: React.FunctionComponent = () => {
       <CompoundButton appearance="subtle" secondaryContent="Compound" style={commonTestStyles.vmargin}>
         Subtle
       </CompoundButton>
-      <CompoundButton secondaryContent="secondaryContent" size="large" style={commonTestStyles.vmargin}>
-        Compound Button
-        <Text>Child element</Text>
-      </CompoundButton>
       <FAB icon={{ svgSource: svgProps, width: 20, height: 20 }} style={commonTestStyles.vmargin} />
       <FAB icon={{ svgSource: svgProps, width: 20, height: 20 }} style={commonTestStyles.vmargin}>
         FAB

--- a/change/@fluentui-react-native-experimental-button-49646ed1-9356-4792-92bc-091fd83fa6dc.json
+++ b/change/@fluentui-react-native-experimental-button-49646ed1-9356-4792-92bc-091fd83fa6dc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed duplicated content and icon for CompoundButton",
+  "packageName": "@fluentui-react-native/experimental-button",
+  "email": "v.kozlova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-cb13d523-2047-4660-b1b5-52f6f0aeadb2.json
+++ b/change/@fluentui-react-native-tester-cb13d523-2047-4660-b1b5-52f6f0aeadb2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed duplicated content and icon for CompoundButton",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "v.kozlova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Button/src/Button.styling.ts
+++ b/packages/experimental/Button/src/Button.styling.ts
@@ -1,9 +1,9 @@
 import { buttonName, ButtonCoreTokens, ButtonTokens, ButtonSlotProps, ButtonPropsWithInnerRef, ButtonSize } from './Button.types';
 import { Theme, UseStylingOptions, buildProps } from '@fluentui-react-native/framework';
-import { borderStyles, layoutStyles, fontStyles, shadowStyles } from '@fluentui-react-native/tokens';
+import { borderStyles, layoutStyles, fontStyles, shadowStyles, FontTokens } from '@fluentui-react-native/tokens';
 import { defaultButtonTokens } from './ButtonTokens';
 import { defaultButtonColorTokens } from './ButtonColorTokens';
-import { Platform } from 'react-native';
+import { Platform, ColorValue } from 'react-native';
 import { getTextMarginAdjustment } from '@fluentui-react-native/styling-utils';
 
 export const buttonCoreStates: (keyof ButtonCoreTokens)[] = ['hovered', 'focused', 'pressed', 'disabled', 'hasContent', 'hasIcon'];
@@ -49,18 +49,9 @@ export const stylingSettings: UseStylingOptions<ButtonPropsWithInnerRef, ButtonS
     ),
     content: buildProps(
       (tokens: ButtonTokens, theme: Theme) => {
-        const spacingIconContent = tokens.spacingIconContent
-          ? {
-              marginLeft: tokens.spacingIconContent,
-              marginRight: tokens.spacingIconContent,
-            }
-          : {};
         return {
           style: {
-            color: tokens.color,
-            ...getTextMarginAdjustment(),
-            ...spacingIconContent,
-            ...fontStyles.from(tokens, theme),
+            ...contentStyling(tokens, theme, tokens.color, tokens),
           },
         };
       },
@@ -87,4 +78,19 @@ export const getDefaultSize = (): ButtonSize => {
   }
 
   return 'medium';
+};
+
+export const contentStyling = (tokens: ButtonTokens, theme: Theme, contentColor: ColorValue, fontStylesTokens: FontTokens) => {
+  const spacingIconContent = tokens.spacingIconContent
+    ? {
+        marginLeft: tokens.spacingIconContent,
+        marginRight: tokens.spacingIconContent,
+      }
+    : {};
+  return {
+    color: contentColor,
+    ...getTextMarginAdjustment(),
+    ...spacingIconContent,
+    ...fontStyles.from(fontStylesTokens, theme),
+  };
 };

--- a/packages/experimental/Button/src/CompoundButton/CompoundButton.styling.ts
+++ b/packages/experimental/Button/src/CompoundButton/CompoundButton.styling.ts
@@ -2,11 +2,10 @@ import { compoundButtonName, CompoundButtonTokens, CompoundButtonSlotProps, Comp
 import { Theme, UseStylingOptions, buildProps } from '@fluentui-react-native/framework';
 import { borderStyles, fontStyles, layoutStyles } from '@fluentui-react-native/tokens';
 import { defaultButtonColorTokens } from '../ButtonColorTokens';
-import { buttonStates } from '../Button.styling';
+import { buttonStates, contentStyling } from '../Button.styling';
 import { defaultButtonTokens } from '../ButtonTokens';
 import { defaultCompoundButtonColorTokens } from './CompoundButtonColorTokens';
 import { defaultCompoundButtonTokens } from './CompoundButtonTokens';
-import { getTextMarginAdjustment } from '@fluentui-react-native/styling-utils';
 
 export const stylingSettings: UseStylingOptions<CompoundButtonPropsWithInnerRef, CompoundButtonSlotProps, CompoundButtonTokens> = {
   tokens: [
@@ -40,32 +39,34 @@ export const stylingSettings: UseStylingOptions<CompoundButtonPropsWithInnerRef,
       },
     },
     content: buildProps(
-      (tokens: CompoundButtonTokens, theme: Theme) => ({
-        style: {
-          ...getTextMarginAdjustment(),
-          color: tokens.color,
-          ...fontStyles.from(tokens, theme),
-        },
-      }),
-      ['color', ...fontStyles.keys],
+      (tokens: CompoundButtonTokens, theme: Theme) => {
+        return {
+          style: {
+            ...contentStyling(tokens, theme, tokens.color, tokens),
+          },
+        };
+      },
+      ['color', 'spacingIconContent', ...fontStyles.keys],
     ),
     secondaryContent: buildProps(
-      (tokens: CompoundButtonTokens, theme: Theme) => ({
-        style: {
-          ...getTextMarginAdjustment(),
-          color: tokens.secondaryContentColor,
-          ...fontStyles.from(tokens.secondaryContentFont, theme),
-        },
-      }),
-      ['secondaryContentColor', 'secondaryContentFont'],
+      (tokens: CompoundButtonTokens, theme: Theme) => {
+        return {
+          style: {
+            ...contentStyling(tokens, theme, tokens.secondaryContentColor, tokens.secondaryContentFont),
+          },
+        };
+      },
+      ['secondaryContentColor', 'secondaryContentFont', ...fontStyles.keys],
     ),
     icon: buildProps(
       (tokens: CompoundButtonTokens) => ({
         style: {
           tintColor: tokens.iconColor,
         },
+        height: tokens.iconSize,
+        width: tokens.iconSize,
       }),
-      ['iconColor'],
+      ['iconColor', 'iconSize'],
     ),
   },
 };

--- a/packages/experimental/Button/src/CompoundButton/CompoundButton.tsx
+++ b/packages/experimental/Button/src/CompoundButton/CompoundButton.tsx
@@ -34,12 +34,12 @@ const CompoundButtonComposed = compose<CompoundButtonType>({
       return (
         <Slots.root {...mergedProps}>
           {icon && iconPosition === 'before' && <Slots.icon {...iconProps} />}
-          {React.Children.map(children, (child) => (
-            <Slots.contentContainer>
-              {typeof child === 'string' ? <Slots.content key="content">{child}</Slots.content> : child}
-              {secondaryContent && <Slots.secondaryContent key="secondaryContent">{secondaryContent}</Slots.secondaryContent>}
-            </Slots.contentContainer>
-          ))}
+          <Slots.contentContainer>
+            {React.Children.map(children, (child) =>
+              typeof child === 'string' ? <Slots.content key="content">{child}</Slots.content> : child,
+            )}
+            {secondaryContent && <Slots.secondaryContent key="secondaryContent">{secondaryContent}</Slots.secondaryContent>}
+          </Slots.contentContainer>
           {icon && iconPosition === 'after' && <Slots.icon {...iconProps} />}
         </Slots.root>
       );

--- a/packages/experimental/Button/src/CompoundButton/CompoundButton.types.ts
+++ b/packages/experimental/Button/src/CompoundButton/CompoundButton.types.ts
@@ -24,7 +24,7 @@ export interface CompoundButtonTokens extends ButtonTokens {
   hasContent?: CompoundButtonTokens;
 }
 
-export interface CompoundButtonPropsWithInnerRef extends ButtonPropsWithInnerRef {
+export interface CompoundButtonPropsWithInnerRef extends Omit<ButtonPropsWithInnerRef, 'iconOnly'> {
   /**
    * Second line of text that describes the action this button takes.
    */

--- a/packages/experimental/Button/src/CompoundButton/CompoundButtonTokens.ts
+++ b/packages/experimental/Button/src/CompoundButton/CompoundButtonTokens.ts
@@ -17,6 +17,9 @@ export const defaultCompoundButtonTokens: TokenSettings<CompoundButtonTokens, Th
       focused: {
         paddingHorizontal: globalTokens.spacing.m,
       },
+      hasIcon: {
+        spacingIconContent: globalTokens.spacing.m,
+      },
     },
   },
   small: {
@@ -32,6 +35,9 @@ export const defaultCompoundButtonTokens: TokenSettings<CompoundButtonTokens, Th
       focused: {
         paddingHorizontal: globalTokens.spacing.s,
       },
+      hasIcon: {
+        spacingIconContent: globalTokens.spacing.s,
+      },
     },
   },
   large: {
@@ -46,6 +52,9 @@ export const defaultCompoundButtonTokens: TokenSettings<CompoundButtonTokens, Th
       secondaryContentFont: { variant: 'bodyStandard' },
       focused: {
         paddingHorizontal: globalTokens.spacing.l,
+      },
+      hasIcon: {
+        spacingIconContent: globalTokens.spacing.l,
       },
     },
   },


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
Fixed icon and duplicated secondary Content for CompoundButton
Still need to clarify with design rules for icons in CompoundButton.

### Verification
**Before:**
1. duplicated content
![image](https://user-images.githubusercontent.com/11574680/146070273-62f0c195-a2e8-4bde-9c2f-b32c937dee05.png)
2. No icon
![image](https://user-images.githubusercontent.com/11574680/146070399-3b12328a-f8c8-4bd5-9289-9a35c3a0e1d9.png)


**After:**
1. 
![image](https://user-images.githubusercontent.com/11574680/146070344-c8da68d1-7914-4d89-92b3-cd1947826293.png)
2. 
![image](https://user-images.githubusercontent.com/11574680/146070487-88cfab36-e8b1-4b73-8e26-1f42792c8d51.png)

### Pull request checklist

This PR has considered (when applicable):
- [X] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
