### PR TITLE
ContextualMenu macOS: Focus on menu after render

### DIFF
--- a/apps/macos/src/Podfile.lock
+++ b/apps/macos/src/Podfile.lock
@@ -1,25 +1,25 @@
 PODS:
   - boost-for-react-native (1.63.0)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.64.22)
-  - FBReactNativeSpec (0.64.22):
+  - FBLazyVector (0.64.25)
+  - FBReactNativeSpec (0.64.25):
     - RCT-Folly (= 2020.01.13.00)
-    - RCTRequired (= 0.64.22)
-    - RCTTypeSafety (= 0.64.22)
-    - React-Core (= 0.64.22)
-    - React-jsi (= 0.64.22)
-    - ReactCommon/turbomodule/core (= 0.64.22)
-  - FRNAvatar (0.14.2):
+    - RCTRequired (= 0.64.25)
+    - RCTTypeSafety (= 0.64.25)
+    - React-Core (= 0.64.25)
+    - React-jsi (= 0.64.25)
+    - ReactCommon/turbomodule/core (= 0.64.25)
+  - FRNAvatar (0.14.3):
     - MicrosoftFluentUI (= 0.3.0)
     - MicrosoftFluentUI/Avatar_ios (= 0.3.0)
     - React
-  - FRNCallout (0.19.16):
+  - FRNCallout (0.19.22):
     - React
-  - FRNCheckbox (0.6.0):
+  - FRNCheckbox (0.6.5):
     - React
-  - FRNMenuButton (0.7.18):
+  - FRNMenuButton (0.7.24):
     - React
-  - FRNRadioButton (0.14.13):
+  - FRNRadioButton (0.14.18):
     - React
   - glog (0.3.5)
   - MicrosoftFluentUI (0.3.0):
@@ -94,256 +94,256 @@ PODS:
     - boost-for-react-native
     - DoubleConversion
     - glog
-  - RCTFocusZone (0.8.13):
+  - RCTFocusZone (0.8.18):
     - React
