### PR TITLE
Fix documentation for Button v2

### DIFF
--- a/change/@fluentui-react-native-experimental-button-a972043a-9979-4739-a8ed-777bf6eb7269.json
+++ b/change/@fluentui-react-native-experimental-button-a972043a-9979-4739-a8ed-777bf6eb7269.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Update documentation",
+  "packageName": "@fluentui-react-native/experimental-button",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Button/SPEC.md
+++ b/packages/experimental/Button/SPEC.md
@@ -106,7 +106,7 @@ export interface ButtonProps extends Omit<IWithPressableOptions<ViewProps>, 'onP
   /**
    * A RefObject to access the IButton interface. Use this to access the public methods and properties of the component.
    */
-  componentRef?: IconSourcesType;
+  componentRef?: React.RefObject<IFocusable>;
 
   /**
    * Icon slot that, if specified, renders an icon either before or after the `children` as specified by the

--- a/packages/experimental/Button/SPEC.md
+++ b/packages/experimental/Button/SPEC.md
@@ -95,7 +95,7 @@ export interface ButtonProps extends Omit<IWithPressableOptions<ViewProps>, 'onP
    * - 'primary': Emphasizes the button as a primary action.
    * - 'subtle': Minimzes emphasis to blend into the background until hovered or focused.
    */
-  appearance?: 'primary' | 'outline' | 'subtle';
+  appearance?: 'primary' | 'subtle';
 
   /**
    * A button can fill the width of its container.
@@ -167,16 +167,6 @@ export interface ButtonTokens extends LayoutTokens, FontTokens, IBorderTokens, I
    * The icon color.
    */
   iconColor?: ColorValue;
-
-  /**
-   * The icon color when hovering over the Button.
-   */
-  iconColorHovered?: ColorValue;
-
-  /**
-   * The icon color when the Button is being pressed.
-   */
-  iconColorPressed?: ColorValue;
 
   /**
    * The size of the icon.

--- a/packages/experimental/Button/src/Button.types.ts
+++ b/packages/experimental/Button/src/Button.types.ts
@@ -18,16 +18,6 @@ export interface ButtonCoreTokens extends LayoutTokens, FontTokens, IBorderToken
   iconColor?: ColorValue;
 
   /**
-   * The icon color when hovering over the Button.
-   */
-  iconColorHovered?: ColorValue;
-
-  /**
-   * The icon color when the Button is being pressed.
-   */
-  iconColorPressed?: ColorValue;
-
-  /**
    * The size of the icon.
    */
   iconSize?: number;

--- a/packages/experimental/Button/src/FAB/SPEC.md
+++ b/packages/experimental/Button/src/FAB/SPEC.md
@@ -48,6 +48,11 @@ The slots can be modified using the `compose` function on the `FAB`. For more in
 
 ```ts
 export interface FABProps extends Omit<IWithPressableOptions<ViewProps>, 'onPress'> {
+  /**
+   * A RefObject to access the IButton interface. Use this to access the public methods and properties of the component.
+   */
+  componentRef?: React.RefObject<IFocusable>;
+
   /*
    * Text to show on the Button.
    * Only used in FAB
@@ -58,8 +63,6 @@ export interface FABProps extends Omit<IWithPressableOptions<ViewProps>, 'onPres
    * Source URL or name of the icon to show on the Button.
    */
   icon?: IconSourcesType;
-
-  innerRef?: React.ForwardedRef<IFocusable>;
 
   /**
    * A callback to call on button click event
@@ -83,16 +86,6 @@ export interface CompoundButtonTokens extends LayoutTokens, FontTokens, IBorderT
    * The icon color.
    */
   iconColor?: ColorValue;
-
-  /**
-   * The icon color when hovering over the Button.
-   */
-  iconColorHovered?: ColorValue;
-
-  /**
-   * The icon color when the Button is being pressed.
-   */
-  iconColorPressed?: ColorValue;
 
   /**
    * The size of the icon.


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

During the test pass I noticed that some of the documentation in the SPEC.md file was wrong:
- the appearance prop has no outline option
- iconColorHovered and iconColorPressed are not used in the Button at all, removing them. They can be set by overwriting the iconColor token for the hovered/pressed tokens.
- FAB's spec still had innerRef even though it's been changed to componentRef
- componentRef's type has been fixed

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
