### PR TITLE
Fix toggle button text color

### DIFF
--- a/change/@fluentui-react-native-experimental-button-ade8b461-9bc0-493a-8e99-aea4ecdd5536.json
+++ b/change/@fluentui-react-native-experimental-button-ade8b461-9bc0-493a-8e99-aea4ecdd5536.json
@@ -1,0 +1,10 @@
+{
+  "type": "patch",
+  "comment": {
+    "title": "",
+    "value": ""
+  },
+  "packageName": "@fluentui-react-native/experimental-button",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-theme-tokens-aeef413c-0cbf-4c4f-8679-50a00723ef38.json
+++ b/change/@fluentui-react-native-theme-tokens-aeef413c-0cbf-4c4f-8679-50a00723ef38.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Fix UWP HC",
+  "packageName": "@fluentui-react-native/theme-tokens",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Button/src/ToggleButton/ToggleButtonColorTokens.win32.ts
+++ b/packages/experimental/Button/src/ToggleButton/ToggleButtonColorTokens.win32.ts
@@ -8,9 +8,9 @@ export const defaultToggleButtonColorTokens: TokenSettings<ToggleButtonTokens, T
     backgroundColor: t.colors.neutralBackground1Selected,
     borderColor: t.colors.neutralStroke1,
     primary: {
+      color: t.colors.neutralForegroundOnBrandSelected,
       backgroundColor: t.colors.brandBackgroundSelected,
       borderColor: t.colors.brandBackgroundSelected,
-      color: t.colors.neutralForeground1Selected,
     },
     subtle: {
       color: t.colors.neutralForeground1Selected,

--- a/packages/experimental/Button/src/ToggleButton/ToggleButtonColorTokens.windows.ts
+++ b/packages/experimental/Button/src/ToggleButton/ToggleButtonColorTokens.windows.ts
@@ -6,18 +6,16 @@ export const defaultToggleButtonColorTokens: TokenSettings<ToggleButtonTokens, T
   checked: {
     color: t.colors.neutralForeground1Selected,
     backgroundColor: t.colors.neutralBackground1Selected,
-    hovered: {
-      color: t.colors.neutralForeground1Hover,
-      backgroundColor: t.colors.neutralBackground1Hover,
+    borderColor: t.colors.neutralStroke1,
+    primary: {
+      color: t.colors.neutralForegroundOnBrandSelected,
+      backgroundColor: t.colors.brandBackgroundSelected,
+      borderColor: t.colors.brandBackgroundSelected,
     },
     subtle: {
       color: t.colors.neutralForeground1Selected,
-      backgroundColor: t.colors.neutralBackground1Selected,
-      hovered: {
-        color: t.colors.neutralForeground1Hover,
-        backgroundColor: t.colors.neutralBackground1Hover,
-        borderColor: t.colors.neutralStroke1,
-      },
+      backgroundColor: t.colors.subtleBackgroundSelected,
+      borderColor: t.colors.subtleBackgroundSelected,
     },
   },
 });

--- a/packages/theming/theme-tokens/src/highContrast/tokens-alias.win32.ts
+++ b/packages/theming/theme-tokens/src/highContrast/tokens-alias.win32.ts
@@ -9,7 +9,7 @@ function processAliasTokens(aliasTokens: any) {
     for (const innerKey in aliasTokens[key]) {
       const entry = aliasTokens[key][innerKey];
       if (typeof entry === 'string' && entry.includes('PlatformColor')) {
-        const color = 'SystemColor' + entry.substring(14, entry.length - 1) + 'Color';
+        const color = entry.substring(14, entry.length - 1);
         aliasTokens[key][innerKey] = PlatformColor(color);
       }
     }


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [x] windows
- [ ] android

### Description of changes

I noticed that the ToggleButton in checked state didn't have legible text, fixing the text match redlines.

This PR also fixes HC for UWP, which I only just realized causes crashes.

### Verification

Tested win32 and UWP in non-HC/HC scenarios

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/4602628/151902939-c7a9d750-90c7-43cd-b891-e2a62ab9c7b6.png) | ![image](https://user-images.githubusercontent.com/4602628/151901707-abb0d30e-c8e0-4a8f-95e6-5824a6afc321.png) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