-  - RCTRequired (0.64.22)
-  - RCTTypeSafety (0.64.22):
-    - FBLazyVector (= 0.64.22)
+  - RCTRequired (0.64.25)
+  - RCTTypeSafety (0.64.25):
+    - FBLazyVector (= 0.64.25)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTRequired (= 0.64.22)
-    - React-Core (= 0.64.22)
-  - React (0.64.22):
-    - React-Core (= 0.64.22)
-    - React-Core/DevSupport (= 0.64.22)
-    - React-Core/RCTWebSocket (= 0.64.22)
-    - React-RCTActionSheet (= 0.64.22)
-    - React-RCTAnimation (= 0.64.22)
-    - React-RCTBlob (= 0.64.22)
-    - React-RCTImage (= 0.64.22)
-    - React-RCTLinking (= 0.64.22)
-    - React-RCTNetwork (= 0.64.22)
-    - React-RCTSettings (= 0.64.22)
-    - React-RCTText (= 0.64.22)
-    - React-RCTVibration (= 0.64.22)
-  - React-callinvoker (0.64.22)
-  - React-Core (0.64.22):
+    - RCTRequired (= 0.64.25)
+    - React-Core (= 0.64.25)
+  - React (0.64.25):
+    - React-Core (= 0.64.25)
+    - React-Core/DevSupport (= 0.64.25)
+    - React-Core/RCTWebSocket (= 0.64.25)
+    - React-RCTActionSheet (= 0.64.25)
+    - React-RCTAnimation (= 0.64.25)
+    - React-RCTBlob (= 0.64.25)
+    - React-RCTImage (= 0.64.25)
+    - React-RCTLinking (= 0.64.25)
+    - React-RCTNetwork (= 0.64.25)
+    - React-RCTSettings (= 0.64.25)
+    - React-RCTText (= 0.64.25)
+    - React-RCTVibration (= 0.64.25)
+  - React-callinvoker (0.64.25)
+  - React-Core (0.64.25):
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.64.22)
-    - React-cxxreact (= 0.64.22)
-    - React-jsi (= 0.64.22)
-    - React-jsiexecutor (= 0.64.22)
-    - React-perflogger (= 0.64.22)
+    - React-Core/Default (= 0.64.25)
+    - React-cxxreact (= 0.64.25)
+    - React-jsi (= 0.64.25)
+    - React-jsiexecutor (= 0.64.25)
+    - React-perflogger (= 0.64.25)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.64.22):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default
-    - React-cxxreact (= 0.64.22)
-    - React-jsi (= 0.64.22)
-    - React-jsiexecutor (= 0.64.22)
-    - React-perflogger (= 0.64.22)
-    - Yoga
-  - React-Core/Default (0.64.22):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-cxxreact (= 0.64.22)
-    - React-jsi (= 0.64.22)
-    - React-jsiexecutor (= 0.64.22)
-    - React-perflogger (= 0.64.22)
-    - Yoga
-  - React-Core/DevSupport (0.64.22):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.64.22)
-    - React-Core/RCTWebSocket (= 0.64.22)
-    - React-cxxreact (= 0.64.22)
-    - React-jsi (= 0.64.22)
-    - React-jsiexecutor (= 0.64.22)
-    - React-jsinspector (= 0.64.22)
-    - React-perflogger (= 0.64.22)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.64.22):
+  - React-Core/CoreModulesHeaders (0.64.25):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.22)
-    - React-jsi (= 0.64.22)
-    - React-jsiexecutor (= 0.64.22)
-    - React-perflogger (= 0.64.22)
+    - React-cxxreact (= 0.64.25)
+    - React-jsi (= 0.64.25)
+    - React-jsiexecutor (= 0.64.25)
+    - React-perflogger (= 0.64.25)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.64.22):
+  - React-Core/Default (0.64.25):
+    - glog
+    - RCT-Folly (= 2020.01.13.00)
+    - React-cxxreact (= 0.64.25)
+    - React-jsi (= 0.64.25)
+    - React-jsiexecutor (= 0.64.25)
+    - React-perflogger (= 0.64.25)
+    - Yoga
+  - React-Core/DevSupport (0.64.25):
+    - glog
+    - RCT-Folly (= 2020.01.13.00)
+    - React-Core/Default (= 0.64.25)
+    - React-Core/RCTWebSocket (= 0.64.25)
+    - React-cxxreact (= 0.64.25)
+    - React-jsi (= 0.64.25)
+    - React-jsiexecutor (= 0.64.25)
+    - React-jsinspector (= 0.64.25)
+    - React-perflogger (= 0.64.25)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.64.25):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.22)
-    - React-jsi (= 0.64.22)
-    - React-jsiexecutor (= 0.64.22)
-    - React-perflogger (= 0.64.22)
+    - React-cxxreact (= 0.64.25)
+    - React-jsi (= 0.64.25)
+    - React-jsiexecutor (= 0.64.25)
+    - React-perflogger (= 0.64.25)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.64.22):
+  - React-Core/RCTAnimationHeaders (0.64.25):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.22)
-    - React-jsi (= 0.64.22)
-    - React-jsiexecutor (= 0.64.22)
-    - React-perflogger (= 0.64.22)
+    - React-cxxreact (= 0.64.25)
+    - React-jsi (= 0.64.25)
+    - React-jsiexecutor (= 0.64.25)
+    - React-perflogger (= 0.64.25)
     - Yoga
-  - React-Core/RCTImageHeaders (0.64.22):
+  - React-Core/RCTBlobHeaders (0.64.25):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.22)
-    - React-jsi (= 0.64.22)
-    - React-jsiexecutor (= 0.64.22)
-    - React-perflogger (= 0.64.22)
+    - React-cxxreact (= 0.64.25)
+    - React-jsi (= 0.64.25)
+    - React-jsiexecutor (= 0.64.25)
+    - React-perflogger (= 0.64.25)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.64.22):
+  - React-Core/RCTImageHeaders (0.64.25):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.22)
-    - React-jsi (= 0.64.22)
-    - React-jsiexecutor (= 0.64.22)
-    - React-perflogger (= 0.64.22)
+    - React-cxxreact (= 0.64.25)
+    - React-jsi (= 0.64.25)
+    - React-jsiexecutor (= 0.64.25)
+    - React-perflogger (= 0.64.25)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.64.22):
+  - React-Core/RCTLinkingHeaders (0.64.25):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.22)
-    - React-jsi (= 0.64.22)
-    - React-jsiexecutor (= 0.64.22)
-    - React-perflogger (= 0.64.22)
+    - React-cxxreact (= 0.64.25)
+    - React-jsi (= 0.64.25)
+    - React-jsiexecutor (= 0.64.25)
+    - React-perflogger (= 0.64.25)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.64.22):
+  - React-Core/RCTNetworkHeaders (0.64.25):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.22)
-    - React-jsi (= 0.64.22)
-    - React-jsiexecutor (= 0.64.22)
-    - React-perflogger (= 0.64.22)
+    - React-cxxreact (= 0.64.25)
+    - React-jsi (= 0.64.25)
+    - React-jsiexecutor (= 0.64.25)
+    - React-perflogger (= 0.64.25)
     - Yoga
