### PR TITLE
Revert RTL changes to win32 Shimmer

### DIFF
--- a/apps/macos/app.json
+++ b/apps/macos/app.json
@@ -2,5 +2,5 @@
   "name": "FluentTester",
   "displayName": "FluentTester",
   "components": [{ "appKey": "FluentTester" }],
-  "resources": ["dist/assets", "dist/index.macos.bundle"]
+  "resources": ["dist/assets", "dist/index.macos.jsbundle"]
 }

--- a/apps/macos/src/Podfile.lock
+++ b/apps/macos/src/Podfile.lock
@@ -1,25 +1,25 @@
 PODS:
   - boost-for-react-native (1.63.0)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.64.21)
-  - FBReactNativeSpec (0.64.21):
+  - FBLazyVector (0.64.22)
+  - FBReactNativeSpec (0.64.22):
     - RCT-Folly (= 2020.01.13.00)
-    - RCTRequired (= 0.64.21)
-    - RCTTypeSafety (= 0.64.21)
-    - React-Core (= 0.64.21)
-    - React-jsi (= 0.64.21)
-    - ReactCommon/turbomodule/core (= 0.64.21)
-  - FRNAvatar (0.14.0):
+    - RCTRequired (= 0.64.22)
+    - RCTTypeSafety (= 0.64.22)
+    - React-Core (= 0.64.22)
+    - React-jsi (= 0.64.22)
+    - ReactCommon/turbomodule/core (= 0.64.22)
+  - FRNAvatar (0.14.2):
     - MicrosoftFluentUI (= 0.3.0)
     - MicrosoftFluentUI/Avatar_ios (= 0.3.0)
     - React
-  - FRNCallout (0.19.14):
+  - FRNCallout (0.19.16):
     - React
-  - FRNCheckbox (0.5.0):
+  - FRNCheckbox (0.6.0):
     - React
-  - FRNMenuButton (0.7.15):
+  - FRNMenuButton (0.7.18):
     - React
-  - FRNRadioButton (0.14.11):
+  - FRNRadioButton (0.14.13):
     - React
   - glog (0.3.5)
   - MicrosoftFluentUI (0.3.0):
@@ -94,256 +94,256 @@ PODS:
     - boost-for-react-native
     - DoubleConversion
     - glog
-  - RCTFocusZone (0.8.11):
+  - RCTFocusZone (0.8.13):
     - React
-  - RCTRequired (0.64.21)
-  - RCTTypeSafety (0.64.21):
-    - FBLazyVector (= 0.64.21)
+  - RCTRequired (0.64.22)
+  - RCTTypeSafety (0.64.22):
+    - FBLazyVector (= 0.64.22)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTRequired (= 0.64.21)
-    - React-Core (= 0.64.21)
-  - React (0.64.21):
-    - React-Core (= 0.64.21)
-    - React-Core/DevSupport (= 0.64.21)
-    - React-Core/RCTWebSocket (= 0.64.21)
-    - React-RCTActionSheet (= 0.64.21)
-    - React-RCTAnimation (= 0.64.21)
-    - React-RCTBlob (= 0.64.21)
-    - React-RCTImage (= 0.64.21)
-    - React-RCTLinking (= 0.64.21)
-    - React-RCTNetwork (= 0.64.21)
-    - React-RCTSettings (= 0.64.21)
-    - React-RCTText (= 0.64.21)
-    - React-RCTVibration (= 0.64.21)
-  - React-callinvoker (0.64.21)
-  - React-Core (0.64.21):
+    - RCTRequired (= 0.64.22)
+    - React-Core (= 0.64.22)
+  - React (0.64.22):
+    - React-Core (= 0.64.22)
+    - React-Core/DevSupport (= 0.64.22)
+    - React-Core/RCTWebSocket (= 0.64.22)
+    - React-RCTActionSheet (= 0.64.22)
+    - React-RCTAnimation (= 0.64.22)
+    - React-RCTBlob (= 0.64.22)
+    - React-RCTImage (= 0.64.22)
+    - React-RCTLinking (= 0.64.22)
+    - React-RCTNetwork (= 0.64.22)
+    - React-RCTSettings (= 0.64.22)
+    - React-RCTText (= 0.64.22)
+    - React-RCTVibration (= 0.64.22)
+  - React-callinvoker (0.64.22)
+  - React-Core (0.64.22):
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.64.21)
-    - React-cxxreact (= 0.64.21)
-    - React-jsi (= 0.64.21)
-    - React-jsiexecutor (= 0.64.21)
-    - React-perflogger (= 0.64.21)
+    - React-Core/Default (= 0.64.22)
+    - React-cxxreact (= 0.64.22)
+    - React-jsi (= 0.64.22)
+    - React-jsiexecutor (= 0.64.22)
+    - React-perflogger (= 0.64.22)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.64.21):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default
-    - React-cxxreact (= 0.64.21)
-    - React-jsi (= 0.64.21)
-    - React-jsiexecutor (= 0.64.21)
-    - React-perflogger (= 0.64.21)
-    - Yoga
-  - React-Core/Default (0.64.21):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-cxxreact (= 0.64.21)
-    - React-jsi (= 0.64.21)
-    - React-jsiexecutor (= 0.64.21)
-    - React-perflogger (= 0.64.21)
-    - Yoga
-  - React-Core/DevSupport (0.64.21):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.64.21)
-    - React-Core/RCTWebSocket (= 0.64.21)
-    - React-cxxreact (= 0.64.21)
-    - React-jsi (= 0.64.21)
-    - React-jsiexecutor (= 0.64.21)
-    - React-jsinspector (= 0.64.21)
-    - React-perflogger (= 0.64.21)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.64.21):
+  - React-Core/CoreModulesHeaders (0.64.22):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.21)
-    - React-jsi (= 0.64.21)
-    - React-jsiexecutor (= 0.64.21)
-    - React-perflogger (= 0.64.21)
+    - React-cxxreact (= 0.64.22)
+    - React-jsi (= 0.64.22)
+    - React-jsiexecutor (= 0.64.22)
+    - React-perflogger (= 0.64.22)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.64.21):
+  - React-Core/Default (0.64.22):
+    - glog
+    - RCT-Folly (= 2020.01.13.00)
+    - React-cxxreact (= 0.64.22)
+    - React-jsi (= 0.64.22)
+    - React-jsiexecutor (= 0.64.22)
+    - React-perflogger (= 0.64.22)
+    - Yoga
+  - React-Core/DevSupport (0.64.22):
+    - glog
+    - RCT-Folly (= 2020.01.13.00)
+    - React-Core/Default (= 0.64.22)
+    - React-Core/RCTWebSocket (= 0.64.22)
+    - React-cxxreact (= 0.64.22)
+    - React-jsi (= 0.64.22)
+    - React-jsiexecutor (= 0.64.22)
+    - React-jsinspector (= 0.64.22)
+    - React-perflogger (= 0.64.22)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.64.22):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.21)
-    - React-jsi (= 0.64.21)
-    - React-jsiexecutor (= 0.64.21)
-    - React-perflogger (= 0.64.21)
+    - React-cxxreact (= 0.64.22)
+    - React-jsi (= 0.64.22)
+    - React-jsiexecutor (= 0.64.22)
+    - React-perflogger (= 0.64.22)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.64.21):
+  - React-Core/RCTAnimationHeaders (0.64.22):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.21)
-    - React-jsi (= 0.64.21)
-    - React-jsiexecutor (= 0.64.21)
-    - React-perflogger (= 0.64.21)
+    - React-cxxreact (= 0.64.22)
+    - React-jsi (= 0.64.22)
+    - React-jsiexecutor (= 0.64.22)
+    - React-perflogger (= 0.64.22)
     - Yoga
