### PR TITLE
Clean up some more tsconfigs

### DIFF
--- a/apps/android/tsconfig.json
+++ b/apps/android/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "noEmit": true
   },

--- a/apps/fluent-tester/tsconfig.json
+++ b/apps/fluent-tester/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
     "importHelpers": true,

--- a/apps/ios/tsconfig.json
+++ b/apps/ios/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "noEmit": true
   },

--- a/apps/macos/tsconfig.json
+++ b/apps/macos/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {

--- a/apps/win32/tsconfig.json
+++ b/apps/win32/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
     "importHelpers": true,

--- a/apps/windows/tsconfig.json
+++ b/apps/windows/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
     "importHelpers": true,

--- a/change/@fluentui-react-native-checkbox-1538c279-4708-4f72-adae-5d84e50e40c3.json
+++ b/change/@fluentui-react-native-checkbox-1538c279-4708-4f72-adae-5d84e50e40c3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "resolve json modules in tsconfig",
+  "packageName": "@fluentui-react-native/checkbox",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-tester-3a520c9f-60d9-4a77-8ab3-294be83eb1b0.json
+++ b/change/@fluentui-react-native-tester-3a520c9f-60d9-4a77-8ab3-294be83eb1b0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "resolve json modules in tsconfig",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-tester-win32-fb53d3c6-99c2-4a34-b551-7f89c1fc1dcc.json
+++ b/change/@fluentui-react-native-tester-win32-fb53d3c6-99c2-4a34-b551-7f89c1fc1dcc.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "resolve json modules in tsconfig",
+  "packageName": "@fluentui-react-native/tester-win32",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-theme-tokens-3481c111-3b98-439b-bb8d-475079a67e3c.json
+++ b/change/@fluentui-react-native-theme-tokens-3481c111-3b98-439b-bb8d-475079a67e3c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "resolve json modules in tsconfig",
+  "packageName": "@fluentui-react-native/theme-tokens",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Checkbox/tsconfig.json
+++ b/packages/components/Checkbox/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib"
   },

--- a/packages/theming/theme-tokens/tsconfig.json
+++ b/packages/theming/theme-tokens/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib",
+    "resolveJsonModule": true,
     "types": ["node", "jest"]
   },
   "include": ["src"]


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Closes #1339 
Change some tsconfigs to extend from the package name, rather than a relative path.
Add `"resolveJsonModule": true` to one tsconfig

### Verification

CI should be enough

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