-  - React-Core/RCTTextHeaders (0.64.22):
+  - React-Core/RCTSettingsHeaders (0.64.25):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.22)
-    - React-jsi (= 0.64.22)
-    - React-jsiexecutor (= 0.64.22)
-    - React-perflogger (= 0.64.22)
+    - React-cxxreact (= 0.64.25)
+    - React-jsi (= 0.64.25)
+    - React-jsiexecutor (= 0.64.25)
+    - React-perflogger (= 0.64.25)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.64.22):
+  - React-Core/RCTTextHeaders (0.64.25):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.22)
-    - React-jsi (= 0.64.22)
-    - React-jsiexecutor (= 0.64.22)
-    - React-perflogger (= 0.64.22)
+    - React-cxxreact (= 0.64.25)
+    - React-jsi (= 0.64.25)
+    - React-jsiexecutor (= 0.64.25)
+    - React-perflogger (= 0.64.25)
     - Yoga
-  - React-Core/RCTWebSocket (0.64.22):
+  - React-Core/RCTVibrationHeaders (0.64.25):
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.64.22)
-    - React-cxxreact (= 0.64.22)
-    - React-jsi (= 0.64.22)
-    - React-jsiexecutor (= 0.64.22)
-    - React-perflogger (= 0.64.22)
+    - React-Core/Default
+    - React-cxxreact (= 0.64.25)
+    - React-jsi (= 0.64.25)
+    - React-jsiexecutor (= 0.64.25)
+    - React-perflogger (= 0.64.25)
     - Yoga
