### PR TITLE
Added active and activeAppearance props

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/Avatar/BasicAvatar.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Avatar/BasicAvatar.tsx
@@ -74,8 +74,8 @@ export const StandardUsage: FunctionComponent = () => {
   const tokens: JSAvatarTokens = {};
   const [isSquare, setSquare] = useState(false);
   const [showImage, setShowImage] = useState(true);
-  const [active, setActive] = useState('unset');
-  const [activeAppearance, setActiveAppearance] = useState('ring');
+  const [active, setActive] = useState<AvatarActive>('unset');
+  const [activeAppearance, setActiveAppearance] = useState<AvatarActiveAppearance>('ring');
   const [imageSize, setImageSize] = useState<WithUndefined<AvatarSize>>('size72');
   const [coinColor, setCoinColor] = useState<WithUndefined<AvatarColor>>('brass');
   const [presence, setPresence] = useState<WithUndefined<AvatarPresence>>('online');

--- a/apps/fluent-tester/src/FluentTester/TestComponents/Avatar/BasicAvatar.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Avatar/BasicAvatar.tsx
@@ -1,5 +1,12 @@
 import React, { useState, useCallback, FunctionComponent } from 'react';
-import { AvatarSize, AvatarColor, JSAvatar, AvatarPresence } from '@fluentui-react-native/experimental-avatar';
+import {
+  AvatarSize,
+  AvatarColor,
+  JSAvatar,
+  AvatarPresence,
+  AvatarActive,
+  AvatarActiveAppearance,
+} from '@fluentui-react-native/experimental-avatar';
 import { Switch, View, Text, Picker, ColorValue } from 'react-native';
 import { satyaPhotoUrl, undefinedText } from './../PersonaCoin/styles';
 import { commonTestStyles as commonStyles } from '../Common/styles';
@@ -7,6 +14,9 @@ import { useTheme } from '@fluentui-react-native/theme-types';
 import { JSAvatarTokens } from '@fluentui-react-native/experimental-avatar';
 
 type WithUndefined<T> = T | typeof undefinedText;
+
+const avatarActive: AvatarActive[] = ['unset', 'active', 'inactive'];
+const avatarActiveAppearance: AvatarActiveAppearance[] = ['ring', 'shadow', 'glow', 'ring-shadow', 'ring-glow'];
 
 const allSizes: WithUndefined<AvatarSize>[] = [
   undefinedText,
@@ -64,10 +74,14 @@ export const StandardUsage: FunctionComponent = () => {
   const tokens: JSAvatarTokens = {};
   const [isSquare, setSquare] = useState(false);
   const [showImage, setShowImage] = useState(true);
+  const [active, setActive] = useState('unset');
+  const [activeAppearance, setActiveAppearance] = useState('ring');
   const [imageSize, setImageSize] = useState<WithUndefined<AvatarSize>>('size72');
   const [coinColor, setCoinColor] = useState<WithUndefined<AvatarColor>>('brass');
   const [presence, setPresence] = useState<WithUndefined<AvatarPresence>>('online');
 
+  const onActiveChange = useCallback((value) => setActive(value), []);
+  const onActiveAppearanceChange = useCallback((value) => setActiveAppearance(value), []);
   const onSizeChange = useCallback((value) => setImageSize(value), []);
   const onColorChange = useCallback((value) => setCoinColor(value), []);
   const onPresenceChange = useCallback((value) => setPresence(value), []);
@@ -90,11 +104,22 @@ export const StandardUsage: FunctionComponent = () => {
         </View>
 
         <StyledPicker prompt="Size" selected={imageSize} onChange={onSizeChange} collection={allSizes} />
+        <StyledPicker prompt="Active" selected={active} onChange={onActiveChange} collection={avatarActive} />
+        {active === 'active' ? (
+          <StyledPicker
+            prompt="Active appearance"
+            selected={activeAppearance}
+            onChange={onActiveAppearanceChange}
+            collection={avatarActiveAppearance}
+          />
+        ) : null}
         <StyledPicker prompt="Coin color" selected={coinColor} onChange={onColorChange} collection={allColors} />
         <StyledPicker prompt="Presence status" selected={presence} onChange={onPresenceChange} collection={allPresences} />
       </View>
 
       <JSAvatar
+        active={active}
+        activeAppearance={activeAppearance}
         size={imageSize === undefinedText ? undefined : imageSize}
         initials="SN"
         shape={isSquare ? 'square' : 'circular'}

--- a/apps/fluent-tester/src/FluentTester/TestComponents/Avatar/CustomizedAvatar.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Avatar/CustomizedAvatar.tsx
@@ -11,7 +11,7 @@ export const CustomizeUsage: React.FunctionComponent = () => {
   const [showImage, setShowImage] = React.useState(true);
   const [coinColor, setCoinColor] = React.useState<string>();
   const [textColor, setTextColor] = React.useState<string>();
-  const [physicalSize, setPhysicalSize] = React.useState<number>(80);
+  const [physicalSize, setPhysicalSize] = React.useState<number>(96);
   const [iconSize, setIconSize] = React.useState<number>(24);
   const [iconStrokeWidth, setIconStrokeWidth] = React.useState<number>(2);
   const [iconStrokeColor, setIconStrokeColor] = React.useState<string>(undefined);
@@ -138,6 +138,8 @@ export const CustomizeUsage: React.FunctionComponent = () => {
       </View>
 
       <CustomizedAvatar
+        active="active"
+        activeAppearance="ring"
         initials="SB"
         imageDescription="Former CEO of Microsoft"
         presence="blocked"

--- a/change/@fluentui-react-native-experimental-avatar-b4167802-8375-4d7b-98b0-e2051abb0ebf.json
+++ b/change/@fluentui-react-native-experimental-avatar-b4167802-8375-4d7b-98b0-e2051abb0ebf.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "added active and activeAppearance props",
+  "packageName": "@fluentui-react-native/experimental-avatar",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-828ddd79-15e0-4a71-9cc4-d4b3cab21d74.json
+++ b/change/@fluentui-react-native-tester-828ddd79-15e0-4a71-9cc4-d4b3cab21d74.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "added active and activeAppearance props",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-win32-bff7ba80-8dd7-432a-9254-a5e475dd7e7c.json
+++ b/change/@fluentui-react-native-tester-win32-bff7ba80-8dd7-432a-9254-a5e475dd7e7c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "added active and activeAppearance props",
+  "packageName": "@fluentui-react-native/tester-win32",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Avatar/src/JSAvatar.helpers.ts
+++ b/packages/experimental/Avatar/src/JSAvatar.helpers.ts
@@ -1,4 +1,4 @@
-import { AvatarSize, AvatarColor, AvatarPresence, JSAvatarTokens, RingThickness } from './JSAvatar.types';
+import { AvatarSize, AvatarColor, AvatarPresence, JSAvatarTokens } from './JSAvatar.types';
 import { ImageURISource } from 'react-native';
 import { globalTokens } from '@fluentui-react-native/theme-tokens';
 
@@ -106,21 +106,22 @@ export function calculateEffectiveSizes(tokens: JSAvatarTokens): AvatarSizeConfi
   }
 }
 
-export function getRingThickness(thickness: RingThickness): number {
-  switch (thickness) {
-    case 'xSmall':
-      return 1;
-    case 'small':
-      return 1;
-    case 'medium':
-      return 2;
-    case 'large':
-      return 2;
-    case 'xlarge':
-      return 2;
-    case 'xxlarge':
-      return 4;
-    default:
-      return thickness < 0 ? 4 : thickness;
-  }
+export function getRingConfig(size: number): any {
+  if (size <= 48)
+    return {
+      size: size + 8,
+      stroke: globalTokens.stroke.width.thick,
+      innerStroke: globalTokens.stroke.width.thick,
+    };
+  if (size <= 71)
+    return {
+      size: size + 12,
+      stroke: globalTokens.stroke.width.thicker,
+      innerStroke: globalTokens.stroke.width.thicker,
+    };
+  return {
+    size: size + 16,
+    stroke: globalTokens.stroke.width.thickest,
+    innerStroke: globalTokens.stroke.width.thickest,
+  };
 }

--- a/packages/experimental/Avatar/src/JSAvatar.helpers.ts
+++ b/packages/experimental/Avatar/src/JSAvatar.helpers.ts
@@ -24,8 +24,12 @@ const presenceIconCache: { [key in AvatarPresence]: ImageURISource } = {
   },
 };
 
-// TODO: Need icons for the OOF statuses
 const presenceOOFIconCache = presenceIconCache;
+const sizeAdjustment = {
+  small: 8,
+  medium: 12,
+  large: 16,
+};
 
 export function getPresenceIconSource(presence: AvatarPresence, isOutOfOffice: boolean): ImageURISource {
   return isOutOfOffice ? presenceOOFIconCache[presence] : presenceIconCache[presence];
@@ -109,18 +113,18 @@ export function calculateEffectiveSizes(tokens: JSAvatarTokens): AvatarSizeConfi
 export function getRingConfig(size: number): any {
   if (size <= 48)
     return {
-      size: size + 8,
+      size: size + sizeAdjustment.small,
       stroke: globalTokens.stroke.width.thick,
       innerStroke: globalTokens.stroke.width.thick,
     };
   if (size <= 71)
     return {
-      size: size + 12,
+      size: size + sizeAdjustment.medium,
       stroke: globalTokens.stroke.width.thicker,
       innerStroke: globalTokens.stroke.width.thicker,
     };
   return {
-    size: size + 16,
+    size: size + sizeAdjustment.large,
     stroke: globalTokens.stroke.width.thickest,
     innerStroke: globalTokens.stroke.width.thickest,
   };

--- a/packages/experimental/Avatar/src/JSAvatar.helpers.ts
+++ b/packages/experimental/Avatar/src/JSAvatar.helpers.ts
@@ -111,18 +111,20 @@ export function calculateEffectiveSizes(tokens: JSAvatarTokens): AvatarSizeConfi
 }
 
 export function getRingConfig(size: number): any {
-  if (size <= 48)
+  if (size <= 48) {
     return {
       size: size + sizeAdjustment.small,
       stroke: globalTokens.stroke.width.thick,
       innerStroke: globalTokens.stroke.width.thick,
     };
-  if (size <= 71)
+  }
+  if (size <= 71) {
     return {
       size: size + sizeAdjustment.medium,
       stroke: globalTokens.stroke.width.thicker,
       innerStroke: globalTokens.stroke.width.thicker,
     };
+  }
   return {
     size: size + sizeAdjustment.large,
     stroke: globalTokens.stroke.width.thickest,

--- a/packages/experimental/Avatar/src/JSAvatar.styling.ts
+++ b/packages/experimental/Avatar/src/JSAvatar.styling.ts
@@ -2,7 +2,7 @@ import { JSAvatarName, JSAvatarTokens, AvatarSlotProps, JSAvatarProps } from './
 import { Theme, UseStylingOptions, buildProps } from '@fluentui-react-native/framework';
 import { defaultJSAvatarTokens } from './JSAvatarTokens';
 import { ViewStyle } from 'react-native';
-import { calculateEffectiveSizes, convertCoinColorFluent, getRingThickness } from './JSAvatar.helpers';
+import { calculateEffectiveSizes, convertCoinColorFluent, getRingConfig } from './JSAvatar.helpers';
 import { borderStyles } from '@fluentui-react-native/tokens';
 
 const nameMap: { [key: string]: string } = {
@@ -11,7 +11,7 @@ const nameMap: { [key: string]: string } = {
   end: 'flex-end',
 };
 
-export const avatarStates: (keyof JSAvatarTokens)[] = ['circular', 'square'];
+export const avatarStates: (keyof JSAvatarTokens)[] = ['circular', 'square', 'inactive'];
 
 export const stylingSettings: UseStylingOptions<JSAvatarProps, AvatarSlotProps, JSAvatarTokens> = {
   tokens: [defaultJSAvatarTokens, JSAvatarName],
@@ -30,10 +30,11 @@ export const stylingSettings: UseStylingOptions<JSAvatarProps, AvatarSlotProps, 
             alignItems: nameMap[verticalIconAlignment || 'end'] as ViewStyle['alignItems'],
             horizontalIconAlignment,
             verticalIconAlignment,
+            opacity: tokens.avatarOpacity,
           },
         };
       },
-      ['horizontalIconAlignment', 'verticalIconAlignment'],
+      ['horizontalIconAlignment', 'verticalIconAlignment', 'avatarOpacity'],
     ),
     initials: buildProps(
       (tokens: JSAvatarTokens) => {
@@ -106,25 +107,19 @@ export const stylingSettings: UseStylingOptions<JSAvatarProps, AvatarSlotProps, 
     ring: buildProps(
       (tokens: JSAvatarTokens, theme: Theme) => {
         const { physicalSize } = calculateEffectiveSizes(tokens);
-        const { ring } = tokens;
+        const ringConfig = getRingConfig(physicalSize);
 
-        if (!ring) return {};
-
-        const innerGap = ring.innerGap != undefined ? getRingThickness(ring.innerGap) : getRingThickness(ring.ringThickness || 'xxlarge');
-
-        const effectiveRingThickness = 2 * getRingThickness(ring.ringThickness || 'xxlarge') + innerGap;
-        const effectiveSize = physicalSize + 2 * effectiveRingThickness;
-        const ringColor = ring.ringBackgroundColor || theme.colors.personaActivityRing;
+        const ringColor = tokens.ringColor;
         return {
           style: {
             borderStyle: 'solid',
             borderColor: ringColor,
-            borderWidth: effectiveRingThickness,
-            width: effectiveSize,
-            height: effectiveSize,
+            borderWidth: ringConfig.stroke,
+            width: ringConfig.size,
+            height: ringConfig.size,
             position: 'absolute',
-            top: -effectiveRingThickness,
-            left: -effectiveRingThickness,
+            top: -ringConfig.stroke * 2,
+            left: -ringConfig.stroke * 2,
             ...borderStyles.from(tokens, theme),
           },
         };
@@ -134,25 +129,19 @@ export const stylingSettings: UseStylingOptions<JSAvatarProps, AvatarSlotProps, 
     glow: buildProps(
       (tokens: JSAvatarTokens, theme: Theme) => {
         const { physicalSize } = calculateEffectiveSizes(tokens);
-        const { ring } = tokens;
+        const ringConfig = getRingConfig(physicalSize);
 
-        if (!ring) return {};
-
-        const innerGap = ring.innerGap != undefined ? getRingThickness(ring.innerGap) : getRingThickness(ring.ringThickness || 'xxlarge');
-
-        const effectiveRingThickness = getRingThickness(ring.ringThickness || 'xxlarge') + innerGap;
-        const effectiveSize = physicalSize + 2 * effectiveRingThickness;
-        const glowColor = ring.accent ? theme.colors.accentButtonBackground : ring.ringColor || theme.colors.personaActivityGlow;
+        const glowColor = tokens.ringColor;
         return {
           style: {
             borderStyle: 'solid',
             borderColor: glowColor,
-            borderWidth: effectiveRingThickness - innerGap,
-            width: effectiveSize,
-            height: effectiveSize,
+            borderWidth: ringConfig.stroke - ringConfig.innerStroke,
+            width: ringConfig.size,
+            height: ringConfig.size,
             position: 'absolute',
-            top: -effectiveRingThickness,
-            left: -effectiveRingThickness,
+            top: -ringConfig.stroke * 2,
+            left: -ringConfig.stroke * 2,
             ...borderStyles.from(tokens, theme),
           },
         };

--- a/packages/experimental/Avatar/src/JSAvatar.tsx
+++ b/packages/experimental/Avatar/src/JSAvatar.tsx
@@ -14,7 +14,13 @@ import { useAvatar } from './useAvatar';
  * @returns Whether the styles that are assigned to the layer should be applied to the avatar
  */
 export const avatarLookup = (layer: string, state: JSAvatarState, userProps: JSAvatarProps): boolean => {
-  return state[layer] || userProps[layer] || layer === userProps['shape'] || (!userProps['shape'] && layer === 'circular');
+  return (
+    state[layer] ||
+    userProps[layer] ||
+    layer === userProps['shape'] ||
+    (!userProps['shape'] && layer === 'circular') ||
+    (userProps.active === 'inactive' && layer === 'inactive')
+  );
 };
 
 export const JSAvatar = compose<JSAvatarType>({
@@ -34,7 +40,7 @@ export const JSAvatar = compose<JSAvatarType>({
     const Slots = useSlots(userProps, (layer) => avatarLookup(layer, avatar.state, userProps));
 
     return (final: JSAvatarProps) => {
-      const { children, accessibilityLabel, ...mergedProps } = mergeProps(avatar.props, final);
+      const { children, accessibilityLabel, activeAppearance, ...mergedProps } = mergeProps(avatar.props, final);
       const { personaPhotoSource, iconSource, showRing, transparentRing } = avatar.state;
 
       return (
@@ -47,7 +53,7 @@ export const JSAvatar = compose<JSAvatarType>({
             </Slots.initialsBackground>
           )}
           {showRing && !transparentRing && <Slots.ring />}
-          {showRing && <Slots.glow />}
+          {activeAppearance === 'glow' && <Slots.glow />}
           {!!iconSource && !!iconSource.uri && <Slots.icon source={iconSource} />}
         </Slots.root>
       );

--- a/packages/experimental/Avatar/src/JSAvatar.types.ts
+++ b/packages/experimental/Avatar/src/JSAvatar.types.ts
@@ -5,7 +5,6 @@ import { IBackgroundColorTokens, IForegroundColorTokens, IBorderTokens } from '@
 export const JSAvatarName = 'Avatar';
 
 export type AvatarSize = 'size8' | 'size24' | 'size32' | 'size40' | 'size48' | 'size56' | 'size72' | 'size100' | 'size120';
-export type Size = 20 | 24 | 28 | 32 | 36 | 40 | 48 | 56 | 64 | 72 | 96 | 120;
 
 export type AvatarShape = 'circular' | 'square';
 export type AvatarActive = 'active' | 'inactive' | 'unset';

--- a/packages/experimental/Avatar/src/JSAvatar.types.ts
+++ b/packages/experimental/Avatar/src/JSAvatar.types.ts
@@ -5,6 +5,7 @@ import { IBackgroundColorTokens, IForegroundColorTokens, IBorderTokens } from '@
 export const JSAvatarName = 'Avatar';
 
 export type AvatarSize = 'size8' | 'size24' | 'size32' | 'size40' | 'size48' | 'size56' | 'size72' | 'size100' | 'size120';
+export type Size = 20 | 24 | 28 | 32 | 36 | 40 | 48 | 56 | 64 | 72 | 96 | 120;
 
 export type AvatarShape = 'circular' | 'square';
 export type AvatarActive = 'active' | 'inactive' | 'unset';
@@ -37,15 +38,13 @@ export type AvatarColor =
 
 export type AvatarPresence = 'none' | 'offline' | 'online' | 'away' | 'dnd' | 'blocked' | 'busy';
 
-export type RingThickness = number | 'xSmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge';
-
 export interface RingConfig {
   accent?: boolean;
   transparent?: boolean;
   ringColor?: ColorValue; // glow
   ringBackgroundColor?: ColorValue; // inner/outer rings
-  ringThickness?: RingThickness;
-  innerGap?: RingThickness;
+  ringThickness?: number;
+  innerGap?: number;
 }
 
 export interface AvatarConfigurableProps {
@@ -88,6 +87,9 @@ export interface JSAvatarTokens extends IBackgroundColorTokens, IForegroundColor
   physicalSize?: number;
   circular?: JSAvatarTokens;
   square?: JSAvatarTokens;
+  inactive?: JSAvatarTokens;
+  avatarOpacity?: number;
+  ringColor?: ColorValue;
 }
 
 export interface JSAvatarState {

--- a/packages/experimental/Avatar/src/JSAvatarTokens.ts
+++ b/packages/experimental/Avatar/src/JSAvatarTokens.ts
@@ -11,10 +11,14 @@ export const defaultJSAvatarTokens: TokenSettings<JSAvatarTokens, Theme> = () =>
     color: 'white', // initials is always 'white', unless overriden by token
     iconStrokeColor: 'white', // icon stroke color is always 'white', unless overriden by token
     backgroundColor: convertCoinColorFluent('cornflower'),
+    avatarOpacity: 1,
     circular: {
       borderRadius: globalTokens.corner.radius.circle,
     },
     square: {
       borderRadius: globalTokens.corner.radius.medium,
+    },
+    inactive: {
+      avatarOpacity: 0.8,
     },
   } as JSAvatarTokens);

--- a/packages/experimental/Avatar/src/useAvatar.ts
+++ b/packages/experimental/Avatar/src/useAvatar.ts
@@ -9,7 +9,7 @@ import { getPresenceIconSource } from './JSAvatar.helpers';
  * @returns configured props and state for FURN Avatar
  */
 export const useAvatar = (props: JSAvatarProps): AvatarInfo => {
-  const { imageUrl, imageDescription, initials, presence, isOutOfOffice, ring, shape, ...rest } = props;
+  const { imageUrl, imageDescription, initials, presence, isOutOfOffice, ring, shape, active, activeAppearance, ...rest } = props;
 
   const personaPhotoSource =
     imageUrl === undefined
@@ -19,7 +19,7 @@ export const useAvatar = (props: JSAvatarProps): AvatarInfo => {
         };
 
   const iconSource = presence === undefined ? undefined : getPresenceIconSource(presence, isOutOfOffice || false);
-  const showRing = !!ring;
+  const showRing = active === 'active' && activeAppearance === 'ring';
   const transparentRing = !!ring?.transparent;
 
   const state: JSAvatarState = {
@@ -35,6 +35,8 @@ export const useAvatar = (props: JSAvatarProps): AvatarInfo => {
       accessibilityLabel: imageDescription,
       shape: shape || 'circular',
       ...rest,
+      active,
+      activeAppearance,
     },
     state: {
       ...state,


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
Added active and activeAppearance props to the Avatar component.
Active contains inactive, active and unset values.
Active appearance is added only for ring because there are still questions to Design.

### Verification
Checked manually in Tester
**Before**
Ring didn't work before for a new Avatar
![image](https://user-images.githubusercontent.com/11574680/148417957-4ebdd408-c344-4523-a109-87493cfc4218.png)


**After**
![image](https://user-images.githubusercontent.com/11574680/148415771-b4f68337-9fad-4127-abc7-42d22a750853.png)
![image](https://user-images.githubusercontent.com/11574680/148415808-660a7bf2-b1a4-49a3-970d-f4c7ad0a05be.png)
![image](https://user-images.githubusercontent.com/11574680/148415861-401f3beb-6c66-431d-b715-4ceec6627098.png)
![image](https://user-images.githubusercontent.com/11574680/148415973-b3c4c6c1-14c4-422b-8f5b-d0dafb6168dc.png)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
