### PR TITLE
Fix experimental button font and spacing

### DIFF
--- a/change/@fluentui-react-native-experimental-button-be3ec315-2371-4f19-8048-9a8c81e5d7d0.json
+++ b/change/@fluentui-react-native-experimental-button-be3ec315-2371-4f19-8048-9a8c81e5d7d0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Font fixes",
+  "packageName": "@fluentui-react-native/experimental-button",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-styling-utils-e25ea61a-be88-4a6c-8f8b-3d7d69c5858f.json
+++ b/change/@fluentui-react-native-styling-utils-e25ea61a-be88-4a6c-8f8b-3d7d69c5858f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "More spacing adjustments",
+  "packageName": "@fluentui-react-native/styling-utils",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Button/src/Button.styling.ts
+++ b/packages/experimental/Button/src/Button.styling.ts
@@ -5,6 +5,7 @@ import { defaultButtonTokens } from './ButtonTokens';
 import { defaultButtonColorTokens } from './ButtonColorTokens';
 import { Platform, ColorValue } from 'react-native';
 import { getTextMarginAdjustment } from '@fluentui-react-native/styling-utils';
+import { defaultButtonFontTokens } from './ButtonFontTokens';
 
 export const buttonCoreStates: (keyof ButtonCoreTokens)[] = ['hovered', 'focused', 'pressed', 'disabled', 'hasContent', 'hasIconBefore'];
 