-  - React-CoreModules (0.64.22):
-    - FBReactNativeSpec (= 0.64.22)
+  - React-Core/RCTWebSocket (0.64.25):
+    - glog
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.64.22)
-    - React-Core/CoreModulesHeaders (= 0.64.22)
-    - React-jsi (= 0.64.22)
-    - React-RCTImage (= 0.64.22)
-    - ReactCommon/turbomodule/core (= 0.64.22)
-  - React-cxxreact (0.64.22):
+    - React-Core/Default (= 0.64.25)
+    - React-cxxreact (= 0.64.25)
+    - React-jsi (= 0.64.25)
+    - React-jsiexecutor (= 0.64.25)
+    - React-perflogger (= 0.64.25)
+    - Yoga
+  - React-CoreModules (0.64.25):
+    - FBReactNativeSpec (= 0.64.25)
+    - RCT-Folly (= 2020.01.13.00)
+    - RCTTypeSafety (= 0.64.25)
+    - React-Core/CoreModulesHeaders (= 0.64.25)
+    - React-jsi (= 0.64.25)
+    - React-RCTImage (= 0.64.25)
+    - ReactCommon/turbomodule/core (= 0.64.25)
+  - React-cxxreact (0.64.25):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.64.22)
-    - React-jsi (= 0.64.22)
-    - React-jsinspector (= 0.64.22)
-    - React-perflogger (= 0.64.22)
-    - React-runtimeexecutor (= 0.64.22)
-  - React-jsi (0.64.22):
+    - React-callinvoker (= 0.64.25)
+    - React-jsi (= 0.64.25)
+    - React-jsinspector (= 0.64.25)
+    - React-perflogger (= 0.64.25)
+    - React-runtimeexecutor (= 0.64.25)
+  - React-jsi (0.64.25):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-jsi/Default (= 0.64.22)
-  - React-jsi/Default (0.64.22):
+    - React-jsi/Default (= 0.64.25)
+  - React-jsi/Default (0.64.25):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-  - React-jsiexecutor (0.64.22):
+  - React-jsiexecutor (0.64.25):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-cxxreact (= 0.64.22)
-    - React-jsi (= 0.64.22)
-    - React-perflogger (= 0.64.22)
-  - React-jsinspector (0.64.22)
-  - React-perflogger (0.64.22)
-  - React-RCTActionSheet (0.64.22):
-    - React-Core/RCTActionSheetHeaders (= 0.64.22)
-  - React-RCTAnimation (0.64.22):
-    - FBReactNativeSpec (= 0.64.22)
+    - React-cxxreact (= 0.64.25)
+    - React-jsi (= 0.64.25)
+    - React-perflogger (= 0.64.25)
+  - React-jsinspector (0.64.25)
+  - React-perflogger (0.64.25)
+  - React-RCTActionSheet (0.64.25):
+    - React-Core/RCTActionSheetHeaders (= 0.64.25)
+  - React-RCTAnimation (0.64.25):
+    - FBReactNativeSpec (= 0.64.25)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.64.22)
-    - React-Core/RCTAnimationHeaders (= 0.64.22)
-    - React-jsi (= 0.64.22)
-    - ReactCommon/turbomodule/core (= 0.64.22)
-  - React-RCTBlob (0.64.22):
-    - FBReactNativeSpec (= 0.64.22)
+    - RCTTypeSafety (= 0.64.25)
+    - React-Core/RCTAnimationHeaders (= 0.64.25)
+    - React-jsi (= 0.64.25)
+    - ReactCommon/turbomodule/core (= 0.64.25)
+  - React-RCTBlob (0.64.25):
+    - FBReactNativeSpec (= 0.64.25)
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/RCTBlobHeaders (= 0.64.22)
-    - React-Core/RCTWebSocket (= 0.64.22)
-    - React-jsi (= 0.64.22)
-    - React-RCTNetwork (= 0.64.22)
-    - ReactCommon/turbomodule/core (= 0.64.22)
-  - React-RCTImage (0.64.22):
-    - FBReactNativeSpec (= 0.64.22)
+    - React-Core/RCTBlobHeaders (= 0.64.25)
+    - React-Core/RCTWebSocket (= 0.64.25)
+    - React-jsi (= 0.64.25)
+    - React-RCTNetwork (= 0.64.25)
+    - ReactCommon/turbomodule/core (= 0.64.25)
+  - React-RCTImage (0.64.25):
+    - FBReactNativeSpec (= 0.64.25)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.64.22)
-    - React-Core/RCTImageHeaders (= 0.64.22)
-    - React-jsi (= 0.64.22)
-    - React-RCTNetwork (= 0.64.22)
-    - ReactCommon/turbomodule/core (= 0.64.22)
-  - React-RCTLinking (0.64.22):
-    - FBReactNativeSpec (= 0.64.22)
-    - React-Core/RCTLinkingHeaders (= 0.64.22)
-    - React-jsi (= 0.64.22)
-    - ReactCommon/turbomodule/core (= 0.64.22)
-  - React-RCTNetwork (0.64.22):
-    - FBReactNativeSpec (= 0.64.22)
+    - RCTTypeSafety (= 0.64.25)
+    - React-Core/RCTImageHeaders (= 0.64.25)
+    - React-jsi (= 0.64.25)
+    - React-RCTNetwork (= 0.64.25)
+    - ReactCommon/turbomodule/core (= 0.64.25)
+  - React-RCTLinking (0.64.25):
+    - FBReactNativeSpec (= 0.64.25)
+    - React-Core/RCTLinkingHeaders (= 0.64.25)
+    - React-jsi (= 0.64.25)
+    - ReactCommon/turbomodule/core (= 0.64.25)
+  - React-RCTNetwork (0.64.25):
+    - FBReactNativeSpec (= 0.64.25)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.64.22)
-    - React-Core/RCTNetworkHeaders (= 0.64.22)
-    - React-jsi (= 0.64.22)
-    - ReactCommon/turbomodule/core (= 0.64.22)
-  - React-RCTSettings (0.64.22):
-    - FBReactNativeSpec (= 0.64.22)
+    - RCTTypeSafety (= 0.64.25)
+    - React-Core/RCTNetworkHeaders (= 0.64.25)
+    - React-jsi (= 0.64.25)
+    - ReactCommon/turbomodule/core (= 0.64.25)
+  - React-RCTSettings (0.64.25):
+    - FBReactNativeSpec (= 0.64.25)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.64.22)
-    - React-Core/RCTSettingsHeaders (= 0.64.22)
-    - React-jsi (= 0.64.22)
-    - ReactCommon/turbomodule/core (= 0.64.22)
-  - React-RCTText (0.64.22):
-    - React-Core/RCTTextHeaders (= 0.64.22)
-  - React-RCTVibration (0.64.22):
-    - FBReactNativeSpec (= 0.64.22)
+    - RCTTypeSafety (= 0.64.25)
+    - React-Core/RCTSettingsHeaders (= 0.64.25)
+    - React-jsi (= 0.64.25)
+    - ReactCommon/turbomodule/core (= 0.64.25)
+  - React-RCTText (0.64.25):
+    - React-Core/RCTTextHeaders (= 0.64.25)
+  - React-RCTVibration (0.64.25):
+    - FBReactNativeSpec (= 0.64.25)
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/RCTVibrationHeaders (= 0.64.22)
-    - React-jsi (= 0.64.22)
-    - ReactCommon/turbomodule/core (= 0.64.22)
-  - React-runtimeexecutor (0.64.22):
-    - React-jsi (= 0.64.22)
-  - ReactCommon/turbomodule/core (0.64.22):
+    - React-Core/RCTVibrationHeaders (= 0.64.25)
+    - React-jsi (= 0.64.25)
+    - ReactCommon/turbomodule/core (= 0.64.25)
+  - React-runtimeexecutor (0.64.25):
+    - React-jsi (= 0.64.25)
+  - ReactCommon/turbomodule/core (0.64.25):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.64.22)
-    - React-Core (= 0.64.22)
-    - React-cxxreact (= 0.64.22)
-    - React-jsi (= 0.64.22)
-    - React-perflogger (= 0.64.22)
+    - React-callinvoker (= 0.64.25)
+    - React-Core (= 0.64.25)
+    - React-cxxreact (= 0.64.25)
+    - React-jsi (= 0.64.25)
+    - React-perflogger (= 0.64.25)
   - ReactTestApp-DevSupport (0.10.2):
     - React-Core
     - React-jsi
