### PR TITLE
Small Button V2 test additions

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonIconTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonIconTestSection.tsx
@@ -1,10 +1,14 @@
 import { Button } from '@fluentui-react-native/experimental-button';
 import * as React from 'react';
-import { Platform, View } from 'react-native';
+import { Platform, View, StyleSheet } from 'react-native';
 import { commonTestStyles, stackStyle } from '../Common/styles';
 import { SvgIconProps } from '@fluentui-react-native/icon';
 import TestSvg from './test.svg';
 import { SvgXml } from 'react-native-svg';
+
+const styles = StyleSheet.create({
+  chevron: { paddingStart: 4 },
+});
 
 export const ButtonIconTest: React.FunctionComponent = () => {
   const fontBuiltInProps = {
@@ -64,7 +68,7 @@ export const ButtonIconTest: React.FunctionComponent = () => {
       {svgIconsEnabled && (
         <Button style={commonTestStyles.vmargin} icon={{ svgSource: svgProps }}>
           Icon Button and Chevron
-          <View style={{ paddingStart: 4 }}>
+          <View style={styles.chevron}>
             <SvgXml xml={chevronXml} />
           </View>
         </Button>

--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonIconTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonIconTestSection.tsx
@@ -39,12 +39,6 @@ export const ButtonIconTest: React.FunctionComponent = () => {
       >
         Icon after
       </Button>
-      {svgIconsEnabled && (
-        <Button style={commonTestStyles.vmargin} icon={{ svgSource: svgProps }}>
-          Icon Button and Chevron
-          <SvgXml xml={chevronXml} />
-        </Button>
-      )}
       <Button icon={{ fontSource: fontBuiltInProps }} style={commonTestStyles.vmargin}>
         Font icon
       </Button>
@@ -67,6 +61,14 @@ export const ButtonIconTest: React.FunctionComponent = () => {
       <Button icon={testImage} style={commonTestStyles.vmargin}>
         PNG
       </Button>
+      {svgIconsEnabled && (
+        <Button style={commonTestStyles.vmargin} icon={{ svgSource: svgProps }}>
+          Icon Button and Chevron
+          <View style={{ paddingStart: 4 }}>
+            <SvgXml xml={chevronXml} />
+          </View>
+        </Button>
+      )}
     </View>
   );
 };

--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonSizeTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ButtonSizeTestSection.tsx
@@ -16,9 +16,27 @@ export const ButtonSizeTest: React.FunctionComponent = () => {
     <View style={[stackStyle, commonTestStyles.view]}>
       {svgIconsEnabled && (
         <>
-          <Button iconOnly size="small" icon={{ svgSource: svgProps }} style={commonTestStyles.vmargin} />
-          <Button iconOnly size="medium" icon={{ svgSource: svgProps }} style={commonTestStyles.vmargin} />
-          <Button iconOnly size="large" icon={{ svgSource: svgProps }} style={commonTestStyles.vmargin} />
+          <Button
+            iconOnly
+            size="small"
+            icon={{ svgSource: svgProps }}
+            accessibilityLabel="Small size button with accessibility icon"
+            style={commonTestStyles.vmargin}
+          />
+          <Button
+            iconOnly
+            size="medium"
+            icon={{ svgSource: svgProps }}
+            accessibilityLabel="Medium size button with accessibility icon"
+            style={commonTestStyles.vmargin}
+          />
+          <Button
+            iconOnly
+            size="large"
+            icon={{ svgSource: svgProps }}
+            accessibilityLabel="Large size button with accessibility icon"
+            style={commonTestStyles.vmargin}
+          />
           <Button size="small" icon={{ svgSource: svgProps }} style={commonTestStyles.vmargin}>
             Small Button with icon
           </Button>

--- a/change/@fluentui-react-native-tester-73e5b853-2d40-4ad9-92d5-9c994ac4070f.json
+++ b/change/@fluentui-react-native-tester-73e5b853-2d40-4ad9-92d5-9c994ac4070f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Implement some test improvements",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

Some asks for the Button test:
1. Add accessibilityLabels to the icon buttons to illustrate how to make the button accessible.
2. Add padding next to the chevron for that specific example to make the spacing better

### Verification

Narrator reads the expected string on the buttons

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/4602628/152244855-a6932d8f-7886-478a-a130-d2ad22090251.png) | ![image](https://user-images.githubusercontent.com/4602628/152244651-e9db3c90-d768-4b8b-a63e-1419d381c7a5.png) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
