### PR TITLE
Callout macOS: Fix focus flickering on click

### DIFF
--- a/change/@fluentui-react-native-callout-9dbb5115-7243-4126-8d3d-423ceae0a64f.json
+++ b/change/@fluentui-react-native-callout-9dbb5115-7243-4126-8d3d-423ceae0a64f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "ContextualMenu macOS: fix focus shifting on click",
+  "packageName": "@fluentui-react-native/callout",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

On macOS, clicking on a view inside a Callout would register the click in seemingly the wrong location, causing keyboard focus / highlight effects to flicker. Clicking on the 1st Menu item inside a ContextualMenu would sometimes move focus (and highlight) to the last (5th) menu item, while still showing the pressed effect on the 1st menu item. So... it would sometimes look like 2 menu items are highlighted when you click. Similarly, clicking the 2nd menu item would highlight the N-1'th (4th) menu item and so on. This was a very weird bug that stumped me for a long time.

It seems this is because macOS by default uses a flipped coordinate system ( (0,0) is the bottom left of the screen instead of the top left), and subclasses of NSView must override [NSView.flipped](https://developer.apple.com/documentation/appkit/nsview/1483532-flipped) to get the more standard origin-in-top-left coordinate space. React Native macOS does this for RCTView/RCTUIView/all of it's native views. 

Inside Callout, I had one view (NSVisualEffectView) that was not flipped. Once I subclassed it into a private `FlippedVisualEffectView`, I seem to no longer reproduce the weird focus flicker.

### Verification

Took a video of using Callout / ContextualMenu after my changes, and things behave as expected. Because this issue is intermittent, I would appreciate if someone else with macOS can test my change on their machine.

https://user-images.githubusercontent.com/6722175/151259224-60d76589-babd-4732-8762-6463729a1c43.mov




### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
