### PR TITLE
Remove references to uifabricshared

### DIFF
--- a/apps/android/just.config.js
+++ b/apps/android/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const {preset} = require('@fluentui-react-native/scripts');
 
 preset();

--- a/apps/android/package.json
+++ b/apps/android/package.json
@@ -41,7 +41,7 @@
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@rnx-kit/cli": "^0.9.57",
     "@rnx-kit/metro-config": "^1.2.26",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "flow-bin": "^0.113.0",
     "metro-react-native-babel-preset": "^0.66.2",
     "react-native-svg-transformer": "^0.14.3",

--- a/apps/fluent-tester/just.config.js
+++ b/apps/fluent-tester/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/apps/fluent-tester/package.json
+++ b/apps/fluent-tester/package.json
@@ -66,7 +66,7 @@
     "@types/jasmine": "3.5.10",
     "@types/react": "^17.0.2",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "@wdio/appium-service": "^6.5.0",
     "@wdio/cli": "^6.5.0",
     "@wdio/jasmine-framework": "^6.5.0",

--- a/apps/ios/just.config.js
+++ b/apps/ios/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const {preset} = require('@fluentui-react-native/scripts');
 
 preset();

--- a/apps/ios/package.json
+++ b/apps/ios/package.json
@@ -38,7 +38,7 @@
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@rnx-kit/cli": "^0.9.57",
     "@rnx-kit/metro-config": "^1.2.26",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "flow-bin": "^0.113.0",
     "metro-config": "^0.66.2",
     "metro-react-native-babel-preset": "^0.66.2",

--- a/apps/macos/just.config.js
+++ b/apps/macos/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const {preset} = require('@fluentui-react-native/scripts');
 
 preset();

--- a/apps/macos/package.json
+++ b/apps/macos/package.json
@@ -38,7 +38,7 @@
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@rnx-kit/cli": "^0.9.57",
     "@rnx-kit/metro-config": "^1.2.26",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "@wdio/appium-service": "^6.5.0",
     "@wdio/cli": "^6.5.0",
     "@wdio/jasmine-framework": "^6.5.0",

--- a/apps/web/just.config.js
+++ b/apps/web/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -34,7 +34,7 @@
     "@types/react": "^17.0.2",
     "@types/react-dom": "^16.9.0",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "file-loader": "^6.0.0",
     "html-webpack-plugin": "^4.3.0",
     "ts-loader": "^7.0.5",

--- a/apps/win32/just.config.js
+++ b/apps/win32/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/apps/win32/package.json
+++ b/apps/win32/package.json
@@ -47,7 +47,7 @@
     "@types/jasmine": "3.5.10",
     "@types/react": "^17.0.2",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@wdio/allure-reporter": "5.22.4",
     "allure-commandline": "2.13.0",

--- a/apps/windows/just.config.js
+++ b/apps/windows/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const {preset} = require('@fluentui-react-native/scripts');
 
 preset();

--- a/apps/windows/package.json
+++ b/apps/windows/package.json
@@ -35,7 +35,7 @@
     "@rnx-kit/cli": "^0.9.57",
     "@rnx-kit/metro-config": "^1.2.26",
     "@types/jasmine": "3.5.10",
-    "@uifabricshared/build-native": "0.1.1",
+    "@fluentui-react-native/scripts": "0.1.1",
     "@wdio/allure-reporter": "5.22.4",
     "@wdio/appium-service": "^6.5.0",
     "@wdio/cli": "^6.5.0",

