### PR TITLE
Add missing theme entries for Android

### DIFF
--- a/change/@fluentui-react-native-default-theme-f2f858fd-d8f8-4947-bcee-ca0f08ded76b.json
+++ b/change/@fluentui-react-native-default-theme-f2f858fd-d8f8-4947-bcee-ca0f08ded76b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add fallback entries",
+  "packageName": "@fluentui-react-native/default-theme",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-theme-types-8549ee75-c2e7-48d5-9c7f-8339ec49be8b.json
+++ b/change/@fluentui-react-native-theme-types-8549ee75-c2e7-48d5-9c7f-8339ec49be8b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add fallback entries",
+  "packageName": "@fluentui-react-native/theme-types",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/theming/default-theme/src/defaultColors.ts
+++ b/packages/theming/default-theme/src/defaultColors.ts
@@ -209,6 +209,14 @@ export function paletteFromFabricColors(p: FabricWebPalette, isInverted?: boolea
     defaultDisabledSecondaryContent: p.neutralTertiary,
     defaultHoveredSecondaryContent: p.neutralTertiary,
     defaultPressedSecondaryContent: p.neutralTertiary,
+
+    checkmarkColor: p.white,
+    checkboxBackground: p.themePrimary,
+    checkboxBackgroundDisabled: p.neutralLighter,
+    checkboxBorderColor: p.neutralSecondaryAlt,
+
+    personaActivityRing: p.white,
+    personaActivityGlow: p.themePrimary,
   };
 }
 

--- a/packages/theming/default-theme/src/defaultColors.ts
+++ b/packages/theming/default-theme/src/defaultColors.ts
@@ -497,6 +497,14 @@ export function getStockWebHCPalette(): ThemeColorDefinition {
     defaultDisabledSecondaryContent: '#ffffff',
     defaultHoveredSecondaryContent: '#000000',
     defaultPressedSecondaryContent: '#000000',
+
+    checkmarkColor: '#ffffff',
+    checkboxBackground: '#000000',
+    checkboxBackgroundDisabled: '#000000',
+    checkboxBorderColor: '#ffffff',
+
+    personaActivityRing: '#ffffff',
+    personaActivityGlow: 'transparent', // glow probably doesn't make sense on HC
     ...createAliasTokens('highContrast'),
   };
 }

--- a/packages/theming/theme-types/src/Color.types.ts
+++ b/packages/theming/theme-types/src/Color.types.ts
@@ -444,6 +444,7 @@ export interface ControlColorTokens {
   checkboxBackground: ColorValue;
   checkboxBackgroundDisabled: ColorValue;
   checkmarkColor: ColorValue;
+  checkboxBorderColor: ColorValue;
 
   personaActivityRing: ColorValue;
   personaActivityGlow: ColorValue;


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [x] android

### Description of changes

Adding missing entries to the default theme so that Android can be run without explicitly specifying a theme. We don't require people to create a theme using FURN to use our components, but on Android our README example doesn't work out of the box because some entries that are used by checkbox are missing from the default theme.

### Verification

Verified via removing theme from tester that checkbox renders properly

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
