### PR TITLE
(Apple) Update nuget_pack_apple.sh to only install cocoapods if needed

### DIFF
--- a/scripts/nuget_pack_apple.sh
+++ b/scripts/nuget_pack_apple.sh
@@ -203,10 +203,10 @@ function do_prerequisites
 	log_action 🏗 "Building yarn tools"
 	run_subprocess yarn build-tools $verbosity_arg
 	run_subprocess popd
-	
-	log_action 📦 "Installing CocoaPods gem"
-	run_subprocess /usr/bin/sudo gem install cocoapods $verbosity_arg
-	
+
+	log_action 📦 "Installing CocoaPods gem if needed"
+	run_subprocess pod --version || /usr/bin/sudo gem install cocoapods $verbosity_arg
+
 	log_action 🔨 "Selecting officially supported Xcode version"
 	run_subprocess "${git_root}/.ado/scripts/xcode_select_current_version.sh"
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

We have a script that will pack a local copy of the `Microsoft.FluentUI.ReactNative` Nuget we consume downstream. This is a small fix to only install cocoa pods if it isn't already installed when running the script with the `-p` flag.

### Verification

script stops trying to install cocoa pods


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