@@ -487,45 +487,45 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost-for-react-native: d5ad1140010aa8cb622323a781ecbeab4425d19a
   DoubleConversion: 0ea4559a49682230337df966e735d6cc7760108e
-  FBLazyVector: 063960f1929bd443f3e3609bcb9989d9c0fb8539
-  FBReactNativeSpec: 198e3871fe54474c1ba10189a085029d2806f6d4
-  FRNAvatar: 88556902a608963bcb9bf6b3219b97e2d1ac8e75
-  FRNCallout: dc44d9620f3a34e0ba4433ebc0f40f50fdaac10b
-  FRNCheckbox: 022cfc6535a51165c799e22d407a2aac25f19b07
-  FRNMenuButton: 719599af7dda3512a9266c89f089b36eb5f02e63
-  FRNRadioButton: 3544b1fa70a7c3191b1e58f7df5e8038cbbdea83
+  FBLazyVector: 83defa09b7188cb1255686bab08adda2b5cafecd
+  FBReactNativeSpec: 8d388b5b295b639127cf59f31934682d6b39c446
+  FRNAvatar: 5e1b7c6304d4132046a9dd77e1b8da2f0bf7fb20
+  FRNCallout: b53d819789cac9ff5024615573335789639cd303
+  FRNCheckbox: d2ad1ecbe47d719ff7139e93b7a0eb17f3cfcb59
+  FRNMenuButton: 0a479294929d7569bea7f9a534b2cdfd6d006110
+  FRNRadioButton: 044455df06b2bd0182e2f945db111ba1c97633a8
   glog: 0dc7efada961c0793012970b60faebbd58b0decb
   MicrosoftFluentUI: b98d877a2122804132365aa167944f58ef4adb69
   RCT-Folly: b3998425a8ee9f695f57a204dc494534246f0fe9
