### PR TITLE
Fixed Toggle Button selected state in HC

### DIFF
--- a/change/@fluentui-react-native-experimental-button-08c12f72-a1d0-4c2a-b32b-627b8ba30722.json
+++ b/change/@fluentui-react-native-experimental-button-08c12f72-a1d0-4c2a-b32b-627b8ba30722.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed Toggle selected state for the Button",
+  "packageName": "@fluentui-react-native/experimental-button",
+  "email": "v.kozlova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Button/src/ToggleButton/ToggleButtonColorTokens.win32.ts
+++ b/packages/experimental/Button/src/ToggleButton/ToggleButtonColorTokens.win32.ts
@@ -10,6 +10,7 @@ export const defaultToggleButtonColorTokens: TokenSettings<ToggleButtonTokens, T
     primary: {
       backgroundColor: t.colors.brandBackgroundSelected,
       borderColor: t.colors.brandBackgroundSelected,
+      color: t.colors.neutralForeground1Selected,
     },
     subtle: {
       color: t.colors.neutralForeground1Selected,


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
Fixed bug in HC for toggle primary Button in selected state
### Verification
**Before:**
![image](https://user-images.githubusercontent.com/11574680/150346854-5759af36-78d9-449c-8398-e6538bf779fd.png)

**After:**
![image](https://user-images.githubusercontent.com/11574680/150346946-f9d69371-8266-4c60-a1a4-a74bf723889e.png)
### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