--- a/change/@fluentui-react-native-54a54f8d-c4ca-4291-906f-30aa3cf32ef7.json
+++ b/change/@fluentui-react-native-54a54f8d-c4ca-4291-906f-30aa3cf32ef7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui/react-native",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-adapters-4bd0fc38-d40e-4736-9256-4f2f4e75b5b2.json
+++ b/change/@fluentui-react-native-adapters-4bd0fc38-d40e-4736-9256-4f2f4e75b5b2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/adapters",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-android-theme-7061b551-b84a-4b00-9b4d-d436bc801d21.json
+++ b/change/@fluentui-react-native-android-theme-7061b551-b84a-4b00-9b4d-d436bc801d21.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/android-theme",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-apple-theme-fcebf958-91f9-4238-9025-c286b41c9c3c.json
+++ b/change/@fluentui-react-native-apple-theme-fcebf958-91f9-4238-9025-c286b41c9c3c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/apple-theme",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-button-6a6029df-2442-4ab8-b401-867d5ce9a4f9.json
+++ b/change/@fluentui-react-native-button-6a6029df-2442-4ab8-b401-867d5ce9a4f9.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/button",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-callout-7dcfd0cd-7e2e-455c-8fb6-311a993f05e2.json
+++ b/change/@fluentui-react-native-callout-7dcfd0cd-7e2e-455c-8fb6-311a993f05e2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/callout",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-checkbox-499a24ef-a147-4708-ab4b-2ba491446433.json
+++ b/change/@fluentui-react-native-checkbox-499a24ef-a147-4708-ab4b-2ba491446433.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/checkbox",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-component-cache-fabec8f9-2314-4f5a-90bc-3abe48ef35f1.json
+++ b/change/@fluentui-react-native-component-cache-fabec8f9-2314-4f5a-90bc-3abe48ef35f1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/component-cache",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-composition-72c15ed5-c246-4530-963a-fedbd151d75d.json
+++ b/change/@fluentui-react-native-composition-72c15ed5-c246-4530-963a-fedbd151d75d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/composition",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-contextual-menu-f341c2f1-5f11-4d69-8aac-9d68f6e7009a.json
+++ b/change/@fluentui-react-native-contextual-menu-f341c2f1-5f11-4d69-8aac-9d68f6e7009a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/contextual-menu",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-default-theme-b8006ad5-3073-4779-be7b-841508df3383.json
+++ b/change/@fluentui-react-native-default-theme-b8006ad5-3073-4779-be7b-841508df3383.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/default-theme",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-activity-indicator-fe1aee9a-9a36-4672-aee4-2f9c9b860e65.json
+++ b/change/@fluentui-react-native-experimental-activity-indicator-fe1aee9a-9a36-4672-aee4-2f9c9b860e65.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/experimental-activity-indicator",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-avatar-aca2dcea-9182-4c82-82d7-410f190844cd.json
+++ b/change/@fluentui-react-native-experimental-avatar-aca2dcea-9182-4c82-82d7-410f190844cd.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/experimental-avatar",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-button-8cd7ec1e-f63f-45fe-a2da-121d2bf5b9bf.json
+++ b/change/@fluentui-react-native-experimental-button-8cd7ec1e-f63f-45fe-a2da-121d2bf5b9bf.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/experimental-button",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-checkbox-7182ef1d-9259-4575-9432-fe9c186db339.json
+++ b/change/@fluentui-react-native-experimental-checkbox-7182ef1d-9259-4575-9432-fe9c186db339.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/experimental-checkbox",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-drawer-0bf0b697-f5be-4e7a-b0a5-b17be5bed2b7.json
+++ b/change/@fluentui-react-native-experimental-drawer-0bf0b697-f5be-4e7a-b0a5-b17be5bed2b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/experimental-drawer",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-expander-1545dd92-3195-4d0e-9772-9272537a6dc7.json
+++ b/change/@fluentui-react-native-experimental-expander-1545dd92-3195-4d0e-9772-9272537a6dc7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/experimental-expander",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-menu-button-6fdab7a5-83b0-4a9d-8c1d-c8e9a74d266b.json
+++ b/change/@fluentui-react-native-experimental-menu-button-6fdab7a5-83b0-4a9d-8c1d-c8e9a74d266b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/experimental-menu-button",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-native-date-picker-fa58ee1e-177f-44c9-bad3-b6bfa62f511d.json
+++ b/change/@fluentui-react-native-experimental-native-date-picker-fa58ee1e-177f-44c9-bad3-b6bfa62f511d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/experimental-native-date-picker",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-shimmer-e442eda0-3ad7-4ff4-8f89-c10f3de94fc1.json
+++ b/change/@fluentui-react-native-experimental-shimmer-e442eda0-3ad7-4ff4-8f89-c10f3de94fc1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/experimental-shimmer",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-tabs-8ee18178-1dba-47c5-8dbc-089881ef5afe.json
+++ b/change/@fluentui-react-native-experimental-tabs-8ee18178-1dba-47c5-8dbc-089881ef5afe.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/experimental-tabs",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-text-4d2f8ba1-b5c6-411a-8987-8314f09557b3.json
+++ b/change/@fluentui-react-native-experimental-text-4d2f8ba1-b5c6-411a-8987-8314f09557b3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/experimental-text",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-focus-trap-zone-54ed94a2-6994-4aae-a28e-450d25d0e595.json
+++ b/change/@fluentui-react-native-focus-trap-zone-54ed94a2-6994-4aae-a28e-450d25d0e595.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/focus-trap-zone",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-focus-zone-eff19f29-f8be-4f36-9fc3-358837d4ad04.json
+++ b/change/@fluentui-react-native-focus-zone-eff19f29-f8be-4f36-9fc3-358837d4ad04.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/focus-zone",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-framework-6cafde3b-0752-4f85-bf4e-f1e966ddca61.json
+++ b/change/@fluentui-react-native-framework-6cafde3b-0752-4f85-bf4e-f1e966ddca61.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/framework",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-icon-a905c32e-fe6e-40a2-a560-3df22ba4bf15.json
+++ b/change/@fluentui-react-native-icon-a905c32e-fe6e-40a2-a560-3df22ba4bf15.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/icon",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-immutable-merge-86e2dff6-775d-4199-9f48-2d0ce2446007.json
+++ b/change/@fluentui-react-native-immutable-merge-86e2dff6-775d-4199-9f48-2d0ce2446007.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/immutable-merge",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-interactive-hooks-5d0c9336-787c-428e-9468-9775bb3714ce.json
+++ b/change/@fluentui-react-native-interactive-hooks-5d0c9336-787c-428e-9468-9775bb3714ce.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/interactive-hooks",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-link-146369dc-bde6-4122-a976-20462c2b7ac2.json
+++ b/change/@fluentui-react-native-link-146369dc-bde6-4122-a976-20462c2b7ac2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/link",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-memo-cache-346e2a7d-f87a-4ba7-a3c3-0afc19202678.json
+++ b/change/@fluentui-react-native-memo-cache-346e2a7d-f87a-4ba7-a3c3-0afc19202678.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/memo-cache",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-menu-button-e42ba10b-16e5-4752-bcce-cef16aec3350.json
+++ b/change/@fluentui-react-native-menu-button-e42ba10b-16e5-4752-bcce-cef16aec3350.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/menu-button",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-merge-props-0a027195-bce3-48f7-9f42-1fea048d8288.json
+++ b/change/@fluentui-react-native-merge-props-0a027195-bce3-48f7-9f42-1fea048d8288.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/merge-props",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-persona-coin-5edc2543-44a0-45d3-9354-73453f493112.json
+++ b/change/@fluentui-react-native-persona-coin-5edc2543-44a0-45d3-9354-73453f493112.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/persona-coin",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-persona-f6668605-184c-4b8a-b94f-9f9145be2e6a.json
+++ b/change/@fluentui-react-native-persona-f6668605-184c-4b8a-b94f-9f9145be2e6a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/persona",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-pressable-d1891789-a7b2-44d6-b49e-bd2f0a0088c0.json
+++ b/change/@fluentui-react-native-pressable-d1891789-a7b2-44d6-b49e-bd2f0a0088c0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/pressable",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-radio-group-ff25595b-1145-4eda-b6bc-55fb7e3e9cd0.json
+++ b/change/@fluentui-react-native-radio-group-ff25595b-1145-4eda-b6bc-55fb7e3e9cd0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/radio-group",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-separator-3387c67f-e699-4980-8b87-ab507d917b46.json
+++ b/change/@fluentui-react-native-separator-3387c67f-e699-4980-8b87-ab507d917b46.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/separator",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-stack-d0fd38af-0ebe-4d48-a07f-83f1b74761bb.json
+++ b/change/@fluentui-react-native-stack-d0fd38af-0ebe-4d48-a07f-83f1b74761bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/stack",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-styling-utils-555dffb0-a336-4c27-bbb3-fbda97cf8176.json
+++ b/change/@fluentui-react-native-styling-utils-555dffb0-a336-4c27-bbb3-fbda97cf8176.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/styling-utils",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-tabs-76d6d97b-cc17-45cc-a0c0-3ac426843bdf.json
+++ b/change/@fluentui-react-native-tabs-76d6d97b-cc17-45cc-a0c0-3ac426843bdf.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/tabs",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-tester-c7d4b54b-8cd3-484e-84eb-43c4e7745e8a.json
+++ b/change/@fluentui-react-native-tester-c7d4b54b-8cd3-484e-84eb-43c4e7745e8a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-tester-win32-989aee24-1157-4abf-be9a-cce25e95717d.json
+++ b/change/@fluentui-react-native-tester-win32-989aee24-1157-4abf-be9a-cce25e95717d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/tester-win32",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-text-fe197a30-2d75-4c6b-92f5-0614d426fb3d.json
+++ b/change/@fluentui-react-native-text-fe197a30-2d75-4c6b-92f5-0614d426fb3d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/text",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-theme-12e10de2-f4c4-4080-b94b-ef3c53e9473b.json
+++ b/change/@fluentui-react-native-theme-12e10de2-f4c4-4080-b94b-ef3c53e9473b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/theme",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-theme-tokens-1d45ce37-d7a6-44c3-8e5c-46da3d1b3175.json
+++ b/change/@fluentui-react-native-theme-tokens-1d45ce37-d7a6-44c3-8e5c-46da3d1b3175.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/theme-tokens",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-theme-types-5f0b18ad-f758-4aaf-a56e-d693394cccbb.json
+++ b/change/@fluentui-react-native-theme-types-5f0b18ad-f758-4aaf-a56e-d693394cccbb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/theme-types",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-themed-stylesheet-15d83954-db66-4e43-8876-ede6ff194292.json
+++ b/change/@fluentui-react-native-themed-stylesheet-15d83954-db66-4e43-8876-ede6ff194292.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/themed-stylesheet",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-theming-utils-b23c7f51-81ee-4dd6-a1bc-c27860bc9472.json
+++ b/change/@fluentui-react-native-theming-utils-b23c7f51-81ee-4dd6-a1bc-c27860bc9472.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/theming-utils",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-tokens-a715c55f-502f-46ba-9894-3cee6f905cc4.json
+++ b/change/@fluentui-react-native-tokens-a715c55f-502f-46ba-9894-3cee6f905cc4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/tokens",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-use-slot-b153b822-d1ca-4872-b28e-0c6fa717147e.json
+++ b/change/@fluentui-react-native-use-slot-b153b822-d1ca-4872-b28e-0c6fa717147e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/use-slot",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-use-slots-4a221277-dba6-4b58-8372-e8e58f6bcbcf.json
+++ b/change/@fluentui-react-native-use-slots-4a221277-dba6-4b58-8372-e8e58f6bcbcf.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/use-slots",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-use-styling-3ab87081-fa4c-44ee-9b47-7c0dc50d8da5.json
+++ b/change/@fluentui-react-native-use-styling-3ab87081-fa4c-44ee-9b47-7c0dc50d8da5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/use-styling",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-use-tokens-a72edfe5-0b05-4295-a916-cc0240f78f11.json
+++ b/change/@fluentui-react-native-use-tokens-a72edfe5-0b05-4295-a916-cc0240f78f11.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/use-tokens",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-win32-theme-2dc12223-2f54-4130-98ac-12d4c417ef8b.json
+++ b/change/@fluentui-react-native-win32-theme-2dc12223-2f54-4130-98ac-12d4c417ef8b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@fluentui-react-native/win32-theme",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@uifabricshared-foundation-composable-7ff048ca-5d90-430e-828d-e447c7b57767.json
+++ b/change/@uifabricshared-foundation-composable-7ff048ca-5d90-430e-828d-e447c7b57767.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@uifabricshared/foundation-composable",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@uifabricshared-foundation-compose-0bc04289-648e-4dc3-9073-00f860bc5720.json
+++ b/change/@uifabricshared-foundation-compose-0bc04289-648e-4dc3-9073-00f860bc5720.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@uifabricshared/foundation-compose",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@uifabricshared-foundation-settings-b723dcf6-768f-46bb-871e-716abf2c51c9.json
+++ b/change/@uifabricshared-foundation-settings-b723dcf6-768f-46bb-871e-716abf2c51c9.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@uifabricshared/foundation-settings",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@uifabricshared-foundation-tokens-cd592630-cc94-4993-b876-06ee7b223b8e.json
+++ b/change/@uifabricshared-foundation-tokens-cd592630-cc94-4993-b876-06ee7b223b8e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@uifabricshared/foundation-tokens",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@uifabricshared-theme-registry-a9f6fd40-0f80-49af-bd05-dcdc8c803f9b.json
+++ b/change/@uifabricshared-theme-registry-a9f6fd40-0f80-49af-bd05-dcdc8c803f9b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@uifabricshared/theme-registry",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@uifabricshared-themed-settings-f46af14a-adcb-4d1b-ae05-80e19c0857bd.json
+++ b/change/@uifabricshared-themed-settings-f46af14a-adcb-4d1b-ae05-80e19c0857bd.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@uifabricshared/themed-settings",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@uifabricshared-theming-ramp-98deb4ce-9897-4493-b11b-1f8f878a6c04.json
+++ b/change/@uifabricshared-theming-ramp-98deb4ce-9897-4493-b11b-1f8f878a6c04.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@uifabricshared/theming-ramp",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@uifabricshared-theming-react-native-e1b629f2-073a-4b4a-abac-ee88a506c22b.json
+++ b/change/@uifabricshared-theming-react-native-e1b629f2-073a-4b4a-abac-ee88a506c22b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove references to uifabricshared",
+  "packageName": "@uifabricshared/theming-react-native",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "uifabric-react-native",
+  "name": "@fluentui-react-native/repo",
   "version": "0.1.1",
   "private": true,
   "description": "",