-  RCTFocusZone: 8fdc903f49e08e973cb4c45fff81bdaf146277a5
-  RCTRequired: 0e6212665df8f1d7caae6de161cdfedc622a89b8
-  RCTTypeSafety: 48a6ae85b5b5f9ecb5ab49dbb896ef42615f233c
-  React: 6efe7745043e253dbd69ecafae3365e9534175e6
-  React-callinvoker: 96e54ae8b1b33d437856a7b987b3dfbf45b2e451
-  React-Core: 4440578aa06480fd9e1483a0421120d28eb36cf1
-  React-CoreModules: ea7d74d9ec6ae0fe992b32a4ee393f3a0e4f177d
-  React-cxxreact: f795a680d8325a91cdf94c308ca2b73ad34c5e29
-  React-jsi: 95b8b2e0e43b186257081f08a1eae277b3923297
-  React-jsiexecutor: bb3cd6caf2fbe4a05a934022f2ed93d505bc7216
-  React-jsinspector: e269739ff2c0a7b8da69140d084a27245c57ab8c
-  React-perflogger: 276bf9f2c98cbe1e4e3671cd3ba102c34c1ecb2a
-  React-RCTActionSheet: bb14afdb9bcc337850fe539a1e179e5d751be839
-  React-RCTAnimation: 1bb128bda781b80ac97aa4fcf1a33fe36facd546
-  React-RCTBlob: b67bca8cc1602eee76e89c9e23b3253c5c8d0c1d
-  React-RCTImage: 2e429d94a798023ae5566862d487f33c306c40e5
-  React-RCTLinking: cfabf32deec3e165d7540a712e58aa929b79d752
-  React-RCTNetwork: cc74b0b1181ae12a6dbb71308af480fed02c5bf8
-  React-RCTSettings: 8a28cbd9ef70f60bc727bc60d2cf7ceba2485c9f
-  React-RCTText: d0d57d162295b595cd87dc9e6b14abb24d8dd96c
-  React-RCTVibration: 76c394da8cd4bd86cd6cffdfdfc047752fdd6906
-  React-runtimeexecutor: 0917ad3b47bc9561749f18ca866a6c4b55f63f31
-  ReactCommon: c710dabcfbc8f09c20e98aa03e8a98965b88f6dd
+  RCTFocusZone: 77a7896433954ebd7107dcd46648e3971f1c7669
+  RCTRequired: e6152197373372893a4e6d627468bbfdf9301311
+  RCTTypeSafety: 9654015c2f88d21127cbee2786696aa9439ccee8
+  React: d13c50ec2e9d1d84ababb77b85da8e6520e18ec5
+  React-callinvoker: 01181efe0eec3268886455945d1932084fe64be5
+  React-Core: 81e90a2ae05c932e2d534699bacaad20de18cc74
+  React-CoreModules: 61b4a9b206fa065315202865a9ce58f0a209b0ed
+  React-cxxreact: f245472176771cfd48263d322e62eec115ec9741
+  React-jsi: 2aba5e3a0ffe8f55fca66d7f19d48c80c951875c
+  React-jsiexecutor: 7704681915f72bd428056d03e1a8b1c3e23fde6a
+  React-jsinspector: 6e1ba51326c5d58cf32ada3d2d28175fb2755af6
+  React-perflogger: d1da9f2ebf56e11f5d3f11bc6effba218c0bca95
+  React-RCTActionSheet: 5907b4b7ac90304beb2fc6b93fc988ed592b9d92
+  React-RCTAnimation: a2b957ad2adbb6c0bdfbfd311c1c47af7ece161a
+  React-RCTBlob: 5bfd4ebbde120c0fa260bf77b1554f6e1ca26b4e
+  React-RCTImage: d9b47c2328cfe161be2a67c103f596221e79a7bc
+  React-RCTLinking: 9d0b2387fb9811860adb3a3306c9d78f67b8c053
+  React-RCTNetwork: 70a5f109ce8efa8a5fe1c42efc975a07e8a73269
+  React-RCTSettings: 56534b0b579f982724766f445ef156ebe004a158
+  React-RCTText: 88da32673048a54dc26a1802d4d4fd2540db47c3
+  React-RCTVibration: 17c9f7ec8cab9938b89c05c254005613bca01907
+  React-runtimeexecutor: 7864e45847b2447083e4bbf67dea2700f792f840
+  ReactCommon: 15390f19fc5d447ab0721b03c6f9c1e2afbc4fe2
   ReactTestApp-DevSupport: 0556335e9e3fbfd74e2309c5a5d2842902b0500f
   ReactTestApp-Resources: 320923a3635f7bf90caa1a28fd29765b577888d9
   RNCPicker: 0991c56da7815c0cf946d6f63cf920b25296e5f6
   RNSVG: 551acb6562324b1d52a4e0758f7ca0ec234e278f
   SwiftLint: 06ac37e4d38c7068e0935bb30cda95f093bec761
