### PR TITLE
Rename boxside on Checkbox to labelPosition

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/CheckboxExperimental/CheckboxTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/CheckboxExperimental/CheckboxTest.tsx
@@ -44,7 +44,7 @@ const otherCheckbox: React.FunctionComponent = () => {
     <View>
       <Checkbox label="This is a controlled Checkbox" onChange={onChangeControlled1} checked={Boolean(isCheckedControlled1)} />
       <Checkbox
-        label="Checkbox rendered with boxSide 'end' (controlled)"
+        label="Checkbox rendered with labelPosition 'after' (controlled)"
         onChange={onChangeControlled2}
         labelPosition="after"
         checked={Boolean(isCheckedControlled2)}

--- a/apps/fluent-tester/src/FluentTester/TestComponents/CheckboxExperimental/CheckboxTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/CheckboxExperimental/CheckboxTest.tsx
@@ -44,9 +44,9 @@ const otherCheckbox: React.FunctionComponent = () => {
     <View>
       <Checkbox label="This is a controlled Checkbox" onChange={onChangeControlled1} checked={Boolean(isCheckedControlled1)} />
       <Checkbox
-        label="Checkbox rendered with labelPosition 'after' (controlled)"
+        label="Checkbox rendered with labelPosition 'before' (controlled)"
         onChange={onChangeControlled2}
-        labelPosition="after"
+        labelPosition="before"
         checked={Boolean(isCheckedControlled2)}
       />
     </View>
@@ -106,7 +106,7 @@ const tokenCheckbox: React.FunctionComponent = () => {
       <BlueCheckbox
         label="Token-customized checkbox. Customizable below."
         onChange={onChangeUncontrolled}
-        labelPosition="after"
+        labelPosition="before"
         defaultChecked={false}
       />
 

--- a/apps/fluent-tester/src/FluentTester/TestComponents/CheckboxExperimental/CheckboxTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/CheckboxExperimental/CheckboxTest.tsx
@@ -46,7 +46,7 @@ const otherCheckbox: React.FunctionComponent = () => {
       <Checkbox
         label="Checkbox rendered with boxSide 'end' (controlled)"
         onChange={onChangeControlled2}
-        boxSide="end"
+        labelPosition="after"
         checked={Boolean(isCheckedControlled2)}
       />
     </View>
@@ -106,7 +106,7 @@ const tokenCheckbox: React.FunctionComponent = () => {
       <BlueCheckbox
         label="Token-customized checkbox. Customizable below."
         onChange={onChangeUncontrolled}
-        boxSide="end"
+        labelPosition="after"
         defaultChecked={false}
       />
 

--- a/change/@fluentui-react-native-experimental-checkbox-4989fe45-f807-4ce2-8580-6a3dfd8548d3.json
+++ b/change/@fluentui-react-native-experimental-checkbox-4989fe45-f807-4ce2-8580-6a3dfd8548d3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Rename boxside to labelPosition",
+  "packageName": "@fluentui-react-native/experimental-checkbox",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-c94cac5a-aac8-4164-9174-68a63b7f4f3b.json
+++ b/change/@fluentui-react-native-tester-c94cac5a-aac8-4164-9174-68a63b7f4f3b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix tests",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Checkbox/src/Checkbox.tsx
+++ b/packages/experimental/Checkbox/src/Checkbox.tsx
@@ -28,7 +28,7 @@ export const Checkbox = compose<CheckboxType>({
 
       return (
         <Slots.root {...mergedProps}>
-          {Checkbox.state.boxAtEnd && <Slots.content key="content">{label}</Slots.content>}
+          {Checkbox.state.labelIsBefore && <Slots.content key="content">{label}</Slots.content>}
           <Slots.checkbox>
             <Slots.checkmark key="checkmark" viewBox="0 0 11 8">
               <Path
@@ -37,7 +37,7 @@ export const Checkbox = compose<CheckboxType>({
               />
             </Slots.checkmark>
           </Slots.checkbox>
-          {!Checkbox.state.boxAtEnd && <Slots.content key="content">{label}</Slots.content>}
+          {!Checkbox.state.labelIsBefore && <Slots.content key="content">{label}</Slots.content>}
           {children}
         </Slots.root>
       );

--- a/packages/experimental/Checkbox/src/Checkbox.types.ts
+++ b/packages/experimental/Checkbox/src/Checkbox.types.ts
@@ -46,6 +46,8 @@ export interface CheckboxProps extends Omit<IViewProps, 'onPress'> {
 
   /**
    * Allows you to set the checkbox to be at the before (start) or after (end) the label
+   *
+   * @default: 'after'
    */
   labelPosition?: 'before' | 'after';
 
@@ -87,9 +89,9 @@ export interface CheckboxState extends IPressableState {
   disabled?: boolean;
 
   /**
-   * Determines position of Checkbox. True if labelPosition is set to 'after'
+   * Determines position of Checkbox. True if labelPosition is set to 'before'
    */
-  boxAtEnd?: boolean;
+  labelIsBefore?: boolean;
 }
 
 export interface CheckboxInfo {

--- a/packages/experimental/Checkbox/src/Checkbox.types.ts
+++ b/packages/experimental/Checkbox/src/Checkbox.types.ts
@@ -47,7 +47,7 @@ export interface CheckboxProps extends Omit<IViewProps, 'onPress'> {
   /**
    * Allows you to set the checkbox to be at the before (start) or after (end) the label
    */
-  boxSide?: 'start' | 'end';
+  labelPosition?: 'before' | 'after';
 
   /**
    * Disabled state of the checkbox.
@@ -87,7 +87,7 @@ export interface CheckboxState extends IPressableState {
   disabled?: boolean;
 
   /**
-   * Determines position of Checkbox. True if boxSide='end'
+   * Determines position of Checkbox. True if labelPosition is set to 'after'
    */
   boxAtEnd?: boolean;
 }

--- a/packages/experimental/Checkbox/src/__tests__/Checkbox.test.tsx
+++ b/packages/experimental/Checkbox/src/__tests__/Checkbox.test.tsx
@@ -14,7 +14,7 @@ describe('Checkbox component tests', () => {
 
   it('Checkbox all props', () => {
     const tree = renderer
-      .create(<Checkbox label="All Props Checkbox" onChange={onChange} defaultChecked={true} boxSide="end" disabled />)
+      .create(<Checkbox label="All Props Checkbox" onChange={onChange} defaultChecked={true} labelPosition="after" disabled />)
       .toJSON();
     expect(tree).toMatchSnapshot();
   });

--- a/packages/experimental/Checkbox/src/__tests__/Checkbox.test.tsx
+++ b/packages/experimental/Checkbox/src/__tests__/Checkbox.test.tsx
@@ -14,7 +14,7 @@ describe('Checkbox component tests', () => {
 
   it('Checkbox all props', () => {
     const tree = renderer
-      .create(<Checkbox label="All Props Checkbox" onChange={onChange} defaultChecked={true} labelPosition="after" disabled />)
+      .create(<Checkbox label="All Props Checkbox" onChange={onChange} defaultChecked={true} labelPosition="before" disabled />)
       .toJSON();
     expect(tree).toMatchSnapshot();
   });

--- a/packages/experimental/Checkbox/src/__tests__/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/experimental/Checkbox/src/__tests__/__snapshots__/Checkbox.test.tsx.snap
@@ -18,10 +18,10 @@ exports[`Checkbox component tests Checkbox all props 1`] = `
     }
   }
   accessible={true}
-  boxSide="end"
   defaultChecked={true}
   disabled={true}
   focusable={false}
+  labelPosition="after"
   onAccessibilityAction={[Function]}
   onBlur={[Function]}
   onChange={[Function]}

--- a/packages/experimental/Checkbox/src/__tests__/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/experimental/Checkbox/src/__tests__/__snapshots__/Checkbox.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`Checkbox component tests Checkbox all props 1`] = `
   defaultChecked={true}
   disabled={true}
   focusable={false}
-  labelPosition="after"
+  labelPosition="before"
   onAccessibilityAction={[Function]}
   onBlur={[Function]}
   onChange={[Function]}
@@ -72,7 +72,7 @@ exports[`Checkbox component tests Checkbox all props 1`] = `
         "borderRadius": 2,
         "borderStyle": "solid",
         "borderWidth": 1,
-        "marginEnd": 0,
+        "marginEnd": 4,
         "marginLeft": undefined,
         "minHeight": 16,
         "minWidth": 16,

--- a/packages/experimental/Checkbox/src/useCheckbox.ts
+++ b/packages/experimental/Checkbox/src/useCheckbox.ts
@@ -24,7 +24,7 @@ export const useCheckbox = (props: CheckboxProps): CheckboxInfo => {
     accessibilityRole,
     checked,
     defaultChecked,
-    boxSide,
+    labelPosition,
     label,
     onChange,
     componentRef = defaultComponentRef,
@@ -54,7 +54,7 @@ export const useCheckbox = (props: CheckboxProps): CheckboxInfo => {
     ...pressable.state,
     disabled: !!props.disabled,
     checked: isChecked,
-    boxAtEnd: boxSide == undefined || boxSide == 'start' ? false : true,
+    boxAtEnd: labelPosition === 'after' ? true : false,
   };
 
   const onAccessibilityAction = React.useCallback(

--- a/packages/experimental/Checkbox/src/useCheckbox.ts
+++ b/packages/experimental/Checkbox/src/useCheckbox.ts
@@ -54,7 +54,7 @@ export const useCheckbox = (props: CheckboxProps): CheckboxInfo => {
     ...pressable.state,
     disabled: !!props.disabled,
     checked: isChecked,
-    boxAtEnd: labelPosition === 'after' ? true : false,
+    labelIsBefore: labelPosition === 'before' ? true : false,
   };
 
   const onAccessibilityAction = React.useCallback(


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

To align with fluentui's prop name, renaming "boxside" to "labelPosition" and using "before"/"after" instead of "start"/"end"

### Verification

Build and tests pass. Tested checkbox on tester app to ensure the checkbox is still positioned correctly.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