--- a/packages/components/Button/babel.config.js
+++ b/packages/components/Button/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/components/Button/jest.config.js
+++ b/packages/components/Button/jest.config.js
@@ -1,2 +1,2 @@
-const { configureReactNativeJest } = require('@uifabricshared/build-native');
+const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
 module.exports = configureReactNativeJest('android');

--- a/packages/components/Button/just.config.js
+++ b/packages/components/Button/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/components/Button/package.json
+++ b/packages/components/Button/package.json
@@ -40,7 +40,7 @@
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@office-iss/react-native-win32": "^0.64.8",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.64.3"
   },
   "peerDependencies": {

--- a/packages/components/Button/tsconfig.json
+++ b/packages/components/Button/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib",
     "types": ["node", "jest"]

--- a/packages/components/Callout/babel.config.js
+++ b/packages/components/Callout/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/components/Callout/jest.config.js
+++ b/packages/components/Callout/jest.config.js
@@ -1,2 +1,2 @@
-const { configureReactNativeJest } = require('@uifabricshared/build-native');
+const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
 module.exports = configureReactNativeJest('android');

--- a/packages/components/Callout/just.config.js
+++ b/packages/components/Callout/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/components/Callout/package.json
+++ b/packages/components/Callout/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.64.3"
   },
   "peerDependencies": {

--- a/packages/components/Callout/tsconfig.json
+++ b/packages/components/Callout/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib",
     "types": ["node", "jest"]

--- a/packages/components/Checkbox/babel.config.js
+++ b/packages/components/Checkbox/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/components/Checkbox/just.config.js
+++ b/packages/components/Checkbox/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/components/Checkbox/package.json
+++ b/packages/components/Checkbox/package.json
@@ -39,7 +39,7 @@
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@office-iss/react-native-win32": "^0.64.8",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.64.3"
   },
   "peerDependencies": {

--- a/packages/components/ContextualMenu/babel.config.js
+++ b/packages/components/ContextualMenu/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/components/ContextualMenu/jest.config.js
+++ b/packages/components/ContextualMenu/jest.config.js
@@ -1,2 +1,2 @@
-const { configureReactNativeJest } = require('@uifabricshared/build-native');
+const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
 module.exports = configureReactNativeJest('android');

--- a/packages/components/ContextualMenu/just.config.js
+++ b/packages/components/ContextualMenu/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/components/ContextualMenu/package.json
+++ b/packages/components/ContextualMenu/package.json
@@ -44,7 +44,7 @@
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/pressable": ">=0.8.11 <1.0.0",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.64.3"
   },
   "peerDependencies": {

--- a/packages/components/ContextualMenu/tsconfig.json
+++ b/packages/components/ContextualMenu/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib",
     "types": ["node", "jest"]

--- a/packages/components/FocusTrapZone/babel.config.js
+++ b/packages/components/FocusTrapZone/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/components/FocusTrapZone/jest.config.js
+++ b/packages/components/FocusTrapZone/jest.config.js
@@ -1,2 +1,2 @@
-const { configureReactNativeJest } = require('@uifabricshared/build-native');
+const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
 module.exports = configureReactNativeJest('android');

--- a/packages/components/FocusTrapZone/just.config.js
+++ b/packages/components/FocusTrapZone/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/components/FocusTrapZone/package.json
+++ b/packages/components/FocusTrapZone/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.64.3"
   },
   "peerDependencies": {

--- a/packages/components/FocusTrapZone/tsconfig.json
+++ b/packages/components/FocusTrapZone/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib",
     "types": ["node", "jest"]

--- a/packages/components/FocusZone/babel.config.js
+++ b/packages/components/FocusZone/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/components/FocusZone/jest.config.js
+++ b/packages/components/FocusZone/jest.config.js
@@ -1,2 +1,2 @@
-const { configureReactNativeJest } = require('@uifabricshared/build-native');
+const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
 module.exports = configureReactNativeJest('android');

--- a/packages/components/FocusZone/just.config.js
+++ b/packages/components/FocusZone/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/components/FocusZone/package.json
+++ b/packages/components/FocusZone/package.json
@@ -35,7 +35,7 @@
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@office-iss/react-native-win32": "^0.64.8",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.64.3"
   },
   "peerDependencies": {

--- a/packages/components/FocusZone/tsconfig.json
+++ b/packages/components/FocusZone/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib",
     "types": ["node", "jest"]

--- a/packages/components/Link/babel.config.js
+++ b/packages/components/Link/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/components/Link/jest.config.js
+++ b/packages/components/Link/jest.config.js
@@ -1,2 +1,2 @@
-const { configureReactNativeJest } = require('@uifabricshared/build-native');
+const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
 module.exports = configureReactNativeJest('android');

--- a/packages/components/Link/just.config.js
+++ b/packages/components/Link/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/components/Link/package.json
+++ b/packages/components/Link/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.64.3"
   },
   "peerDependencies": {

--- a/packages/components/Link/tsconfig.json
+++ b/packages/components/Link/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib",
     "types": ["node", "jest"]

--- a/packages/components/MenuButton/babel.config.js
+++ b/packages/components/MenuButton/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/components/MenuButton/jest.config.js
+++ b/packages/components/MenuButton/jest.config.js
@@ -1,2 +1,2 @@
-const { configureReactNativeJest } = require('@uifabricshared/build-native');
+const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
 module.exports = configureReactNativeJest('android');

--- a/packages/components/MenuButton/just.config.js
+++ b/packages/components/MenuButton/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/components/MenuButton/package.json
+++ b/packages/components/MenuButton/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.64.3"
   },
   "peerDependencies": {

--- a/packages/components/MenuButton/tsconfig.json
+++ b/packages/components/MenuButton/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib",
     "types": ["node", "jest"]

--- a/packages/components/Persona/babel.config.js
+++ b/packages/components/Persona/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/components/Persona/just.config.js
+++ b/packages/components/Persona/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/components/Persona/package.json
+++ b/packages/components/Persona/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.64.3"
   },
   "peerDependencies": {

--- a/packages/components/Persona/tsconfig.json
+++ b/packages/components/Persona/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib"
   },

--- a/packages/components/PersonaCoin/babel.config.js
+++ b/packages/components/PersonaCoin/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/components/PersonaCoin/just.config.js
+++ b/packages/components/PersonaCoin/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/components/PersonaCoin/package.json
+++ b/packages/components/PersonaCoin/package.json
@@ -39,7 +39,7 @@
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@office-iss/react-native-win32": "^0.64.8",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.64.3"
   },
   "peerDependencies": {

--- a/packages/components/PersonaCoin/tsconfig.json
+++ b/packages/components/PersonaCoin/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib"
   },

