### PR TITLE
Fix RTL for ContextualMenu on macOS

### DIFF
--- a/change/@fluentui-react-native-callout-72255e1c-311b-440c-801d-68811c410a2c.json
+++ b/change/@fluentui-react-native-callout-72255e1c-311b-440c-801d-68811c410a2c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix RTL for ContextualMenu on macOS",
+  "packageName": "@fluentui-react-native/callout",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-contextual-menu-a7cce320-4c55-4f34-ac0a-b29e7f21e183.json
+++ b/change/@fluentui-react-native-contextual-menu-a7cce320-4c55-4f34-ac0a-b29e7f21e183.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix RTL for ContextualMenu on macOS",
+  "packageName": "@fluentui-react-native/contextual-menu",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Callout/macos/Callout.swift
+++ b/packages/components/Callout/macos/Callout.swift
@@ -110,6 +110,7 @@ class CalloutView: RCTView, CalloutWindowLifeCycleDelegate {
 		let anchorScreenRect = anchorRect.equalTo(.null) ? calculateAnchorViewScreenRect() : calculateAnchorRectScreenRect()
 		let calloutScreenRect = bestCalloutRect(relativeTo: anchorScreenRect)
 
+		proxyView.frame.origin = .zero
 		calloutWindow.setFrame(calloutScreenRect, display: false)
 	}
 

--- a/packages/components/ContextualMenu/src/ContextualMenu.settings.macos.ts
+++ b/packages/components/ContextualMenu/src/ContextualMenu.settings.macos.ts
@@ -1,8 +1,12 @@
 import { contextualMenuName, ContextualMenuType } from './ContextualMenu.types';
 import { IComposeSettings } from '@uifabricshared/foundation-compose';
+import { I18nManager } from 'react-native';
 
 export const settings: IComposeSettings<ContextualMenuType> = [
   {
+    tokens: {
+      directionalHint: I18nManager.isRTL ? 'bottomRightEdge' : 'bottonLeftEdge',
+    },
     container: {
       style: {
         padding: 5,

--- a/packages/components/ContextualMenu/src/Submenu.settings.macos.ts
+++ b/packages/components/ContextualMenu/src/Submenu.settings.macos.ts
@@ -1,0 +1,19 @@
+import { submenuName, SubmenuType } from './Submenu.types';
+import { IComposeSettings } from '@uifabricshared/foundation-compose';
+import { I18nManager } from 'react-native';
+
+export const settings: IComposeSettings<SubmenuType> = [
+  {
+    root: {
+      accessibilityRole: 'menu',
+      directionalHint: I18nManager.isRTL ? 'leftTopEdge' : 'rightTopEdge',
+    },
+    container: {
+      style: {
+        padding: 5,
+        flex: 1,
+      },
+    },
+  },
+  submenuName,
+];


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Previously, ContextualMenu's would show up as completely blank on macOS if we ran FluentTester in RTL. This is because in our native code, the x coordinate for the view was off, so the actual view would not be within the bounds of the Callout. This is because within Callout, there is _a lot_ of manual positioning code that converts coordinates between different coordinate spaces of views/windows/screens. 

A simple fix is to make sure we reset the Callout's proxyView's (the view that holds the RN view hierarchy) frame's origin to zero, ensuring that it is always rendering within the Callout.  

Let's also change the directional hint in RTL to be the mirror of what it is manually via settings. In the future, we should implement the 'bottom_auto_edge' hint to flip in RTL. But really, in the future I think we should re-evaluate the directionalHint enum to be more RN Friendly / LTR-RTL agnostic.

### Verification

Ran FluentTester in RTL and verified that the ContextualMenu and submenus flipped.

<img width="411" alt="Screen Shot 2021-12-22 at 12 37 13 PM" src="https://user-images.githubusercontent.com/6722175/147140457-945a96ca-a91b-4612-ab1e-67f23a4edd8c.png">

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [x] Internationalization and Right-to-left Layouts
