### PR TITLE
Add fallback theme if no palette is passed in

### DIFF
--- a/change/@fluentui-react-native-win32-theme-016ef9ec-cc81-4a3c-962d-7e4e67fe1f8f.json
+++ b/change/@fluentui-react-native-win32-theme-016ef9ec-cc81-4a3c-962d-7e4e67fe1f8f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fallback to WhiteColors",
+  "packageName": "@fluentui-react-native/win32-theme",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/theming/win32-theme/src/createOfficeTheme.ts
+++ b/packages/theming/win32-theme/src/createOfficeTheme.ts
@@ -30,7 +30,7 @@ export function createOfficeTheme(options: ThemeOptions = {}): ThemeReference {
   const themeRef = new ThemeReference(
     createDefaultTheme(options),
     () => {
-      const name = paletteName || '';
+      const name = paletteName || 'WhiteColors';
       const palette = handlePaletteCall(ref.module.getPalette(name));
       return createPartialOfficeTheme(module, ref.themeName, palette);
     },


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

We should fall back to some sort of palette if none is passed in. Since there is some unresolved discussion around using the newer palette, I'm just going to fall back to what we already use generally, the White Colors palette.