--- a/packages/components/Pressable/babel.config.js
+++ b/packages/components/Pressable/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/components/Pressable/just.config.js
+++ b/packages/components/Pressable/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/components/Pressable/package.json
+++ b/packages/components/Pressable/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.64.3"
   },
   "peerDependencies": {

--- a/packages/components/Pressable/tsconfig.json
+++ b/packages/components/Pressable/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib"
   },

--- a/packages/components/RadioGroup/babel.config.js
+++ b/packages/components/RadioGroup/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/components/RadioGroup/jest.config.js
+++ b/packages/components/RadioGroup/jest.config.js
@@ -1,2 +1,2 @@
-const { configureReactNativeJest } = require('@uifabricshared/build-native');
+const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
 module.exports = configureReactNativeJest('android');

--- a/packages/components/RadioGroup/just.config.js
+++ b/packages/components/RadioGroup/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/components/RadioGroup/package.json
+++ b/packages/components/RadioGroup/package.json
@@ -42,7 +42,7 @@
     "@fluentui-react-native/test-tools": ">=0.1.1 <1.0.0",
     "@office-iss/react-native-win32": "^0.64.8",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.64.3"
   },
   "peerDependencies": {

--- a/packages/components/RadioGroup/tsconfig.json
+++ b/packages/components/RadioGroup/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib",
     "types": ["node", "jest"]

--- a/packages/components/Separator/babel.config.js
+++ b/packages/components/Separator/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/components/Separator/jest.config.js
+++ b/packages/components/Separator/jest.config.js
@@ -1,2 +1,2 @@
-const { configureReactNativeJest } = require('@uifabricshared/build-native');
+const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
 module.exports = configureReactNativeJest('android');

--- a/packages/components/Separator/just.config.js
+++ b/packages/components/Separator/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/components/Separator/package.json
+++ b/packages/components/Separator/package.json
@@ -32,7 +32,7 @@
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@office-iss/react-native-win32": "^0.64.8",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.64.3"
   },
   "peerDependencies": {

--- a/packages/components/Separator/tsconfig.json
+++ b/packages/components/Separator/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib",
     "types": ["node", "jest"]

--- a/packages/components/Stack/babel.config.js
+++ b/packages/components/Stack/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/components/Stack/jest.config.js
+++ b/packages/components/Stack/jest.config.js
@@ -1,2 +1,2 @@
-const { configureReactNativeJest } = require('@uifabricshared/build-native');
+const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
 module.exports = configureReactNativeJest('android');

--- a/packages/components/Stack/just.config.js
+++ b/packages/components/Stack/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/components/Stack/package.json
+++ b/packages/components/Stack/package.json
@@ -38,7 +38,7 @@
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/text": ">=0.11.6 <1.0.0",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.64.3"
   },
   "peerDependencies": {

--- a/packages/components/Stack/tsconfig.json
+++ b/packages/components/Stack/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib",
     "types": ["node", "jest"]

--- a/packages/components/Tabs/api-extractor.json
+++ b/packages/components/Tabs/api-extractor.json
@@ -1,3 +1,0 @@
-{
-  "extends": "@uifabricshared/build-native/api-extractor.json"
-}

--- a/packages/components/Tabs/babel.config.js
+++ b/packages/components/Tabs/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/components/Tabs/jest.config.js
+++ b/packages/components/Tabs/jest.config.js
@@ -1,2 +1,2 @@
-const { configureReactNativeJest } = require('@uifabricshared/build-native');
+const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
 module.exports = configureReactNativeJest('android');

--- a/packages/components/Tabs/just.config.js
+++ b/packages/components/Tabs/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/components/Tabs/package.json
+++ b/packages/components/Tabs/package.json
@@ -44,7 +44,7 @@
     "@fluentui-react-native/test-tools": ">=0.1.1 <1.0.0",
     "@office-iss/react-native-win32": "^0.64.8",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.64.3"
   },
   "peerDependencies": {

--- a/packages/components/Tabs/tsconfig.json
+++ b/packages/components/Tabs/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib",
     "types": ["node", "jest"]

--- a/packages/components/text/babel.config.js
+++ b/packages/components/text/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/components/text/jest.config.js
+++ b/packages/components/text/jest.config.js
@@ -1,2 +1,2 @@
-const { configureReactNativeJest } = require('@uifabricshared/build-native');
+const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
 module.exports = configureReactNativeJest('android');

--- a/packages/components/text/just.config.js
+++ b/packages/components/text/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/components/text/package.json
+++ b/packages/components/text/package.json
@@ -34,7 +34,7 @@
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/test-tools": ">=0.1.1 <1.0.0",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.64.3"
   },
   "peerDependencies": {

--- a/packages/components/text/tsconfig.json
+++ b/packages/components/text/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib",
     "types": ["node", "jest"]

--- a/packages/deprecated/foundation-composable/babel.config.js
+++ b/packages/deprecated/foundation-composable/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/deprecated/foundation-composable/just.config.js
+++ b/packages/deprecated/foundation-composable/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/deprecated/foundation-composable/package.json
+++ b/packages/deprecated/foundation-composable/package.json
@@ -40,7 +40,7 @@
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/jest": "^26.0.0",
     "@types/react": "^17.0.2",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react": "17.0.1"
   }
 }

--- a/packages/deprecated/foundation-composable/test.js
+++ b/packages/deprecated/foundation-composable/test.js
@@ -1,2 +1,2 @@
-const { createConfig } = require('@uifabricshared/build-native/jest/jest-resources');
+const { createConfig } = require('@fluentui-react-native/scripts/jest/jest-resources');
 console.log(createConfig());

--- a/packages/deprecated/foundation-composable/tsconfig.json
+++ b/packages/deprecated/foundation-composable/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib"
   },

--- a/packages/deprecated/foundation-compose/babel.config.js
+++ b/packages/deprecated/foundation-compose/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/deprecated/foundation-compose/just.config.js
+++ b/packages/deprecated/foundation-compose/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/deprecated/foundation-compose/tsconfig.json
+++ b/packages/deprecated/foundation-compose/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib"
   },

--- a/packages/deprecated/foundation-settings/babel.config.js
+++ b/packages/deprecated/foundation-settings/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/deprecated/foundation-settings/jest.config.js
+++ b/packages/deprecated/foundation-settings/jest.config.js
@@ -1,2 +1,2 @@
-const { configureJest } = require('@uifabricshared/build-native');
+const { configureJest } = require('@fluentui-react-native/scripts');
 module.exports = configureJest();

--- a/packages/deprecated/foundation-settings/just.config.js
+++ b/packages/deprecated/foundation-settings/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/deprecated/foundation-settings/package.json
+++ b/packages/deprecated/foundation-settings/package.json
@@ -40,7 +40,7 @@
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/jest": "^26.0.0",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.64.3"
   },
   "peerDependencies": {

--- a/packages/deprecated/foundation-settings/tsconfig.json
+++ b/packages/deprecated/foundation-settings/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib"
   },

--- a/packages/deprecated/foundation-tokens/babel.config.js
+++ b/packages/deprecated/foundation-tokens/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/deprecated/foundation-tokens/jest.config.js
+++ b/packages/deprecated/foundation-tokens/jest.config.js
@@ -1,2 +1,2 @@
-const { configureJest } = require('@uifabricshared/build-native');
+const { configureJest } = require('@fluentui-react-native/scripts');
 module.exports = configureJest();

--- a/packages/deprecated/foundation-tokens/just.config.js
+++ b/packages/deprecated/foundation-tokens/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/deprecated/foundation-tokens/package.json
+++ b/packages/deprecated/foundation-tokens/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.0",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "@fluentui-react-native/memo-cache": "^1.1.7",
     "react-native": "^0.64.3"
   },

--- a/packages/deprecated/foundation-tokens/tsconfig.json
+++ b/packages/deprecated/foundation-tokens/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib",
     "types": ["node", "jest", "react"]

--- a/packages/deprecated/theme-registry/babel.config.js
+++ b/packages/deprecated/theme-registry/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/deprecated/theme-registry/jest.config.js
+++ b/packages/deprecated/theme-registry/jest.config.js
@@ -1,2 +1,2 @@
-const { configureJest } = require('@uifabricshared/build-native');
+const { configureJest } = require('@fluentui-react-native/scripts');
 module.exports = configureJest();