@@ -28,7 +29,7 @@ export const buttonStates: (keyof ButtonTokens)[] = [
 ];
 
 export const stylingSettings: UseStylingOptions<ButtonPropsWithInnerRef, ButtonSlotProps, ButtonTokens> = {
-  tokens: [defaultButtonTokens, defaultButtonColorTokens, buttonName],
+  tokens: [defaultButtonTokens, defaultButtonFontTokens, defaultButtonColorTokens, buttonName],
   states: buttonStates,
   slotProps: {
     root: buildProps(

--- a/packages/experimental/Button/src/ButtonFontTokens.ts
+++ b/packages/experimental/Button/src/ButtonFontTokens.ts
@@ -1,0 +1,20 @@
+import { Theme } from '@fluentui-react-native/framework';
+import { TokenSettings } from '@fluentui-react-native/use-styling';
+import { ButtonTokens } from './Button.types';
+
+export const defaultButtonFontTokens: TokenSettings<ButtonTokens, Theme> = (_t: Theme) =>
+  ({
+    medium: {
+      hasContent: {
+        variant: 'bodySemibold',
+      },
+    },
+    small: {
+      hasContent: {
+        variant: 'secondaryStandard',
+      },
+    },
+    large: {
+      variant: 'subheaderSemibold',
+    },
+  } as ButtonTokens);

--- a/packages/experimental/Button/src/ButtonFontTokens.win32.ts
+++ b/packages/experimental/Button/src/ButtonFontTokens.win32.ts
@@ -1,0 +1,29 @@
+import { Theme } from '@fluentui-react-native/framework';
+import { globalTokens } from '@fluentui-react-native/theme-tokens';
+import { TokenSettings } from '@fluentui-react-native/use-styling';
+import { ButtonTokens } from './Button.types';
+
+export const defaultButtonFontTokens: TokenSettings<ButtonTokens, Theme> = (t: Theme) =>
+  ({
+    medium: {
+      hasContent: {
+        fontFamily: t.typography.families.secondary,
+        fontSize: globalTokens.font.size[300],
+        fontWeight: globalTokens.font.weight.semibold,
+      },
+    },
+    small: {
+      hasContent: {
+        fontFamily: t.typography.families.primary,
+        fontSize: globalTokens.font.size[200],
+        fontWeight: globalTokens.font.weight.regular,
+      },
+    },
+    large: {
+      hasContent: {
+        fontFamily: t.typography.families.secondary,
+        fontSize: globalTokens.font.size[400],
+        fontWeight: globalTokens.font.weight.semibold,
+      },
+    },
+  } as ButtonTokens);

--- a/packages/experimental/Button/src/ButtonTokens.ts
+++ b/packages/experimental/Button/src/ButtonTokens.ts
@@ -19,7 +19,6 @@ export const defaultButtonTokens: TokenSettings<ButtonTokens, Theme> = () =>
       hasContent: {
         minWidth: 96,
         paddingHorizontal: globalTokens.spacing.m - globalTokens.stroke.width.thin,
-        variant: 'bodySemibold',
         hasIconAfter: {
           spacingIconContentAfter: globalTokens.spacing.sNudge,
         },
@@ -42,7 +41,6 @@ export const defaultButtonTokens: TokenSettings<ButtonTokens, Theme> = () =>
       hasContent: {
         minWidth: 64,
         paddingHorizontal: globalTokens.spacing.s - globalTokens.stroke.width.thin,
-        variant: 'secondaryStandard',
         hasIconAfter: {
           spacingIconContentAfter: globalTokens.spacing.xs,
         },
@@ -65,7 +63,6 @@ export const defaultButtonTokens: TokenSettings<ButtonTokens, Theme> = () =>
       hasContent: {
         minWidth: 96,
         paddingHorizontal: globalTokens.spacing.l - globalTokens.stroke.width.thin,
-        variant: 'subheaderSemibold',
         hasIconAfter: {
           spacingIconContentAfter: globalTokens.spacing.sNudge,
         },

--- a/packages/experimental/Button/src/ButtonTokens.win32.ts
+++ b/packages/experimental/Button/src/ButtonTokens.win32.ts
@@ -1,0 +1,92 @@
+import { Theme } from '@fluentui-react-native/framework';
+import { globalTokens } from '@fluentui-react-native/theme-tokens';
+import { TokenSettings } from '@fluentui-react-native/use-styling';
+import { ButtonTokens } from './Button.types';
+
+export const defaultButtonTokens: TokenSettings<ButtonTokens, Theme> = () =>
+  ({
+    block: {
+      width: '100%',
+    },
+    medium: {
+      padding: globalTokens.spacing.s - globalTokens.stroke.width.thin,
+      borderWidth: globalTokens.stroke.width.thin,
+      iconSize: 16,
+      focused: {
+        borderWidth: 0,
+        padding: globalTokens.spacing.s,
+      },
+      hasContent: {
+        minWidth: 96,
+        padding: globalTokens.spacing.sNudge - globalTokens.stroke.width.thin,
+        paddingHorizontal: globalTokens.spacing.m - globalTokens.stroke.width.thin,
+        hasIconAfter: {
+          spacingIconContentAfter: globalTokens.spacing.s,
+        },
+        hasIconBefore: {
+          spacingIconContentBefore: globalTokens.spacing.s,
+        },
+        focused: {
+          padding: globalTokens.spacing.sNudge,
+          paddingHorizontal: globalTokens.spacing.m,
+        },
+      },
+    },
+    small: {
+      padding: globalTokens.spacing.xs - globalTokens.stroke.width.thin,
+      borderWidth: globalTokens.stroke.width.thin,
+      iconSize: 16,
+      focused: {
+        borderWidth: 0,
+        padding: globalTokens.spacing.xs,
+      },
+      hasContent: {
+        minWidth: 64,
+        minHeight: 32,
+        paddingHorizontal: globalTokens.spacing.s - globalTokens.stroke.width.thin,
+        hasIconAfter: {
+          spacingIconContentAfter: globalTokens.spacing.xs,
+        },
+        hasIconBefore: {
+          spacingIconContentBefore: globalTokens.spacing.xs,
+        },
+        focused: {
+          paddingHorizontal: globalTokens.spacing.s,
+        },
+      },
+    },
+    large: {
+      padding: globalTokens.spacing.mNudge - globalTokens.stroke.width.thin,
+      borderWidth: globalTokens.stroke.width.thin,
+      iconSize: 20,
+      focused: {
+        borderWidth: 0,
+        padding: globalTokens.spacing.mNudge,
+      },
+      hasContent: {
+        minWidth: 96,
+        minHeight: 40,
+        padding: globalTokens.spacing.s - globalTokens.stroke.width.thin,
+        paddingHorizontal: globalTokens.spacing.l - globalTokens.stroke.width.thin,
+        hasIconAfter: {
+          spacingIconContentAfter: globalTokens.spacing.sNudge,
+        },
+        hasIconBefore: {
+          spacingIconContentBefore: globalTokens.spacing.sNudge,
+        },
+        focused: {
+          padding: globalTokens.spacing.s,
+          paddingHorizontal: globalTokens.spacing.l,
+        },
+      },
+    },
+    rounded: {
+      borderRadius: globalTokens.corner.radius.medium,
+    },
+    circular: {
+      borderRadius: globalTokens.corner.radius.circle,
+    },
+    square: {
+      borderRadius: globalTokens.corner.radius.none,
+    },
+  } as ButtonTokens);

--- a/packages/experimental/Button/src/CompoundButton/CompoundButton.styling.ts
+++ b/packages/experimental/Button/src/CompoundButton/CompoundButton.styling.ts
@@ -6,12 +6,14 @@ import { buttonStates, contentStyling } from '../Button.styling';
 import { defaultButtonTokens } from '../ButtonTokens';
 import { defaultCompoundButtonColorTokens } from './CompoundButtonColorTokens';
 import { defaultCompoundButtonTokens } from './CompoundButtonTokens';
+import { defaultCompoundButtonFontTokens } from './CompoundButtonFontTokens';
 
 export const stylingSettings: UseStylingOptions<CompoundButtonPropsWithInnerRef, CompoundButtonSlotProps, CompoundButtonTokens> = {
   tokens: [
     defaultButtonTokens,
     defaultButtonColorTokens,
     defaultCompoundButtonTokens,
+    defaultCompoundButtonFontTokens,
     defaultCompoundButtonColorTokens,
     compoundButtonName,
   ],

--- a/packages/experimental/Button/src/CompoundButton/CompoundButtonFontTokens.ts
+++ b/packages/experimental/Button/src/CompoundButton/CompoundButtonFontTokens.ts
@@ -1,0 +1,24 @@
+import { Theme } from '@fluentui-react-native/framework';
+import { TokenSettings } from '@fluentui-react-native/use-styling';
+import { CompoundButtonTokens } from './CompoundButton.types';
+
+export const defaultCompoundButtonFontTokens: TokenSettings<CompoundButtonTokens, Theme> = (_t: Theme): CompoundButtonTokens => ({
+  medium: {
+    hasContent: {
+      variant: 'bodySemibold',
+      secondaryContentFont: { variant: 'secondaryStandard' },
+    },
+  },
+  small: {
+    hasContent: {
+      variant: 'bodyStandard',
+      secondaryContentFont: { variant: 'secondaryStandard' },
+    },
+  },
+  large: {
+    hasContent: {
+      variant: 'subheaderSemibold',
+      secondaryContentFont: { variant: 'bodyStandard' },
+    },
+  },
+});

--- a/packages/experimental/Button/src/CompoundButton/CompoundButtonFontTokens.win32.ts
+++ b/packages/experimental/Button/src/CompoundButton/CompoundButtonFontTokens.win32.ts
@@ -1,0 +1,43 @@
+import { FontWeightValue, Theme } from '@fluentui-react-native/framework';
+import { globalTokens } from '@fluentui-react-native/theme-tokens';
+import { TokenSettings } from '@fluentui-react-native/use-styling';
+import { CompoundButtonTokens } from './CompoundButton.types';
+
+export const defaultCompoundButtonFontTokens: TokenSettings<CompoundButtonTokens, Theme> = (t: Theme): CompoundButtonTokens => ({
+  medium: {
+    hasContent: {
+      fontFamily: t.typography.families.secondary,
+      fontSize: globalTokens.font.size[200],
+      fontWeight: globalTokens.font.weight.semibold as FontWeightValue,
+      secondaryContentFont: {
+        fontFamily: t.typography.families.secondary,
+        fontSize: globalTokens.font.size[100],
+        fontWeight: globalTokens.font.weight.semibold as FontWeightValue,
+      },
+    },
+  },
+  small: {
+    hasContent: {
+      fontFamily: t.typography.families.primary,
+      fontSize: globalTokens.font.size[200],
+      fontWeight: globalTokens.font.weight.regular as FontWeightValue,
+      secondaryContentFont: {
+        fontFamily: t.typography.families.secondary,
+        fontSize: globalTokens.font.size[100],
+        fontWeight: globalTokens.font.weight.semibold as FontWeightValue,
+      },
+    },
+  },
+  large: {
+    hasContent: {
+      fontFamily: t.typography.families.secondary,
+      fontSize: globalTokens.font.size[400],
+      fontWeight: globalTokens.font.weight.semibold as FontWeightValue,
+      secondaryContentFont: {
+        fontFamily: t.typography.families.primary,
+        fontSize: globalTokens.font.size[200],
+        fontWeight: globalTokens.font.weight.regular as FontWeightValue,
+      },
+    },
+  },
+});

--- a/packages/experimental/Button/src/CompoundButton/CompoundButtonTokens.ts
+++ b/packages/experimental/Button/src/CompoundButton/CompoundButtonTokens.ts
@@ -12,8 +12,6 @@ export const defaultCompoundButtonTokens: TokenSettings<CompoundButtonTokens, Th
     hasContent: {
       paddingHorizontal: globalTokens.spacing.m - globalTokens.stroke.width.thin,
       minWidth: 96,
-      variant: 'bodySemibold',
-      secondaryContentFont: { variant: 'secondaryStandard' },
       focused: {
         paddingHorizontal: globalTokens.spacing.m,
       },
@@ -33,8 +31,6 @@ export const defaultCompoundButtonTokens: TokenSettings<CompoundButtonTokens, Th
     hasContent: {
       paddingHorizontal: globalTokens.spacing.s - globalTokens.stroke.width.thin,
       minWidth: 64,
-      variant: 'bodyStandard',
-      secondaryContentFont: { variant: 'secondaryStandard' },
       focused: {
         paddingHorizontal: globalTokens.spacing.s,
       },
@@ -54,8 +50,6 @@ export const defaultCompoundButtonTokens: TokenSettings<CompoundButtonTokens, Th
     hasContent: {
       paddingHorizontal: globalTokens.spacing.l - globalTokens.stroke.width.thin,
       minWidth: 96,
-      variant: 'subheaderSemibold',
-      secondaryContentFont: { variant: 'bodyStandard' },
       focused: {
         paddingHorizontal: globalTokens.spacing.l,
       },

--- a/packages/experimental/Button/src/ToggleButton/ToggleButton.styling.ts
+++ b/packages/experimental/Button/src/ToggleButton/ToggleButton.styling.ts
@@ -5,9 +5,10 @@ import { defaultButtonColorTokens } from '../ButtonColorTokens';
 import { buttonStates, contentStyling } from '../Button.styling';
 import { defaultToggleButtonColorTokens } from './ToggleButtonColorTokens';
 import { defaultButtonTokens } from '../ButtonTokens';
+import { defaultButtonFontTokens } from '../ButtonFontTokens';
 
 export const stylingSettings: UseStylingOptions<ToggleButtonPropsWithInnerRef, ToggleButtonSlotProps, ToggleButtonTokens> = {
-  tokens: [defaultButtonTokens, defaultButtonColorTokens, defaultToggleButtonColorTokens, toggleButtonName],
+  tokens: [defaultButtonTokens, defaultButtonFontTokens, defaultButtonColorTokens, defaultToggleButtonColorTokens, toggleButtonName],
   states: ['checked', ...buttonStates],
   slotProps: {
     root: buildProps(

--- a/packages/utils/styling/src/getMarginAdjustment.win32.ts
+++ b/packages/utils/styling/src/getMarginAdjustment.win32.ts
@@ -1,4 +1,4 @@
-const margins = { marginTop: -1, marginBottom: 1, marginStart: 1, marginEnd: -1 };
+const margins = { marginTop: -1, marginBottom: 1, marginStart: 0, marginEnd: -2 };
 
 /**
  * Adjusts the margin of text so that it's centered within the layout area of the text.


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

1. Font size was off on the button for win32 - the font tokens are slightly smaller on win32. I haven't properly done the font token work yet so for now I'm directly plugging in the font tokens into the button, and will clean this up in a different PR.
2. Spacing was fixed for various parts of the button as they are subtly different from web/uwp.

### Verification

| Before | After |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/4602628/149444340-be7204a3-50f8-46fc-87d5-ad15627a25de.png) | ![image](https://user-images.githubusercontent.com/4602628/149444248-5588541e-9e9b-4688-92f7-47d35743e880.png) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
