### PR TITLE
Add `smallerMargins` prop to experimental checkbox

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/CheckboxExperimental/CheckboxTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/CheckboxExperimental/CheckboxTest.tsx
@@ -26,6 +26,7 @@ const basicCheckbox: React.FunctionComponent = () => {
       <Checkbox label="Disabled checked checkbox" onChange={onChangeUncontrolled} defaultChecked={true} disabled={true} />
       <Checkbox label="Checkbox will display a tooltip" onChange={onChangeUncontrolled} tooltip="This is a tooltip" />
       <Checkbox label="A circular checkbox" circular onChange={onChangeUncontrolled} defaultChecked={false} />
+      <Checkbox label="Checkbox with smaller margins" smallerMargins onChange={onChangeUncontrolled} defaultChecked={false} />
     </View>
   );
 };

--- a/change/@fluentui-react-native-experimental-checkbox-14d2b601-3b2c-47c0-9f3d-5d7049113ec6.json
+++ b/change/@fluentui-react-native-experimental-checkbox-14d2b601-3b2c-47c0-9f3d-5d7049113ec6.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add smallerMargins prop",
+  "packageName": "@fluentui-react-native/experimental-checkbox",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-a1418ec9-d222-4b78-8221-cb2a13820d92.json
+++ b/change/@fluentui-react-native-tester-a1418ec9-d222-4b78-8221-cb2a13820d92.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add smallerMargins prop",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Checkbox/src/Checkbox.styling.ts
+++ b/packages/experimental/Checkbox/src/Checkbox.styling.ts
@@ -5,6 +5,7 @@ import { defaultCheckboxTokens } from './CheckboxTokens';
 
 export const checkboxStates: (keyof CheckboxTokens)[] = [
   'labelIsBefore',
+  'smallerMargins',
   'circular',
   'hovered',
   'focused',
@@ -26,10 +27,10 @@ export const stylingSettings: UseStylingOptions<CheckboxProps, CheckboxSlotProps
           alignSelf: 'flex-start',
           backgroundColor: tokens.backgroundColor,
           ...borderStyles.from(tokens, theme),
-          padding: 4,
+          padding: tokens.padding,
         },
       }),