--- a/packages/deprecated/theme-registry/just.config.js
+++ b/packages/deprecated/theme-registry/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/deprecated/theme-registry/package.json
+++ b/packages/deprecated/theme-registry/package.json
@@ -38,7 +38,7 @@
     "@fluentui-react-native/immutable-merge": "^1.1.6",
     "@types/jest": "^26.0.0",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.64.3"
   }
 }

--- a/packages/deprecated/theme-registry/tsconfig.json
+++ b/packages/deprecated/theme-registry/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib"
   },

--- a/packages/deprecated/themed-settings/babel.config.js
+++ b/packages/deprecated/themed-settings/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/deprecated/themed-settings/jest.config.js
+++ b/packages/deprecated/themed-settings/jest.config.js
@@ -1,2 +1,2 @@
-const { configureJest } = require('@uifabricshared/build-native');
+const { configureJest } = require('@fluentui-react-native/scripts');
 module.exports = configureJest();

--- a/packages/deprecated/themed-settings/just.config.js
+++ b/packages/deprecated/themed-settings/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/deprecated/themed-settings/package.json
+++ b/packages/deprecated/themed-settings/package.json
@@ -41,7 +41,7 @@
     "@types/jest": "^26.0.0",
     "@types/node": "^10.3.5",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.64.3"
   },
   "peerDependencies": {

--- a/packages/deprecated/themed-settings/tsconfig.json
+++ b/packages/deprecated/themed-settings/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib"
   },

--- a/packages/deprecated/theming-ramp/babel.config.js
+++ b/packages/deprecated/theming-ramp/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/deprecated/theming-ramp/jest.config.js
+++ b/packages/deprecated/theming-ramp/jest.config.js
@@ -1,2 +1,2 @@
-const { configureJest } = require('@uifabricshared/build-native');
+const { configureJest } = require('@fluentui-react-native/scripts');
 module.exports = configureJest();

--- a/packages/deprecated/theming-ramp/just.config.js
+++ b/packages/deprecated/theming-ramp/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/deprecated/theming-ramp/package.json
+++ b/packages/deprecated/theming-ramp/package.json
@@ -42,7 +42,7 @@
     "@fluentui-react-native/test-tools": ">=0.1.1 <1.0.0",
     "@types/jest": "^26.0.0",
     "@types/react": "^17.0.2",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react": "17.0.1"
   },
   "peerDependencies": {

--- a/packages/deprecated/theming-ramp/tsconfig.json
+++ b/packages/deprecated/theming-ramp/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib",
     "types": ["node", "jest"]

--- a/packages/deprecated/theming-react-native/babel.config.js
+++ b/packages/deprecated/theming-react-native/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/deprecated/theming-react-native/just.config.js
+++ b/packages/deprecated/theming-react-native/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/deprecated/theming-react-native/package.json
+++ b/packages/deprecated/theming-react-native/package.json
@@ -42,7 +42,7 @@
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/jest": "^26.0.0",
     "@types/react": "^17.0.2",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react": "17.0.1",
     "react-native": "^0.64.3",
     "typescript": "4.5.4"

--- a/packages/deprecated/theming-react-native/tsconfig.json
+++ b/packages/deprecated/theming-react-native/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib"
   },

--- a/packages/experimental/ActivityIndicator/just.config.js
+++ b/packages/experimental/ActivityIndicator/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/experimental/ActivityIndicator/package.json
+++ b/packages/experimental/ActivityIndicator/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.64.3"
   },
   "peerDependencies": {

--- a/packages/experimental/ActivityIndicator/tsconfig.json
+++ b/packages/experimental/ActivityIndicator/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib"
   },

--- a/packages/experimental/Avatar/babel.config.js
+++ b/packages/experimental/Avatar/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/experimental/Avatar/just.config.js
+++ b/packages/experimental/Avatar/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/experimental/Avatar/package.json
+++ b/packages/experimental/Avatar/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.64.3",
     "react": "17.0.1"
   },

--- a/packages/experimental/Avatar/tsconfig.json
+++ b/packages/experimental/Avatar/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib"
   },

--- a/packages/experimental/Button/babel.config.js
+++ b/packages/experimental/Button/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/experimental/Button/jest.config.js
+++ b/packages/experimental/Button/jest.config.js
@@ -1,2 +1,2 @@
-const { configureReactNativeJest } = require('@uifabricshared/build-native');
+const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
 module.exports = configureReactNativeJest('android');

--- a/packages/experimental/Button/just.config.js
+++ b/packages/experimental/Button/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/experimental/Button/package.json
+++ b/packages/experimental/Button/package.json
@@ -43,7 +43,7 @@
     "@fluentui-react-native/test-tools": ">=0.1.1 <1.0.0",
     "@office-iss/react-native-win32": "^0.64.8",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react": "17.0.1",
     "react-native": "^0.64.3"
   },

--- a/packages/experimental/Button/tsconfig.json
+++ b/packages/experimental/Button/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "importHelpers": true,
     "outDir": "lib",

--- a/packages/experimental/Checkbox/jest.config.js
+++ b/packages/experimental/Checkbox/jest.config.js
@@ -1,2 +1,2 @@
-const { configureReactNativeJest } = require('@uifabricshared/build-native');
+const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
 module.exports = configureReactNativeJest('android');

--- a/packages/experimental/Checkbox/just.config.js
+++ b/packages/experimental/Checkbox/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/experimental/Checkbox/package.json
+++ b/packages/experimental/Checkbox/package.json
@@ -42,7 +42,7 @@
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@office-iss/react-native-win32": "^0.64.8",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react": "17.0.1",
     "react-native": "^0.64.3"
   },

--- a/packages/experimental/Checkbox/tsconfig.json
+++ b/packages/experimental/Checkbox/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "importHelpers": true,
     "outDir": "lib",

--- a/packages/experimental/Drawer/just.config.js
+++ b/packages/experimental/Drawer/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/experimental/Drawer/package.json
+++ b/packages/experimental/Drawer/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "immediate": "~3.0.5",
     "lie": "~3.3.0",
     "pako": "~1.0.2",

--- a/packages/experimental/Drawer/tsconfig.json
+++ b/packages/experimental/Drawer/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "importHelpers": true,
     "outDir": "lib",

--- a/packages/experimental/Expander/babel.config.js
+++ b/packages/experimental/Expander/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/experimental/Expander/just.config.js
+++ b/packages/experimental/Expander/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/experimental/Expander/package.json
+++ b/packages/experimental/Expander/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react": "17.0.1",
     "react-native": "^0.64.3",
     "react-native-windows": "^0.64.3"

--- a/packages/experimental/Expander/tsconfig.json
+++ b/packages/experimental/Expander/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib"
   },

--- a/packages/experimental/Icon/just.config.js
+++ b/packages/experimental/Icon/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/experimental/Icon/package.json
+++ b/packages/experimental/Icon/package.json
@@ -36,7 +36,7 @@
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@office-iss/react-native-win32": "^0.64.8",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.64.3",
     "react-native-svg-transformer": "^0.14.3"
   },

--- a/packages/experimental/Icon/tsconfig.json
+++ b/packages/experimental/Icon/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib"
   },

--- a/packages/experimental/MenuButton/babel.config.js
+++ b/packages/experimental/MenuButton/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/experimental/MenuButton/jest.config.js
+++ b/packages/experimental/MenuButton/jest.config.js
@@ -1,2 +1,2 @@
-const { configureReactNativeJest } = require('@uifabricshared/build-native');
+const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
 module.exports = configureReactNativeJest('android');

--- a/packages/experimental/MenuButton/just.config.js
+++ b/packages/experimental/MenuButton/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/experimental/MenuButton/package.json
+++ b/packages/experimental/MenuButton/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react": "17.0.1",
     "react-native": "^0.64.3"
   },

--- a/packages/experimental/MenuButton/tsconfig.json
+++ b/packages/experimental/MenuButton/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib",
     "types": ["node", "jest"]

--- a/packages/experimental/NativeDatePicker/babel.config.js
+++ b/packages/experimental/NativeDatePicker/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/experimental/NativeDatePicker/just.config.js
+++ b/packages/experimental/NativeDatePicker/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/experimental/NativeDatePicker/package.json
+++ b/packages/experimental/NativeDatePicker/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.64.3",
     "react": "17.0.1"
   },

