### PR TITLE
Fix customize and compose on the Button

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonHOCTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonHOCTestSection.tsx
@@ -1,0 +1,36 @@
+import { Button } from '@fluentui-react-native/experimental-button';
+import { Icon } from '@fluentui-react-native/icon';
+import * as React from 'react';
+import { View, Text } from 'react-native';
+import { commonTestStyles, stackStyle } from '../Common/styles';
+
+export const ButtonHOCTest: React.FunctionComponent = () => {
+  const buttonRef = React.useRef(null);
+  const CustomButton = Button.customize({ backgroundColor: 'pink' });
+  const ComposedButton = Button.compose({
+    slots: {
+      root: View,
+      icon: Icon,
+      content: Text,
+    },
+  });
+
+  return (
+    <View style={[stackStyle, commonTestStyles.view]}>
+      <CustomButton style={commonTestStyles.vmargin} ref={buttonRef}>
+        Customized Button with ref
+      </CustomButton>
+      <Button
+        style={commonTestStyles.vmargin}
+        onClick={() => {
+          if (buttonRef.current) {
+            buttonRef.current.focus();
+          }
+        }}
+      >
+        Press to focus Customized Button
+      </Button>
+      <ComposedButton style={commonTestStyles.vmargin}>Composed button using RNText for text slot</ComposedButton>
+    </View>
+  );
+};

--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonTest.tsx
@@ -7,6 +7,7 @@ import { ButtonIconTest } from './ButtonIconTestSection';
 import { ButtonSizeTest } from './ButtonSizeTestSection';
 import { ButtonShapeTest } from './ButtonShapeTestSection';
 import { E2EButtonExperimentalTest } from './E2EButtonTest';
