### PR TITLE
ContextualMenu: Flip arrow key navigation in RTL

### DIFF
--- a/change/@fluentui-react-native-contextual-menu-2d845135-e093-4c58-9e89-9b6e7e2bec2b.json
+++ b/change/@fluentui-react-native-contextual-menu-2d845135-e093-4c58-9e89-9b6e7e2bec2b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Flip arrow key navigation in RTL",
+  "packageName": "@fluentui-react-native/contextual-menu",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/ContextualMenu/src/Submenu.tsx
+++ b/packages/components/ContextualMenu/src/Submenu.tsx
@@ -1,6 +1,6 @@
 /** @jsx withSlots */
 import * as React from 'react';
-import { View, ScrollView, Platform } from 'react-native';
+import { View, ScrollView, Platform, I18nManager } from 'react-native';
 import { submenuName, SubmenuProps, SubmenuSlotProps, SubmenuType, SubmenuRenderData, SubmenuState } from './Submenu.types';
 import { settings } from './Submenu.settings';
 import { IUseComposeStyling, compose } from '@uifabricshared/foundation-compose';
@@ -72,8 +72,23 @@ export const Submenu = compose<SubmenuType>({
 
     const styleProps = useStyling(userProps, (override: string) => state[override] || userProps[override]);
 
+    const dismissWithArrowKey = React.useCallback(
+      (e: any) => {
+        if (I18nManager.isRTL) {
+          if (e.nativeEvent.key === 'ArrowRight') {
+            onDismiss();
+          }
+        } else {
+          if (e.nativeEvent.key === 'ArrowLeft') {
+            onDismiss();
+          }
+        }
+      },
+      [onDismiss],
+    );
+
     // Explicitly override onKeyDown to override the native windows behavior of moving focus with arrow keys.
-    const onKeyDownProps = useKeyDownProps(onDismiss, 'ArrowLeft');
+    const onKeyDownProps = useKeyDownProps(dismissWithArrowKey, 'ArrowLeft', 'ArrowRight');
 
     const containerPropsWin32: IViewProps = {
       accessible: shouldFocusOnContainer,

--- a/packages/components/ContextualMenu/src/Submenu.tsx
+++ b/packages/components/ContextualMenu/src/Submenu.tsx
@@ -74,14 +74,9 @@ export const Submenu = compose<SubmenuType>({
 
     const dismissWithArrowKey = React.useCallback(
       (e: any) => {
-        if (I18nManager.isRTL) {
-          if (e.nativeEvent.key === 'ArrowRight') {
-            onDismiss();
-          }
-        } else {
-          if (e.nativeEvent.key === 'ArrowLeft') {
-            onDismiss();
-          }
+        const arrowKey = I18nManager.isRTL ? 'ArrowRight' : 'ArrowLeft';
+        if (e.nativeEvent.key === arrowKey) {
+          onDismiss();
         }
       },
       [onDismiss],

--- a/packages/components/ContextualMenu/src/SubmenuItem.tsx
+++ b/packages/components/ContextualMenu/src/SubmenuItem.tsx
@@ -111,14 +111,9 @@ export const SubmenuItem = compose<SubmenuItemType>({
 
     const showWithArrowKey = React.useCallback(
       (e: any) => {
-        if (I18nManager.isRTL) {
-          if (e.nativeEvent.key === 'ArrowLeft') {
-            onItemHoverIn(e);
-          }
-        } else {
-          if (e.nativeEvent.key === 'ArrowRight') {
-            onItemHoverIn(e);
-          }
+        const arrowKey = I18nManager.isRTL ? 'ArrowRight' : 'ArrowLeft';
+        if (e.nativeEvent.key === arrowKey) {
+          onItemHoverIn(e);
         }
       },
       [onItemHoverIn],

--- a/packages/components/ContextualMenu/src/SubmenuItem.tsx
+++ b/packages/components/ContextualMenu/src/SubmenuItem.tsx
@@ -111,7 +111,7 @@ export const SubmenuItem = compose<SubmenuItemType>({
 
     const showWithArrowKey = React.useCallback(
       (e: any) => {
-        const arrowKey = I18nManager.isRTL ? 'ArrowRight' : 'ArrowLeft';
+        const arrowKey = I18nManager.isRTL ? 'ArrowLeft' : 'ArrowRight';
         if (e.nativeEvent.key === arrowKey) {
           onItemHoverIn(e);
         }

--- a/packages/components/ContextualMenu/src/SubmenuItem.tsx
+++ b/packages/components/ContextualMenu/src/SubmenuItem.tsx
@@ -109,11 +109,26 @@ export const SubmenuItem = compose<SubmenuItemType>({
       icon: !!icon,
     };
 
+    const showWithArrowKey = React.useCallback(
+      (e: any) => {
+        if (I18nManager.isRTL) {
+          if (e.nativeEvent.key === 'ArrowLeft') {
+            onItemHoverIn(e);
+          }
+        } else {
+          if (e.nativeEvent.key === 'ArrowRight') {
+            onItemHoverIn(e);
+          }
+        }
+      },
+      [onItemHoverIn],
+    );
+
     /**
-     * SubmenuItem launches the submenu onMouseEnter event. Submenu should be launched with Spacebar, Enter, or right arrow.
+     * SubmenuItem launches the submenu onMouseEnter event. Submenu should be launched with Spacebar, Enter, or right arrow (flipped for RTL).
      * Explicitly override onKeyDown to override the native windows behavior of moving focus with arrow keys.
      */
-    const onKeyDownProps = useKeyDownProps(onItemHoverIn, ' ', 'Enter', 'ArrowRight');
+    const onKeyDownProps = useKeyDownProps(showWithArrowKey, ' ', 'Enter', 'ArrowLeft', 'ArrowRight');
 
     // grab the styling information, referencing the state as well as the props
     const styleProps = useStyling(userProps, (override: string) => state[override] || userProps[override]);


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

When in an RTL language, the menus will flip what side they present from. As such we should flip our "ArrowRight to open a submenu, ArrowLeft to close a submenu" assumption when we are running in RTL.

### Verification

Ran FluentTester on macOS in LTR, and a RTL pseudolanguage.

**LTR Behavior (preserved):**

https://user-images.githubusercontent.com/6722175/153304722-86a3a1ce-dc0f-41ea-9cbb-2c7bfa648f8d.mov

**RTL Behavior (flipped):**

https://user-images.githubusercontent.com/6722175/153304769-188c3606-8901-4a38-8eb1-328d565419cc.mov

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [x] Keyboard Accessibility
- [ ] Voiceover
- [x] Internationalization and Right-to-left Layouts