-  - React-Core/RCTImageHeaders (0.64.21):
+  - React-Core/RCTBlobHeaders (0.64.22):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.21)
-    - React-jsi (= 0.64.21)
-    - React-jsiexecutor (= 0.64.21)
-    - React-perflogger (= 0.64.21)
+    - React-cxxreact (= 0.64.22)
+    - React-jsi (= 0.64.22)
+    - React-jsiexecutor (= 0.64.22)
+    - React-perflogger (= 0.64.22)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.64.21):
+  - React-Core/RCTImageHeaders (0.64.22):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.21)
-    - React-jsi (= 0.64.21)
-    - React-jsiexecutor (= 0.64.21)
-    - React-perflogger (= 0.64.21)
+    - React-cxxreact (= 0.64.22)
+    - React-jsi (= 0.64.22)
+    - React-jsiexecutor (= 0.64.22)
+    - React-perflogger (= 0.64.22)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.64.21):
+  - React-Core/RCTLinkingHeaders (0.64.22):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.21)
-    - React-jsi (= 0.64.21)
-    - React-jsiexecutor (= 0.64.21)
-    - React-perflogger (= 0.64.21)
+    - React-cxxreact (= 0.64.22)
+    - React-jsi (= 0.64.22)
+    - React-jsiexecutor (= 0.64.22)
+    - React-perflogger (= 0.64.22)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.64.21):
+  - React-Core/RCTNetworkHeaders (0.64.22):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.21)
-    - React-jsi (= 0.64.21)
-    - React-jsiexecutor (= 0.64.21)
-    - React-perflogger (= 0.64.21)
+    - React-cxxreact (= 0.64.22)
+    - React-jsi (= 0.64.22)
+    - React-jsiexecutor (= 0.64.22)
+    - React-perflogger (= 0.64.22)
     - Yoga
-  - React-Core/RCTTextHeaders (0.64.21):
+  - React-Core/RCTSettingsHeaders (0.64.22):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.21)
-    - React-jsi (= 0.64.21)
-    - React-jsiexecutor (= 0.64.21)
-    - React-perflogger (= 0.64.21)
+    - React-cxxreact (= 0.64.22)
+    - React-jsi (= 0.64.22)
+    - React-jsiexecutor (= 0.64.22)
+    - React-perflogger (= 0.64.22)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.64.21):
+  - React-Core/RCTTextHeaders (0.64.22):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.21)
-    - React-jsi (= 0.64.21)
-    - React-jsiexecutor (= 0.64.21)
-    - React-perflogger (= 0.64.21)
+    - React-cxxreact (= 0.64.22)
+    - React-jsi (= 0.64.22)
+    - React-jsiexecutor (= 0.64.22)
+    - React-perflogger (= 0.64.22)
     - Yoga