-  Yoga: 3b0ecc1a0ddf03b4363ea73cc42e10d76b052007
+  Yoga: c45b437df892ecf6ad56016e7a491c50e40b5845
 
 PODFILE CHECKSUM: 568704fb95966cf7ad6daa54a1d36eb2d5c3bba6
 

--- a/change/@fluentui-react-native-contextual-menu-9b954a91-0bff-46f4-95c5-be925ee03ebf.json
+++ b/change/@fluentui-react-native-contextual-menu-9b954a91-0bff-46f4-95c5-be925ee03ebf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Focus on Menu with useLayoutEffect",
+  "packageName": "@fluentui-react-native/contextual-menu",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/ContextualMenu/src/Submenu.tsx
+++ b/packages/components/ContextualMenu/src/Submenu.tsx
@@ -4,7 +4,7 @@ import { View, ScrollView, Platform } from 'react-native';
 import { submenuName, SubmenuProps, SubmenuSlotProps, SubmenuType, SubmenuRenderData, SubmenuState } from './Submenu.types';
 import { settings } from './Submenu.settings';
 import { IUseComposeStyling, compose } from '@uifabricshared/foundation-compose';
-import { useSelectedKey } from '@fluentui-react-native/interactive-hooks';
+import { IFocusable, useSelectedKey } from '@fluentui-react-native/interactive-hooks';
 import { mergeSettings } from '@uifabricshared/foundation-settings';
 import { backgroundColorTokens, borderTokens } from '@fluentui-react-native/tokens';
 import { Callout } from '@fluentui-react-native/callout';

--- a/packages/components/ContextualMenu/src/Submenu.tsx
+++ b/packages/components/ContextualMenu/src/Submenu.tsx
@@ -18,6 +18,21 @@ export const Submenu = compose<SubmenuType>({
   usePrepareProps: (userProps: SubmenuProps, useStyling: IUseComposeStyling<SubmenuType>) => {
     const { setShowMenu, maxWidth, maxHeight, shouldFocusOnMount = true, shouldFocusOnContainer = true, ...rest } = userProps;
 
+    /**
+     * On macOS, focus isn't placed by default on the first focusable element. We get around this by focusing on the inner FocusZone
+     * hosting the menu. For whatever reason, to get the timing _just_ right to actually focus, we need an additional `setTimeout`
+     *  on top of the `useLayoutEffect` hook.
+     */
+    const focusZoneRef = React.useRef<IFocusable>(null);
+
+    React.useLayoutEffect(() => {
+      if (Platform.OS === 'macos') {
+        setTimeout(() => {
+          focusZoneRef.current?.focus();
+        }, 0);
+      }
+    }, []);
+
     // Grabs the context information from ContextualMenu (onDismissMenu callback)
     const context = React.useContext(CMContext);
 
@@ -81,6 +96,7 @@ export const Submenu = compose<SubmenuType>({
         showsVerticalScrollIndicator: true,
       },
       focusZone: {
+        componentRef: focusZoneRef,
         focusZoneDirection: 'vertical',
       },
     });


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This is the one of the changes that I'm breaking https://github.com/microsoft/fluentui-react-native/pull/1400 apart into.

This is a macOS only change.  This changes adds a layoutEffect to ContextualMenu to focuses on it's FocusZone slot, effectively placing focus on the menu. 

Unlike Win32, Callouts / NSWindows on macOS do not automatically place focus on the first focusable item once presented. Instead, you have to natively set an NSWindows' `initialFirstResponder` property to do that. 

So now, I could add a new property to Callout called initialFocusRef, have it internally map to [NSWindow initialFirstResponder], and then have ContextualMenu set it's initialFocusRef to it's FocusZone slot...
... or I could just use the hook useLayoutEffect() to imperatively focus on the inner focus zone after render. This solution was much less code and seemed simpler. I also needed a setTimeout(..., 0) in there for some reason 🤷🏾. 

I'll probably go through the path of properly adding a new prop initialFocusRef to Callout after this change goes in, since that seems the more correct solution. I would also want to take some time and reconcile the win32 props (`setInitalFocus/focusOnMount/focusOnContainer`) and see if we can support them on macOS. 

### Verification

This is the current behavior. We don't get `ArrowLeft` to close submenu yet, as that depends on #1411 to land.

https://user-images.githubusercontent.com/6722175/152618264-3842223f-3e21-40eb-a9b1-7b0e16a23ea8.mov


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
