### PR TITLE
ContextualMenu macOS - Override NSResponder.cancelOperation(sender) instead of keyDown to close Callout on escape key press

### DIFF
--- a/change/@fluentui-react-native-callout-8e3b6be0-8bbc-434f-816b-a2363deea498.json
+++ b/change/@fluentui-react-native-callout-8e3b6be0-8bbc-434f-816b-a2363deea498.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "remove carbon header",
+  "packageName": "@fluentui-react-native/callout",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Callout/macos/CalloutWindow.swift
+++ b/packages/components/Callout/macos/CalloutWindow.swift
@@ -1,6 +1,5 @@
 import Foundation
 import AppKit
-import Carbon.HIToolbox
 
 protocol CalloutWindowLifeCycleDelegate: AnyObject {
 	/// Notify the delegate that the Callout is about to dismiss
@@ -41,6 +40,7 @@ class CalloutWindow: NSWindow {
 		return false
 	}
 
+	// Required to close the window on escape key press
 	override func cancelOperation(_ sender: Any?) {
 		dismissCallout()
 	}

--- a/packages/components/Callout/macos/CalloutWindow.swift
+++ b/packages/components/Callout/macos/CalloutWindow.swift
@@ -41,14 +41,8 @@ class CalloutWindow: NSWindow {
 		return false
 	}
 
-	// Dismiss the Callout if the user presses the Escape Key
-	override func keyDown(with event: NSEvent)  {
-		switch Int(event.keyCode) {
-		case kVK_Escape:
-			dismissCallout()
-		default:
-			return super.keyDown(with: event)
-		}
+	override func cancelOperation(_ sender: Any?) {
+		dismissCallout()
 	}
 
 	@objc private func dismissCallout() {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Right after I checked in #1255 , @mischreiber pointed out we could have override `cancelOperation` (which NSWindow inherits from NSResponder) to get the same behavior of closing the window on escape key press. Presumably we will get other native behavior of closing a window for free from this, too. Best of all, we no longer need a Carbon header :D 

### Verification

Callout still dismisses on escape key press.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [x] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