-  - React-Core/RCTWebSocket (0.64.21):
+  - React-Core/RCTVibrationHeaders (0.64.22):
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.64.21)
-    - React-cxxreact (= 0.64.21)
-    - React-jsi (= 0.64.21)
-    - React-jsiexecutor (= 0.64.21)
-    - React-perflogger (= 0.64.21)
+    - React-Core/Default
+    - React-cxxreact (= 0.64.22)
+    - React-jsi (= 0.64.22)
+    - React-jsiexecutor (= 0.64.22)
+    - React-perflogger (= 0.64.22)
     - Yoga
-  - React-CoreModules (0.64.21):
-    - FBReactNativeSpec (= 0.64.21)
+  - React-Core/RCTWebSocket (0.64.22):
+    - glog
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.64.21)
-    - React-Core/CoreModulesHeaders (= 0.64.21)
-    - React-jsi (= 0.64.21)
-    - React-RCTImage (= 0.64.21)
-    - ReactCommon/turbomodule/core (= 0.64.21)
-  - React-cxxreact (0.64.21):
+    - React-Core/Default (= 0.64.22)
+    - React-cxxreact (= 0.64.22)
+    - React-jsi (= 0.64.22)
+    - React-jsiexecutor (= 0.64.22)
+    - React-perflogger (= 0.64.22)
+    - Yoga
+  - React-CoreModules (0.64.22):
+    - FBReactNativeSpec (= 0.64.22)
+    - RCT-Folly (= 2020.01.13.00)
+    - RCTTypeSafety (= 0.64.22)
+    - React-Core/CoreModulesHeaders (= 0.64.22)
+    - React-jsi (= 0.64.22)
+    - React-RCTImage (= 0.64.22)
+    - ReactCommon/turbomodule/core (= 0.64.22)
+  - React-cxxreact (0.64.22):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.64.21)
-    - React-jsi (= 0.64.21)
-    - React-jsinspector (= 0.64.21)
-    - React-perflogger (= 0.64.21)
-    - React-runtimeexecutor (= 0.64.21)
-  - React-jsi (0.64.21):
+    - React-callinvoker (= 0.64.22)
+    - React-jsi (= 0.64.22)
+    - React-jsinspector (= 0.64.22)
+    - React-perflogger (= 0.64.22)
+    - React-runtimeexecutor (= 0.64.22)
+  - React-jsi (0.64.22):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-jsi/Default (= 0.64.21)
-  - React-jsi/Default (0.64.21):
+    - React-jsi/Default (= 0.64.22)
+  - React-jsi/Default (0.64.22):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-  - React-jsiexecutor (0.64.21):
+  - React-jsiexecutor (0.64.22):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-cxxreact (= 0.64.21)
-    - React-jsi (= 0.64.21)
-    - React-perflogger (= 0.64.21)
-  - React-jsinspector (0.64.21)
-  - React-perflogger (0.64.21)
-  - React-RCTActionSheet (0.64.21):
-    - React-Core/RCTActionSheetHeaders (= 0.64.21)
-  - React-RCTAnimation (0.64.21):
-    - FBReactNativeSpec (= 0.64.21)
+    - React-cxxreact (= 0.64.22)
+    - React-jsi (= 0.64.22)
+    - React-perflogger (= 0.64.22)
+  - React-jsinspector (0.64.22)
+  - React-perflogger (0.64.22)
+  - React-RCTActionSheet (0.64.22):
+    - React-Core/RCTActionSheetHeaders (= 0.64.22)
+  - React-RCTAnimation (0.64.22):
+    - FBReactNativeSpec (= 0.64.22)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.64.21)
-    - React-Core/RCTAnimationHeaders (= 0.64.21)
-    - React-jsi (= 0.64.21)
-    - ReactCommon/turbomodule/core (= 0.64.21)
-  - React-RCTBlob (0.64.21):
-    - FBReactNativeSpec (= 0.64.21)
+    - RCTTypeSafety (= 0.64.22)
+    - React-Core/RCTAnimationHeaders (= 0.64.22)
+    - React-jsi (= 0.64.22)
+    - ReactCommon/turbomodule/core (= 0.64.22)
+  - React-RCTBlob (0.64.22):
+    - FBReactNativeSpec (= 0.64.22)
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/RCTBlobHeaders (= 0.64.21)
-    - React-Core/RCTWebSocket (= 0.64.21)
-    - React-jsi (= 0.64.21)
-    - React-RCTNetwork (= 0.64.21)
-    - ReactCommon/turbomodule/core (= 0.64.21)
-  - React-RCTImage (0.64.21):
-    - FBReactNativeSpec (= 0.64.21)
+    - React-Core/RCTBlobHeaders (= 0.64.22)
+    - React-Core/RCTWebSocket (= 0.64.22)
+    - React-jsi (= 0.64.22)
+    - React-RCTNetwork (= 0.64.22)
+    - ReactCommon/turbomodule/core (= 0.64.22)
+  - React-RCTImage (0.64.22):
+    - FBReactNativeSpec (= 0.64.22)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.64.21)
-    - React-Core/RCTImageHeaders (= 0.64.21)
-    - React-jsi (= 0.64.21)
-    - React-RCTNetwork (= 0.64.21)
-    - ReactCommon/turbomodule/core (= 0.64.21)
-  - React-RCTLinking (0.64.21):
-    - FBReactNativeSpec (= 0.64.21)
-    - React-Core/RCTLinkingHeaders (= 0.64.21)
-    - React-jsi (= 0.64.21)
-    - ReactCommon/turbomodule/core (= 0.64.21)
-  - React-RCTNetwork (0.64.21):
-    - FBReactNativeSpec (= 0.64.21)
+    - RCTTypeSafety (= 0.64.22)
+    - React-Core/RCTImageHeaders (= 0.64.22)
+    - React-jsi (= 0.64.22)
+    - React-RCTNetwork (= 0.64.22)
+    - ReactCommon/turbomodule/core (= 0.64.22)
+  - React-RCTLinking (0.64.22):
+    - FBReactNativeSpec (= 0.64.22)
+    - React-Core/RCTLinkingHeaders (= 0.64.22)
+    - React-jsi (= 0.64.22)
+    - ReactCommon/turbomodule/core (= 0.64.22)
+  - React-RCTNetwork (0.64.22):
+    - FBReactNativeSpec (= 0.64.22)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.64.21)
-    - React-Core/RCTNetworkHeaders (= 0.64.21)
-    - React-jsi (= 0.64.21)
-    - ReactCommon/turbomodule/core (= 0.64.21)
-  - React-RCTSettings (0.64.21):
-    - FBReactNativeSpec (= 0.64.21)
+    - RCTTypeSafety (= 0.64.22)
+    - React-Core/RCTNetworkHeaders (= 0.64.22)
+    - React-jsi (= 0.64.22)
+    - ReactCommon/turbomodule/core (= 0.64.22)
+  - React-RCTSettings (0.64.22):
+    - FBReactNativeSpec (= 0.64.22)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.64.21)
-    - React-Core/RCTSettingsHeaders (= 0.64.21)
-    - React-jsi (= 0.64.21)
-    - ReactCommon/turbomodule/core (= 0.64.21)
-  - React-RCTText (0.64.21):
-    - React-Core/RCTTextHeaders (= 0.64.21)
-  - React-RCTVibration (0.64.21):
-    - FBReactNativeSpec (= 0.64.21)
+    - RCTTypeSafety (= 0.64.22)
+    - React-Core/RCTSettingsHeaders (= 0.64.22)
+    - React-jsi (= 0.64.22)
+    - ReactCommon/turbomodule/core (= 0.64.22)
+  - React-RCTText (0.64.22):
+    - React-Core/RCTTextHeaders (= 0.64.22)
+  - React-RCTVibration (0.64.22):
+    - FBReactNativeSpec (= 0.64.22)
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/RCTVibrationHeaders (= 0.64.21)
-    - React-jsi (= 0.64.21)
-    - ReactCommon/turbomodule/core (= 0.64.21)
-  - React-runtimeexecutor (0.64.21):
-    - React-jsi (= 0.64.21)
-  - ReactCommon/turbomodule/core (0.64.21):
+    - React-Core/RCTVibrationHeaders (= 0.64.22)
+    - React-jsi (= 0.64.22)
+    - ReactCommon/turbomodule/core (= 0.64.22)
+  - React-runtimeexecutor (0.64.22):
+    - React-jsi (= 0.64.22)
+  - ReactCommon/turbomodule/core (0.64.22):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.64.21)
-    - React-Core (= 0.64.21)
-    - React-cxxreact (= 0.64.21)
-    - React-jsi (= 0.64.21)
-    - React-perflogger (= 0.64.21)
+    - React-callinvoker (= 0.64.22)
+    - React-Core (= 0.64.22)
+    - React-cxxreact (= 0.64.22)
+    - React-jsi (= 0.64.22)
+    - React-perflogger (= 0.64.22)
   - ReactTestApp-DevSupport (0.10.2):
     - React-Core
     - React-jsi