-      ['backgroundColor', ...borderStyles.keys],
+      ['backgroundColor', 'padding', ...borderStyles.keys],
     ),
     label: buildProps(
       (tokens: CheckboxTokens, theme: Theme) => ({

--- a/packages/experimental/Checkbox/src/Checkbox.types.ts
+++ b/packages/experimental/Checkbox/src/Checkbox.types.ts
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { ColorValue } from 'react-native';
-import { FontTokens, IBorderTokens, IForegroundColorTokens, IBackgroundColorTokens } from '@fluentui-react-native/tokens';
+import { FontTokens, IBorderTokens, IForegroundColorTokens, IBackgroundColorTokens, LayoutTokens } from '@fluentui-react-native/tokens';
 import { IFocusable, IPressableState } from '@fluentui-react-native/interactive-hooks';
 import type { ITextProps, IViewProps } from '@fluentui-react-native/adapters';
 import { SvgProps } from 'react-native-svg';
 
 export const checkboxName = 'Checkbox';
 
-export interface CheckboxTokens extends FontTokens, IForegroundColorTokens, IBackgroundColorTokens, IBorderTokens {
+export interface CheckboxTokens extends FontTokens, IForegroundColorTokens, IBackgroundColorTokens, IBorderTokens, LayoutTokens {
   checkboxBackgroundColor?: ColorValue;
   checkboxBorderColor?: ColorValue;
   checkboxBorderRadius?: number;
@@ -28,6 +28,7 @@ export interface CheckboxTokens extends FontTokens, IForegroundColorTokens, IBac
   pressed?: CheckboxTokens;
   checked?: CheckboxTokens;
   circular?: CheckboxTokens;
+  smallerMargins?: CheckboxTokens;
 }
 
 export interface CheckboxProps extends Omit<IViewProps, 'onPress'> {
@@ -76,6 +77,11 @@ export interface CheckboxProps extends Omit<IViewProps, 'onPress'> {
    * Callback that is called when the checked value has changed.
    */
   onChange?: (isChecked: boolean) => void;
+
+  /**
+   * Inserts smaller margin on the label so that the text is closer to the checkbox
+   */
+  smallerMargins?: boolean;
 
   /**
    * Provides a tooltip while hovering over Checkbox component

--- a/packages/experimental/Checkbox/src/CheckboxTokens.ts
+++ b/packages/experimental/Checkbox/src/CheckboxTokens.ts
@@ -15,6 +15,7 @@ export const defaultCheckboxTokens: TokenSettings<CheckboxTokens, Theme> = (t: T
     spacingLabelAfter: globalTokens.spacing.m,
     checkmarkOpacity: 0,
     color: t.colors.menuItemText,
+    padding: globalTokens.spacing.s,
     variant: 'bodyStandard',
     disabled: {
       checkboxBorderColor: t.colors.buttonBorderDisabled,
@@ -41,5 +42,12 @@ export const defaultCheckboxTokens: TokenSettings<CheckboxTokens, Theme> = (t: T
     labelIsBefore: {
       spacingLabelBefore: globalTokens.spacing.m,
       spacingLabelAfter: 0,
+      smallerMargins: {
+        spacingLabelBefore: globalTokens.spacing.xs,
+      },
+    },
+    smallerMargins: {
+      spacingLabelAfter: globalTokens.spacing.xs,
+      padding: globalTokens.spacing.xs,
     },
   } as CheckboxTokens);

--- a/packages/experimental/Checkbox/src/CheckboxTokens.win32.ts
+++ b/packages/experimental/Checkbox/src/CheckboxTokens.win32.ts
@@ -17,6 +17,7 @@ export const defaultCheckboxTokens: TokenSettings<CheckboxTokens, Theme> = (t: T
     fontWeight: globalTokens.font.weight.regular,
     fontFamily: t.typography.families.primary,
     checkmarkOpacity: 0,
+    padding: globalTokens.spacing.s,
     disabled: {
       checkboxBorderColor: t.colors.neutralStrokeDisabled,
       color: t.colors.neutralForegroundDisabled,
@@ -59,5 +60,12 @@ export const defaultCheckboxTokens: TokenSettings<CheckboxTokens, Theme> = (t: T
     labelIsBefore: {
       spacingLabelBefore: globalTokens.spacing.m,
       spacingLabelAfter: 0,
+      smallerMargins: {
+        spacingLabelBefore: globalTokens.spacing.xs,
+      },
+    },
+    smallerMargins: {
+      spacingLabelAfter: globalTokens.spacing.xs,
+      padding: globalTokens.spacing.xs,
     },
   } as CheckboxTokens);

--- a/packages/experimental/Checkbox/src/CheckboxTokens.windows.ts
+++ b/packages/experimental/Checkbox/src/CheckboxTokens.windows.ts
@@ -13,6 +13,7 @@ export const defaultCheckboxTokens: TokenSettings<CheckboxTokens, Theme> = (t: T
     checkboxSize: 16,
     color: t.colors.neutralForeground3,
     spacingLabelAfter: globalTokens.spacing.m,
+    padding: globalTokens.spacing.s,
     variant: 'bodyStandard',
     checkmarkOpacity: 0,
     disabled: {
@@ -57,5 +58,12 @@ export const defaultCheckboxTokens: TokenSettings<CheckboxTokens, Theme> = (t: T
     labelIsBefore: {
       spacingLabelBefore: globalTokens.spacing.m,
       spacingLabelAfter: 0,
+      smallerMargins: {
+        spacingLabelBefore: globalTokens.spacing.xs,
+      },
+    },
+    smallerMargins: {
+      spacingLabelAfter: globalTokens.spacing.xs,
+      padding: globalTokens.spacing.xs,
     },
   } as CheckboxTokens);


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

Note: Not really sure about this name if anyone has better suggestions I'd be open to them.

Win32 has checkboxes with smaller spacing around/between the elements of the checkbox. This is not a specification on other endpoints, so we're on our own with the prop name here.

Adding a prop which enables this smaller-spacing mode of the checkbox. Added a test for it, too.

### Verification

![image](https://user-images.githubusercontent.com/4602628/152623651-9c02051c-e100-426b-a0ed-382a48b054a2.png)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
