### PR TITLE
Some fixes for high contrast

### DIFF
--- a/change/@fluentui-react-native-button-4e1165b7-c497-4230-ba47-c8758a1faebf.json
+++ b/change/@fluentui-react-native-button-4e1165b7-c497-4230-ba47-c8758a1faebf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix HC issues",
+  "packageName": "@fluentui-react-native/button",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-link-42ebef98-c191-44d0-b421-e7d124d0344a.json
+++ b/change/@fluentui-react-native-link-42ebef98-c191-44d0-b421-e7d124d0344a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix HC issues",
+  "packageName": "@fluentui-react-native/link",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Button/src/Button.settings.win32.ts
+++ b/packages/components/Button/src/Button.settings.win32.ts
@@ -5,9 +5,9 @@ import type { IViewProps } from '@fluentui-react-native/adapters';
 export const settings: IComposeSettings<IButtonType> = [
   {
     tokens: {
-      backgroundColor: 'neutralBackground1',
-      color: 'neutralForeground1',
-      borderColor: 'neutralStroke1',
+      backgroundColor: 'buttonBackground',
+      color: 'buttonText',
+      borderColor: 'buttonBorder',
       borderWidth: 1,
       borderRadius: 4,
       wrapperBorderColor: 'transparent',
@@ -63,31 +63,31 @@ export const settings: IComposeSettings<IButtonType> = [
     _overrides: {
       disabled: {
         tokens: {
-          backgroundColor: 'neutralBackgroundDisabled',
-          color: 'neutralForegroundDisabled',
-          borderColor: 'neutralStrokeDisabled',
+          backgroundColor: 'buttonBackgroundDisabled',
+          color: 'buttonTextDisabled',
+          borderColor: 'buttonBorderDisabled',
         },
       },
       hovered: {
         tokens: {
-          backgroundColor: 'neutralBackground1Hover',
-          color: 'neutralForeground1',
-          borderColor: 'neutralStroke1',
+          backgroundColor: 'buttonBackgroundHovered',
+          color: 'buttonTextHovered',
+          borderColor: 'buttonBorderHovered',
         },
       },
       pressed: {
         tokens: {
-          backgroundColor: 'neutralBackground1Pressed',
-          color: 'neutralForeground1',
-          borderColor: 'neutralStroke1',
+          backgroundColor: 'buttonBackgroundPressed',
+          color: 'buttonTextPressed',
+          borderColor: 'buttonPressedBorder',
         },
       },
       focused: {
         tokens: {
-          backgroundColor: 'neutralBackground1Hover',
-          color: 'neutralForeground1',
-          borderColor: 'strokeFocus2',
-          wrapperBorderColor: 'strokeFocus2',
+          borderColor: 'buttonBorderFocused',
+          color: 'buttonTextHovered',
+          backgroundColor: 'buttonBackgroundHovered',
+          wrapperBorderColor: 'buttonBorderFocused',
         },
       },
     },

--- a/packages/components/Button/src/PrimaryButton/PrimaryButton.settings.win32.ts
+++ b/packages/components/Button/src/PrimaryButton/PrimaryButton.settings.win32.ts
@@ -4,9 +4,9 @@ import { IComposeSettings } from '@uifabricshared/foundation-compose';
 export const settings: IComposeSettings<IButtonType> = [
   {
     tokens: {
-      backgroundColor: 'brandBackground',
-      color: 'neutralForegroundOnBrand',
-      borderColor: 'brandBackground',
+      backgroundColor: 'primaryButtonBackground',
+      color: 'primaryButtonText',
+      borderColor: 'primaryButtonBorder',
     },
     // TODO - #728: neutralForegroundOnBrand is not working for icon color.
     endIcon: {
@@ -18,30 +18,30 @@ export const settings: IComposeSettings<IButtonType> = [
     _overrides: {
       disabled: {
         tokens: {
-          backgroundColor: 'neutralBackgroundDisabled',
-          color: 'neutralForegroundDisabled',
-          borderColor: 'neutralBackgroundDisabled',
+          backgroundColor: 'primaryButtonBackgroundDisabled',
+          color: 'primaryButtonTextDisabled',
+          borderColor: 'primaryButtonBackgroundDisabled',
         },
       },
       hovered: {
         tokens: {
-          backgroundColor: 'brandBackgroundHover',
-          color: 'neutralForegroundOnBrand',
-          borderColor: 'brandBackgroundHover',
+          backgroundColor: 'primaryButtonBackgroundHovered',
+          color: 'primaryButtonTextHovered',
+          borderColor: 'primaryButtonBorderHovered',
         },
       },
       pressed: {
         tokens: {
-          backgroundColor: 'brandBackgroundPressed',
-          color: 'neutralForegroundOnBrand',
-          borderColor: 'brandBackgroundPressed',
+          backgroundColor: 'primaryButtonBackgroundPressed',
+          color: 'primaryButtonTextPressed',
+          borderColor: 'primaryButtonBorderPressed',
         },
       },
       focused: {
         tokens: {
-          backgroundColor: 'brandBackgroundHover',
-          borderColor: 'strokeFocus2',
-          color: 'neutralForegroundInvertedLinkHover',
+          borderColor: 'primaryButtonBorderFocused',
+          backgroundColor: 'primaryButtonBackgroundHovered',
+          color: 'primaryButtonTextHovered',
         },
       },
     },

--- a/packages/components/Link/src/Link.settings.ts
+++ b/packages/components/Link/src/Link.settings.ts
@@ -52,7 +52,7 @@ export const settings: IComposeSettings<ILinkType> = [
       },
       focused: {
         tokens: {
-          borderColor: 'strokeFocus2',
+          borderColor: 'focusBorder',
         },
       },
     },


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Some users have been hitting issues with Link and Button in high contrast/other themes.

The issue is that the old theming provider doesn't integrate with design tokens, so any component using design tokens isn't updating their colors properly under the old theming provider. Since we haven't explicitly marked it as deprecated yet, I'm changing the colors back to ones that work for now. I will work on marking the old theming provider as deprecated in the future.

This also means any clients using the experimental buttons must use the newer theming provider for colors to work correctly.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/4602628/149427227-3c33caff-a01c-45fd-8316-e9715009d541.png) | ![image](https://user-images.githubusercontent.com/4602628/149426810-b5a593ed-9f52-4cea-9e0d-0be4e69d1c81.png) |
| ![image](https://user-images.githubusercontent.com/4602628/149427270-2af0c0e0-83c6-4dbf-a2eb-b24691cd05ad.png) | ![image](https://user-images.githubusercontent.com/4602628/149427309-32e85eb4-1edc-4f4f-abfb-fc4df0af9923.png) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