--- a/packages/experimental/NativeDatePicker/tsconfig.json
+++ b/packages/experimental/NativeDatePicker/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib"
   },

--- a/packages/experimental/Shimmer/just.config.js
+++ b/packages/experimental/Shimmer/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/experimental/Shimmer/package.json
+++ b/packages/experimental/Shimmer/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "assert-never": "^1.2.1",
     "react-native": "^0.64.3"
   },

--- a/packages/experimental/Shimmer/tsconfig.json
+++ b/packages/experimental/Shimmer/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib"
   },

--- a/packages/experimental/Stack/babel.config.js
+++ b/packages/experimental/Stack/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/experimental/Stack/just.config.js
+++ b/packages/experimental/Stack/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/experimental/Stack/package.json
+++ b/packages/experimental/Stack/package.json
@@ -35,7 +35,7 @@
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/text": ">=0.11.6 <1.0.0",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react": "17.0.1",
     "react-native": "^0.64.3",
     "tslib": "^2.3.1"

--- a/packages/experimental/Stack/tsconfig.json
+++ b/packages/experimental/Stack/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "importHelpers": true,
     "outDir": "lib",

--- a/packages/experimental/Tabs/api-extractor.json
+++ b/packages/experimental/Tabs/api-extractor.json
@@ -1,3 +1,0 @@
-{
-  "extends": "@uifabricshared/build-native/api-extractor.json"
-}

--- a/packages/experimental/Tabs/babel.config.js
+++ b/packages/experimental/Tabs/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/experimental/Tabs/jest.config.js
+++ b/packages/experimental/Tabs/jest.config.js
@@ -1,2 +1,2 @@
-const { configureReactNativeJest } = require('@uifabricshared/build-native');
+const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
 module.exports = configureReactNativeJest('android');

--- a/packages/experimental/Tabs/just.config.js
+++ b/packages/experimental/Tabs/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/experimental/Tabs/package.json
+++ b/packages/experimental/Tabs/package.json
@@ -41,7 +41,7 @@
     "@fluentui-react-native/test-tools": ">=0.1.1 <1.0.0",
     "@office-iss/react-native-win32": "^0.64.8",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react": "17.0.1",
     "react-native": "^0.64.3"
   },

--- a/packages/experimental/Tabs/tsconfig.json
+++ b/packages/experimental/Tabs/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "importHelpers": true,
     "outDir": "lib",

--- a/packages/experimental/Text/babel.config.js
+++ b/packages/experimental/Text/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/experimental/Text/jest.config.js
+++ b/packages/experimental/Text/jest.config.js
@@ -1,2 +1,2 @@
-const { configureReactNativeJest } = require('@uifabricshared/build-native');
+const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
 module.exports = configureReactNativeJest('android');

--- a/packages/experimental/Text/just.config.js
+++ b/packages/experimental/Text/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/experimental/Text/package.json
+++ b/packages/experimental/Text/package.json
@@ -34,7 +34,7 @@
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/test-tools": ">=0.1.1 <1.0.0",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.64.3"
   },
   "peerDependencies": {

--- a/packages/experimental/Text/tsconfig.json
+++ b/packages/experimental/Text/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "importHelpers": true,
     "outDir": "lib",

--- a/packages/framework/component-cache/babel.config.js
+++ b/packages/framework/component-cache/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/framework/component-cache/just.config.js
+++ b/packages/framework/component-cache/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/framework/component-cache/package.json
+++ b/packages/framework/component-cache/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.0",
     "@types/node": "^10.3.5",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "react": "17.0.1",
     "react-native": "^0.64.3"

--- a/packages/framework/component-cache/tsconfig.json
+++ b/packages/framework/component-cache/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib"
   },

--- a/packages/framework/composition/babel.config.js
+++ b/packages/framework/composition/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/framework/composition/jest.config.js
+++ b/packages/framework/composition/jest.config.js
@@ -1,2 +1,2 @@
-const { configureReactNativeJest } = require('@uifabricshared/build-native');
+const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
 module.exports = configureReactNativeJest('android');

--- a/packages/framework/composition/just.config.js
+++ b/packages/framework/composition/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/framework/composition/package.json
+++ b/packages/framework/composition/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.64.3"
   },
   "peerDependencies": {

--- a/packages/framework/composition/tsconfig.json
+++ b/packages/framework/composition/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib",
     "types": ["node", "jest"]

--- a/packages/framework/framework/jest.config.js
+++ b/packages/framework/framework/jest.config.js
@@ -1,2 +1,2 @@
-const { configureReactNativeJest } = require('@uifabricshared/build-native');
+const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
 module.exports = configureReactNativeJest('android');

--- a/packages/framework/framework/just.config.js
+++ b/packages/framework/framework/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/framework/framework/package.json
+++ b/packages/framework/framework/package.json
@@ -47,7 +47,7 @@
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react": "^17.0.2",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "react-native": "^0.64.3",

--- a/packages/framework/immutable-merge/babel.config.js
+++ b/packages/framework/immutable-merge/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/framework/immutable-merge/jest.config.js
+++ b/packages/framework/immutable-merge/jest.config.js
@@ -1,2 +1,2 @@
-const { configureJest } = require('@uifabricshared/build-native');
+const { configureJest } = require('@fluentui-react-native/scripts');
 module.exports = configureJest();

--- a/packages/framework/immutable-merge/just.config.js
+++ b/packages/framework/immutable-merge/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/framework/immutable-merge/package.json
+++ b/packages/framework/immutable-merge/package.json
@@ -39,6 +39,6 @@
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/jest": "^26.0.0",
     "@types/node": "^10.3.5",
-    "@uifabricshared/build-native": "^0.1.1"
+    "@fluentui-react-native/scripts": "^0.1.1"
   }
 }

--- a/packages/framework/immutable-merge/tsconfig.json
+++ b/packages/framework/immutable-merge/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "importHelpers": true,
     "outDir": "lib"

--- a/packages/framework/memo-cache/babel.config.js
+++ b/packages/framework/memo-cache/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/framework/memo-cache/jest.config.js
+++ b/packages/framework/memo-cache/jest.config.js
@@ -1,2 +1,2 @@
-const { configureJest } = require('@uifabricshared/build-native');
+const { configureJest } = require('@fluentui-react-native/scripts');
 module.exports = configureJest();

--- a/packages/framework/memo-cache/just.config.js
+++ b/packages/framework/memo-cache/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/framework/memo-cache/package.json
+++ b/packages/framework/memo-cache/package.json
@@ -36,7 +36,7 @@
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/jest": "^26.0.0",
     "@types/node": "^10.3.5",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "tslib": "^2.3.1"
   }
 }

--- a/packages/framework/memo-cache/tsconfig.json
+++ b/packages/framework/memo-cache/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "importHelpers": true,
     "outDir": "lib"

--- a/packages/framework/merge-props/babel.config.js
+++ b/packages/framework/merge-props/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/framework/merge-props/jest.config.js
+++ b/packages/framework/merge-props/jest.config.js
@@ -1,2 +1,2 @@
-const { configureJest } = require('@uifabricshared/build-native');
+const { configureJest } = require('@fluentui-react-native/scripts');
 module.exports = configureJest();

--- a/packages/framework/merge-props/just.config.js
+++ b/packages/framework/merge-props/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/framework/merge-props/package.json
+++ b/packages/framework/merge-props/package.json
@@ -41,7 +41,7 @@
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/jest": "^26.0.0",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.64.3"
   },
   "peerDependencies": {

--- a/packages/framework/merge-props/tsconfig.json
+++ b/packages/framework/merge-props/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "importHelpers": true,
     "outDir": "lib"

--- a/packages/framework/theme/babel.config.js
+++ b/packages/framework/theme/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/framework/theme/jest.config.js
+++ b/packages/framework/theme/jest.config.js
@@ -1,2 +1,2 @@
-const { configureReactNativeJest } = require('@uifabricshared/build-native');
+const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
 module.exports = configureReactNativeJest('android');

--- a/packages/framework/theme/just.config.js
+++ b/packages/framework/theme/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/framework/theme/package.json
+++ b/packages/framework/theme/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@fluentui-react-native/test-tools": ">=0.1.1 <1.0.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react": "17.0.1",
     "react-native": "^0.64.3"
   },

--- a/packages/framework/theme/tsconfig.json
+++ b/packages/framework/theme/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib",
     "types": ["node", "jest"]