@@ -487,45 +487,45 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost-for-react-native: d5ad1140010aa8cb622323a781ecbeab4425d19a
   DoubleConversion: 0ea4559a49682230337df966e735d6cc7760108e
-  FBLazyVector: 08fff72f3b01eb9b9baf972906087c914e3119a6
-  FBReactNativeSpec: 6928c5e69db03a7f7fc96eae3fea454aaf7d8a7c
-  FRNAvatar: ee3725b4d4cdbaac3fcf84e7ef097dcaebf19593
-  FRNCallout: c9fe1e6b6f915a3377042af27e49b10603776a71
-  FRNCheckbox: 0d0065f831cc60b55e37ebda411f80ca212ce769
-  FRNMenuButton: ad20e4bd5e4c30ca9446b52721351a536f690b84
-  FRNRadioButton: ccc9d2eadcd9a53f21c181a775aadcdc2fa2b57a
+  FBLazyVector: 063960f1929bd443f3e3609bcb9989d9c0fb8539
+  FBReactNativeSpec: 198e3871fe54474c1ba10189a085029d2806f6d4
+  FRNAvatar: 88556902a608963bcb9bf6b3219b97e2d1ac8e75
+  FRNCallout: dc44d9620f3a34e0ba4433ebc0f40f50fdaac10b
+  FRNCheckbox: 022cfc6535a51165c799e22d407a2aac25f19b07
+  FRNMenuButton: 719599af7dda3512a9266c89f089b36eb5f02e63
+  FRNRadioButton: 3544b1fa70a7c3191b1e58f7df5e8038cbbdea83
   glog: 0dc7efada961c0793012970b60faebbd58b0decb
   MicrosoftFluentUI: b98d877a2122804132365aa167944f58ef4adb69
   RCT-Folly: b3998425a8ee9f695f57a204dc494534246f0fe9
