### PR TITLE
Fix `block` prop for CompoundButton

### DIFF
--- a/change/@fluentui-react-native-experimental-button-4a0c58ec-1076-494b-aa34-34c0f5af453b.json
+++ b/change/@fluentui-react-native-experimental-button-4a0c58ec-1076-494b-aa34-34c0f5af453b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix block for CompoundButton",
+  "packageName": "@fluentui-react-native/experimental-button",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Button/src/CompoundButton/CompoundButton.styling.ts
+++ b/packages/experimental/Button/src/CompoundButton/CompoundButton.styling.ts
@@ -27,12 +27,13 @@ export const stylingSettings: UseStylingOptions<CompoundButtonProps, CompoundBut
           flexDirection: 'row',
           alignSelf: 'flex-start',
           justifyContent: 'center',
+          width: tokens.width,
           backgroundColor: tokens.backgroundColor,
           ...borderStyles.from(tokens, theme),
           ...layoutStyles.from(tokens, theme),
         },
       }),
-      ['backgroundColor', ...borderStyles.keys, ...layoutStyles.keys],
+      ['backgroundColor', 'width', ...borderStyles.keys, ...layoutStyles.keys],
     ),
     contentContainer: {
       style: {

--- a/packages/experimental/Button/src/CompoundButton/__snapshots__/CompoundButton.test.tsx.snap
+++ b/packages/experimental/Button/src/CompoundButton/__snapshots__/CompoundButton.test.tsx.snap
@@ -36,6 +36,7 @@ exports[`CompoundButton default 1`] = `
       "minWidth": 96,
       "padding": 11,
       "paddingHorizontal": 11,
+      "width": undefined,
     }
   }
 >


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

The `block` prop should be able to be applied to the `CompoundButton`, but it currently no-ops. The `width` token was not affecting any styling on the `CompoundButton`, leading to the bug. Passing the width token to the root fixes the bug.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/4602628/152216806-bd0105ed-c94b-4a14-a847-6c55e54082e8.png) | ![image](https://user-images.githubusercontent.com/4602628/152216290-70315c00-4274-43ce-82eb-261057a560d4.png) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