--- a/packages/framework/themed-stylesheet/babel.config.js
+++ b/packages/framework/themed-stylesheet/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/framework/themed-stylesheet/jest.config.js
+++ b/packages/framework/themed-stylesheet/jest.config.js
@@ -1,2 +1,2 @@
-const { configureReactNativeJest } = require('@uifabricshared/build-native');
+const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
 module.exports = configureReactNativeJest('android');

--- a/packages/framework/themed-stylesheet/just.config.js
+++ b/packages/framework/themed-stylesheet/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/framework/themed-stylesheet/package.json
+++ b/packages/framework/themed-stylesheet/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.64.3"
   },
   "peerDependencies": {

--- a/packages/framework/themed-stylesheet/tsconfig.json
+++ b/packages/framework/themed-stylesheet/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib"
   },

--- a/packages/framework/use-slot/babel.config.js
+++ b/packages/framework/use-slot/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/framework/use-slot/jest.config.js
+++ b/packages/framework/use-slot/jest.config.js
@@ -1,2 +1,2 @@
-const { configureReactNativeJest } = require('@uifabricshared/build-native');
+const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
 module.exports = configureReactNativeJest('android');

--- a/packages/framework/use-slot/just.config.js
+++ b/packages/framework/use-slot/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/framework/use-slot/package.json
+++ b/packages/framework/use-slot/package.json
@@ -37,7 +37,7 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react": "17.0.1",
     "react-native": "^0.64.3"
   },

--- a/packages/framework/use-slot/tsconfig.json
+++ b/packages/framework/use-slot/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "importHelpers": true,
     "outDir": "lib",

--- a/packages/framework/use-slots/babel.config.js
+++ b/packages/framework/use-slots/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/framework/use-slots/jest.config.js
+++ b/packages/framework/use-slots/jest.config.js
@@ -1,2 +1,2 @@
-const { configureReactNativeJest } = require('@uifabricshared/build-native');
+const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
 module.exports = configureReactNativeJest('android');

--- a/packages/framework/use-slots/just.config.js
+++ b/packages/framework/use-slots/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/framework/use-slots/package.json
+++ b/packages/framework/use-slots/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@fluentui-react-native/merge-props": ">=0.4.2 <1.0.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react": "17.0.1",
     "react-native": "^0.64.3"
   },

--- a/packages/framework/use-slots/tsconfig.json
+++ b/packages/framework/use-slots/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib",
     "types": ["node", "jest"]

--- a/packages/framework/use-styling/babel.config.js
+++ b/packages/framework/use-styling/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/framework/use-styling/jest.config.js
+++ b/packages/framework/use-styling/jest.config.js
@@ -1,2 +1,2 @@
-const { configureReactNativeJest } = require('@uifabricshared/build-native');
+const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
 module.exports = configureReactNativeJest('android');

--- a/packages/framework/use-styling/just.config.js
+++ b/packages/framework/use-styling/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/framework/use-styling/package.json
+++ b/packages/framework/use-styling/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.0",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react": "17.0.1",
     "react-native": "^0.64.3"
   }

--- a/packages/framework/use-styling/tsconfig.json
+++ b/packages/framework/use-styling/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "importHelpers": true,
     "outDir": "lib"

--- a/packages/framework/use-tokens/babel.config.js
+++ b/packages/framework/use-tokens/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/framework/use-tokens/jest.config.js
+++ b/packages/framework/use-tokens/jest.config.js
@@ -1,2 +1,2 @@
-const { configureReactNativeJest } = require('@uifabricshared/build-native');
+const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
 module.exports = configureReactNativeJest('android');

--- a/packages/framework/use-tokens/just.config.js
+++ b/packages/framework/use-tokens/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/framework/use-tokens/package.json
+++ b/packages/framework/use-tokens/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@fluentui-react-native/merge-props": "^0.4.2",
     "@types/jest": "^26.0.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react": "17.0.1",
     "react-native": "^0.64.3"
   }

--- a/packages/framework/use-tokens/tsconfig.json
+++ b/packages/framework/use-tokens/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "importHelpers": true,
     "outDir": "lib"

--- a/packages/libraries/core/jest.config.win32.js
+++ b/packages/libraries/core/jest.config.win32.js
@@ -1,2 +1,2 @@
-const { configureReactNativeJest } = require('@uifabricshared/build-native');
+const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
 module.exports = configureReactNativeJest('win32');

--- a/packages/libraries/core/just.config.js
+++ b/packages/libraries/core/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/libraries/core/package.json
+++ b/packages/libraries/core/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react": "17.0.1",
     "react-native": "^0.64.3"
   },

--- a/packages/theming/android-theme/babel.config.js
+++ b/packages/theming/android-theme/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/theming/android-theme/just.config.js
+++ b/packages/theming/android-theme/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/theming/android-theme/package.json
+++ b/packages/theming/android-theme/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.64.3"
   },
   "peerDependencies": {

--- a/packages/theming/android-theme/tsconfig.json
+++ b/packages/theming/android-theme/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib",
     "types": ["node", "jest"]

--- a/packages/theming/apple-theme/babel.config.js
+++ b/packages/theming/apple-theme/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/theming/apple-theme/just.config.js
+++ b/packages/theming/apple-theme/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/theming/apple-theme/package.json
+++ b/packages/theming/apple-theme/package.json
@@ -44,7 +44,7 @@
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react": "^17.0.2",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.64.3"
   },
   "peerDependencies": {

--- a/packages/theming/apple-theme/tsconfig.json
+++ b/packages/theming/apple-theme/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib",
     "types": ["node", "jest"]

--- a/packages/theming/default-theme/babel.config.js
+++ b/packages/theming/default-theme/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/theming/default-theme/just.config.js
+++ b/packages/theming/default-theme/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/theming/default-theme/package.json
+++ b/packages/theming/default-theme/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react": "^17.0.2",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react": "17.0.1",
     "react-native": "^0.64.3"
   },

--- a/packages/theming/default-theme/tsconfig.json
+++ b/packages/theming/default-theme/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib",
     "types": ["node", "jest"]

--- a/packages/theming/theme-tokens/babel.config.js
+++ b/packages/theming/theme-tokens/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/theming/theme-tokens/just.config.js
+++ b/packages/theming/theme-tokens/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/theming/theme-tokens/package.json
+++ b/packages/theming/theme-tokens/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.64.3"
   },
   "peerDependencies": {

--- a/packages/theming/theme-tokens/tsconfig.json
+++ b/packages/theming/theme-tokens/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib",
     "types": ["node", "jest"]

--- a/packages/theming/theme-types/babel.config.js
+++ b/packages/theming/theme-types/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/theming/theme-types/just.config.js
+++ b/packages/theming/theme-types/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/theming/theme-types/package.json
+++ b/packages/theming/theme-types/package.json
@@ -37,7 +37,7 @@
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react": "^17.0.2",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react": "17.0.1",
     "react-native": "^0.64.3"
   },

--- a/packages/theming/theme-types/tsconfig.json
+++ b/packages/theming/theme-types/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib",
     "types": ["node", "jest"]

--- a/packages/theming/theming-utils/babel.config.js
+++ b/packages/theming/theming-utils/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/theming/theming-utils/just.config.js
+++ b/packages/theming/theming-utils/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/theming/theming-utils/package.json
+++ b/packages/theming/theming-utils/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.64.3",
     "react-native-windows": "^0.64.3"
   },

--- a/packages/theming/theming-utils/tsconfig.json
+++ b/packages/theming/theming-utils/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib"
   },

--- a/packages/theming/win32-theme/babel.config.js
+++ b/packages/theming/win32-theme/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/theming/win32-theme/just.config.js
+++ b/packages/theming/win32-theme/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/theming/win32-theme/package.json
+++ b/packages/theming/win32-theme/package.json
@@ -45,7 +45,7 @@
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react": "^17.0.2",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react": "17.0.1",
     "react-native": "^0.64.3"
   },

--- a/packages/theming/win32-theme/tsconfig.json
+++ b/packages/theming/win32-theme/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "importHelpers": true,
     "outDir": "lib",

--- a/packages/utils/adapters/babel.config.js
+++ b/packages/utils/adapters/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/utils/adapters/jest.config.js
+++ b/packages/utils/adapters/jest.config.js
@@ -1,2 +1,2 @@
-const { configureJest } = require('@uifabricshared/build-native');
+const { configureJest } = require('@fluentui-react-native/scripts');
 module.exports = configureJest();

