### PR TITLE
Revert RTL changes to Win32 Shimmer

### DIFF
--- a/change/@fluentui-react-native-experimental-shimmer-7d5185ed-805a-4f43-8d50-553a340b3c63.json
+++ b/change/@fluentui-react-native-experimental-shimmer-7d5185ed-805a-4f43-8d50-553a340b3c63.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Revert RTL changes to Win32 Shimmer",
+  "packageName": "@fluentui-react-native/experimental-shimmer",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Shimmer/src/Shimmer.win32.tsx
+++ b/packages/experimental/Shimmer/src/Shimmer.win32.tsx
@@ -1,7 +1,7 @@
 /** @jsx withSlots */
 import { compose, mergeProps, UseSlots } from '@fluentui-react-native/framework';
-import { I18nManager, View } from 'react-native';
-import { ClipPath, Defs, G, LinearGradient, Path, Rect, Stop, Svg, SvgProps, TransformObject } from 'react-native-svg';
+import { View } from 'react-native';
+import { ClipPath, Defs, LinearGradient, Path, Rect, Stop, Svg, SvgProps } from 'react-native-svg';
 import { stylingSettings } from './Shimmer.styling.win32';
 import { ShimmerElementTypes, shimmerName, ShimmerProps } from './Shimmer.types';
 import { ClippingMaskProps, ShimmerType, ShimmerWaveProps } from './Shimmer.types.win32';
@@ -61,18 +61,12 @@ const wave: React.FunctionComponent<ShimmerWaveProps> = (props: ShimmerWaveProps
   );
 };
 
-const waveContainer: React.FunctionComponent<ShimmerWaveProps> = (props: ShimmerWaveProps, children: React.ReactNode[]) => {
+const waveContainer: React.FunctionComponent<ShimmerWaveProps> = (props: ShimmerWaveProps) => {
   const { shimmerColor, viewBoxHeight, viewBoxWidth } = props;
-
-  // Flip the SVG if we are running in RTL
-  const rtlTransfrom: TransformObject = I18nManager.isRTL ? { translateX: viewBoxWidth, scaleX: -1 } : {};
-
   return (
     <RCTNativeAnimatedShimmer
       {...{ ...props, style: { backgroundColor: shimmerColor, height: viewBoxHeight, width: viewBoxWidth, overflow: 'hidden' } }}
-    >
-      <G transform={rtlTransfrom}>{children}</G>
-    </RCTNativeAnimatedShimmer>
+    />
   );
 };
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Revert changes to Win32 Shimmer from #1284 , as they were causing a crash downstream.

### Verification

I don't have a dev setup to test Win32 Shimmer... so will defer to someone in CXE.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
