### PR TITLE
Fix disabled button bug on macOS

### DIFF
--- a/change/@fluentui-react-native-93cc4596-fd02-4b18-8147-0223cdd4e260.json
+++ b/change/@fluentui-react-native-93cc4596-fd02-4b18-8147-0223cdd4e260.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui/react-native",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-android-theme-245d7338-2333-4b00-b560-e86082dc62e5.json
+++ b/change/@fluentui-react-native-android-theme-245d7338-2333-4b00-b560-e86082dc62e5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/android-theme",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-apple-theme-31d71ac9-1037-41f5-a418-addd24b11ef1.json
+++ b/change/@fluentui-react-native-apple-theme-31d71ac9-1037-41f5-a418-addd24b11ef1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/apple-theme",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-button-a61e23fe-0a5a-4eb4-94d2-e91fa6e93e24.json
+++ b/change/@fluentui-react-native-button-a61e23fe-0a5a-4eb4-94d2-e91fa6e93e24.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/button",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-callout-bfd46f1c-5ddf-468a-8fd5-31a74bcf47bb.json
+++ b/change/@fluentui-react-native-callout-bfd46f1c-5ddf-468a-8fd5-31a74bcf47bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/callout",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-checkbox-c83fe82c-c26c-427c-b913-c859aac5cbc4.json
+++ b/change/@fluentui-react-native-checkbox-c83fe82c-c26c-427c-b913-c859aac5cbc4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/checkbox",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-contextual-menu-4d4166da-5c64-40a5-a5e3-9cab210ca462.json
+++ b/change/@fluentui-react-native-contextual-menu-4d4166da-5c64-40a5-a5e3-9cab210ca462.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disable buttonn",
+  "packageName": "@fluentui-react-native/contextual-menu",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-default-theme-6d1c73a0-ae6c-4fad-8998-11d4533a26e6.json
+++ b/change/@fluentui-react-native-default-theme-6d1c73a0-ae6c-4fad-8998-11d4533a26e6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/default-theme",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-activity-indicator-2f28b1d5-2198-4fc4-a481-6185f5b750de.json
+++ b/change/@fluentui-react-native-experimental-activity-indicator-2f28b1d5-2198-4fc4-a481-6185f5b750de.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/experimental-activity-indicator",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-avatar-d69bdcf7-5495-424a-91cc-bc563a02eac2.json
+++ b/change/@fluentui-react-native-experimental-avatar-d69bdcf7-5495-424a-91cc-bc563a02eac2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/experimental-avatar",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-button-3184c3f0-751d-462a-8bdc-652144e3651d.json
+++ b/change/@fluentui-react-native-experimental-button-3184c3f0-751d-462a-8bdc-652144e3651d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/experimental-button",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-checkbox-04e6b1f2-39f2-41a9-8855-52d67a29ab82.json
+++ b/change/@fluentui-react-native-experimental-checkbox-04e6b1f2-39f2-41a9-8855-52d67a29ab82.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/experimental-checkbox",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-drawer-407299f9-f26a-4fcc-aad0-2ec99e44f653.json
+++ b/change/@fluentui-react-native-experimental-drawer-407299f9-f26a-4fcc-aad0-2ec99e44f653.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/experimental-drawer",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-expander-10cd06e1-008e-4033-b9ee-7a00fdb95862.json
+++ b/change/@fluentui-react-native-experimental-expander-10cd06e1-008e-4033-b9ee-7a00fdb95862.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/experimental-expander",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-menu-button-45e372ba-91f3-43a9-b181-53131eda0392.json
+++ b/change/@fluentui-react-native-experimental-menu-button-45e372ba-91f3-43a9-b181-53131eda0392.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/experimental-menu-button",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-shimmer-ef92c08d-bc5c-432e-a949-8a63b8f93e87.json
+++ b/change/@fluentui-react-native-experimental-shimmer-ef92c08d-bc5c-432e-a949-8a63b8f93e87.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/experimental-shimmer",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-tabs-326d7882-1ab5-41df-9194-f98731d07ee9.json
+++ b/change/@fluentui-react-native-experimental-tabs-326d7882-1ab5-41df-9194-f98731d07ee9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/experimental-tabs",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-text-78216c6d-bff4-48cb-a4e5-45bf95c2f1af.json
+++ b/change/@fluentui-react-native-experimental-text-78216c6d-bff4-48cb-a4e5-45bf95c2f1af.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/experimental-text",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-focus-trap-zone-8f1a391a-9688-48a8-b393-83d7f9abeb52.json
+++ b/change/@fluentui-react-native-focus-trap-zone-8f1a391a-9688-48a8-b393-83d7f9abeb52.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled buttonn",
+  "packageName": "@fluentui-react-native/focus-trap-zone",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-focus-zone-e23974f5-94c8-4988-9db0-e4e777e722c7.json
+++ b/change/@fluentui-react-native-focus-zone-e23974f5-94c8-4988-9db0-e4e777e722c7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/focus-zone",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-framework-be976bb7-1494-4226-af45-73af2c53c2f1.json
+++ b/change/@fluentui-react-native-framework-be976bb7-1494-4226-af45-73af2c53c2f1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/framework",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-icon-3b843773-5b1b-4820-a33c-f432ebac84ad.json
+++ b/change/@fluentui-react-native-icon-3b843773-5b1b-4820-a33c-f432ebac84ad.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/icon",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-interactive-hooks-a851f342-6765-4a39-a6b0-d2fafc34af44.json
+++ b/change/@fluentui-react-native-interactive-hooks-a851f342-6765-4a39-a6b0-d2fafc34af44.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/interactive-hooks",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-link-4f106d6d-f177-46a0-9692-3d95b51256e8.json
+++ b/change/@fluentui-react-native-link-4f106d6d-f177-46a0-9692-3d95b51256e8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/link",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-menu-button-682dd1de-6fc6-4fd4-a54d-14d3088fc8b3.json
+++ b/change/@fluentui-react-native-menu-button-682dd1de-6fc6-4fd4-a54d-14d3088fc8b3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/menu-button",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-persona-3860a284-cf5d-46c3-b35d-8aa470f64232.json
+++ b/change/@fluentui-react-native-persona-3860a284-cf5d-46c3-b35d-8aa470f64232.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/persona",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-persona-coin-cd661e2f-a385-4f8e-8f68-f85f0b2e36ba.json
+++ b/change/@fluentui-react-native-persona-coin-cd661e2f-a385-4f8e-8f68-f85f0b2e36ba.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/persona-coin",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-pressable-de2449ee-0398-44d2-9398-f2feb54c11be.json
+++ b/change/@fluentui-react-native-pressable-de2449ee-0398-44d2-9398-f2feb54c11be.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/pressable",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-radio-group-c0111716-2f28-4e2e-a473-d686b0375e6c.json
+++ b/change/@fluentui-react-native-radio-group-c0111716-2f28-4e2e-a473-d686b0375e6c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/radio-group",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-separator-348f53e9-4d9a-4863-9fee-4d7027671f75.json
+++ b/change/@fluentui-react-native-separator-348f53e9-4d9a-4863-9fee-4d7027671f75.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/separator",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-stack-f75ed70e-285d-471d-b9f2-38646737ac5d.json
+++ b/change/@fluentui-react-native-stack-f75ed70e-285d-471d-b9f2-38646737ac5d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/stack",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-styling-utils-b00a01ea-6404-4028-831b-8080b85a9ed4.json
+++ b/change/@fluentui-react-native-styling-utils-b00a01ea-6404-4028-831b-8080b85a9ed4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/styling-utils",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tabs-b8c3445c-95fd-4f8d-8e78-d98cd9eacf50.json
+++ b/change/@fluentui-react-native-tabs-b8c3445c-95fd-4f8d-8e78-d98cd9eacf50.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/tabs",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-c76ad0c3-cb8d-4f52-a3ba-62284ae4e27a.json
+++ b/change/@fluentui-react-native-tester-c76ad0c3-cb8d-4f52-a3ba-62284ae4e27a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-win32-e4b5d0ce-9304-4bde-809a-74a7286556a8.json
+++ b/change/@fluentui-react-native-tester-win32-e4b5d0ce-9304-4bde-809a-74a7286556a8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/tester-win32",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-text-824e0212-9fbe-4659-8298-1f3bdebe7d28.json
+++ b/change/@fluentui-react-native-text-824e0212-9fbe-4659-8298-1f3bdebe7d28.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/text",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-theme-ab615954-71a6-4438-9ba3-22804c04a9b7.json
+++ b/change/@fluentui-react-native-theme-ab615954-71a6-4438-9ba3-22804c04a9b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/theme",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-theme-tokens-2a1f2341-9795-45c7-8b37-11d68dc50dc4.json
+++ b/change/@fluentui-react-native-theme-tokens-2a1f2341-9795-45c7-8b37-11d68dc50dc4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/theme-tokens",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-theme-types-1e02a77b-978f-4de6-951f-66656e2c06bd.json
+++ b/change/@fluentui-react-native-theme-types-1e02a77b-978f-4de6-951f-66656e2c06bd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/theme-types",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-theming-utils-26db582d-1984-4b80-8cc0-93cd05428ff1.json
+++ b/change/@fluentui-react-native-theming-utils-26db582d-1984-4b80-8cc0-93cd05428ff1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/theming-utils",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tokens-ae2784c6-6a8d-43bf-8229-b12d4c25f536.json
+++ b/change/@fluentui-react-native-tokens-ae2784c6-6a8d-43bf-8229-b12d4c25f536.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/tokens",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-win32-theme-c22b1a6b-761b-4da0-8214-63b11eef7dde.json
+++ b/change/@fluentui-react-native-win32-theme-c22b1a6b-761b-4da0-8214-63b11eef7dde.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@fluentui-react-native/win32-theme",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabricshared-foundation-compose-ad786135-4f8c-4ecf-afe7-ca467898caa2.json
+++ b/change/@uifabricshared-foundation-compose-ad786135-4f8c-4ecf-afe7-ca467898caa2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@uifabricshared/foundation-compose",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabricshared-theming-ramp-81ed55ae-fa8f-444e-8a27-93a1d90c4c35.json
+++ b/change/@uifabricshared-theming-ramp-81ed55ae-fa8f-444e-8a27-93a1d90c4c35.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@uifabricshared/theming-ramp",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabricshared-theming-react-native-c19dc22e-910f-428b-b08b-f6ebf5a05eff.json
+++ b/change/@uifabricshared-theming-react-native-c19dc22e-910f-428b-b08b-f6ebf5a05eff.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix disabled button",
+  "packageName": "@uifabricshared/theming-react-native",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Button/src/useButton.ts
+++ b/packages/experimental/Button/src/useButton.ts
@@ -8,7 +8,7 @@ export const useButton = (props: ButtonPropsWithInnerRef): ButtonState => {
   const defaultRef = React.useRef(null);
   const { onClick, innerRef, disabled, loading, ...rest } = props;
   const ref = innerRef !== null ? innerRef : defaultRef;
-  const onClickWithFocus = useOnPressWithFocus(ref, onClick);
+  const onClickWithFocus = disabled ? null : useOnPressWithFocus(ref, onClick);
   const pressable = useAsPressable({ ...rest, onPress: onClickWithFocus });
   const onKeyUpProps = useKeyUpProps(onClick, ' ', 'Enter');
   const isDisabled = !!disabled || !!loading;

--- a/packages/experimental/Button/src/useButton.ts
+++ b/packages/experimental/Button/src/useButton.ts
@@ -8,7 +8,7 @@ export const useButton = (props: ButtonPropsWithInnerRef): ButtonState => {
   const defaultRef = React.useRef(null);
   const { onClick, innerRef, disabled, loading, ...rest } = props;
   const ref = innerRef !== null ? innerRef : defaultRef;
-  // Set focusRef to null if button is disabled to prevent getting keyboard focus. This is a workaround for GH:1336
+  // GH #1336: Set focusRef to null if button is disabled to prevent getting keyboard focus.
   const focusRef = disabled ? null : ref;
   const onClickWithFocus = useOnPressWithFocus(focusRef, onClick);
   const pressable = useAsPressable({ ...rest, onPress: onClickWithFocus });

--- a/packages/experimental/Button/src/useButton.ts
+++ b/packages/experimental/Button/src/useButton.ts
@@ -8,7 +8,9 @@ export const useButton = (props: ButtonPropsWithInnerRef): ButtonState => {
   const defaultRef = React.useRef(null);
   const { onClick, innerRef, disabled, loading, ...rest } = props;
   const ref = innerRef !== null ? innerRef : defaultRef;
-  const onClickWithFocus = disabled ? null : useOnPressWithFocus(ref, onClick);
+  // Set focusRef to null if button is disabled to prevent getting keyboard focus. This is a workaround for GH:1336
+  const focusRef = disabled ? null : ref;
+  const onClickWithFocus = useOnPressWithFocus(focusRef, onClick);
   const pressable = useAsPressable({ ...rest, onPress: onClickWithFocus });
   const onKeyUpProps = useKeyUpProps(onClick, ' ', 'Enter');
   const isDisabled = !!disabled || !!loading;


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

The disabled button is selectable on macOS, so let's not pass in `onClickWithFocus` to pressable if button is disabled.

### Verification
Ensured the disabled button is working as expected. 


Before

https://user-images.githubusercontent.com/67026167/148841745-66ba4550-b918-46c1-873c-ae5ea20a289c.mov


After

https://user-images.githubusercontent.com/67026167/148841708-e0adbf43-51e3-4cc0-a8ea-be30bb0393c2.mov


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