--- a/packages/utils/adapters/just.config.js
+++ b/packages/utils/adapters/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/utils/adapters/package.json
+++ b/packages/utils/adapters/package.json
@@ -30,7 +30,7 @@
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/jest": "^26.0.0",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1"
+    "@fluentui-react-native/scripts": "^0.1.1"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.64.8",

--- a/packages/utils/adapters/tsconfig.json
+++ b/packages/utils/adapters/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib"
   },

--- a/packages/utils/interactive-hooks/babel.config.js
+++ b/packages/utils/interactive-hooks/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/utils/interactive-hooks/just.config.js
+++ b/packages/utils/interactive-hooks/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/utils/interactive-hooks/package.json
+++ b/packages/utils/interactive-hooks/package.json
@@ -37,7 +37,7 @@
     "@types/invariant": "^2.2.0",
     "@types/react": "^17.0.2",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react": "17.0.1",
     "react-native": "^0.64.3"
   },

--- a/packages/utils/interactive-hooks/tsconfig.json
+++ b/packages/utils/interactive-hooks/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "importHelpers": true,
     "outDir": "lib"

--- a/packages/utils/styling/babel.config.js
+++ b/packages/utils/styling/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/utils/styling/just.config.js
+++ b/packages/utils/styling/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/utils/styling/package.json
+++ b/packages/utils/styling/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
-    "@uifabricshared/build-native": "^0.1.1"
+    "@fluentui-react-native/scripts": "^0.1.1"
   },
   "peerDependencies": {
     "react": "^17.0.1",

--- a/packages/utils/styling/tsconfig.json
+++ b/packages/utils/styling/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib"
   },

--- a/packages/utils/test-tools/babel.config.js
+++ b/packages/utils/test-tools/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/utils/test-tools/jest.config.js
+++ b/packages/utils/test-tools/jest.config.js
@@ -1,2 +1,2 @@
-const { configureReactNativeJest } = require('@uifabricshared/build-native');
+const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
 module.exports = configureReactNativeJest('android');

--- a/packages/utils/test-tools/just.config.js
+++ b/packages/utils/test-tools/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/utils/test-tools/package.json
+++ b/packages/utils/test-tools/package.json
@@ -29,7 +29,7 @@
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react": "^17.0.2",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react": "17.0.1",
     "react-native": "^0.64.3"
   },

--- a/packages/utils/test-tools/tsconfig.json
+++ b/packages/utils/test-tools/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib"
   },

--- a/packages/utils/tokens/babel.config.js
+++ b/packages/utils/tokens/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@uifabricshared/build-native/babel.config');
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/utils/tokens/just.config.js
+++ b/packages/utils/tokens/just.config.js
@@ -1,3 +1,3 @@
-const { preset } = require('@uifabricshared/build-native');
+const { preset } = require('@fluentui-react-native/scripts');
 
 preset();

--- a/packages/utils/tokens/package.json
+++ b/packages/utils/tokens/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@types/react-native": "^0.64.0",
-    "@uifabricshared/build-native": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.64.3"
   },
   "peerDependencies": {

--- a/packages/utils/tokens/tsconfig.json
+++ b/packages/utils/tokens/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "importHelpers": true,
     "outDir": "lib"

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@uifabricshared/build-native",
+  "name": "@fluentui-react-native/scripts",
   "version": "0.1.1",
   "private": true,
   "main": "./lib/index.js",

--- a/scripts/src/tasks/depcheck.js
+++ b/scripts/src/tasks/depcheck.js
@@ -9,7 +9,7 @@ function mergeOneLevel(a, b = {}) {
 }
 
 function scriptsDevDeps() {
-  const config = require('@uifabricshared/build-native/package.json');
+  const config = require('@fluentui-react-native/scripts/package.json');
   return Object.keys(config.devDependencies);
 }
 
@@ -22,7 +22,7 @@ function depcheckTask() {
     const options = mergeOneLevel(
       {
         ignorePatterns: ['*eslint*', '/lib/*', '/lib-commonjs/*'],
-        ignoreMatches: ['@uifabricshared/build-native', '@fluentui-react-native/eslint-config-rules', 'tslib', ...scriptsDevDeps()],
+        ignoreMatches: ['@fluentui-react-native/scripts', '@fluentui-react-native/eslint-config-rules', 'tslib', ...scriptsDevDeps()],
         specials: [depcheck.special.eslint, depcheck.special.webpack, depcheck.special.jest],
       },
       config.depcheck,

--- a/scripts/src/webpack/webpack-resources.js
+++ b/scripts/src/webpack/webpack-resources.js
@@ -1,13 +1,5 @@
-const { just } = require('@uifabricshared/build-native');
-const {
-  basicWebpackConfig,
-  htmlOverlay,
-  webpackMerge,
-  tsOverlay,
-  fileOverlay,
-  displayBailoutOverlay,
-  stylesOverlay,
-} = just;
+const { just } = require('@fluentui-react-native/scripts');
+const { basicWebpackConfig, htmlOverlay, webpackMerge, tsOverlay, fileOverlay, displayBailoutOverlay, stylesOverlay } = just;
 
 const _isProduction = process.argv.indexOf('--production') > -1;
 
@@ -18,17 +10,17 @@ const tsOverlayConfig = tsOverlay({
   loaderOptions: {
     transpileOnly: true,
     compilerOptions: {
-      "declaration": false,
-      "declarationMap": false
-    }
+      declaration: false,
+      declarationMap: false,
+    },
   },
   checkerOptions: {
     transpileOnly: true,
     compilerOptions: {
-      "declaration": false,
-      "declarationMap": false
-    }
-  }
+      declaration: false,
+      declarationMap: false,
+    },
+  },
 });
 
 module.exports = {
@@ -46,17 +38,17 @@ module.exports = {
           rules: [
             {
               test: /\.js?$/,
-              use: "source-map-loader",
-              enforce: 'pre'
-            }
-          ]
+              use: 'source-map-loader',
+              enforce: 'pre',
+            },
+          ],
         },
         output: {
-          filename: `${bundleName}.js`
+          filename: `${bundleName}.js`,
         },
-        plugins: getPlugins(bundleName, _isProduction)
+        plugins: getPlugins(bundleName, _isProduction),
       },
-      additionalOptions
+      additionalOptions,
     );
   },
   createAppConfig(bundleName, overlayTarget, additionalOptions) {
@@ -67,30 +59,30 @@ module.exports = {
       fileOverlay(),
       displayBailoutOverlay(),
       htmlOverlay({
-        template: overlayTarget
+        template: overlayTarget,
       }),
       {
         entry: {
-          [bundleName]: './src/index.tsx'
+          [bundleName]: './src/index.tsx',
         },
         devtool: 'cheap-module-eval-source-map',
         output: {
-          filename: `${bundleName}.js`
+          filename: `${bundleName}.js`,
         },
         module: {
           rules: [
             {
               test: /\.js?$/,
-              use: "source-map-loader",
-              enforce: 'pre'
-            }
-          ]
+              use: 'source-map-loader',
+              enforce: 'pre',
+            },
+          ],
         },
-        plugins: getPlugins(bundleName, _isProduction)
+        plugins: getPlugins(bundleName, _isProduction),
       },
-      additionalOptions
+      additionalOptions,
     );
-  }
+  },
 };
 
 function getPlugins(bundleName, isProduction) {
@@ -108,11 +100,11 @@ function getPlugins(bundleName, isProduction) {
         statsOptions: {
           source: false,
           reasons: false,
-          chunks: false
+          chunks: false,
         },
         statsFilename: bundleName + '.stats.json',
-        logLevel: 'warn'
-      })
+        logLevel: 'warn',
+      }),
     );
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@uifabricshared/build-native/tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib"
   }


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This change does two things:

1) Search and replace all strings "@uifabricshared/build-native" to "@fluentui-react-native/scripts". 

2) Renames the package at our root package.json from " uifabric-react-native" to "@fluentui-react-native/repo".
This is a private package mostly used for monorepo management. The public "@fluentui/react-native"  at libraries/core/package.json" if left untouched

Addresses most of #1339, I still need to add some more tsconfigs which I'll do separately.

### Verification

Only editing private packages, so CI passing should be enough.

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
