### PR TITLE
Specify path to bundles in app.json for each test app

### DIFF
--- a/apps/android/app.json
+++ b/apps/android/app.json
@@ -1,6 +1,6 @@
 {
   "name": "FluentTester",
   "displayName": "FluentTester",
-  "components": [{"appKey": "FluentTester"}],
-  "resources": ["dist/res", "dist/index.bundle"]
+  "components": [{ "appKey": "FluentTester" }],
+  "resources": ["dist/assets", "dist/index.android.bundle"]
 }

--- a/apps/ios/app.json
+++ b/apps/ios/app.json
@@ -1,7 +1,6 @@
 {
   "name": "FluentTester",
   "displayName": "FluentTester",
-  "components": [
-    { "appKey": "FluentTester" }
-  ]
+  "components": [{ "appKey": "FluentTester" }],
+  "resources": ["dist/assets", "dist/index.ios.bundle"]
 }

--- a/apps/macos/app.json
+++ b/apps/macos/app.json
@@ -1,7 +1,6 @@
 {
   "name": "FluentTester",
   "displayName": "FluentTester",
-  "components": [
-    { "appKey": "FluentTester" }
-  ]
+  "components": [{ "appKey": "FluentTester" }],
+  "resources": ["dist/assets", "dist/index.macos.bundle"]
 }

--- a/apps/windows/app.json
+++ b/apps/windows/app.json
@@ -7,10 +7,5 @@
       "displayName": "FluentTester"
     }
   ],
-  "resources": {
-    "windows": [
-      "dist/assets",
-      "dist/index.windows.bundle"
-    ]
-  }
+  "resources": ["dist/assets", "dist/index.windows.bundle"]
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [ ] win32 (Office)
- [x] windows
- [x] android

### Description of changes

The inspiration for this PR was I wanted an easy way to share the FluentTester test app to my coworkers without having them set up an RN dev environment. We can achieve this by embedding the JS Bundle in the test app, before packaging the test app for export on each platform. 

We use [React Native Test App](https://github.com/microsoft/react-native-test-app) to manage most of our test apps. TO embed a JS Bundle in a test app, RNTA specifies that we need to include the path to it in the manifest (app.json) of each test app. This is necessary to have the test app run without needing a packaging server.

### Verification

I built the macOS bundle (`yarn bundle` at `apps/macOS`), then built and ran the macOS test app. I verified that the macOS test app ran without needing a packaging server also running.  


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