-  RCTFocusZone: 853a22d460a271f3320d2611c62f22b773d70f7d
-  RCTRequired: 1480acf52e3c7d3a0f953683ecc1abac5e9ea13e
-  RCTTypeSafety: 0cdb82a80c73054cd3652833e930b1918327d6bd
-  React: 937b1cc13e5849a1b75375e321d161b5e5ac16c8
-  React-callinvoker: 3ec84e4846ea40fc803f476bbda033b8030c4d17
-  React-Core: e470858e72963b4265f21a355dd8bfbca0396481
-  React-CoreModules: 35c1f66164bdc018ba7a444da10434b5d88adf58
-  React-cxxreact: 5de0ca18700565c17e88daaa56683a209b6ebf52
-  React-jsi: 11ce95dedbf38986ee7c8e2a0743b09fd55cd962
-  React-jsiexecutor: 236f12aa3c9dd7277a483e0e8b4bebf8314ffb26
-  React-jsinspector: 67c392b190da60d342be72218946f07c0f5acc81
-  React-perflogger: 7009449c69ec3d48ec88d44368c4aaee7dc094c0
-  React-RCTActionSheet: d6978ed5852897da9b3dc19a2f5bc9c5c3ad7a10
-  React-RCTAnimation: 9614cc4a7c431d35ef91c977b963f85908bd9bb4
-  React-RCTBlob: 2dea54e77f4f27ac289a125d8d15f2ac6997ca22
-  React-RCTImage: 26f620ea2aa520482b77367eb8f3da9799d2ee19
-  React-RCTLinking: 93eff6dad7605a5e5f70021d4ee07216f9ac63c2
-  React-RCTNetwork: d89b434480abf102e804c048d83542ab1fff05e8
-  React-RCTSettings: 4a2415bb19633e4f67e42be9bc9621f0f2fe448a
-  React-RCTText: 406a842f3df3749bf9355228196a6bdef488a675
-  React-RCTVibration: 18ebd113445ab3694555b7bfcfe486417fce9486
-  React-runtimeexecutor: 0a5d1fb04170d359b38fec9e6c61b242266ddf39
-  ReactCommon: 77f3feac4009cc6ba948f68a4bcf7755d4c480e8
+  RCTFocusZone: 8fdc903f49e08e973cb4c45fff81bdaf146277a5
+  RCTRequired: 0e6212665df8f1d7caae6de161cdfedc622a89b8
+  RCTTypeSafety: 48a6ae85b5b5f9ecb5ab49dbb896ef42615f233c
+  React: 6efe7745043e253dbd69ecafae3365e9534175e6
+  React-callinvoker: 96e54ae8b1b33d437856a7b987b3dfbf45b2e451
+  React-Core: 4440578aa06480fd9e1483a0421120d28eb36cf1
+  React-CoreModules: ea7d74d9ec6ae0fe992b32a4ee393f3a0e4f177d
+  React-cxxreact: f795a680d8325a91cdf94c308ca2b73ad34c5e29
+  React-jsi: 95b8b2e0e43b186257081f08a1eae277b3923297
+  React-jsiexecutor: bb3cd6caf2fbe4a05a934022f2ed93d505bc7216
+  React-jsinspector: e269739ff2c0a7b8da69140d084a27245c57ab8c
+  React-perflogger: 276bf9f2c98cbe1e4e3671cd3ba102c34c1ecb2a
+  React-RCTActionSheet: bb14afdb9bcc337850fe539a1e179e5d751be839
+  React-RCTAnimation: 1bb128bda781b80ac97aa4fcf1a33fe36facd546
+  React-RCTBlob: b67bca8cc1602eee76e89c9e23b3253c5c8d0c1d
+  React-RCTImage: 2e429d94a798023ae5566862d487f33c306c40e5
+  React-RCTLinking: cfabf32deec3e165d7540a712e58aa929b79d752
+  React-RCTNetwork: cc74b0b1181ae12a6dbb71308af480fed02c5bf8
+  React-RCTSettings: 8a28cbd9ef70f60bc727bc60d2cf7ceba2485c9f
+  React-RCTText: d0d57d162295b595cd87dc9e6b14abb24d8dd96c
+  React-RCTVibration: 76c394da8cd4bd86cd6cffdfdfc047752fdd6906
+  React-runtimeexecutor: 0917ad3b47bc9561749f18ca866a6c4b55f63f31
+  ReactCommon: c710dabcfbc8f09c20e98aa03e8a98965b88f6dd
   ReactTestApp-DevSupport: 0556335e9e3fbfd74e2309c5a5d2842902b0500f
-  ReactTestApp-Resources: 4397038d4bf3b15e109ade7ce4a7df489d172bee
+  ReactTestApp-Resources: 320923a3635f7bf90caa1a28fd29765b577888d9
   RNCPicker: 0991c56da7815c0cf946d6f63cf920b25296e5f6
   RNSVG: 551acb6562324b1d52a4e0758f7ca0ec234e278f
   SwiftLint: 06ac37e4d38c7068e0935bb30cda95f093bec761
