### PR TITLE
Fix disabled button behavior

### DIFF
--- a/change/@fluentui-react-native-experimental-button-a7425d7c-22b9-4d11-b836-e9f504dd72e5.json
+++ b/change/@fluentui-react-native-experimental-button-a7425d7c-22b9-4d11-b836-e9f504dd72e5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix disabled button behavior",
+  "packageName": "@fluentui-react-native/experimental-button",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Button/src/useButton.ts
+++ b/packages/experimental/Button/src/useButton.ts
@@ -11,6 +11,7 @@ export const useButton = (props: ButtonPropsWithInnerRef): ButtonState => {
   const onClickWithFocus = useOnPressWithFocus(ref, onClick);
   const pressable = useAsPressable({ ...rest, onPress: onClickWithFocus });
   const onKeyUpProps = useKeyUpProps(onClick, ' ', 'Enter');
+  const isDisabled = !!disabled || !!loading;
 
   return {
     props: {
@@ -19,9 +20,9 @@ export const useButton = (props: ButtonPropsWithInnerRef): ButtonState => {
       accessibilityRole: 'button',
       onAccessibilityTap: props.onAccessibilityTap || props.onClick,
       accessibilityLabel: props.accessibilityLabel || props.content,
-      accessibilityState: getAccessibilityState(!!disabled || !!loading),
+      accessibilityState: getAccessibilityState(isDisabled),
       enableFocusRing: true,
-      focusable: true,
+      focusable: !isDisabled,
       ref: useViewCommandFocus(ref),
       ...onKeyUpProps,
       iconPosition: props.iconPosition || 'before',


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [ ] win32 (Office)
- [x] windows
- [x] android

### Description of changes

Disabled and loading buttons were interactable outside of win32.

focusable should not be set to true if button is disabled.

### Verification

Tabbed and clicked on buttons to ensure interaction is not occurring anymore

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [x] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
