### PR TITLE
Replace `ref` with `componentRef` on the Button to bring back `customize` and `compose`

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonHOCTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonHOCTestSection.tsx
@@ -17,7 +17,7 @@ export const ButtonHOCTest: React.FunctionComponent = () => {
 
   return (
     <View style={[stackStyle, commonTestStyles.view]}>
-      <CustomButton style={commonTestStyles.vmargin} ref={buttonRef}>
+      <CustomButton style={commonTestStyles.vmargin} componentRef={buttonRef}>
         Customized Button with ref
       </CustomButton>
       <Button

--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonHOCTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonHOCTestSection.tsx
@@ -1,17 +1,24 @@
 import { Button } from '@fluentui-react-native/experimental-button';
+import { Text } from '@fluentui-react-native/experimental-text';
 import { Icon } from '@fluentui-react-native/icon';
 import * as React from 'react';
-import { View, Text } from 'react-native';
+import { View } from 'react-native';
 import { commonTestStyles, stackStyle } from '../Common/styles';
 
 export const ButtonHOCTest: React.FunctionComponent = () => {
   const buttonRef = React.useRef(null);
+  const CustomText = Text.customize({ fontSize: 'header', color: 'hotpink' });
   const CustomButton = Button.customize({ backgroundColor: 'pink' });
   const ComposedButton = Button.compose({
     slots: {
       root: View,
       icon: Icon,
-      content: Text,
+      content: CustomText,
+    },
+    slotProps: {
+      content: {
+        style: { marginTop: -1, marginBottom: 1, marginStart: 0, marginEnd: -2 },
+      },
     },
   });
 
@@ -30,7 +37,7 @@ export const ButtonHOCTest: React.FunctionComponent = () => {
       >
         Press to focus Customized Button
       </Button>
-      <ComposedButton style={commonTestStyles.vmargin}>Composed button using RNText for text slot</ComposedButton>
+      <ComposedButton style={commonTestStyles.vmargin}>Composed button using customized Text for text slot</ComposedButton>
     </View>
   );
 };

--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonHOCTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonHOCTestSection.tsx
@@ -1,0 +1,36 @@
+import { Button } from '@fluentui-react-native/experimental-button';
+import { Icon } from '@fluentui-react-native/icon';
+import * as React from 'react';
+import { View, Text } from 'react-native';
+import { commonTestStyles, stackStyle } from '../Common/styles';
+
+export const ButtonHOCTest: React.FunctionComponent = () => {
+  const buttonRef = React.useRef(null);
+  const CustomButton = Button.customize({ backgroundColor: 'pink' });
+  const ComposedButton = Button.compose({
+    slots: {
+      root: View,
+      icon: Icon,
+      content: Text,
+    },
+  });
+
+  return (
+    <View style={[stackStyle, commonTestStyles.view]}>
+      <CustomButton style={commonTestStyles.vmargin} ref={buttonRef}>
+        Customized Button with ref
+      </CustomButton>
+      <Button
+        style={commonTestStyles.vmargin}
+        onClick={() => {
+          if (buttonRef.current) {
+            buttonRef.current.focus();
+          }
+        }}
+      >
+        Press to focus Customized Button
+      </Button>
+      <ComposedButton style={commonTestStyles.vmargin}>Composed button using RNText for text slot</ComposedButton>
+    </View>
+  );
+};

--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonHOCTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonHOCTestSection.tsx
@@ -16,7 +16,7 @@ export const ButtonHOCTest: React.FunctionComponent = () => {
   });
 
   return (
-    <View style={[stackStyle, commonTestStyles.view]}>
+    <View style={stackStyle}>
       <CustomButton style={commonTestStyles.vmargin} componentRef={buttonRef}>
         Customized Button with ref
       </CustomButton>

--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonTest.tsx
@@ -7,6 +7,7 @@ import { ButtonIconTest } from './ButtonIconTestSection';
 import { ButtonSizeTest } from './ButtonSizeTestSection';
 import { ButtonShapeTest } from './ButtonShapeTestSection';
 import { E2EButtonExperimentalTest } from './E2EButtonTest';
+import { ButtonHOCTest } from './ButtonHOCTestSection';
 
 const buttonSections: TestSection[] = [
   {
@@ -29,6 +30,10 @@ const buttonSections: TestSection[] = [
   {
     name: 'Sizes',
     component: ButtonSizeTest,
+  },
+  {
+    name: 'Customize, Compose, and Ref',
+    component: ButtonHOCTest,
   },
   {
     name: 'E2E Button Testing',

--- a/change/@fluentui-react-native-experimental-button-6e770adf-271c-4072-9c19-0280d8d9497e.json
+++ b/change/@fluentui-react-native-experimental-button-6e770adf-271c-4072-9c19-0280d8d9497e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Revert \"Add ref to v1 Button (#1218)\"",
+  "packageName": "@fluentui-react-native/experimental-button",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-menu-button-b3b44272-7d9d-4b1a-b208-7252132d5d92.json
+++ b/change/@fluentui-react-native-experimental-menu-button-b3b44272-7d9d-4b1a-b208-7252132d5d92.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Revert \"Add ref to v1 Button (#1218)\"",
+  "packageName": "@fluentui-react-native/experimental-menu-button",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-interactive-hooks-741c4ed3-822a-49a0-92f7-33fa899c4fa4.json
+++ b/change/@fluentui-react-native-interactive-hooks-741c4ed3-822a-49a0-92f7-33fa899c4fa4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Revert \"Add ref to v1 Button (#1218)\"",
+  "packageName": "@fluentui-react-native/interactive-hooks",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-061ce2b5-dc84-4ad6-80cc-fdbed5f06346.json
+++ b/change/@fluentui-react-native-tester-061ce2b5-dc84-4ad6-80cc-fdbed5f06346.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Let's add some tests",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Button/MIGRATION.md
+++ b/packages/experimental/Button/MIGRATION.md
@@ -19,6 +19,7 @@ Primary and Stealth buttons now map to `Button`:
 ### Props that remain as is
 
 - `children`
+- `componentRef`
 - `icon`
 - `onClick`
 - `testID`
@@ -26,7 +27,6 @@ Primary and Stealth buttons now map to `Button`:
 
 ### Props no longer supported with an equivalent functionality in v1 Button
 
-- `componentRef` => Use regular `ref` instead
 - `content` => Pass the content as `children` instead
 - `endIcon` => Use `after` value for `iconPosition` prop and pass icon information into `icon` prop instead
 - `startIcon` => Use `before` value for `iconPosition` prop and pass icon information into `icon` prop instead
@@ -54,6 +54,7 @@ No `Button` specific renames. See [this porting guide](../../../docs/pages/Guide
 
 - `icon` takes in a props object instead of the JSX element itself. This is due to framework differences from FluentUI.
 - `iconOnly` must be supplied for components do not have any text content for them to be styled correctly. This is due to framework differences from FluentUI.
+- `ref` is exposed as `componentRef`, similar to previous versions of FluentUI. This is due to framework differences from FluentUI.
 
 ### Other Prop differences
 
@@ -64,7 +65,7 @@ No `Button` specific renames. See [this porting guide](../../../docs/pages/Guide
 
 | v0 `Button`    | v1 `Button`    |
 | -------------- | -------------- |
-| `componentRef` | `ref`          |
+| `componentRef` | `componentRef` |
 | `content`      |                |
 | `endIcon`      | `iconPosition` |
 | `icon`         | `icon`         |

--- a/packages/experimental/Button/MIGRATION.md
+++ b/packages/experimental/Button/MIGRATION.md
@@ -26,7 +26,7 @@ Primary and Stealth buttons now map to `Button`:
 
 ### Props no longer supported with an equivalent functionality in v1 Button
 
-- `componentRef` => Use `ref` instead
+- `componentRef` => Use regular `ref` instead
 - `content` => Pass the content as `children` instead
 - `endIcon` => Use `after` value for `iconPosition` prop and pass icon information into `icon` prop instead
 - `startIcon` => Use `before` value for `iconPosition` prop and pass icon information into `icon` prop instead

--- a/packages/experimental/Button/SPEC.md
+++ b/packages/experimental/Button/SPEC.md
@@ -125,13 +125,6 @@ export interface ButtonProps extends Omit<IWithPressableOptions<ViewProps>, 'onP
   loading?: boolean;
 
   /**
-   * A ref to access the IButton interface. Use this to access the public methods and properties of the component.
-   *
-   * NOTE: Callbacks will not invoke focus on click behavior, caller will need to add that behavior if desired.
-   */
-  ref?: React.ForwardedRef<IFocusable>;
-
-  /**
    * A button can be rounded, circular, or square.
    * @default 'rounded'
    */

--- a/packages/experimental/Button/SPEC.md
+++ b/packages/experimental/Button/SPEC.md
@@ -88,34 +88,33 @@ export interface ButtonProps extends Omit<IWithPressableOptions<ViewProps>, 'onP
   appearance?: 'primary' | 'outline' | 'subtle';
 
   /**
-   * Icon slot that, if specified, renders an icon either before or after the `children` as specified by the
-   * `iconPosition` prop.
-   */
-  icon?: IconSourcesType;
-
-  /**
-   * Loader slot that, if specified, renders a `loader` before the `icon` and `children` while the `loading` flag
-   * is set to `true`.
-   */
-  loader?: ActivityIndicator;
-
-  /**
    * A button can fill the width of its container.
    * @default false
    */
   block?: boolean;
 
   /**
-   * A button can format its icon to appear before or after its content.
-   * @default 'before'
+   * A RefObject to access the IButton interface. Use this to access the public methods and properties of the component.
    */
-  iconPosition?: 'before' | 'after';
+  componentRef?: IconSourcesType;
+
+  /**
+   * Icon slot that, if specified, renders an icon either before or after the `children` as specified by the
+   * `iconPosition` prop.
+   */
+  icon?: IconSourcesType;
 
   /**
    * Button contains only icon, there's no text content
    * Must be set for button to style correctly when button has not content.
    */
   iconOnly?: boolean;
+
+  /**
+   * A button can format its icon to appear before or after its content.
+   * @default 'before'
+   */
+  iconPosition?: 'before' | 'after';
 
   /**
    * A button can show a loading indicator if it is waiting for another action to happen before allowing itself to

--- a/packages/experimental/Button/src/Button.styling.ts
+++ b/packages/experimental/Button/src/Button.styling.ts
@@ -1,4 +1,4 @@
-import { buttonName, ButtonCoreTokens, ButtonTokens, ButtonSlotProps, ButtonPropsWithInnerRef, ButtonSize } from './Button.types';
+import { buttonName, ButtonCoreTokens, ButtonTokens, ButtonSlotProps, ButtonProps, ButtonSize } from './Button.types';
 import { Theme, UseStylingOptions, buildProps } from '@fluentui-react-native/framework';
 import { borderStyles, layoutStyles, fontStyles, shadowStyles, FontTokens } from '@fluentui-react-native/tokens';
 import { defaultButtonTokens } from './ButtonTokens';
@@ -28,7 +28,7 @@ export const buttonStates: (keyof ButtonTokens)[] = [
   'square',
 ];
 
-export const stylingSettings: UseStylingOptions<ButtonPropsWithInnerRef, ButtonSlotProps, ButtonTokens> = {
+export const stylingSettings: UseStylingOptions<ButtonProps, ButtonSlotProps, ButtonTokens> = {
   tokens: [defaultButtonTokens, defaultButtonFontTokens, defaultButtonColorTokens, buttonName],
   states: buttonStates,
   slotProps: {

--- a/packages/experimental/Button/src/Button.test.tsx
+++ b/packages/experimental/Button/src/Button.test.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { Button } from './Button';
 import * as renderer from 'react-test-renderer';
 import { checkRenderConsistency, checkReRender } from '@fluentui-react-native/test-tools';
+import { Text, View } from 'react-native';
+import { Icon } from '@fluentui-react-native/icon';
 
 describe('Button component tests', () => {
   it('Button default', () => {
@@ -36,6 +38,24 @@ describe('Button component tests', () => {
 
   it('Button large', () => {
     const tree = renderer.create(<Button size="large">Large Button</Button>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('Button customized', () => {
+    const CustomButton = Button.customize({ backgroundColor: 'pink' });
+    const tree = renderer.create(<CustomButton>Custom Button</CustomButton>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('Button composed', () => {
+    const ComposedButton = Button.compose({
+      slots: {
+        root: View,
+        icon: Icon,
+        content: Text,
+      },
+    });
+    const tree = renderer.create(<ComposedButton>Composed Button with RNText</ComposedButton>).toJSON();
     expect(tree).toMatchSnapshot();
   });
 

--- a/packages/experimental/Button/src/Button.tsx
+++ b/packages/experimental/Button/src/Button.tsx
@@ -2,13 +2,13 @@
 import * as React from 'react';
 import { View } from 'react-native';
 import { ActivityIndicator } from '@fluentui-react-native/experimental-activity-indicator';
-import { buttonName, ButtonType, ButtonProps, ButtonPropsWithInnerRef } from './Button.types';
+import { buttonName, ButtonType, ButtonProps } from './Button.types';
 import { Text } from '@fluentui-react-native/experimental-text';
 import { stylingSettings, getDefaultSize } from './Button.styling';
 import { compose, mergeProps, withSlots, UseSlots } from '@fluentui-react-native/framework';
 import { useButton } from './useButton';
 import { Icon } from '@fluentui-react-native/icon';
-import { createIconProps, IFocusable, IPressableState } from '@fluentui-react-native/interactive-hooks';
+import { createIconProps, IPressableState } from '@fluentui-react-native/interactive-hooks';
 
 /**
  * A function which determines if a set of styles should be applied to the compoent given the current state and props of the button.
@@ -18,7 +18,7 @@ import { createIconProps, IFocusable, IPressableState } from '@fluentui-react-na
  * @param userProps The props that were passed into the button
  * @returns Whether the styles that are assigned to the layer should be applied to the button
  */
-export const buttonLookup = (layer: string, state: IPressableState, userProps: ButtonPropsWithInnerRef): boolean => {
+export const buttonLookup = (layer: string, state: IPressableState, userProps: ButtonProps): boolean => {
   return (
     state[layer] ||
     userProps[layer] ||
@@ -33,7 +33,7 @@ export const buttonLookup = (layer: string, state: IPressableState, userProps: B
   );
 };
 
-const ButtonComposed = compose<ButtonType>({
+export const Button = compose<ButtonType>({
   displayName: buttonName,
   ...stylingSettings,
   slots: {
@@ -41,14 +41,14 @@ const ButtonComposed = compose<ButtonType>({
     icon: Icon,
     content: Text,
   },
-  render: (userProps: ButtonPropsWithInnerRef, useSlots: UseSlots<ButtonType>) => {
+  render: (userProps: ButtonProps, useSlots: UseSlots<ButtonType>) => {
     const button = useButton(userProps);
     const iconProps = createIconProps(userProps.icon);
     // grab the styled slots
     const Slots = useSlots(userProps, (layer) => buttonLookup(layer, button.state, userProps));
 
     // now return the handler for finishing render
-    return (final: ButtonPropsWithInnerRef, ...children: React.ReactNode[]) => {
+    return (final: ButtonProps, ...children: React.ReactNode[]) => {
       const { icon, iconOnly, iconPosition, loading, accessibilityLabel, ...mergedProps } = mergeProps(button.props, final);
 
       const shouldShowIcon = !loading && icon;
@@ -83,7 +83,5 @@ const ButtonComposed = compose<ButtonType>({
     };
   },
 });
-
-export const Button = React.forwardRef<IFocusable, ButtonProps>((props, ref) => <ButtonComposed {...props} innerRef={ref} />);
 
 export default Button;

--- a/packages/experimental/Button/src/Button.types.ts
+++ b/packages/experimental/Button/src/Button.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ViewStyle, ColorValue, ViewProps } from 'react-native';
+import { ViewProps, ViewStyle, ColorValue } from 'react-native';
 import { TextProps } from '@fluentui-react-native/experimental-text';
 import { FontTokens, IBorderTokens, IColorTokens, IShadowTokens, LayoutTokens } from '@fluentui-react-native/tokens';
 import { IFocusable, IPressableHooks, IWithPressableOptions } from '@fluentui-react-native/interactive-hooks';
@@ -79,7 +79,7 @@ export interface ButtonTokens extends ButtonCoreTokens {
   hasIconAfter?: ButtonTokens;
 }
 
-export interface ButtonCorePropsWithInnerRef extends Omit<IWithPressableOptions<ViewProps>, 'onPress'> {
+export interface ButtonCoreProps extends Omit<IWithPressableOptions<ViewProps>, 'onPress'> {
   /*
    * Source URL or name of the icon to show on the Button.
    */
@@ -91,7 +91,10 @@ export interface ButtonCorePropsWithInnerRef extends Omit<IWithPressableOptions<
    */
   iconOnly?: boolean;
 
-  innerRef?: React.ForwardedRef<IFocusable>;
+  /**
+   * A RefObject to access the IButton interface. Use this to access the public methods and properties of the component.
+   */
+  componentRef?: React.RefObject<IFocusable>;
 
   /**
    * A callback to call on button click event
@@ -104,9 +107,7 @@ export interface ButtonCorePropsWithInnerRef extends Omit<IWithPressableOptions<
   tooltip?: string;
 }
 
-export type ButtonCoreProps = Omit<ButtonCorePropsWithInnerRef, 'innerRef'>;
-
-export interface ButtonPropsWithInnerRef extends ButtonCorePropsWithInnerRef {
+export interface ButtonProps extends ButtonCoreProps {
   /**
    * A button can have its content and borders styled for greater emphasis or to be subtle.
    * - 'primary': Emphasizes the button as a primary action.
@@ -145,9 +146,7 @@ export interface ButtonPropsWithInnerRef extends ButtonCorePropsWithInnerRef {
   loading?: boolean;
 }
 
-export type ButtonProps = Omit<ButtonPropsWithInnerRef, 'innerRef'>;
-
-export type ButtonState = IPressableHooks<ButtonPropsWithInnerRef & React.ComponentPropsWithRef<any>>;
+export type ButtonState = IPressableHooks<ButtonProps & React.ComponentPropsWithRef<any>>;
 
 export interface ButtonSlotProps {
   root: React.PropsWithRef<IViewProps>;
@@ -156,7 +155,7 @@ export interface ButtonSlotProps {
 }
 
 export interface ButtonType {
-  props: ButtonPropsWithInnerRef;
+  props: ButtonProps;
   tokens: ButtonTokens;
   slotProps: ButtonSlotProps;
 }

--- a/packages/experimental/Button/src/CompoundButton/CompoundButton.styling.ts
+++ b/packages/experimental/Button/src/CompoundButton/CompoundButton.styling.ts
@@ -1,4 +1,4 @@
-import { compoundButtonName, CompoundButtonTokens, CompoundButtonSlotProps, CompoundButtonPropsWithInnerRef } from './CompoundButton.types';
+import { compoundButtonName, CompoundButtonTokens, CompoundButtonSlotProps, CompoundButtonProps } from './CompoundButton.types';
 import { Theme, UseStylingOptions, buildProps } from '@fluentui-react-native/framework';
 import { borderStyles, fontStyles, layoutStyles } from '@fluentui-react-native/tokens';
 import { defaultButtonColorTokens } from '../ButtonColorTokens';
@@ -8,7 +8,7 @@ import { defaultCompoundButtonColorTokens } from './CompoundButtonColorTokens';
 import { defaultCompoundButtonTokens } from './CompoundButtonTokens';
 import { defaultCompoundButtonFontTokens } from './CompoundButtonFontTokens';
 
-export const stylingSettings: UseStylingOptions<CompoundButtonPropsWithInnerRef, CompoundButtonSlotProps, CompoundButtonTokens> = {
+export const stylingSettings: UseStylingOptions<CompoundButtonProps, CompoundButtonSlotProps, CompoundButtonTokens> = {
   tokens: [
     defaultButtonTokens,
     defaultButtonColorTokens,

--- a/packages/experimental/Button/src/CompoundButton/CompoundButton.tsx
+++ b/packages/experimental/Button/src/CompoundButton/CompoundButton.tsx
@@ -2,16 +2,16 @@
 import * as React from 'react';
 import { View } from 'react-native';
 import { ActivityIndicator } from '@fluentui-react-native/experimental-activity-indicator';
-import { CompoundButtonPropsWithInnerRef, compoundButtonName, CompoundButtonType, CompoundButtonProps } from './CompoundButton.types';
+import { CompoundButtonProps, compoundButtonName, CompoundButtonType } from './CompoundButton.types';
 import { Text } from '@fluentui-react-native/experimental-text';
 import { stylingSettings } from './CompoundButton.styling';
 import { compose, mergeProps, withSlots, UseSlots } from '@fluentui-react-native/framework';
 import { useButton } from '../useButton';
 import { Icon } from '@fluentui-react-native/icon';
-import { createIconProps, IFocusable } from '@fluentui-react-native/interactive-hooks';
+import { createIconProps } from '@fluentui-react-native/interactive-hooks';
 import { buttonLookup } from '../Button';
 
-const CompoundButtonComposed = compose<CompoundButtonType>({
+export const CompoundButton = compose<CompoundButtonType>({
   displayName: compoundButtonName,
   ...stylingSettings,
   slots: {
@@ -21,7 +21,7 @@ const CompoundButtonComposed = compose<CompoundButtonType>({
     secondaryContent: Text,
     contentContainer: View,
   },
-  render: (userProps: CompoundButtonPropsWithInnerRef, useSlots: UseSlots<CompoundButtonType>) => {
+  render: (userProps: CompoundButtonProps, useSlots: UseSlots<CompoundButtonType>) => {
     const button = useButton(userProps);
     const iconProps = createIconProps(userProps.icon);
 
@@ -29,7 +29,7 @@ const CompoundButtonComposed = compose<CompoundButtonType>({
     const Slots = useSlots(userProps, (layer) => buttonLookup(layer, button.state, userProps));
 
     // now return the handler for finishing render
-    return (final: CompoundButtonPropsWithInnerRef, ...children: React.ReactNode[]) => {
+    return (final: CompoundButtonProps, ...children: React.ReactNode[]) => {
       const { icon, iconOnly, secondaryContent, iconPosition, loading, accessibilityLabel, ...mergedProps } = mergeProps(
         button.props,
         final,
@@ -74,9 +74,5 @@ const CompoundButtonComposed = compose<CompoundButtonType>({
     };
   },
 });
-
-export const CompoundButton = React.forwardRef<IFocusable, CompoundButtonProps>((props, ref) => (
-  <CompoundButtonComposed {...props} innerRef={ref} />
-));
 
 export default CompoundButton;

--- a/packages/experimental/Button/src/CompoundButton/CompoundButton.types.ts
+++ b/packages/experimental/Button/src/CompoundButton/CompoundButton.types.ts
@@ -1,6 +1,6 @@
 import { ViewProps, ColorValue } from 'react-native';
 import { TextProps } from '@fluentui-react-native/experimental-text';
-import { ButtonSlotProps, ButtonTokens, ButtonPropsWithInnerRef } from '../Button.types';
+import { ButtonSlotProps, ButtonTokens, ButtonProps } from '../Button.types';
 import { FontTokens } from '@fluentui-react-native/tokens';
 
 export const compoundButtonName = 'CompoundButton';
@@ -32,14 +32,12 @@ export interface CompoundButtonTokens extends ButtonTokens {
   hasContent?: CompoundButtonTokens;
 }
 
-export interface CompoundButtonPropsWithInnerRef extends Omit<ButtonPropsWithInnerRef, 'iconOnly'> {
+export interface CompoundButtonProps extends ButtonProps {
   /**
    * Second line of text that describes the action this button takes.
    */
   secondaryContent?: string;
 }
-
-export type CompoundButtonProps = Omit<CompoundButtonPropsWithInnerRef, 'innerRef'>;
 
 export interface CompoundButtonSlotProps extends ButtonSlotProps {
   contentContainer: ViewProps;
@@ -47,7 +45,7 @@ export interface CompoundButtonSlotProps extends ButtonSlotProps {
 }
 
 export interface CompoundButtonType {
-  props: CompoundButtonPropsWithInnerRef;
+  props: CompoundButtonProps;
   tokens: CompoundButtonTokens;
   slotProps: CompoundButtonSlotProps;
 }

--- a/packages/experimental/Button/src/FAB/FAB.styling.ts
+++ b/packages/experimental/Button/src/FAB/FAB.styling.ts
@@ -1,4 +1,4 @@
-import { ButtonCoreTokens, ButtonSlotProps, ButtonCorePropsWithInnerRef } from '../Button.types';
+import { ButtonCoreTokens, ButtonSlotProps, ButtonCoreProps } from '../Button.types';
 import { Theme, UseStylingOptions, buildProps } from '@fluentui-react-native/framework';
 import { borderStyles, layoutStyles, fontStyles } from '@fluentui-react-native/tokens';
 import { buttonCoreStates } from '../Button.styling';
@@ -6,7 +6,7 @@ import { getTextMarginAdjustment } from '@fluentui-react-native/styling-utils';
 import { defaultFABTokens } from './FABTokens';
 import { defaultFABColorTokens } from './FABColorTokens';
 
-export const stylingSettings: UseStylingOptions<ButtonCorePropsWithInnerRef, ButtonSlotProps, ButtonCoreTokens> = {
+export const stylingSettings: UseStylingOptions<ButtonCoreProps, ButtonSlotProps, ButtonCoreTokens> = {
   tokens: [defaultFABTokens, defaultFABColorTokens],
   states: [...buttonCoreStates],
   slotProps: {

--- a/packages/experimental/Button/src/FAB/FAB.tsx
+++ b/packages/experimental/Button/src/FAB/FAB.tsx
@@ -3,25 +3,22 @@ import * as React from 'react';
 import { View } from 'react-native';
 import { fabName, FABType } from './FAB.types';
 import { Text } from '@fluentui-react-native/experimental-text';
-import { compose, UseSlots, withSlots } from '@fluentui-react-native/framework';
+import { compose, UseSlots } from '@fluentui-react-native/framework';
 import { Icon } from '@fluentui-react-native/icon';
-import { ButtonCorePropsWithInnerRef, ButtonCoreProps } from '../Button.types';
-import { IFocusable } from '@fluentui-react-native/interactive-hooks';
+import { ButtonCoreProps } from '../Button.types';
 
-const FABComposed = compose<FABType>({
+export const FAB = compose<FABType>({
   displayName: fabName,
   slots: {
     root: View,
     icon: Icon,
     content: Text,
   },
-  render: (_userProps: ButtonCorePropsWithInnerRef, _useSlots: UseSlots<FABType>) => {
-    return (_final: ButtonCorePropsWithInnerRef, ..._children: React.ReactNode[]) => {
+  render: (_userProps: ButtonCoreProps, _useSlots: UseSlots<FABType>) => {
+    return (_final: ButtonCoreProps, ..._children: React.ReactNode[]) => {
       return null; // Only implemented for mobile endpoints
     };
   },
 });
-
-export const FAB = React.forwardRef<IFocusable, ButtonCoreProps>((props, ref) => <FABComposed {...props} innerRef={ref} />);
 
 export default FAB;

--- a/packages/experimental/Button/src/FAB/FAB.types.ts
+++ b/packages/experimental/Button/src/FAB/FAB.types.ts
@@ -1,9 +1,9 @@
-import { ButtonSlotProps, ButtonCoreTokens, ButtonCorePropsWithInnerRef } from '../Button.types';
+import { ButtonSlotProps, ButtonCoreTokens, ButtonCoreProps } from '../Button.types';
 
 export const fabName = 'FAB';
 
 export interface FABType {
-  props: ButtonCorePropsWithInnerRef;
+  props: ButtonCoreProps;
   tokens: ButtonCoreTokens;
   slotProps: ButtonSlotProps;
 }

--- a/packages/experimental/Button/src/FAB/FABCore.tsx
+++ b/packages/experimental/Button/src/FAB/FABCore.tsx
@@ -7,8 +7,8 @@ import { stylingSettings } from './FAB.styling';
 import { compose, mergeProps, withSlots, UseSlots } from '@fluentui-react-native/framework';
 import { useButton } from '../useButton';
 import { Icon } from '@fluentui-react-native/icon';
-import { createIconProps, IFocusable, IPressableState } from '@fluentui-react-native/interactive-hooks';
-import { ButtonCorePropsWithInnerRef, ButtonCoreProps } from '../Button.types';
+import { createIconProps, IPressableState } from '@fluentui-react-native/interactive-hooks';
+import { ButtonCoreProps } from '../Button.types';
 
 /**
  * A function which determines if a set of styles should be applied to the compoent given the current state and props of the button.
@@ -18,13 +18,13 @@ import { ButtonCorePropsWithInnerRef, ButtonCoreProps } from '../Button.types';
  * @param userProps The props that were passed into the button
  * @returns Whether the styles that are assigned to the layer should be applied to the button
  */
-const buttonLookup = (layer: string, state: IPressableState, userProps: ButtonCorePropsWithInnerRef): boolean => {
+const buttonLookup = (layer: string, state: IPressableState, userProps: ButtonCoreProps): boolean => {
   return (
     state[layer] || userProps[layer] || (layer === 'hasContent' && !userProps.iconOnly) || (layer === 'hasIconBefore' && userProps.icon)
   );
 };
 
-const FABComposed = compose<FABType>({
+export const FAB = compose<FABType>({
   displayName: fabName,
   ...stylingSettings,
   slots: {
@@ -32,7 +32,7 @@ const FABComposed = compose<FABType>({
     icon: Icon,
     content: Text,
   },
-  render: (userProps: ButtonCorePropsWithInnerRef, useSlots: UseSlots<FABType>) => {
+  render: (userProps: ButtonCoreProps, useSlots: UseSlots<FABType>) => {
     const { icon, onClick, ...rest } = userProps;
 
     const iconProps = createIconProps(userProps.icon);
@@ -42,7 +42,7 @@ const FABComposed = compose<FABType>({
     const Slots = useSlots(userProps, (layer) => buttonLookup(layer, button.state, userProps));
 
     // now return the handler for finishing render
-    return (final: ButtonCorePropsWithInnerRef, ...children: React.ReactNode[]) => {
+    return (final: ButtonCoreProps, ...children: React.ReactNode[]) => {
       const { iconOnly, accessibilityLabel, ...mergedProps } = mergeProps(button.props, final);
 
       if (__DEV__ && iconOnly) {
@@ -74,7 +74,5 @@ const FABComposed = compose<FABType>({
     };
   },
 });
-
-export const FAB = React.forwardRef<IFocusable, ButtonCoreProps>((props, ref) => <FABComposed {...props} innerRef={ref} />);
 
 export default FAB;

--- a/packages/experimental/Button/src/ToggleButton/ToggleButton.styling.ts
+++ b/packages/experimental/Button/src/ToggleButton/ToggleButton.styling.ts
@@ -1,4 +1,4 @@
-import { toggleButtonName, ToggleButtonTokens, ToggleButtonSlotProps, ToggleButtonPropsWithInnerRef } from './ToggleButton.types';
+import { toggleButtonName, ToggleButtonTokens, ToggleButtonSlotProps, ToggleButtonProps } from './ToggleButton.types';
 import { Theme, UseStylingOptions, buildProps } from '@fluentui-react-native/framework';
 import { borderStyles, layoutStyles, fontStyles } from '@fluentui-react-native/tokens';
 import { defaultButtonColorTokens } from '../ButtonColorTokens';
@@ -7,7 +7,7 @@ import { defaultToggleButtonColorTokens } from './ToggleButtonColorTokens';
 import { defaultButtonTokens } from '../ButtonTokens';
 import { defaultButtonFontTokens } from '../ButtonFontTokens';
 
-export const stylingSettings: UseStylingOptions<ToggleButtonPropsWithInnerRef, ToggleButtonSlotProps, ToggleButtonTokens> = {
+export const stylingSettings: UseStylingOptions<ToggleButtonProps, ToggleButtonSlotProps, ToggleButtonTokens> = {
   tokens: [defaultButtonTokens, defaultButtonFontTokens, defaultButtonColorTokens, defaultToggleButtonColorTokens, toggleButtonName],
   states: ['checked', ...buttonStates],
   slotProps: {

--- a/packages/experimental/Button/src/ToggleButton/ToggleButton.tsx
+++ b/packages/experimental/Button/src/ToggleButton/ToggleButton.tsx
@@ -2,17 +2,17 @@
 import * as React from 'react';
 import { View } from 'react-native';
 import { ActivityIndicator } from '@fluentui-react-native/experimental-activity-indicator';
-import { ToggleButtonPropsWithInnerRef, ToggleButtonProps, toggleButtonName, ToggleButtonType } from './ToggleButton.types';
+import { ToggleButtonProps, toggleButtonName, ToggleButtonType } from './ToggleButton.types';
 import { Text } from '@fluentui-react-native/experimental-text';
 import { stylingSettings } from './ToggleButton.styling';
 import { compose, mergeProps, withSlots, UseSlots } from '@fluentui-react-native/framework';
 import { useButton } from '../useButton';
-import { IFocusable, useAsToggle } from '@fluentui-react-native/interactive-hooks';
+import { useAsToggle } from '@fluentui-react-native/interactive-hooks';
 import { Icon } from '@fluentui-react-native/icon';
 import { createIconProps } from '@fluentui-react-native/interactive-hooks';
 import { buttonLookup } from '../Button';
 
-const ToggleButtonComposed = compose<ToggleButtonType>({
+export const ToggleButton = compose<ToggleButtonType>({
   displayName: toggleButtonName,
   ...stylingSettings,
   slots: {
@@ -20,7 +20,7 @@ const ToggleButtonComposed = compose<ToggleButtonType>({
     icon: Icon,
     content: Text,
   },
-  render: (userProps: ToggleButtonPropsWithInnerRef, useSlots: UseSlots<ToggleButtonType>) => {
+  render: (userProps: ToggleButtonProps, useSlots: UseSlots<ToggleButtonType>) => {
     const { defaultChecked, checked, onClick, ...rest } = userProps;
     const iconProps = createIconProps(userProps.icon);
 
@@ -35,7 +35,7 @@ const ToggleButtonComposed = compose<ToggleButtonType>({
     const Slots = useSlots(userProps, (layer) => (layer === 'checked' && checkedValue) || buttonLookup(layer, button.state, userProps));
 
     // now return the handler for finishing render
-    return (final: ToggleButtonPropsWithInnerRef, ...children: React.ReactNode[]) => {
+    return (final: ToggleButtonProps, ...children: React.ReactNode[]) => {
       const { icon, iconPosition, iconOnly, loading, accessibilityLabel, ...mergedProps } = mergeProps(button.props, final);
       const shouldShowIcon = !loading && icon;
 
@@ -70,9 +70,5 @@ const ToggleButtonComposed = compose<ToggleButtonType>({
     };
   },
 });
-
-export const ToggleButton = React.forwardRef<IFocusable, ToggleButtonProps>((props, ref) => (
-  <ToggleButtonComposed {...props} innerRef={ref} />
-));
 
 export default ToggleButton;

--- a/packages/experimental/Button/src/ToggleButton/ToggleButton.types.ts
+++ b/packages/experimental/Button/src/ToggleButton/ToggleButton.types.ts
@@ -1,4 +1,4 @@
-import { ButtonSlotProps, ButtonTokens, ButtonPropsWithInnerRef } from '../Button.types';
+import { ButtonSlotProps, ButtonTokens, ButtonProps } from '../Button.types';
 
 export const toggleButtonName = 'ToggleButton';
 
@@ -6,7 +6,7 @@ export interface ToggleButtonTokens extends ButtonTokens {
   checked?: ToggleButtonTokens;
 }
 
-export interface ToggleButtonPropsWithInnerRef extends ButtonPropsWithInnerRef {
+export interface ToggleButtonProps extends ButtonProps {
   /**
    * Defines the controlled checked state of the `ToggleButton`.
    * Mutually exclusive to `defaultChecked`.
@@ -21,12 +21,10 @@ export interface ToggleButtonPropsWithInnerRef extends ButtonPropsWithInnerRef {
   defaultChecked?: boolean;
 }
 
-export type ToggleButtonProps = Omit<ToggleButtonPropsWithInnerRef, 'innerRef'>;
-
 export interface ToggleButtonSlotProps extends ButtonSlotProps {}
 
 export interface ToggleButtonType {
-  props: ToggleButtonPropsWithInnerRef;
+  props: ToggleButtonProps;
   tokens: ToggleButtonTokens;
   slotProps: ToggleButtonSlotProps;
 }

--- a/packages/experimental/Button/src/__snapshots__/Button.test.tsx.snap
+++ b/packages/experimental/Button/src/__snapshots__/Button.test.tsx.snap
@@ -61,6 +61,125 @@ exports[`Button component tests Button circular 1`] = `
 </View>
 `;
 
+exports[`Button component tests Button composed 1`] = `
+<View
+  accessibilityLabel="Composed Button with RNText"
+  accessibilityRole="button"
+  accessibilityState={
+    Object {
+      "disabled": false,
+    }
+  }
+  accessible={true}
+  enableFocusRing={true}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onPress={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "alignItems": "center",
+      "alignSelf": "flex-start",
+      "backgroundColor": "#f3f2f1",
+      "borderColor": "#8a8886",
+      "borderRadius": 4,
+      "borderWidth": 1,
+      "display": "flex",
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "minWidth": 96,
+      "padding": 5,
+      "paddingHorizontal": 11,
+      "width": undefined,
+    }
+  }
+>
+  <Text
+    style={
+      Object {
+        "color": "#323130",
+        "fontFamily": "Segoe UI",
+        "fontSize": 14,
+        "fontWeight": "600",
+        "marginBottom": 0,
+        "marginEnd": 0,
+        "marginStart": 0,
+        "marginTop": 0,
+      }
+    }
+  >
+    Composed Button with RNText
+  </Text>
+</View>
+`;
+
+exports[`Button component tests Button customized 1`] = `
+<View
+  accessibilityLabel="Custom Button"
+  accessibilityRole="button"
+  accessibilityState={
+    Object {
+      "disabled": false,
+    }
+  }
+  accessible={true}
+  enableFocusRing={true}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onPress={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "alignItems": "center",
+      "alignSelf": "flex-start",
+      "backgroundColor": "pink",
+      "borderColor": "#8a8886",
+      "borderRadius": 4,
+      "borderWidth": 1,
+      "display": "flex",
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "minWidth": 96,
+      "padding": 5,
+      "paddingHorizontal": 11,
+      "width": undefined,
+    }
+  }
+>
+  <Text
+    style={
+      Object {
+        "color": "#323130",
+        "fontFamily": "Segoe UI",
+        "fontSize": 14,
+        "fontWeight": "600",
+        "margin": 0,
+        "marginBottom": 0,
+        "marginEnd": 0,
+        "marginStart": 0,
+        "marginTop": 0,
+      }
+    }
+  >
+    Custom Button
+  </Text>
+</View>
+`;
+
 exports[`Button component tests Button default 1`] = `
 <View
   accessibilityLabel="Default Button"

--- a/packages/experimental/Button/src/useButton.ts
+++ b/packages/experimental/Button/src/useButton.ts
@@ -1,15 +1,14 @@
 import * as React from 'react';
 import { useAsPressable, useKeyProps, useOnPressWithFocus, useViewCommandFocus } from '@fluentui-react-native/interactive-hooks';
-import { ButtonPropsWithInnerRef, ButtonState } from './Button.types';
+import { ButtonProps, ButtonState } from './Button.types';
 import { memoize } from '@fluentui-react-native/framework';
 
-export const useButton = (props: ButtonPropsWithInnerRef): ButtonState => {
+export const useButton = (props: ButtonProps): ButtonState => {
   // attach the pressable state handlers
-  const defaultRef = React.useRef(null);
-  const { onClick, innerRef, disabled, loading, ...rest } = props;
-  const ref = innerRef !== null ? innerRef : defaultRef;
+  const defaultComponentRef = React.useRef(null);
+  const { onClick, componentRef = defaultComponentRef, disabled, loading, ...rest } = props;
   // GH #1336: Set focusRef to null if button is disabled to prevent getting keyboard focus.
-  const focusRef = disabled ? null : ref;
+  const focusRef = disabled ? null : componentRef;
   const onClickWithFocus = useOnPressWithFocus(focusRef, onClick);
   const pressable = useAsPressable({ ...rest, onPress: onClickWithFocus });
   const onKeyUpProps = useKeyProps(onClick, ' ', 'Enter');
@@ -25,7 +24,7 @@ export const useButton = (props: ButtonPropsWithInnerRef): ButtonState => {
       accessibilityState: getAccessibilityState(isDisabled),
       enableFocusRing: true,
       focusable: !isDisabled,
-      ref: useViewCommandFocus(ref),
+      ref: useViewCommandFocus(componentRef),
       ...onKeyUpProps,
       iconPosition: props.iconPosition || 'before',
       loading,

--- a/packages/experimental/MenuButton/src/MenuButton.tsx
+++ b/packages/experimental/MenuButton/src/MenuButton.tsx
@@ -38,7 +38,7 @@ export const MenuButton = compose<MenuButtonType>({
       appearance,
       icon,
       style,
-      ref: stdBtnRef,
+      componentRef: stdBtnRef,
       onClick: toggleShowContextualMenu,
       iconOnly: content ? false : true,
       ...rest,

--- a/packages/experimental/MenuButton/src/MenuButton.types.ts
+++ b/packages/experimental/MenuButton/src/MenuButton.types.ts
@@ -1,6 +1,6 @@
 import { ContextualMenuItemProps, ContextualMenuProps, SubmenuProps } from '@fluentui-react-native/contextual-menu';
 import { FontTokens, IForegroundColorTokens, IBackgroundColorTokens, IBorderTokens } from '@fluentui-react-native/tokens';
-import { ButtonProps as ButtonWithRefProps } from '@fluentui-react-native/experimental-button';
+import { ButtonProps } from '@fluentui-react-native/experimental-button';
 import { SvgProps, XmlProps } from 'react-native-svg';
 
 export const menuButtonName = 'MenuButton';
@@ -22,7 +22,7 @@ export interface MenuButtonItemProps extends ContextualMenuItemProps {
   showSubmenu?: boolean;
 }
 
-export interface MenuButtonProps extends ButtonWithRefProps {
+export interface MenuButtonProps extends ButtonProps {
   menuItems?: MenuButtonItemProps[];
   onItemClick?: (key: string) => void;
   contextualMenu?: ContextualMenuProps;

--- a/packages/utils/interactive-hooks/src/useOnPressWithFocus.ts
+++ b/packages/utils/interactive-hooks/src/useOnPressWithFocus.ts
@@ -11,13 +11,11 @@ export type OnPressWithFocusCallback = () => void;
  * RETURNS:
  *         onPressWithFocus() - Callback to set focus after calling the userCallback for onPress
  */
-export function useOnPressWithFocus(focusRef: React.ForwardedRef<any>, userCallback: OnPressCallback): OnPressWithFocusCallback {
+export function useOnPressWithFocus(focusRef: React.RefObject<any>, userCallback: OnPressCallback): OnPressWithFocusCallback {
   const onPressWithFocus = React.useCallback(
     (args?: any) => {
       userCallback && userCallback(args);
-      if (typeof focusRef !== 'function') {
-        focusRef?.current?.focus();
-      }
+      focusRef?.current?.focus();
     },
     [userCallback, focusRef],
   );


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

Turns out wrapping a component in `forwardRef` erases any exposing of APIs on that component. Whoops.
Reverting the change to add `ref` to bring back `customize` and `compose` functionality, Adding tests as well so that we get notified next time we break it.

Technically (as in like due to technical reasons) there isn't a way to have all of:
- A functional component (which prevents `ref` from being added as a prop to the component directly)
- Adding the `ref` prop through `forwardRef` (which will prevent us from exposing any functions on the component)
- Having callable functions on the component (which is what `compose` and `customize` are)
- Keeping the component returned a callable function (forwardRef returns a type derived from `ExoticNamedComponents` which explicitly does not allow for this behavior, but a callable component is needed for useSlots to work properly)

Following up with FluentUI on their new APIs since they don't have this issue, but in the meantime we go back to `componentRef` which allows us to support everything.

### Verification

![image](https://user-images.githubusercontent.com/4602628/151081850-aea72ee6-2ede-4104-ab03-936f65fed73a.png)

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
