### PR TITLE
Remove dynamically built path from build tokens script

### DIFF
--- a/scripts/build-tokens.js
+++ b/scripts/build-tokens.js
@@ -118,8 +118,7 @@ async function run() {
   fs.unlinkSync(path.join(process.cwd(), 'packages/theming/theme-tokens/src/generated/highContrast/reactnative/tokens-controls.json'));
 
   console.log('Running prettier...');
-  const input = path.join(process.cwd(), 'packages/theming/theme-tokens/src/generated');
-  child_process.execSync('prettier --write ' + input);
+  child_process.execSync('prettier --write ./packages/theming/theme-tokens/src/generated');
 
   console.log('Done!');
 }


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This should fix one of the code scanning alerts we have.

### Verification

Fix verified by CodeQL output

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
