### PR TITLE
Several macOS FocusZone fixes

### DIFF
--- a/change/@fluentui-react-native-focus-zone-19acdc9f-3ed5-4ce7-9b5f-b8662469fe0f.json
+++ b/change/@fluentui-react-native-focus-zone-19acdc9f-3ed5-4ce7-9b5f-b8662469fe0f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Several fixes to macOS FocusZone",
+  "packageName": "@fluentui-react-native/focus-zone",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/FocusZone/macos/RCTFocusZone.h
+++ b/packages/components/FocusZone/macos/RCTFocusZone.h
@@ -15,6 +15,6 @@ typedef NS_ENUM(NSInteger, FocusZoneDirection) {
 @property(nonatomic) BOOL disabled;
 @property(nonatomic) FocusZoneDirection focusZoneDirection;
 @property(nonatomic) NSString *navigateAtEnd;
-@property(nonatomic) NSView *defaultTabbableElement;
+@property(nonatomic) NSView *defaultKeyView;
 
 @end

--- a/packages/components/FocusZone/macos/RCTFocusZoneManager.m
+++ b/packages/components/FocusZone/macos/RCTFocusZoneManager.m
@@ -40,7 +40,7 @@ RCT_CUSTOM_VIEW_PROPERTY(defaultTabbableElement, NSNumber, RCTFocusZone)
 	NSNumber *tag = [RCTConvert NSNumber:json];
 	RCTUIManager *manager = [[self bridge] uiManager];
 	NSView *element = [manager viewForReactTag:tag];
-	[view setDefaultTabbableElement:element];
+	[view setDefaultKeyView:element];
 }
 
 - (RCTView *)view


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This is the one of a few changes that I'm breaking https://github.com/microsoft/fluentui-react-native/pull/1400 apart into.

This change makes several bug fixes to macOS FocusZone. 

**1. Renames defaultTabbableElement macOS native property to defaultKeyView.**

The public JS API is still defaultTabbableElement, but the native module now sets a property with the name defualtkeyView. The name feels much more idiomatic to me for macOS. The public facing API of FocusZone does not change, so this shouldn't affect any downstream clients.

**2. Have FocusZone focus on the first key view within itself, rather than it's nextValidKeyView.**

Previously, FocusZone would focus on its' nextValidKeyView if no defaultTabbableElement was set. I believe the intent was "focus on the first key view inside the FocusZone". However, I believe this would actually focus on the first key view outside the FocusZone. In the case of ContextualMenu (where there was no key view after the FocusZone), it meant focus went nowhere. Instead, I wrote a helper method GetFirstKeyViewWithin(NSView *parentView) that will recursively search for the first key view within a view's subviews, and set that as the "firstKeyView".

**3. We now call [super keyDown:Event] if a FocusZone does not handle a keyboard event, instead of doing nothing.**

If the user pressed Arrow(Left|Right) in a vertical FocusZone or Arrow(Up|Down) in a horizontal FocusZone, then focusZone would ignore the key event. This is incorrect, it should call [super keyDown:event] in those cases so that it's superview / base class may be able to handle the keyboard event. This prevented us from letting ArrowLeft close a submenu.

### Verification

The FocusZone test page still behaves as expected. Additionally, the RadioGroup and Tabs (both of which depend on FocusZone) test pages also behave as expected.

Pending: Test downstream integration into Office to make sure the changes don't break existing clients. 

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
