### PR TITLE
Add circular prop to checkbox

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/CheckboxExperimental/CheckboxTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/CheckboxExperimental/CheckboxTest.tsx
@@ -25,6 +25,7 @@ const basicCheckbox: React.FunctionComponent = () => {
       <Checkbox label="Disabled checkbox" onChange={onChangeUncontrolled} defaultChecked={false} disabled={true} />
       <Checkbox label="Disabled checked checkbox" onChange={onChangeUncontrolled} defaultChecked={true} disabled={true} />
       <Checkbox label="Checkbox will display a tooltip" onChange={onChangeUncontrolled} tooltip="This is a tooltip" />
+      <Checkbox label="A circular checkbox" circular onChange={onChangeUncontrolled} defaultChecked={false} />
     </View>
   );
 };
@@ -54,10 +55,7 @@ const otherCheckbox: React.FunctionComponent = () => {
 };
 
 const tokenCheckbox: React.FunctionComponent = () => {
-  const CircularCheckbox = Checkbox.customize({ borderRadius: 50 });
-
   const CircleColorCheckbox = Checkbox.customize({
-    borderRadius: 50,
     checkboxBackgroundColor: 'white',
     checked: {
       checkboxBackgroundColor: 'green',
@@ -100,9 +98,8 @@ const tokenCheckbox: React.FunctionComponent = () => {
   };
   return (
     <View>
-      <CircularCheckbox label="A circular checkbox" onChange={onChangeUncontrolled} defaultChecked={false} />
       <HoverCheckbox label="A checkbox with checkmark visible on hover" onChange={onChangeUncontrolled} defaultChecked={false} />
-      <CircleColorCheckbox label="A circular token-customized checkbox" onChange={onChangeUncontrolled} defaultChecked={true} />
+      <CircleColorCheckbox label="A circular token-customized checkbox" circular onChange={onChangeUncontrolled} defaultChecked={true} />
       <BlueCheckbox
         label="Token-customized checkbox. Customizable below."
         onChange={onChangeUncontrolled}

--- a/change/@fluentui-react-native-experimental-checkbox-f19b5b51-4f8a-4306-8415-67d96a2b3eb9.json
+++ b/change/@fluentui-react-native-experimental-checkbox-f19b5b51-4f8a-4306-8415-67d96a2b3eb9.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Implement circular styling",
+  "packageName": "@fluentui-react-native/experimental-checkbox",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-6173098b-2490-44be-b88d-50222f50719e.json
+++ b/change/@fluentui-react-native-tester-6173098b-2490-44be-b88d-50222f50719e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Implement circular styling",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Checkbox/src/Checkbox.styling.ts
+++ b/packages/experimental/Checkbox/src/Checkbox.styling.ts
@@ -1,8 +1,18 @@
 import { checkboxName, CheckboxTokens, CheckboxSlotProps, CheckboxProps } from './Checkbox.types';
 import { Theme, UseStylingOptions, buildProps } from '@fluentui-react-native/framework';
 import { borderStyles, fontStyles } from '@fluentui-react-native/tokens';
-import { checkboxStates, defaultCheckboxTokens } from './CheckboxTokens';
+import { defaultCheckboxTokens } from './CheckboxTokens';
 import { globalTokens } from '@fluentui-react-native/theme-tokens';
+
+export const checkboxStates: (keyof CheckboxTokens)[] = [
+  'labelIsBefore',
+  'circular',
+  'hovered',
+  'focused',
+  'pressed',
+  'checked',
+  'disabled',
+];
 
 export const stylingSettings: UseStylingOptions<CheckboxProps, CheckboxSlotProps, CheckboxTokens> = {
   tokens: [defaultCheckboxTokens, checkboxName],

--- a/packages/experimental/Checkbox/src/Checkbox.types.ts
+++ b/packages/experimental/Checkbox/src/Checkbox.types.ts
@@ -41,6 +41,8 @@ export interface CheckboxProps extends Omit<IViewProps, 'onPress'> {
 
   /**
    * Allows you to set the checkbox to have circular styling.
+   *
+   * @platform Android, iOS, windows, win32
    */
   circular?: boolean;
 

--- a/packages/experimental/Checkbox/src/Checkbox.types.ts
+++ b/packages/experimental/Checkbox/src/Checkbox.types.ts
@@ -24,7 +24,7 @@ export interface CheckboxTokens extends FontTokens, IForegroundColorTokens, IBac
    * States that can be applied to a checkbox
    */
   disabled?: CheckboxTokens;
-  boxAtEnd?: CheckboxTokens;
+  labelIsBefore?: CheckboxTokens;
   hovered?: CheckboxTokens;
   focused?: CheckboxTokens;
   pressed?: CheckboxTokens;

--- a/packages/experimental/Checkbox/src/Checkbox.types.ts
+++ b/packages/experimental/Checkbox/src/Checkbox.types.ts
@@ -55,7 +55,7 @@ export interface CheckboxProps extends Omit<IViewProps, 'onPress'> {
   /**
    * Allows you to set the checkbox to be at the before (start) or after (end) the label
    *
-   * @default: 'after'
+   * @default after
    */
   labelPosition?: 'before' | 'after';
 

--- a/packages/experimental/Checkbox/src/Checkbox.types.ts
+++ b/packages/experimental/Checkbox/src/Checkbox.types.ts
@@ -29,6 +29,7 @@ export interface CheckboxTokens extends FontTokens, IForegroundColorTokens, IBac
   focused?: CheckboxTokens;
   pressed?: CheckboxTokens;
   checked?: CheckboxTokens;
+  circular?: CheckboxTokens;
 }
 
 export interface CheckboxProps extends Omit<IViewProps, 'onPress'> {
@@ -37,6 +38,11 @@ export interface CheckboxProps extends Omit<IViewProps, 'onPress'> {
    * and plan to pass in the correct value based on handling onChange events and re-rendering.
    */
   checked?: boolean;
+
+  /**
+   * Allows you to set the checkbox to have circular styling.
+   */
+  circular?: boolean;
 
   /**
    * Default checked state. Mutually exclusive to ‘checked’. Use this if you want an uncontrolled component, and

--- a/packages/experimental/Checkbox/src/CheckboxTokens.ts
+++ b/packages/experimental/Checkbox/src/CheckboxTokens.ts
@@ -1,8 +1,6 @@
 import { Theme } from '@fluentui-react-native/framework';
 import { TokenSettings } from '@fluentui-react-native/use-styling';
-import { CheckboxTokens } from '.';
-
-export const checkboxStates: (keyof CheckboxTokens)[] = ['labelIsBefore', 'hovered', 'focused', 'pressed', 'checked', 'disabled'];
+import { CheckboxTokens } from './Checkbox.types';
 
 export const defaultCheckboxTokens: TokenSettings<CheckboxTokens, Theme> = (t: Theme) =>
   ({
@@ -40,5 +38,8 @@ export const defaultCheckboxTokens: TokenSettings<CheckboxTokens, Theme> = (t: T
     labelIsBefore: {
       checkboxMarginStart: 4,
       checkboxMarginEnd: 0,
+    },
+    circular: {
+      borderRadius: 9999,
     },
   } as CheckboxTokens);

--- a/packages/experimental/Checkbox/src/CheckboxTokens.ts
+++ b/packages/experimental/Checkbox/src/CheckboxTokens.ts
@@ -2,7 +2,7 @@ import { Theme } from '@fluentui-react-native/framework';
 import { TokenSettings } from '@fluentui-react-native/use-styling';
 import { CheckboxTokens } from '.';
 
-export const checkboxStates: (keyof CheckboxTokens)[] = ['boxAtEnd', 'hovered', 'focused', 'pressed', 'checked', 'disabled'];
+export const checkboxStates: (keyof CheckboxTokens)[] = ['labelIsBefore', 'hovered', 'focused', 'pressed', 'checked', 'disabled'];
 
 export const defaultCheckboxTokens: TokenSettings<CheckboxTokens, Theme> = (t: Theme) =>
   ({
@@ -37,7 +37,7 @@ export const defaultCheckboxTokens: TokenSettings<CheckboxTokens, Theme> = (t: T
     checked: {
       checkmarkOpacity: 1,
     },
-    boxAtEnd: {
+    labelIsBefore: {
       checkboxMarginStart: 4,
       checkboxMarginEnd: 0,
     },

--- a/packages/experimental/Checkbox/src/CheckboxTokens.win32.ts
+++ b/packages/experimental/Checkbox/src/CheckboxTokens.win32.ts
@@ -1,9 +1,7 @@
 import { Theme } from '@fluentui-react-native/framework';
 import { TokenSettings } from '@fluentui-react-native/use-styling';
 import { globalTokens } from '@fluentui-react-native/theme-tokens';
-import { CheckboxTokens } from '.';
-
-export const checkboxStates: (keyof CheckboxTokens)[] = ['labelIsBefore', 'hovered', 'focused', 'pressed', 'checked', 'disabled'];
+import { CheckboxTokens } from './Checkbox.types';
 
 export const defaultCheckboxTokens: TokenSettings<CheckboxTokens, Theme> = (t: Theme) =>
   ({
@@ -52,12 +50,14 @@ export const defaultCheckboxTokens: TokenSettings<CheckboxTokens, Theme> = (t: T
       checkboxBorderColor: t.colors.brandBackground,
       checkmarkOpacity: 1,
       checkmarkColor: t.colors.neutralForegroundOnBrand,
-      borderRadius: globalTokens.corner.radius.medium,
       disabled: {
         checkmarkColor: t.colors.neutralForegroundDisabled,
       },
     },
     labelIsBefore: {
       checkboxMarginEnd: 0,
+    },
+    circular: {
+      borderRadius: globalTokens.corner.radius.circle,
     },
   } as CheckboxTokens);

--- a/packages/experimental/Checkbox/src/CheckboxTokens.win32.ts
+++ b/packages/experimental/Checkbox/src/CheckboxTokens.win32.ts
@@ -3,7 +3,7 @@ import { TokenSettings } from '@fluentui-react-native/use-styling';
 import { globalTokens } from '@fluentui-react-native/theme-tokens';
 import { CheckboxTokens } from '.';
 
-export const checkboxStates: (keyof CheckboxTokens)[] = ['boxAtEnd', 'hovered', 'focused', 'pressed', 'checked', 'disabled'];
+export const checkboxStates: (keyof CheckboxTokens)[] = ['labelIsBefore', 'hovered', 'focused', 'pressed', 'checked', 'disabled'];
 
 export const defaultCheckboxTokens: TokenSettings<CheckboxTokens, Theme> = (t: Theme) =>
   ({
@@ -57,7 +57,7 @@ export const defaultCheckboxTokens: TokenSettings<CheckboxTokens, Theme> = (t: T
         checkmarkColor: t.colors.neutralForegroundDisabled,
       },
     },
-    boxAtEnd: {
+    labelIsBefore: {
       checkboxMarginEnd: 0,
     },
   } as CheckboxTokens);

--- a/packages/experimental/Checkbox/src/__tests__/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/experimental/Checkbox/src/__tests__/__snapshots__/Checkbox.test.tsx.snap
@@ -72,7 +72,7 @@ exports[`Checkbox component tests Checkbox all props 1`] = `
         "borderRadius": 2,
         "borderStyle": "solid",
         "borderWidth": 1,
-        "marginEnd": 4,
+        "marginEnd": 0,
         "marginLeft": undefined,
         "minHeight": 16,
         "minWidth": 16,


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

Add `circular` prop to checkbox. This consists of adding a circular state and exposing a prop that users can set to make the checkbox circular.

The tokens will be revamped in the future, just trying to fill out the set of props for now.

### Verification

![image](https://user-images.githubusercontent.com/4602628/148477981-10bf2e26-c49a-4b6e-a1cf-524818867256.png)


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
