### PR TITLE
Fix brand colors in the Tester in HC

### DIFF
--- a/apps/fluent-tester/src/FluentTester/theme/CustomThemes.ts
+++ b/apps/fluent-tester/src/FluentTester/theme/CustomThemes.ts
@@ -42,7 +42,7 @@ export class TesterThemeReference extends ThemeReference {
     super(
       baseTheme,
       (parent) => applyTheme(parent, this._themeName, this.options.appearance),
-      () => applyBrand(this._themeName, this._brand),
+      (parent) => applyBrand(parent, this._themeName, this._brand),
     );
     this.baseTheme = baseTheme;
     this.options = themeOptions;

--- a/apps/fluent-tester/src/FluentTester/theme/applyBrand.ts
+++ b/apps/fluent-tester/src/FluentTester/theme/applyBrand.ts
@@ -1,4 +1,4 @@
-import { PartialTheme } from '@fluentui-react-native/theme-types';
+import { PartialTheme, Theme } from '@fluentui-react-native/theme-types';
 import { getCurrentBrandAliasTokens } from '@fluentui-react-native/win32-theme';
 
 export type OfficeBrand = 'Default' | 'Office' | 'Word' | 'Excel' | 'Powerpoint' | 'Outlook';
@@ -123,7 +123,11 @@ const brandColors: BrandRamps = {
 
 export const brandOptions = Object.keys(brandColors).map((brand) => ({ label: brand, value: brand }));
 
-export const applyBrand = (themeName: string, currentBrand: string): PartialTheme => {
+export const applyBrand = (parent: Theme, themeName: string, currentBrand: string): PartialTheme => {
+  if (parent.name === 'HighContrast') {
+    return {};
+  }
+
   const ramp = brandColors[currentBrand];
   return ramp
     ? {

--- a/change/@fluentui-react-native-tester-fe9d466f-4781-4e72-bcce-08ab936cbff0.json
+++ b/change/@fluentui-react-native-tester-fe9d466f-4781-4e72-bcce-08ab936cbff0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Make brands in HC not show in tester",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

In the tester, changing the Brand still applied Brand colors to controls in the Tester.
The way theming/branding works in the tester is a bit wonky because we try to mock the branding behavior instead of using the built-in functionality due to branding depending on the host's app name. So, bugs seen in the tester around branding are not necessarily present in the actual usage of the components.

Anyway, fix is to bail in the applyBrand call if the theme returned by createOfficeTheme says that it is the HighContrast theme (instead of White/Colorful/etc.)

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/4602628/152233370-7649ecea-71f1-43b9-aaef-44ab1c1720b6.png) | ![image](https://user-images.githubusercontent.com/4602628/152232755-909e1a20-268d-48da-bbf7-750e0705f948.png) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