+import { ButtonHOCTest } from './ButtonHOCTestSection';
 
 const buttonSections: TestSection[] = [
   {
@@ -29,6 +30,10 @@ const buttonSections: TestSection[] = [
   {
     name: 'Sizes',
     component: ButtonSizeTest,
+  },
+  {
+    name: 'Customize, Compose, and Ref',
+    component: ButtonHOCTest,
   },
   {
     name: 'E2E Button Testing',

--- a/change/@fluentui-react-native-composition-a3e882f8-e06f-4d4c-be4a-27c6fd7f60cf.json
+++ b/change/@fluentui-react-native-composition-a3e882f8-e06f-4d4c-be4a-27c6fd7f60cf.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Get customize and ref to work",
+  "packageName": "@fluentui-react-native/composition",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-button-e87f2a09-efb7-4185-acfe-635bbc2d2114.json
+++ b/change/@fluentui-react-native-experimental-button-e87f2a09-efb7-4185-acfe-635bbc2d2114.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Get customize and ref to work",
+  "packageName": "@fluentui-react-native/experimental-button",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-use-slot-d7afa43b-0d67-4cdb-82e5-0d1114b41af9.json
+++ b/change/@fluentui-react-native-use-slot-d7afa43b-0d67-4cdb-82e5-0d1114b41af9.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Get customize and ref to work",
+  "packageName": "@fluentui-react-native/use-slot",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Button/src/Button.styling.ts
+++ b/packages/experimental/Button/src/Button.styling.ts
@@ -1,4 +1,4 @@
-import { buttonName, ButtonCoreTokens, ButtonTokens, ButtonSlotProps, ButtonPropsWithInnerRef, ButtonSize } from './Button.types';
+import { buttonName, ButtonCoreTokens, ButtonTokens, ButtonSlotProps, ButtonProps, ButtonSize } from './Button.types';
 import { Theme, UseStylingOptions, buildProps } from '@fluentui-react-native/framework';
 import { borderStyles, layoutStyles, fontStyles, shadowStyles, FontTokens } from '@fluentui-react-native/tokens';
 import { defaultButtonTokens } from './ButtonTokens';
@@ -28,7 +28,7 @@ export const buttonStates: (keyof ButtonTokens)[] = [
   'square',
 ];
 
-export const stylingSettings: UseStylingOptions<ButtonPropsWithInnerRef, ButtonSlotProps, ButtonTokens> = {
+export const stylingSettings: UseStylingOptions<ButtonProps, ButtonSlotProps, ButtonTokens> = {
   tokens: [defaultButtonTokens, defaultButtonFontTokens, defaultButtonColorTokens, buttonName],
   states: buttonStates,
   slotProps: {

--- a/packages/experimental/Button/src/Button.tsx
+++ b/packages/experimental/Button/src/Button.tsx
@@ -8,7 +8,7 @@ import { stylingSettings, getDefaultSize } from './Button.styling';
 import { compose, mergeProps, withSlots, UseSlots } from '@fluentui-react-native/framework';
 import { useButton } from './useButton';
 import { Icon } from '@fluentui-react-native/icon';
-import { createIconProps, IFocusable, IPressableState } from '@fluentui-react-native/interactive-hooks';
+import { createIconProps, IPressableState } from '@fluentui-react-native/interactive-hooks';
 
 /**
  * A function which determines if a set of styles should be applied to the compoent given the current state and props of the button.
@@ -33,7 +33,7 @@ export const buttonLookup = (layer: string, state: IPressableState, userProps: B
   );
 };
 
-const ButtonComposed = compose<ButtonType>({
+export const Button = compose<ButtonType>({
   displayName: buttonName,
   ...stylingSettings,
   slots: {
@@ -41,14 +41,14 @@ const ButtonComposed = compose<ButtonType>({
     icon: Icon,
     content: Text,
   },
-  render: (userProps: ButtonPropsWithInnerRef, useSlots: UseSlots<ButtonType>) => {
-    const button = useButton(userProps);
+  render: (userProps: ButtonProps, useSlots: UseSlots<ButtonType>, ref: any) => {
+    const button = useButton(userProps, ref);
     const iconProps = createIconProps(userProps.icon);
     // grab the styled slots
     const Slots = useSlots(userProps, (layer) => buttonLookup(layer, button.state, userProps));
 
     // now return the handler for finishing render
-    return (final: ButtonPropsWithInnerRef, ...children: React.ReactNode[]) => {
+    return (final: ButtonProps, ...children: React.ReactNode[]) => {
       const { icon, iconOnly, iconPosition, loading, accessibilityLabel, ...mergedProps } = mergeProps(button.props, final);
 
       const shouldShowIcon = !loading && icon;
@@ -83,7 +83,3 @@ const ButtonComposed = compose<ButtonType>({
     };
   },
 });
-
-export const Button = React.forwardRef<IFocusable, ButtonProps>((props, ref) => <ButtonComposed {...props} innerRef={ref} />);
-
-export default Button;

--- a/packages/experimental/Button/src/Button.tsx
+++ b/packages/experimental/Button/src/Button.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { View } from 'react-native';
 import { ActivityIndicator } from '@fluentui-react-native/experimental-activity-indicator';
-import { buttonName, ButtonType, ButtonProps, ButtonPropsWithInnerRef } from './Button.types';
+import { buttonName, ButtonType, ButtonProps } from './Button.types';
 import { Text } from '@fluentui-react-native/experimental-text';
 import { stylingSettings, getDefaultSize } from './Button.styling';
 import { compose, mergeProps, withSlots, UseSlots } from '@fluentui-react-native/framework';
@@ -18,7 +18,7 @@ import { createIconProps, IPressableState } from '@fluentui-react-native/interac
  * @param userProps The props that were passed into the button
  * @returns Whether the styles that are assigned to the layer should be applied to the button
  */
-export const buttonLookup = (layer: string, state: IPressableState, userProps: ButtonPropsWithInnerRef): boolean => {
+export const buttonLookup = (layer: string, state: IPressableState, userProps: ButtonProps): boolean => {
   return (
     state[layer] ||
     userProps[layer] ||

--- a/packages/experimental/Button/src/Button.types.ts
+++ b/packages/experimental/Button/src/Button.types.ts
@@ -156,7 +156,7 @@ export interface ButtonSlotProps {
 }
 
 export interface ButtonType {
-  props: ButtonPropsWithInnerRef;
+  props: ButtonProps;
   tokens: ButtonTokens;
   slotProps: ButtonSlotProps;
 }

--- a/packages/experimental/Button/src/Button.types.ts
+++ b/packages/experimental/Button/src/Button.types.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { ViewStyle, ColorValue, ViewProps } from 'react-native';
 import { TextProps } from '@fluentui-react-native/experimental-text';
 import { FontTokens, IBorderTokens, IColorTokens, IShadowTokens, LayoutTokens } from '@fluentui-react-native/tokens';
-import { IFocusable, IPressableHooks, IWithPressableOptions } from '@fluentui-react-native/interactive-hooks';
+import { IPressableHooks, IWithPressableOptions } from '@fluentui-react-native/interactive-hooks';
 import { IconProps, IconSourcesType } from '@fluentui-react-native/icon';
 import { IViewProps } from '@fluentui-react-native/adapters';
 
@@ -79,7 +79,7 @@ export interface ButtonTokens extends ButtonCoreTokens {
   hasIconAfter?: ButtonTokens;
 }
 
-export interface ButtonCorePropsWithInnerRef extends Omit<IWithPressableOptions<ViewProps>, 'onPress'> {
+export interface ButtonCoreProps extends Omit<IWithPressableOptions<ViewProps>, 'onPress'> {
   /*
    * Source URL or name of the icon to show on the Button.
    */
@@ -90,8 +90,6 @@ export interface ButtonCorePropsWithInnerRef extends Omit<IWithPressableOptions<
    * Must be set for button to style correctly when button has not content.
    */
   iconOnly?: boolean;
-
-  innerRef?: React.ForwardedRef<IFocusable>;
 
   /**
    * A callback to call on button click event
@@ -104,9 +102,7 @@ export interface ButtonCorePropsWithInnerRef extends Omit<IWithPressableOptions<
   tooltip?: string;
 }
 
-export type ButtonCoreProps = Omit<ButtonCorePropsWithInnerRef, 'innerRef'>;
-
-export interface ButtonPropsWithInnerRef extends ButtonCorePropsWithInnerRef {
+export interface ButtonProps extends ButtonCoreProps {
   /**
    * A button can have its content and borders styled for greater emphasis or to be subtle.
    * - 'primary': Emphasizes the button as a primary action.
@@ -145,9 +141,7 @@ export interface ButtonPropsWithInnerRef extends ButtonCorePropsWithInnerRef {
   loading?: boolean;
 }
 
-export type ButtonProps = Omit<ButtonPropsWithInnerRef, 'innerRef'>;
-
-export type ButtonState = IPressableHooks<ButtonPropsWithInnerRef & React.ComponentPropsWithRef<any>>;
+export type ButtonState = IPressableHooks<ButtonProps & React.ComponentPropsWithRef<any>>;
 
 export interface ButtonSlotProps {
   root: React.PropsWithRef<IViewProps>;

--- a/packages/experimental/Button/src/CompoundButton/CompoundButton.styling.ts
+++ b/packages/experimental/Button/src/CompoundButton/CompoundButton.styling.ts
@@ -1,4 +1,4 @@
-import { compoundButtonName, CompoundButtonTokens, CompoundButtonSlotProps, CompoundButtonPropsWithInnerRef } from './CompoundButton.types';
+import { compoundButtonName, CompoundButtonTokens, CompoundButtonSlotProps, CompoundButtonProps } from './CompoundButton.types';
 import { Theme, UseStylingOptions, buildProps } from '@fluentui-react-native/framework';
 import { borderStyles, fontStyles, layoutStyles } from '@fluentui-react-native/tokens';
 import { defaultButtonColorTokens } from '../ButtonColorTokens';
@@ -8,7 +8,7 @@ import { defaultCompoundButtonColorTokens } from './CompoundButtonColorTokens';
 import { defaultCompoundButtonTokens } from './CompoundButtonTokens';
 import { defaultCompoundButtonFontTokens } from './CompoundButtonFontTokens';
 
-export const stylingSettings: UseStylingOptions<CompoundButtonPropsWithInnerRef, CompoundButtonSlotProps, CompoundButtonTokens> = {
+export const stylingSettings: UseStylingOptions<CompoundButtonProps, CompoundButtonSlotProps, CompoundButtonTokens> = {
   tokens: [
     defaultButtonTokens,
     defaultButtonColorTokens,

--- a/packages/experimental/Button/src/CompoundButton/CompoundButton.tsx
+++ b/packages/experimental/Button/src/CompoundButton/CompoundButton.tsx
@@ -2,16 +2,16 @@
 import * as React from 'react';
 import { View } from 'react-native';
 import { ActivityIndicator } from '@fluentui-react-native/experimental-activity-indicator';
-import { CompoundButtonPropsWithInnerRef, compoundButtonName, CompoundButtonType, CompoundButtonProps } from './CompoundButton.types';
+import { compoundButtonName, CompoundButtonType, CompoundButtonProps } from './CompoundButton.types';
 import { Text } from '@fluentui-react-native/experimental-text';
 import { stylingSettings } from './CompoundButton.styling';
 import { compose, mergeProps, withSlots, UseSlots } from '@fluentui-react-native/framework';
 import { useButton } from '../useButton';
 import { Icon } from '@fluentui-react-native/icon';
-import { createIconProps, IFocusable } from '@fluentui-react-native/interactive-hooks';
+import { createIconProps } from '@fluentui-react-native/interactive-hooks';
 import { buttonLookup } from '../Button';
 
-const CompoundButtonComposed = compose<CompoundButtonType>({
+export const CompoundButton = compose<CompoundButtonType>({
   displayName: compoundButtonName,
   ...stylingSettings,
   slots: {
@@ -21,15 +21,15 @@ const CompoundButtonComposed = compose<CompoundButtonType>({
     secondaryContent: Text,
     contentContainer: View,
   },
-  render: (userProps: CompoundButtonPropsWithInnerRef, useSlots: UseSlots<CompoundButtonType>) => {
-    const button = useButton(userProps);
+  render: (userProps: CompoundButtonProps, useSlots: UseSlots<CompoundButtonType>, ref: any) => {
+    const button = useButton(userProps, ref);
     const iconProps = createIconProps(userProps.icon);
 
     // grab the styled slots
     const Slots = useSlots(userProps, (layer) => buttonLookup(layer, button.state, userProps));
 
     // now return the handler for finishing render
-    return (final: CompoundButtonPropsWithInnerRef, ...children: React.ReactNode[]) => {
+    return (final: CompoundButtonProps, ...children: React.ReactNode[]) => {
       const { icon, iconOnly, secondaryContent, iconPosition, loading, accessibilityLabel, ...mergedProps } = mergeProps(
         button.props,
         final,
@@ -74,9 +74,5 @@ const CompoundButtonComposed = compose<CompoundButtonType>({
     };
   },
 });
-
-export const CompoundButton = React.forwardRef<IFocusable, CompoundButtonProps>((props, ref) => (
-  <CompoundButtonComposed {...props} innerRef={ref} />
-));
 
 export default CompoundButton;

--- a/packages/experimental/Button/src/CompoundButton/CompoundButton.types.ts
+++ b/packages/experimental/Button/src/CompoundButton/CompoundButton.types.ts
@@ -47,7 +47,7 @@ export interface CompoundButtonSlotProps extends ButtonSlotProps {
 }
 
 export interface CompoundButtonType {
-  props: CompoundButtonPropsWithInnerRef;
+  props: CompoundButtonProps;
   tokens: CompoundButtonTokens;
   slotProps: CompoundButtonSlotProps;
 }

--- a/packages/experimental/Button/src/CompoundButton/CompoundButton.types.ts
+++ b/packages/experimental/Button/src/CompoundButton/CompoundButton.types.ts
@@ -1,6 +1,6 @@
 import { ViewProps, ColorValue } from 'react-native';
 import { TextProps } from '@fluentui-react-native/experimental-text';
-import { ButtonSlotProps, ButtonTokens, ButtonPropsWithInnerRef } from '../Button.types';
+import { ButtonSlotProps, ButtonTokens, ButtonProps } from '../Button.types';
 import { FontTokens } from '@fluentui-react-native/tokens';
 
 export const compoundButtonName = 'CompoundButton';
@@ -32,15 +32,12 @@ export interface CompoundButtonTokens extends ButtonTokens {
   hasContent?: CompoundButtonTokens;
 }
 
-export interface CompoundButtonPropsWithInnerRef extends Omit<ButtonPropsWithInnerRef, 'iconOnly'> {
+export interface CompoundButtonProps extends Omit<ButtonProps, 'iconOnly'> {
   /**
    * Second line of text that describes the action this button takes.
    */
   secondaryContent?: string;
 }
-
-export type CompoundButtonProps = Omit<CompoundButtonPropsWithInnerRef, 'innerRef'>;
-
 export interface CompoundButtonSlotProps extends ButtonSlotProps {
   contentContainer: ViewProps;
   secondaryContent: TextProps;

--- a/packages/experimental/Button/src/FAB/FAB.styling.ts
+++ b/packages/experimental/Button/src/FAB/FAB.styling.ts
@@ -1,4 +1,4 @@
-import { ButtonCoreTokens, ButtonSlotProps, ButtonCorePropsWithInnerRef } from '../Button.types';
+import { ButtonCoreTokens, ButtonSlotProps, ButtonCoreProps } from '../Button.types';
 import { Theme, UseStylingOptions, buildProps } from '@fluentui-react-native/framework';
 import { borderStyles, layoutStyles, fontStyles } from '@fluentui-react-native/tokens';
 import { buttonCoreStates } from '../Button.styling';
@@ -6,7 +6,7 @@ import { getTextMarginAdjustment } from '@fluentui-react-native/styling-utils';
 import { defaultFABTokens } from './FABTokens';
 import { defaultFABColorTokens } from './FABColorTokens';
 
-export const stylingSettings: UseStylingOptions<ButtonCorePropsWithInnerRef, ButtonSlotProps, ButtonCoreTokens> = {
+export const stylingSettings: UseStylingOptions<ButtonCoreProps, ButtonSlotProps, ButtonCoreTokens> = {
   tokens: [defaultFABTokens, defaultFABColorTokens],
   states: [...buttonCoreStates],
   slotProps: {

--- a/packages/experimental/Button/src/FAB/FAB.tsx
+++ b/packages/experimental/Button/src/FAB/FAB.tsx
@@ -3,25 +3,22 @@ import * as React from 'react';
 import { View } from 'react-native';
 import { fabName, FABType } from './FAB.types';
 import { Text } from '@fluentui-react-native/experimental-text';
-import { compose, UseSlots, withSlots } from '@fluentui-react-native/framework';
+import { compose, UseSlots } from '@fluentui-react-native/framework';
 import { Icon } from '@fluentui-react-native/icon';
-import { ButtonCorePropsWithInnerRef, ButtonCoreProps } from '../Button.types';
-import { IFocusable } from '@fluentui-react-native/interactive-hooks';
+import { ButtonCoreProps } from '../Button.types';
 
-const FABComposed = compose<FABType>({
+export const FAB = compose<FABType>({
   displayName: fabName,
   slots: {
     root: View,
     icon: Icon,
     content: Text,
   },
-  render: (_userProps: ButtonCorePropsWithInnerRef, _useSlots: UseSlots<FABType>) => {
-    return (_final: ButtonCorePropsWithInnerRef, ..._children: React.ReactNode[]) => {
+  render: (_userProps: ButtonCoreProps, _useSlots: UseSlots<FABType>, _ref: any) => {
+    return (_final: ButtonCoreProps, ..._children: React.ReactNode[]) => {
       return null; // Only implemented for mobile endpoints
     };
   },
 });
-
-export const FAB = React.forwardRef<IFocusable, ButtonCoreProps>((props, ref) => <FABComposed {...props} innerRef={ref} />);
 
 export default FAB;

--- a/packages/experimental/Button/src/FAB/FAB.types.ts
+++ b/packages/experimental/Button/src/FAB/FAB.types.ts
@@ -1,9 +1,9 @@
-import { ButtonSlotProps, ButtonCoreTokens, ButtonCorePropsWithInnerRef } from '../Button.types';
+import { ButtonSlotProps, ButtonCoreTokens, ButtonCoreProps } from '../Button.types';
 
 export const fabName = 'FAB';
 
 export interface FABType {
-  props: ButtonCorePropsWithInnerRef;
+  props: ButtonCoreProps;
   tokens: ButtonCoreTokens;
   slotProps: ButtonSlotProps;
 }

--- a/packages/experimental/Button/src/FAB/FABCore.tsx
+++ b/packages/experimental/Button/src/FAB/FABCore.tsx
@@ -7,8 +7,8 @@ import { stylingSettings } from './FAB.styling';
 import { compose, mergeProps, withSlots, UseSlots } from '@fluentui-react-native/framework';
 import { useButton } from '../useButton';
 import { Icon } from '@fluentui-react-native/icon';
-import { createIconProps, IFocusable, IPressableState } from '@fluentui-react-native/interactive-hooks';
-import { ButtonCorePropsWithInnerRef, ButtonCoreProps } from '../Button.types';
+import { createIconProps, IPressableState } from '@fluentui-react-native/interactive-hooks';
+import { ButtonCoreProps } from '../Button.types';
 
 /**
  * A function which determines if a set of styles should be applied to the compoent given the current state and props of the button.
@@ -18,13 +18,13 @@ import { ButtonCorePropsWithInnerRef, ButtonCoreProps } from '../Button.types';
  * @param userProps The props that were passed into the button
  * @returns Whether the styles that are assigned to the layer should be applied to the button
  */
-const buttonLookup = (layer: string, state: IPressableState, userProps: ButtonCorePropsWithInnerRef): boolean => {
+const buttonLookup = (layer: string, state: IPressableState, userProps: ButtonCoreProps): boolean => {
   return (
     state[layer] || userProps[layer] || (layer === 'hasContent' && !userProps.iconOnly) || (layer === 'hasIconBefore' && userProps.icon)
   );
 };
 
-const FABComposed = compose<FABType>({
+export const FAB = compose<FABType>({
   displayName: fabName,
   ...stylingSettings,
   slots: {
@@ -32,17 +32,17 @@ const FABComposed = compose<FABType>({
     icon: Icon,
     content: Text,
   },
-  render: (userProps: ButtonCorePropsWithInnerRef, useSlots: UseSlots<FABType>) => {
+  render: (userProps: ButtonCoreProps, useSlots: UseSlots<FABType>, ref: any) => {
     const { icon, onClick, ...rest } = userProps;
 
     const iconProps = createIconProps(userProps.icon);
-    const button = useButton(rest);
+    const button = useButton(rest, ref);
 
     // grab the styled slots
     const Slots = useSlots(userProps, (layer) => buttonLookup(layer, button.state, userProps));
 
     // now return the handler for finishing render
-    return (final: ButtonCorePropsWithInnerRef, ...children: React.ReactNode[]) => {
+    return (final: ButtonCoreProps, ...children: React.ReactNode[]) => {
       const { iconOnly, accessibilityLabel, ...mergedProps } = mergeProps(button.props, final);
 
       if (__DEV__ && iconOnly) {
@@ -74,7 +74,5 @@ const FABComposed = compose<FABType>({
     };
   },
 });
-
-export const FAB = React.forwardRef<IFocusable, ButtonCoreProps>((props, ref) => <FABComposed {...props} innerRef={ref} />);
 
 export default FAB;

--- a/packages/experimental/Button/src/ToggleButton/ToggleButton.styling.ts
+++ b/packages/experimental/Button/src/ToggleButton/ToggleButton.styling.ts
@@ -1,4 +1,4 @@
-import { toggleButtonName, ToggleButtonTokens, ToggleButtonSlotProps, ToggleButtonPropsWithInnerRef } from './ToggleButton.types';
+import { toggleButtonName, ToggleButtonTokens, ToggleButtonSlotProps, ToggleButtonProps } from './ToggleButton.types';
 import { Theme, UseStylingOptions, buildProps } from '@fluentui-react-native/framework';
 import { borderStyles, layoutStyles, fontStyles } from '@fluentui-react-native/tokens';
 import { defaultButtonColorTokens } from '../ButtonColorTokens';
@@ -7,7 +7,7 @@ import { defaultToggleButtonColorTokens } from './ToggleButtonColorTokens';
 import { defaultButtonTokens } from '../ButtonTokens';
 import { defaultButtonFontTokens } from '../ButtonFontTokens';
 
-export const stylingSettings: UseStylingOptions<ToggleButtonPropsWithInnerRef, ToggleButtonSlotProps, ToggleButtonTokens> = {
+export const stylingSettings: UseStylingOptions<ToggleButtonProps, ToggleButtonSlotProps, ToggleButtonTokens> = {
   tokens: [defaultButtonTokens, defaultButtonFontTokens, defaultButtonColorTokens, defaultToggleButtonColorTokens, toggleButtonName],
   states: ['checked', ...buttonStates],
   slotProps: {

--- a/packages/experimental/Button/src/ToggleButton/ToggleButton.tsx
+++ b/packages/experimental/Button/src/ToggleButton/ToggleButton.tsx
@@ -2,17 +2,17 @@
 import * as React from 'react';
 import { View } from 'react-native';
 import { ActivityIndicator } from '@fluentui-react-native/experimental-activity-indicator';
-import { ToggleButtonPropsWithInnerRef, ToggleButtonProps, toggleButtonName, ToggleButtonType } from './ToggleButton.types';
+import { ToggleButtonProps, toggleButtonName, ToggleButtonType } from './ToggleButton.types';
 import { Text } from '@fluentui-react-native/experimental-text';
 import { stylingSettings } from './ToggleButton.styling';
 import { compose, mergeProps, withSlots, UseSlots } from '@fluentui-react-native/framework';
 import { useButton } from '../useButton';
-import { IFocusable, useAsToggle } from '@fluentui-react-native/interactive-hooks';
+import { useAsToggle } from '@fluentui-react-native/interactive-hooks';
 import { Icon } from '@fluentui-react-native/icon';
 import { createIconProps } from '@fluentui-react-native/interactive-hooks';
 import { buttonLookup } from '../Button';
 
-const ToggleButtonComposed = compose<ToggleButtonType>({
+export const ToggleButton = compose<ToggleButtonType>({
   displayName: toggleButtonName,
   ...stylingSettings,
   slots: {
@@ -20,7 +20,7 @@ const ToggleButtonComposed = compose<ToggleButtonType>({
     icon: Icon,
     content: Text,
   },
-  render: (userProps: ToggleButtonPropsWithInnerRef, useSlots: UseSlots<ToggleButtonType>) => {
+  render: (userProps: ToggleButtonProps, useSlots: UseSlots<ToggleButtonType>, ref: any) => {
     const { defaultChecked, checked, onClick, ...rest } = userProps;
     const iconProps = createIconProps(userProps.icon);
 
@@ -29,13 +29,13 @@ const ToggleButtonComposed = compose<ToggleButtonType>({
       console.warn('defaultChecked and checked are mutually exclusive to one another. Use one or the other.');
     }
     const [checkedValue, toggle] = useAsToggle(defaultChecked, checked, onClick);
-    const button = useButton({ onClick: toggle, ...rest });
+    const button = useButton({ onClick: toggle, ...rest }, ref);
 
     // grab the styled slots
     const Slots = useSlots(userProps, (layer) => (layer === 'checked' && checkedValue) || buttonLookup(layer, button.state, userProps));
 
     // now return the handler for finishing render
-    return (final: ToggleButtonPropsWithInnerRef, ...children: React.ReactNode[]) => {
+    return (final: ToggleButtonProps, ...children: React.ReactNode[]) => {
       const { icon, iconPosition, iconOnly, loading, accessibilityLabel, ...mergedProps } = mergeProps(button.props, final);
       const shouldShowIcon = !loading && icon;
 
@@ -70,9 +70,5 @@ const ToggleButtonComposed = compose<ToggleButtonType>({
     };
   },
 });
-
-export const ToggleButton = React.forwardRef<IFocusable, ToggleButtonProps>((props, ref) => (
-  <ToggleButtonComposed {...props} innerRef={ref} />
-));
 
 export default ToggleButton;

--- a/packages/experimental/Button/src/ToggleButton/ToggleButton.types.ts
+++ b/packages/experimental/Button/src/ToggleButton/ToggleButton.types.ts
@@ -26,7 +26,7 @@ export type ToggleButtonProps = Omit<ToggleButtonPropsWithInnerRef, 'innerRef'>;
 export interface ToggleButtonSlotProps extends ButtonSlotProps {}
 
 export interface ToggleButtonType {
-  props: ToggleButtonPropsWithInnerRef;
+  props: ToggleButtonProps;
   tokens: ToggleButtonTokens;
   slotProps: ToggleButtonSlotProps;
 }

--- a/packages/experimental/Button/src/ToggleButton/ToggleButton.types.ts
+++ b/packages/experimental/Button/src/ToggleButton/ToggleButton.types.ts
@@ -1,4 +1,4 @@
-import { ButtonSlotProps, ButtonTokens, ButtonPropsWithInnerRef } from '../Button.types';
+import { ButtonSlotProps, ButtonTokens, ButtonProps } from '../Button.types';
 
 export const toggleButtonName = 'ToggleButton';
 
@@ -6,7 +6,7 @@ export interface ToggleButtonTokens extends ButtonTokens {
   checked?: ToggleButtonTokens;
 }
 
-export interface ToggleButtonPropsWithInnerRef extends ButtonPropsWithInnerRef {
+export interface ToggleButtonProps extends ButtonProps {
   /**
    * Defines the controlled checked state of the `ToggleButton`.
    * Mutually exclusive to `defaultChecked`.
@@ -20,8 +20,6 @@ export interface ToggleButtonPropsWithInnerRef extends ButtonPropsWithInnerRef {
    */
   defaultChecked?: boolean;
 }
-
-export type ToggleButtonProps = Omit<ToggleButtonPropsWithInnerRef, 'innerRef'>;
 
 export interface ToggleButtonSlotProps extends ButtonSlotProps {}
 

--- a/packages/experimental/Button/src/useButton.ts
+++ b/packages/experimental/Button/src/useButton.ts
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { useAsPressable, useKeyUpProps, useOnPressWithFocus, useViewCommandFocus } from '@fluentui-react-native/interactive-hooks';
-import { ButtonPropsWithInnerRef, ButtonState } from './Button.types';
+import { ButtonProps, ButtonState } from './Button.types';
 import { memoize } from '@fluentui-react-native/framework';
 
-export const useButton = (props: ButtonPropsWithInnerRef): ButtonState => {
+export const useButton = (props: ButtonProps, ref: any): ButtonState => {
   // attach the pressable state handlers
   const defaultRef = React.useRef(null);
-  const { onClick, innerRef, disabled, loading, ...rest } = props;
-  const ref = innerRef !== null ? innerRef : defaultRef;
+  const { onClick, disabled, loading, ...rest } = props;
+  const innerRef = ref !== null && ref !== undefined ? ref : defaultRef;
   // GH #1336: Set focusRef to null if button is disabled to prevent getting keyboard focus.
-  const focusRef = disabled ? null : ref;
+  const focusRef = disabled ? null : innerRef;
   const onClickWithFocus = useOnPressWithFocus(focusRef, onClick);
   const pressable = useAsPressable({ ...rest, onPress: onClickWithFocus });
   const onKeyUpProps = useKeyUpProps(onClick, ' ', 'Enter');
@@ -25,7 +25,7 @@ export const useButton = (props: ButtonPropsWithInnerRef): ButtonState => {
       accessibilityState: getAccessibilityState(isDisabled),
       enableFocusRing: true,
       focusable: !isDisabled,
-      ref: useViewCommandFocus(ref),
+      ref: useViewCommandFocus(innerRef),
       ...onKeyUpProps,
       iconPosition: props.iconPosition || 'before',
       loading,

--- a/packages/framework/composition/src/composeFactory.ts
+++ b/packages/framework/composition/src/composeFactory.ts
@@ -21,7 +21,7 @@ export type ComposeFactoryOptions<TProps, TSlotProps, TTokens, TTheme, TStatics 
     /**
      * staged render function that takes props and a useSlots hook as an input
      */
-    render: (props: TProps, useSlots: UseStyledSlots<TProps, TSlotProps>) => React.FunctionComponent<TProps>;
+    render: (props: TProps, useSlots: UseStyledSlots<TProps, TSlotProps>, ref: any) => React.FunctionComponent<TProps>;
 
     /**
      * optional statics to attach to the component
@@ -64,7 +64,7 @@ export function composeFactory<TProps, TSlotProps, TTokens, TTheme, TStatics ext
   const useSlots = buildUseSlots(options) as UseStyledSlots<TProps, TSlotProps>;
 
   // build the staged component
-  const component = stagedComponent<TProps>((props) => options.render(props, useSlots)) as LocalComponent;
+  const component = stagedComponent<TProps>((props, ref) => options.render(props, useSlots, ref)) as LocalComponent;
 
   // attach additional props to the returned component
   component.displayName = options.displayName;

--- a/packages/framework/use-slot/src/useSlot.ts
+++ b/packages/framework/use-slot/src/useSlot.ts
@@ -31,7 +31,7 @@ export function useSlot<TProps>(
   type MemoTuple = [SlotFn<TProps>, ResultHolder];
 
   // extract the staged component function if that pattern is being used, will be undefined if it is a standard component
-  const stagedComponent = getStagedRender<TProps>(component);
+  const stagedRenderFn = getStagedRender<TProps>(component);
 
   // build the secondary processing function and the result holder, done via useMemo so the function identity stays the same. Rebuilding the closure every time would invalidate render
   const [fn, results] = React.useMemo<MemoTuple>(() => {
@@ -60,7 +60,7 @@ export function useSlot<TProps>(
   }, [component, filter]);
 
   // if it is a staged component executre the first part with the props, otherwise just remember the props
-  results.result = stagedComponent ? stagedComponent(props) : props;
+  results.result = stagedRenderFn ? stagedRenderFn(props) : props;
 
   // return the function
   return fn;


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Bringing back customize and compose.

Draft as I still need to do some cleanup & want to add tests. Oh and clean up that "any" I added if I can

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