-  Yoga: d3afd4101d256293040fb1ecd6cfbbbf630cbc4a
+  Yoga: 3b0ecc1a0ddf03b4363ea73cc42e10d76b052007
 
 PODFILE CHECKSUM: 568704fb95966cf7ad6daa54a1d36eb2d5c3bba6
 

--- a/packages/components/Button/src/Button.tsx
+++ b/packages/components/Button/src/Button.tsx
@@ -12,7 +12,7 @@ import { mergeSettings } from '@uifabricshared/foundation-settings';
 
 import {
   useAsPressable,
-  useKeyUpProps,
+  useKeyProps,
   useViewCommandFocus,
   createIconProps,
   useOnPressWithFocus,
@@ -40,7 +40,7 @@ export const Button = compose<IButtonType>({
     const onPressWithFocus = useOnPressWithFocus(componentRef, onClick);
     // attach the pressable state handlers
     const pressable = useAsPressable({ ...rest, onPress: onPressWithFocus });
-    const onKeyUpProps = useKeyUpProps(onClick, ' ', 'Enter');
+    const onKeyProps = useKeyProps(onClick, ' ', 'Enter');
     // set up state
     const state: IButtonState = {
       info: {
@@ -64,7 +64,7 @@ export const Button = compose<IButtonType>({
         onAccessibilityTap: onAccessibilityTap,
         accessibilityLabel: accessibilityLabel,
         accessibilityState: { disabled: state.info.disabled },
-        ...onKeyUpProps,
+        ...onKeyProps,
         testID,
       },
       content: { children: content },

--- a/packages/components/Checkbox/src/Checkbox.tsx
+++ b/packages/components/Checkbox/src/Checkbox.tsx
@@ -13,7 +13,7 @@ import {
   useAsToggle,
   useAsPressable,
   useViewCommandFocus,
-  useKeyUpProps,
+  useKeyProps,
   useOnPressWithFocus,
 } from '@fluentui-react-native/interactive-hooks';
 import { backgroundColorTokens } from '@fluentui-react-native/tokens';
@@ -54,7 +54,7 @@ export const Checkbox = compose<ICheckboxType>({
     const buttonRef = useViewCommandFocus(componentRef);
 
     // Handles the "Space" key toggling the Checkbox
-    const onKeyUpProps = useKeyUpProps(toggleChecked, ' ');
+    const onKeyProps = useKeyProps(toggleChecked, ' ');
 
     const state: ICheckboxState = {
       ...pressable.state,
@@ -90,7 +90,7 @@ export const Checkbox = compose<ICheckboxType>({
         accessibilityActions: [{ name: 'Toggle', label: checkboxSelectActionLabel }],
         focusable: !state.disabled,
         onAccessibilityAction: onAccessibilityAction,
-        ...onKeyUpProps,
+        ...onKeyProps,
       },
       // Temporary checkmark until SVG functionality
       checkmark: { children: '✓' },

--- a/packages/components/ContextualMenu/src/ContextualMenuItem.tsx
+++ b/packages/components/ContextualMenu/src/ContextualMenuItem.tsx
@@ -15,7 +15,7 @@ import { Text } from '@fluentui-react-native/text';
 import { settings } from './ContextualMenuItem.settings';
 import { backgroundColorTokens, borderTokens, textTokens, foregroundColorTokens, getPaletteFromTheme } from '@fluentui-react-native/tokens';
 import { mergeSettings } from '@uifabricshared/foundation-settings';
-import { useAsPressable, useKeyUpProps, useViewCommandFocus } from '@fluentui-react-native/interactive-hooks';
+import { useAsPressable, useKeyProps, useViewCommandFocus } from '@fluentui-react-native/interactive-hooks';
 import { CMContext } from './ContextualMenu';
 import { Icon } from '@fluentui-react-native/icon';
 import { createIconProps } from '@fluentui-react-native/interactive-hooks';
@@ -65,7 +65,7 @@ export const ContextualMenuItem = compose<ContextualMenuItemType>({
 
     const pressable = useAsPressable({ ...rest, onPress: onItemClick, onHoverIn: onItemHoverIn });
 
-    const onKeyUpProps = useKeyUpProps(onItemClick, ' ', 'Enter');
+    const onKeyUpProps = useKeyProps(onItemClick, ' ', 'Enter');
 
     // set up state
     const state: ContextualMenuItemState = {

--- a/packages/components/ContextualMenu/src/SubmenuItem.tsx
+++ b/packages/components/ContextualMenu/src/SubmenuItem.tsx
@@ -15,7 +15,7 @@ import { Text } from '@fluentui-react-native/text';
 import { settings } from './SubmenuItem.settings';
 import { backgroundColorTokens, borderTokens, textTokens, foregroundColorTokens, getPaletteFromTheme } from '@fluentui-react-native/tokens';
 import { mergeSettings } from '@uifabricshared/foundation-settings';
-import { useAsPressable, useKeyUpProps, useViewCommandFocus } from '@fluentui-react-native/interactive-hooks';
+import { useAsPressable, useKeyProps, useViewCommandFocus } from '@fluentui-react-native/interactive-hooks';
 import { SvgXml } from 'react-native-svg';
 import { CMContext } from './ContextualMenu';
 import { Icon } from '@fluentui-react-native/icon';
@@ -114,7 +114,7 @@ export const SubmenuItem = compose<SubmenuItemType>({
     /*
      * SubmenuItem launches the submenu onMouseEnter event. For keyboarding, submenu should be launched with Spacebar, Enter, or right arrow.
      */
-    const onKeyUpProps = useKeyUpProps(onItemHoverIn, ' ', 'Enter', 'ArrowRight');
+    const onKeyUpProps = useKeyProps(onItemHoverIn, ' ', 'Enter', 'ArrowRight');
 
     // grab the styling information, referencing the state as well as the props
     const styleProps = useStyling(userProps, (override: string) => state[override] || userProps[override]);

--- a/packages/components/Link/src/Link.tsx
+++ b/packages/components/Link/src/Link.tsx
@@ -7,7 +7,7 @@ import { compose, IUseComposeStyling } from '@uifabricshared/foundation-compose'
 import { ILinkProps, ILinkSlotProps, ILinkState, ILinkRenderData, IWithLinkOptions, linkName, ILinkType } from './Link.types';
 import { settings } from './Link.settings';
 import { foregroundColorTokens, textTokens, borderTokens } from '@fluentui-react-native/tokens';
-import { useAsPressable, useKeyUpProps, useOnPressWithFocus, useViewCommandFocus } from '@fluentui-react-native/interactive-hooks';
+import { useAsPressable, useKeyProps, useOnPressWithFocus, useViewCommandFocus } from '@fluentui-react-native/interactive-hooks';
 import { mergeSettings } from '@uifabricshared/foundation-settings';
 import { ISlots, withSlots } from '@uifabricshared/foundation-composable';
 import { IViewProps } from '@fluentui-react-native/adapters';
@@ -34,7 +34,7 @@ export function useAsLink(userProps: IWithLinkOptions<IViewProps>, ref: React.Re
   const linkOnPressWithFocus = useOnPressWithFocus(ref, linkOnPress);
 
   const pressable = useAsPressable({ onPress: linkOnPressWithFocus, ...rest });
-  const onKeyUpProps = useKeyUpProps(linkOnPress, ' ', 'Enter');
+  const onKeyUpProps = useKeyProps(linkOnPress, ' ', 'Enter');
 
   const newState = {
     ...pressable.state,

--- a/packages/experimental/Button/src/useButton.ts
+++ b/packages/experimental/Button/src/useButton.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useAsPressable, useKeyUpProps, useOnPressWithFocus, useViewCommandFocus } from '@fluentui-react-native/interactive-hooks';
+import { useAsPressable, useKeyProps, useOnPressWithFocus, useViewCommandFocus } from '@fluentui-react-native/interactive-hooks';
 import { ButtonPropsWithInnerRef, ButtonState } from './Button.types';
 import { memoize } from '@fluentui-react-native/framework';
 
@@ -12,7 +12,7 @@ export const useButton = (props: ButtonPropsWithInnerRef): ButtonState => {
   const focusRef = disabled ? null : ref;
   const onClickWithFocus = useOnPressWithFocus(focusRef, onClick);
   const pressable = useAsPressable({ ...rest, onPress: onClickWithFocus });
-  const onKeyUpProps = useKeyUpProps(onClick, ' ', 'Enter');
+  const onKeyUpProps = useKeyProps(onClick, ' ', 'Enter');
   const isDisabled = !!disabled || !!loading;
 
   return {

--- a/packages/experimental/Checkbox/src/useCheckbox.ts
+++ b/packages/experimental/Checkbox/src/useCheckbox.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {
   useAsPressable,
-  useKeyUpProps,
+  useKeyProps,
   useOnPressWithFocus,
   useViewCommandFocus,
   useAsToggle,
@@ -48,7 +48,7 @@ export const useCheckbox = (props: CheckboxProps): CheckboxInfo => {
   const buttonRef = useViewCommandFocus(componentRef);
 
   // Handles the "Space" key toggling the Checkbox
-  const onKeyUpProps = useKeyUpProps(toggleChecked, ' ');
+  const onKeyUpProps = useKeyProps(toggleChecked, ' ');
 
   const state: CheckboxState = {
     ...pressable.state,

--- a/packages/experimental/Shimmer/src/Shimmer.win32.tsx
+++ b/packages/experimental/Shimmer/src/Shimmer.win32.tsx
@@ -1,7 +1,7 @@
 /** @jsx withSlots */
 import { compose, mergeProps, UseSlots } from '@fluentui-react-native/framework';
-import { I18nManager, View } from 'react-native';
-import { ClipPath, Defs, G, LinearGradient, Path, Rect, Stop, Svg, SvgProps, TransformObject } from 'react-native-svg';
+import { View } from 'react-native';
+import { ClipPath, Defs, LinearGradient, Path, Rect, Stop, Svg, SvgProps } from 'react-native-svg';
 import { stylingSettings } from './Shimmer.styling.win32';
 import { ShimmerElementTypes, shimmerName, ShimmerProps } from './Shimmer.types';
 import { ClippingMaskProps, ShimmerType, ShimmerWaveProps } from './Shimmer.types.win32';
@@ -61,18 +61,12 @@ const wave: React.FunctionComponent<ShimmerWaveProps> = (props: ShimmerWaveProps
   );
 };
 
-const waveContainer: React.FunctionComponent<ShimmerWaveProps> = (props: ShimmerWaveProps, children: React.ReactNode[]) => {
+const waveContainer: React.FunctionComponent<ShimmerWaveProps> = (props: ShimmerWaveProps) => {
   const { shimmerColor, viewBoxHeight, viewBoxWidth } = props;
-
-  // Flip the SVG if we are running in RTL
-  const rtlTransfrom: TransformObject = I18nManager.isRTL ? { translateX: viewBoxWidth, scaleX: -1 } : {};
-
   return (
     <RCTNativeAnimatedShimmer
       {...{ ...props, style: { backgroundColor: shimmerColor, height: viewBoxHeight, width: viewBoxWidth, overflow: 'hidden' } }}
-    >
-      <G transform={rtlTransfrom}>{children}</G>
-    </RCTNativeAnimatedShimmer>
+    />
   );
 };
 

--- a/packages/experimental/Tabs/src/useTabsItem.ts
+++ b/packages/experimental/Tabs/src/useTabsItem.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useAsPressable, useKeyUpProps, useOnPressWithFocus, useViewCommandFocus } from '@fluentui-react-native/interactive-hooks';
+import { useAsPressable, useKeyProps, useOnPressWithFocus, useViewCommandFocus } from '@fluentui-react-native/interactive-hooks';
 import { TabsItemProps, TabsItemInfo } from './TabsItem.types';
 import { TabsContext } from './Tabs';
 
@@ -32,7 +32,7 @@ export const useTabsItem = (props: TabsItemProps): TabsItemInfo => {
     onFocus: changeSelection,
   });
 
-  const onKeyUpProps = useKeyUpProps(changeSelection, ' ', 'Enter');
+  const onKeyUpProps = useKeyProps(changeSelection, ' ', 'Enter');
 
   // Used when creating accessibility properties in mergeSettings below.
   const onAccessibilityAction = React.useCallback(

--- a/packages/libraries/core/src/index.ts
+++ b/packages/libraries/core/src/index.ts
@@ -160,6 +160,7 @@ export {
   useAsToggle,
   useFocusState,
   useHoverState,
+  useKeyProps,
   useKeyUpProps,
   useKeyDownProps,
   useOnPressWithFocus,

--- a/packages/utils/interactive-hooks/src/useKeyProps.macos.ts
+++ b/packages/utils/interactive-hooks/src/useKeyProps.macos.ts
@@ -36,8 +36,8 @@ function getKeyCallbackWorker(userCallback?: KeyCallback, ...keys: string[]) {
 
 function getKeyUpPropsWorker(userCallback: KeyCallback, ...keys: string[]): KeyPressProps {
   return {
-    onKeyUp: getKeyCallbackWorker(userCallback, ...keys),
-    validKeysUp: keys, // macOS needs an array of supported keys passed as well
+    onKeyDown: getKeyCallbackWorker(userCallback, ...keys),
+    validKeysDown: keys, // macOS needs an array of supported keys passed as well
   };
 }
 
@@ -63,3 +63,11 @@ export const useKeyUpProps = memoize(getKeyUpPropsWorker);
  * @returns KeyPressProps: An object containing the correct platform specific props to  handle key press
  */
 export const useKeyDownProps = memoize(getKeyDownPropsWorker);
+
+/**
+ * Re-usable hook for keyboard events. on macOS, this is onKeyDown, while on windows this is onKeyUp.
+ * @param userCallback The function you want to be called once the key has been activated on key down
+ * @param keys A string of the key you want to perform some action on. If undefined, always invokes userCallback
+ * @returns KeyPressProps: An object containing the correct platform specific props to  handle key press
+ */
+export const useKeyProps = memoize(getKeyDownPropsWorker);

--- a/packages/utils/interactive-hooks/src/useKeyProps.ts
+++ b/packages/utils/interactive-hooks/src/useKeyProps.ts
@@ -44,3 +44,11 @@ export const useKeyUpProps = noOp2;
  * @returns KeyPressProps: An object containing the correct platform specific props to  handle key press
  */
 export const useKeyDownProps = noOp2;
+
+/**
+ * Re-usable hook for keyboard events. on macOS, this is onKeyDown, while on windows this is onKeyUp.
+ * @param userCallback The function you want to be called once the key has been activated on key down
+ * @param keys A string of the key you want to perform some action on. If undefined, always invokes userCallback
+ * @returns KeyPressProps: An object containing the correct platform specific props to  handle key press
+ */
+export const useKeyProps = noOp2;

--- a/packages/utils/interactive-hooks/src/useKeyProps.win32.ts
+++ b/packages/utils/interactive-hooks/src/useKeyProps.win32.ts
@@ -61,3 +61,11 @@ export const useKeyUpProps = memoize(getKeyUpPropsWorker);
  * @returns KeyPressProps: An object containing the correct platform specific props to  handle key press
  */
 export const useKeyDownProps = memoize(getKeyDownPropsWorker);
+
+/**
+ * Re-usable hook for keyboard events. on macOS, this is onKeyDown, while on windows this is onKeyUp.
+ * @param userCallback The function you want to be called once the key has been activated on key down
+ * @param keys A string of the key you want to perform some action on. If undefined, always invokes userCallback
+ * @returns KeyPressProps: An object containing the correct platform specific props to  handle key press
+ */
+export const useKeyProps = memoize(getKeyUpPropsWorker);


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

#1284 Caused a crash downstream in Shimmer on win32. Let's revert the changes we made to that file. 

### Verification

I don't have a dev setup to test Shimmer on win32.. so will defer to someone in CXE..

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
