### PR TITLE
Change how setAndForwardRef is exported

### DIFF
--- a/change/@fluentui-react-native-interactive-hooks-895a08e4-cde5-45ba-8710-b3814c6129b8.json
+++ b/change/@fluentui-react-native-interactive-hooks-895a08e4-cde5-45ba-8710-b3814c6129b8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Change export method",
+  "packageName": "@fluentui-react-native/interactive-hooks",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/utils/interactive-hooks/src/setAndForwardRef.ts
+++ b/packages/utils/interactive-hooks/src/setAndForwardRef.ts
@@ -41,14 +41,12 @@ type Args = {
  *     }
  *   }
  *
- *   const MyViewWithRef = React.forwardRef((props, ref) => (
+ *   export const MyViewWithRef = React.forwardRef((props, ref) => (
  *     <MyView {...props} forwardedRef={ref} />
  *   ));
- *
- *   module.exports = MyViewWithRef;
  */
 
-function setAndForwardRef({ getForwardedRef, setLocalRef }: Args): (ref: ElementRef<any>) => void {
+export function setAndForwardRef({ getForwardedRef, setLocalRef }: Args): (ref: ElementRef<any>) => void {
   return function forwardRef(ref: ElementRef<any>) {
     const forwardedRef = getForwardedRef();
 
@@ -64,5 +62,3 @@ function setAndForwardRef({ getForwardedRef, setLocalRef }: Args): (ref: Element
     }
   };
 }
-
-module.exports = setAndForwardRef;

--- a/packages/utils/interactive-hooks/src/useViewCommandFocus.macos.ts
+++ b/packages/utils/interactive-hooks/src/useViewCommandFocus.macos.ts
@@ -17,11 +17,11 @@ export function useViewCommandFocus(
   /**
    * Set up the forwarding ref to enable adding the focus method.
    */
-  const focusRef = React.useRef<React.Component>();
+  const focusRef = React.useRef<any>();
 
   const _setNativeRef = setAndForwardRef({
     getForwardedRef: () => forwardedRef,
-    setLocalRef: (localRef) => {
+    setLocalRef: (localRef: any) => {
       focusRef.current = localRef;
 
       /**

--- a/packages/utils/interactive-hooks/src/useViewCommandFocus.macos.ts
+++ b/packages/utils/interactive-hooks/src/useViewCommandFocus.macos.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { findNodeHandle, UIManager, View } from 'react-native';
-
-const setAndForwardRef = require('./setAndForwardRef');
+import { setAndForwardRef } from './setAndForwardRef';
 
 export type IFocusable = View;
 /**

--- a/packages/utils/interactive-hooks/src/useViewCommandFocus.win32.ts
+++ b/packages/utils/interactive-hooks/src/useViewCommandFocus.win32.ts
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { findNodeHandle, UIManager } from 'react-native';
 import { IViewWin32 } from '@office-iss/react-native-win32';
-
-const setAndForwardRef = require('./setAndForwardRef');
+import { setAndForwardRef } from './setAndForwardRef';
 
 export type IFocusable = IViewWin32;
 /**

--- a/packages/utils/interactive-hooks/src/useViewCommandFocus.win32.ts
+++ b/packages/utils/interactive-hooks/src/useViewCommandFocus.win32.ts
@@ -18,11 +18,11 @@ export function useViewCommandFocus(
   /**
    * Set up the forwarding ref to enable adding the focus method.
    */
-  const focusRef = React.useRef<React.Component>();
+  const focusRef = React.useRef<any>();
 
   const _setNativeRef = setAndForwardRef({
     getForwardedRef: () => forwardedRef,
-    setLocalRef: (localRef) => {
+    setLocalRef: (localRef: any) => {
       focusRef.current = localRef;
 
       /**


### PR DESCRIPTION
Fixes #1316 

### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Change how setAndForwardRef is exported. The module.exports assignment is apparently causing issues with bundles for partners. Changing export method to using the export keyword. This also means updating places where it is imported to using the import keyword instead of require.

I had to add any to a few types to get things to compile. This is a blocking issue so I'd rather get this fixed first and figure out the typing issues when this is not a blocking issue.

### Verification

Verified js doesn't generate the module.exports lines. Build passes. Loaded tester app, no crash, focus logic runs as expected.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
