### PR TITLE
Accessibility fixes toggleButton

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ToggleButtonTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ButtonExperimental/ToggleButtonTestSection.tsx
@@ -34,10 +34,13 @@ export const ToggleButtonTest: React.FunctionComponent = () => {
         Unchecked Default Toggle
       </ToggleButton>
       <ToggleButton appearance="primary" style={commonTestStyles.vmargin}>
-        Primary Toggle
+        Checked Primary Toggle
+      </ToggleButton>
+      <ToggleButton disabled defaultChecked appearance="primary" style={commonTestStyles.vmargin}>
+        Checked Primary Toggle Disabled
       </ToggleButton>
       <ToggleButton defaultChecked appearance="primary" style={commonTestStyles.vmargin}>
-        Primary Toggle
+        Unchecked Primary Toggle
       </ToggleButton>
       <View style={styles.row}>
         <ToggleButton appearance="subtle" onClick={onGhostClicked} checked={subtleChecked} style={commonTestStyles.vmargin}>

--- a/change/@fluentui-react-native-experimental-button-e9f2e8df-56fb-4245-9ac1-209477da3c8c.json
+++ b/change/@fluentui-react-native-experimental-button-e9f2e8df-56fb-4245-9ac1-209477da3c8c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "useToggleButton and implement accessibilityAction/onAccessibilityAction",
+  "packageName": "@fluentui-react-native/experimental-button",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-995700f6-25cc-4980-a77a-68b289f0770d.json
+++ b/change/@fluentui-react-native-tester-995700f6-25cc-4980-a77a-68b289f0770d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix test",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Button/src/CompoundButton/CompoundButton.test.tsx
+++ b/packages/experimental/Button/src/CompoundButton/CompoundButton.test.tsx
@@ -1,8 +1,27 @@
 import * as React from 'react';
 import { CompoundButton } from './CompoundButton';
+import { checkRenderConsistency, checkReRender } from '@fluentui-react-native/test-tools';
 import * as renderer from 'react-test-renderer';
 
 it('CompoundButton default', () => {
   const tree = renderer.create(<CompoundButton secondaryContent="sublabel">Default Button</CompoundButton>).toJSON();
   expect(tree).toMatchSnapshot();
+});
+
+it('Button simple rendering does not invalidate styling', () => {
+  checkRenderConsistency(() => <CompoundButton>Default button</CompoundButton>, 2);
+});
+
+it('Button re-renders correctly', () => {
+  checkReRender(() => <CompoundButton>Render twice</CompoundButton>, 2);
+});
+
+it('Button shares produced styles across multiple renders', () => {
+  const style = { backgroundColor: 'black' };
+  checkRenderConsistency(() => <CompoundButton style={style}>Shared styles</CompoundButton>, 2);
+});
+
+it('Button re-renders correctly with style', () => {
+  const style = { borderColor: 'blue' };
+  checkReRender(() => <CompoundButton style={style}>Shared Style Render</CompoundButton>, 2);
 });

--- a/packages/experimental/Button/src/ToggleButton/ToggleButton.test.tsx
+++ b/packages/experimental/Button/src/ToggleButton/ToggleButton.test.tsx
@@ -1,8 +1,27 @@
 import * as React from 'react';
 import { ToggleButton } from './ToggleButton';
+import { checkRenderConsistency, checkReRender } from '@fluentui-react-native/test-tools';
 import * as renderer from 'react-test-renderer';
 
 it('ToggleButton default', () => {
   const tree = renderer.create(<ToggleButton>Default Button</ToggleButton>).toJSON();
   expect(tree).toMatchSnapshot();
+});
+
+it('Button simple rendering does not invalidate styling', () => {
+  checkRenderConsistency(() => <ToggleButton>Default button</ToggleButton>, 2);
+});
+
+it('Button re-renders correctly', () => {
+  checkReRender(() => <ToggleButton>Render twice</ToggleButton>, 2);
+});
+
+it('Button shares produced styles across multiple renders', () => {
+  const style = { backgroundColor: 'black' };
+  checkRenderConsistency(() => <ToggleButton style={style}>Shared styles</ToggleButton>, 2);
+});
+
+it('Button re-renders correctly with style', () => {
+  const style = { borderColor: 'blue' };
+  checkReRender(() => <ToggleButton style={style}>Shared Style Render</ToggleButton>, 2);
 });

--- a/packages/experimental/Button/src/ToggleButton/ToggleButton.tsx
+++ b/packages/experimental/Button/src/ToggleButton/ToggleButton.tsx
@@ -6,11 +6,10 @@ import { ToggleButtonProps, toggleButtonName, ToggleButtonType } from './ToggleB
 import { Text } from '@fluentui-react-native/experimental-text';
 import { stylingSettings } from './ToggleButton.styling';
 import { compose, mergeProps, withSlots, UseSlots } from '@fluentui-react-native/framework';
-import { useButton } from '../useButton';
-import { useAsToggle } from '@fluentui-react-native/interactive-hooks';
 import { Icon } from '@fluentui-react-native/icon';
 import { createIconProps } from '@fluentui-react-native/interactive-hooks';
 import { buttonLookup } from '../Button';
+import { useToggleButton } from './useToggleButton';
 
 export const ToggleButton = compose<ToggleButtonType>({
   displayName: toggleButtonName,
@@ -21,22 +20,15 @@ export const ToggleButton = compose<ToggleButtonType>({
     content: Text,
   },
   render: (userProps: ToggleButtonProps, useSlots: UseSlots<ToggleButtonType>) => {
-    const { defaultChecked, checked, onClick, ...rest } = userProps;
     const iconProps = createIconProps(userProps.icon);
-
-    // Warns defaultChecked and checked being mutually exclusive.
-    if (defaultChecked != undefined && checked != undefined) {
-      console.warn('defaultChecked and checked are mutually exclusive to one another. Use one or the other.');
-    }
-    const [checkedValue, toggle] = useAsToggle(defaultChecked, checked, onClick);
-    const button = useButton({ onClick: toggle, ...rest });
+    const toggleButton = useToggleButton(userProps);
 
     // grab the styled slots
-    const Slots = useSlots(userProps, (layer) => (layer === 'checked' && checkedValue) || buttonLookup(layer, button.state, userProps));
+    const Slots = useSlots(userProps, (layer) => buttonLookup(layer, toggleButton.state, userProps));
 
     // now return the handler for finishing render
     return (final: ToggleButtonProps, ...children: React.ReactNode[]) => {
-      const { icon, iconPosition, iconOnly, loading, accessibilityLabel, ...mergedProps } = mergeProps(button.props, final);
+      const { icon, iconPosition, iconOnly, loading, accessibilityLabel, ...mergedProps } = mergeProps(toggleButton.props, final);
       const shouldShowIcon = !loading && icon;
 
       if (__DEV__ && iconOnly) {

--- a/packages/experimental/Button/src/ToggleButton/ToggleButton.types.ts
+++ b/packages/experimental/Button/src/ToggleButton/ToggleButton.types.ts
@@ -1,3 +1,4 @@
+import { ButtonState } from '..';
 import { ButtonSlotProps, ButtonTokens, ButtonProps } from '../Button.types';
 
 export const toggleButtonName = 'ToggleButton';
@@ -19,6 +20,15 @@ export interface ToggleButtonProps extends ButtonProps {
    * Mutually exclusive to `checked`.
    */
   defaultChecked?: boolean;
+}
+
+export interface ToggleButtonState extends ButtonState {
+  state: ButtonState['state'] & {
+    /**
+     * Whether the ToggleButton is toggled or not
+     */
+    checked?: boolean;
+  };
 }
 
 export interface ToggleButtonSlotProps extends ButtonSlotProps {}

--- a/packages/experimental/Button/src/ToggleButton/__snapshots__/ToggleButton.test.tsx.snap
+++ b/packages/experimental/Button/src/ToggleButton/__snapshots__/ToggleButton.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`ToggleButton default 1`] = `
   accessibilityRole="button"
   accessibilityState={
     Object {
+      "checked": undefined,
       "disabled": false,
     }
   }
@@ -20,7 +21,6 @@ exports[`ToggleButton default 1`] = `
   enableFocusRing={true}
   focusable={true}
   onAccessibilityAction={[Function]}
-  onAccessibilityTap={[Function]}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}

--- a/packages/experimental/Button/src/ToggleButton/__snapshots__/ToggleButton.test.tsx.snap
+++ b/packages/experimental/Button/src/ToggleButton/__snapshots__/ToggleButton.test.tsx.snap
@@ -2,6 +2,13 @@
 
 exports[`ToggleButton default 1`] = `
 <View
+  accessibilityActions={
+    Array [
+      Object {
+        "name": "Toggle",
+      },
+    ]
+  }
   accessibilityLabel="Default Button"
   accessibilityRole="button"
   accessibilityState={
@@ -12,6 +19,7 @@ exports[`ToggleButton default 1`] = `
   accessible={true}
   enableFocusRing={true}
   focusable={true}
+  onAccessibilityAction={[Function]}
   onAccessibilityTap={[Function]}
   onBlur={[Function]}
   onClick={[Function]}

--- a/packages/experimental/Button/src/ToggleButton/useToggleButton.ts
+++ b/packages/experimental/Button/src/ToggleButton/useToggleButton.ts
@@ -24,7 +24,7 @@ export const useToggleButton = (props: ToggleButtonProps): ToggleButtonState => 
           toggle();
           break;
       }
-      onAccessibilityAction(event);
+      onAccessibilityAction && onAccessibilityAction(event);
     },
     [toggle, onAccessibilityAction],
   );

--- a/packages/experimental/Button/src/ToggleButton/useToggleButton.ts
+++ b/packages/experimental/Button/src/ToggleButton/useToggleButton.ts
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { ToggleButtonProps, ToggleButtonState } from './ToggleButton.types';
+import { useButton } from '../useButton';
+import { useAsToggle } from '@fluentui-react-native/interactive-hooks';
+
+const defaultAccessibilityActions = [{ name: 'Toggle' }];
+
+export const useToggleButton = (props: ToggleButtonProps): ToggleButtonState => {
+  const { accessibilityActions, defaultChecked, checked, onAccessibilityAction, onClick, ...rest } = props;
+  // Warns defaultChecked and checked being mutually exclusive.
+  if (defaultChecked != undefined && checked != undefined) {
+    console.warn('defaultChecked and checked are mutually exclusive to one another. Use one or the other.');
+  }
+  const [checkedValue, toggle] = useAsToggle(defaultChecked, checked, onClick);
+  const accessibilityActionsProp = accessibilityActions
+    ? [...accessibilityActions, ...defaultAccessibilityActions]
+    : defaultAccessibilityActions;
+  const onAccessibilityActionProp = React.useCallback(
+    (event) => {
+      switch (event.nativeEvent.actionName) {
+        case 'Toggle':
+          toggle();
+          break;
+      }
+      onAccessibilityAction(event);
+    },
+    [toggle, onAccessibilityAction],
+  );
+
+  const button = useButton({
+    onClick: toggle,
+    accessibilityActions: accessibilityActionsProp,
+    onAccessibilityAction: onAccessibilityActionProp,
+    ...rest,
+  });
+
+  return {
+    props: button.props,
+    state: { ...button.state, checked: checkedValue },
+  };
+};

--- a/packages/experimental/Button/src/ToggleButton/useToggleButton.ts
+++ b/packages/experimental/Button/src/ToggleButton/useToggleButton.ts
@@ -2,18 +2,20 @@ import * as React from 'react';
 import { ToggleButtonProps, ToggleButtonState } from './ToggleButton.types';
 import { useButton } from '../useButton';
 import { useAsToggle } from '@fluentui-react-native/interactive-hooks';
+import { memoize } from '@fluentui-react-native/framework';
+import { AccessibilityState } from 'react-native';
 
 const defaultAccessibilityActions = [{ name: 'Toggle' }];
 
 export const useToggleButton = (props: ToggleButtonProps): ToggleButtonState => {
-  const { accessibilityActions, defaultChecked, checked, onAccessibilityAction, onClick, ...rest } = props;
+  const { accessibilityActions, accessibilityState, defaultChecked, checked, onAccessibilityAction, onClick, ...rest } = props;
   // Warns defaultChecked and checked being mutually exclusive.
   if (defaultChecked != undefined && checked != undefined) {
     console.warn('defaultChecked and checked are mutually exclusive to one another. Use one or the other.');
   }
   const [checkedValue, toggle] = useAsToggle(defaultChecked, checked, onClick);
   const accessibilityActionsProp = accessibilityActions
-    ? [...accessibilityActions, ...defaultAccessibilityActions]
+    ? [...defaultAccessibilityActions, ...accessibilityActions]
     : defaultAccessibilityActions;
   const onAccessibilityActionProp = React.useCallback(
     (event) => {
@@ -30,6 +32,7 @@ export const useToggleButton = (props: ToggleButtonProps): ToggleButtonState => 
   const button = useButton({
     onClick: toggle,
     accessibilityActions: accessibilityActionsProp,
+    accessibilityState: getAccessibilityState(checkedValue, accessibilityState),
     onAccessibilityAction: onAccessibilityActionProp,
     ...rest,
   });
@@ -39,3 +42,11 @@ export const useToggleButton = (props: ToggleButtonProps): ToggleButtonState => 
     state: { ...button.state, checked: checkedValue },
   };
 };
+
+const getAccessibilityState = memoize(getAccessibilityStateWorker);
+function getAccessibilityStateWorker(toggled: boolean, accessibilityState?: AccessibilityState) {
+  if (accessibilityState) {
+    return { selected: toggled, ...accessibilityState };
+  }
+  return { selected: toggled };
+}

--- a/packages/experimental/Button/src/ToggleButton/useToggleButton.ts
+++ b/packages/experimental/Button/src/ToggleButton/useToggleButton.ts
@@ -46,7 +46,7 @@ export const useToggleButton = (props: ToggleButtonProps): ToggleButtonState => 
 const getAccessibilityState = memoize(getAccessibilityStateWorker);
 function getAccessibilityStateWorker(toggled: boolean, accessibilityState?: AccessibilityState) {
   if (accessibilityState) {
-    return { selected: toggled, ...accessibilityState };
+    return { checked: toggled, ...accessibilityState };
   }
-  return { selected: toggled };
+  return { checked: toggled };
 }

--- a/packages/experimental/Button/src/useButton.ts
+++ b/packages/experimental/Button/src/useButton.ts
@@ -14,13 +14,14 @@ export const useButton = (props: ButtonProps): ButtonState => {
   const pressable = useAsPressable({ ...rest, onPress: onClickWithFocus });
   const onKeyUpProps = useKeyProps(onClick, ' ', 'Enter');
   const isDisabled = !!disabled || !!loading;
+  const hasTogglePattern = props.accessibilityActions && !!props.accessibilityActions.find((action) => action.name === 'Toggle');
 
   return {
     props: {
       ...pressable.props,
       accessible: true,
       accessibilityRole: 'button',
-      onAccessibilityTap: props.onAccessibilityTap || props.onClick,
+      onAccessibilityTap: props.onAccessibilityTap || (!hasTogglePattern ? props.onClick : undefined),
       accessibilityLabel: props.accessibilityLabel,
       accessibilityState: getAccessibilityState(isDisabled, accessibilityState),
       enableFocusRing: true,

--- a/packages/experimental/Button/src/useButton.ts
+++ b/packages/experimental/Button/src/useButton.ts
@@ -2,11 +2,12 @@ import * as React from 'react';
 import { useAsPressable, useKeyProps, useOnPressWithFocus, useViewCommandFocus } from '@fluentui-react-native/interactive-hooks';
 import { ButtonProps, ButtonState } from './Button.types';
 import { memoize } from '@fluentui-react-native/framework';
+import { AccessibilityState } from 'react-native';
 
 export const useButton = (props: ButtonProps): ButtonState => {
   // attach the pressable state handlers
   const defaultComponentRef = React.useRef(null);
-  const { onClick, componentRef = defaultComponentRef, disabled, loading, ...rest } = props;
+  const { onClick, accessibilityState, componentRef = defaultComponentRef, disabled, loading, ...rest } = props;
   // GH #1336: Set focusRef to null if button is disabled to prevent getting keyboard focus.
   const focusRef = disabled ? null : componentRef;
   const onClickWithFocus = useOnPressWithFocus(focusRef, onClick);
@@ -21,7 +22,7 @@ export const useButton = (props: ButtonProps): ButtonState => {
       accessibilityRole: 'button',
       onAccessibilityTap: props.onAccessibilityTap || props.onClick,
       accessibilityLabel: props.accessibilityLabel,
-      accessibilityState: getAccessibilityState(isDisabled),
+      accessibilityState: getAccessibilityState(isDisabled, accessibilityState),
       enableFocusRing: true,
       focusable: !isDisabled,
       ref: useViewCommandFocus(componentRef),
@@ -34,6 +35,9 @@ export const useButton = (props: ButtonProps): ButtonState => {
 };
 
 const getAccessibilityState = memoize(getAccessibilityStateWorker);
-function getAccessibilityStateWorker(disabled: boolean) {
+function getAccessibilityStateWorker(disabled: boolean, accessibilityState?: AccessibilityState) {
+  if (accessibilityState) {
+    return { disabled: disabled, ...accessibilityState };
+  }
   return { disabled: disabled };
 }


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This PR fixes several a11y issues with the Toggle Button:
1. ToggleButton has to properly set "checked" accessibilityState when toggled. Otherwise screen readers will announce that it is in state "off" even if it's toggled
2. ToggleButtons are supposed to implement to Toggle pattern, and not the Invoke pattern, per UIA guidelines. The Toggle pattern is controlled by adding the "Toggle" action to accessibilityActions and a "Toggle" case handler to onAccessibilityAction. Removing the Invoke pattern from ToggleButton is handled by not passing onClick to the onAccessibilityTap prop when the Toggle accessibilityAction is handled.
3. To make code a little cleaner, I moved all the hooks into a useToggleButton file, and added checked to the ToggleButton's state so that it can be accessed in the render function.

### Verification

Verified via accessibility checker that Buttons with onClick implemented have the Invoke pattern, and that buttons that handle the Toggle accessibilityAction only have the Toggle pattern
Verified via Narrator that toggled state is announced correctly for toggle buttons, and that it works even with multiple states (like disabled + toggled)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
