### PR TITLE
Revert content prop removal

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/E2EButtonTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/E2EButtonTest.tsx
@@ -23,12 +23,13 @@ export const E2EButtonExperimentalTest: React.FunctionComponent = () => {
   return (
     <View>
       <Stack style={stackStyle}>
-        <Button testID={BUTTONEXPERIMENTAL_TEST_COMPONENT} onClick={onClick} accessibilityLabel={BUTTONEXPERIMENTAL_ACCESSIBILITY_LABEL}>
-          This is a button for E2E testing
-        </Button>
-        <Button testID={BUTTONEXPERIMENTAL_NO_A11Y_LABEL_COMPONENT} onClick={onClick}>
-          {BUTTONEXPERIMENTAL_TEST_COMPONENT_LABEL}
-        </Button>
+        <Button
+          content="This is a button for E2E testing"
+          testID={BUTTONEXPERIMENTAL_TEST_COMPONENT}
+          onClick={onClick}
+          accessibilityLabel={BUTTONEXPERIMENTAL_ACCESSIBILITY_LABEL}
+        />
+        <Button content={BUTTONEXPERIMENTAL_TEST_COMPONENT_LABEL} testID={BUTTONEXPERIMENTAL_NO_A11Y_LABEL_COMPONENT} onClick={onClick} />
         {buttonPressed ? <Text testID={BUTTONEXPERIMENTAL_ON_PRESS}>Button Pressed</Text> : null}
       </Stack>
     </View>

--- a/change/@fluentui-react-native-experimental-button-77a3259d-9ab6-408a-8ff0-bf8e662e6e3d.json
+++ b/change/@fluentui-react-native-experimental-button-77a3259d-9ab6-408a-8ff0-bf8e662e6e3d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Revert \"Remove content prop (#1257)\"",
+  "packageName": "@fluentui-react-native/experimental-button",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-menu-button-8b6eb04c-4d5b-4f61-b364-a9c3463e86b9.json
+++ b/change/@fluentui-react-native-experimental-menu-button-8b6eb04c-4d5b-4f61-b364-a9c3463e86b9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Revert \"Remove content prop (#1257)\"",
+  "packageName": "@fluentui-react-native/experimental-menu-button",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-5f71e6a8-3dca-4ac9-973e-0ccb4229d075.json
+++ b/change/@fluentui-react-native-tester-5f71e6a8-3dca-4ac9-973e-0ccb4229d075.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Revert \"Remove content prop (#1257)\"",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-use-slot-aebc0724-7699-4365-bd70-45119cea7f39.json
+++ b/change/@fluentui-react-native-use-slot-aebc0724-7699-4365-bd70-45119cea7f39.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Revert \"Remove content prop (#1257)\"",
+  "packageName": "@fluentui-react-native/use-slot",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Button/src/Button.tsx
+++ b/packages/experimental/Button/src/Button.tsx
@@ -47,20 +47,10 @@ const ButtonComposed = compose<ButtonType>({
     const Slots = useSlots(userProps, (layer) => buttonLookup(layer, button.state, userProps));
 
     // now return the handler for finishing render
-    return (final: ButtonPropsWithInnerRef, children: React.ReactNode[]) => {
-      const { icon, iconPosition, loading, accessiblityLabel, ...mergedProps } = mergeProps(button.props, final);
-      let childText = '';
-      if (accessiblityLabel === undefined) {
-        React.Children.forEach(children, (child) => {
-          if (typeof child === 'string') {
-            childText = child; // We only automatically support the one child string.
-          }
-        });
-      }
-      const label = accessiblityLabel ? accessiblityLabel : childText;
-
+    return (final: ButtonPropsWithInnerRef, ...children: React.ReactNode[]) => {
+      const { icon, iconPosition, loading, ...mergedProps } = mergeProps(button.props, final);
       return (
-        <Slots.root {...mergedProps} accessibilityLabel={label}>
+        <Slots.root {...mergedProps}>
           {icon && iconPosition === 'before' && <Slots.icon {...iconProps} />}
           {loading && <ActivityIndicator />}
           {React.Children.map(children, (child) =>

--- a/packages/experimental/Button/src/Button.types.ts
+++ b/packages/experimental/Button/src/Button.types.ts
@@ -75,15 +75,15 @@ export interface ButtonTokens extends ButtonCoreTokens {
 
 export interface ButtonCorePropsWithInnerRef extends Omit<IWithPressableOptions<ViewProps>, 'onPress'> {
   /*
+   * Text to show on the Button.
+   * Only used in FAB
+   */
+  content?: string;
+
+  /*
    * Source URL or name of the icon to show on the Button.
    */
   icon?: IconSourcesType;
-
-  /**
-   * Button contains only icon, there's no text content
-   * Must be set for button to style correctly when button has not content.
-   */
-  iconOnly?: boolean;
 
   innerRef?: React.ForwardedRef<IFocusable>;
 
@@ -137,6 +137,12 @@ export interface ButtonPropsWithInnerRef extends ButtonCorePropsWithInnerRef {
    * @default false
    */
   loading?: boolean;
+
+  /**
+   * Button contains only icon, there's no text content
+   * Must be set for button to style correctly when button has not content.
+   */
+  iconOnly?: boolean;
 }
 
 export type ButtonProps = Omit<ButtonPropsWithInnerRef, 'innerRef'>;

--- a/packages/experimental/Button/src/FAB/FABCore.tsx
+++ b/packages/experimental/Button/src/FAB/FABCore.tsx
@@ -19,7 +19,7 @@ import { ButtonCorePropsWithInnerRef, ButtonCoreProps } from '../Button.types';
  * @returns Whether the styles that are assigned to the layer should be applied to the button
  */
 const buttonLookup = (layer: string, state: IPressableState, userProps: ButtonCorePropsWithInnerRef): boolean => {
-  return state[layer] || userProps[layer] || (layer === 'hasContent' && !userProps.iconOnly) || (layer === 'hasIcon' && userProps.icon);
+  return state[layer] || userProps[layer] || (layer === 'hasContent' && userProps.content) || (layer === 'hasIcon' && userProps.icon);
 };
 
 const FABComposed = compose<FABType>({

--- a/packages/experimental/Button/src/__snapshots__/Button.test.tsx.snap
+++ b/packages/experimental/Button/src/__snapshots__/Button.test.tsx.snap
@@ -2,7 +2,6 @@
 
 exports[`Button component tests Button circular 1`] = `
 <View
-  accessibilityLabel="Circular Button"
   accessibilityRole="button"
   accessibilityState={
     Object {
@@ -63,7 +62,6 @@ exports[`Button component tests Button circular 1`] = `
 
 exports[`Button component tests Button default 1`] = `
 <View
-  accessibilityLabel="Default Button"
   accessibilityRole="button"
   accessibilityState={
     Object {
@@ -123,7 +121,6 @@ exports[`Button component tests Button default 1`] = `
 
 exports[`Button component tests Button large 1`] = `
 <View
-  accessibilityLabel="Large Button"
   accessibilityRole="button"
   accessibilityState={
     Object {
@@ -184,7 +181,6 @@ exports[`Button component tests Button large 1`] = `
 
 exports[`Button component tests Button primary 1`] = `
 <View
-  accessibilityLabel="Primary Button"
   accessibilityRole="button"
   accessibilityState={
     Object {
@@ -245,7 +241,6 @@ exports[`Button component tests Button primary 1`] = `
 
 exports[`Button component tests Button small 1`] = `
 <View
-  accessibilityLabel="Small Button"
   accessibilityRole="button"
   accessibilityState={
     Object {
@@ -306,7 +301,6 @@ exports[`Button component tests Button small 1`] = `
 
 exports[`Button component tests Button square 1`] = `
 <View
-  accessibilityLabel="Square Button"
   accessibilityRole="button"
   accessibilityState={
     Object {
@@ -367,7 +361,6 @@ exports[`Button component tests Button square 1`] = `
 
 exports[`Button component tests Button subtle 1`] = `
 <View
-  accessibilityLabel="Subtle Button"
   accessibilityRole="button"
   accessibilityState={
     Object {

--- a/packages/experimental/Button/src/useButton.ts
+++ b/packages/experimental/Button/src/useButton.ts
@@ -18,7 +18,7 @@ export const useButton = (props: ButtonPropsWithInnerRef): ButtonState => {
       accessible: true,
       accessibilityRole: 'button',
       onAccessibilityTap: props.onAccessibilityTap || props.onClick,
-      accessibilityLabel: props.accessibilityLabel,
+      accessibilityLabel: props.accessibilityLabel || props.content,
       accessibilityState: getAccessibilityState(!!disabled || !!loading),
       enableFocusRing: true,
       focusable: true,

--- a/packages/experimental/MenuButton/src/MenuButton.tsx
+++ b/packages/experimental/MenuButton/src/MenuButton.tsx
@@ -34,13 +34,13 @@ export const MenuButton = compose<MenuButtonType>({
     }, [showContextualMenu, setShowContextualMenu]);
 
     const buttonProps = {
+      content,
       disabled,
       appearance,
       icon,
       style,
       ref: stdBtnRef,
       onClick: toggleShowContextualMenu,
-      iconOnly: content ? false : true,
       ...rest,
     };
 
@@ -82,10 +82,11 @@ export const MenuButton = compose<MenuButtonType>({
           <svg width="12" height="16" viewBox="0 0 11 6" color=${chevronColor}>
             <path fill='currentColor' d='M0.646447 0.646447C0.841709 0.451184 1.15829 0.451184 1.35355 0.646447L5.5 4.79289L9.64645 0.646447C9.84171 0.451185 10.1583 0.451185 10.3536 0.646447C10.5488 0.841709 10.5488 1.15829 10.3536 1.35355L5.85355 5.85355C5.65829 6.04882 5.34171 6.04882 5.14645 5.85355L0.646447 1.35355C0.451184 1.15829 0.451184 0.841709 0.646447 0.646447Z' />
           </svg>`;
+      const { content, ...restButtonProps } = buttonProps;
 
       return (
         <Slots.root>
-          <Button {...buttonProps}>
+          <Button {...restButtonProps}>
             {content}
             <Slots.chevronIcon xml={chevronXml} />
           </Button>

--- a/packages/experimental/MenuButton/src/MenuButton.types.ts
+++ b/packages/experimental/MenuButton/src/MenuButton.types.ts
@@ -26,7 +26,6 @@ export interface MenuButtonProps extends ButtonWithRefProps {
   menuItems?: MenuButtonItemProps[];
   onItemClick?: (key: string) => void;
   contextualMenu?: ContextualMenuProps;
-  content?: string;
 }
 
 export type MenuButtonSlotProps = {

--- a/packages/experimental/MenuButton/src/__tests__/__snapshots__/MenuButton.test.tsx.snap
+++ b/packages/experimental/MenuButton/src/__tests__/__snapshots__/MenuButton.test.tsx.snap
@@ -2,7 +2,6 @@
 
 exports[`ContextualMenu default 1`] = `
 <View
-  accessibilityLabel="Press for Nested MenuButton"
   accessibilityRole="button"
   accessibilityState={
     Object {
@@ -12,7 +11,6 @@ exports[`ContextualMenu default 1`] = `
   accessible={true}
   enableFocusRing={true}
   focusable={true}
-  iconOnly={false}
   onAccessibilityTap={[Function]}
   onBlur={[Function]}
   onClick={[Function]}

--- a/packages/framework/use-slot/src/stagedComponent.ts
+++ b/packages/framework/use-slot/src/stagedComponent.ts
@@ -45,7 +45,7 @@ function asArray<T>(val: T | T[]): T[] {
 export function stagedComponent<TProps>(staged: StagedRender<TProps>, memo?: boolean): ComposableFunction<TProps> {
   const component = (props: React.PropsWithChildren<TProps>) => {
     const { children, ...rest } = props;
-    return staged(rest as TProps)({} as React.PropsWithChildren<TProps>, asArray(children));
+    return staged(rest as TProps)({} as React.PropsWithChildren<TProps>, ...asArray(children));
   };
   const stagedComponent = memo ? React.memo(component) : component;
   Object.assign(stagedComponent, { _staged: staged });


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This change is causing a11y and build issues, reverting to unblock build

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
