### PR TITLE
Fix Compound button hover color

### DIFF
--- a/change/@fluentui-react-native-apple-theme-5904ecaa-3e32-4b09-a624-13494f8c43a4.json
+++ b/change/@fluentui-react-native-apple-theme-5904ecaa-3e32-4b09-a624-13494f8c43a4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix button hover color",
+  "packageName": "@fluentui-react-native/apple-theme",
+  "email": "email not defined",
+  "dependentChangeType": "none"
+}

--- a/packages/theming/apple-theme/src/appleColors.macos.ts
+++ b/packages/theming/apple-theme/src/appleColors.macos.ts
@@ -490,7 +490,7 @@ export function fallbackApplePalette(): ThemeColorDefinition {
     brandedPressedSecondaryContent: ColorWithSystemEffectMacOS(fluentUIApple.neutralForegroundInverted, 'pressed'),
 
     defaultDisabledSecondaryContent: fluentUIApple.brandForegroundDisabled,
-    defaultHoveredSecondaryContent: fluentUIApple.neutralForegroundInverted,
+    defaultHoveredSecondaryContent: fluentUIApple.neutralForeground3,
     defaultPressedSecondaryContent: fluentUIApple.neutralForegroundInverted,
 
     checkboxBackground: fluentUIApple.communicationBlue,


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Let's set secondary content hover color the same as default content hover color.

### Verification
https://user-images.githubusercontent.com/67026167/146438174-af86ae2c-305a-4e0b-a913-d3163b36db76.mov


https://user-images.githubusercontent.com/67026167/146438237-e4b40b66-3f88-47c0-91c4-339d5df7cde7.mov


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
