### PR TITLE
Fix iconColor token being no-op

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/Button/ButtonHOCTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Button/ButtonHOCTestSection.tsx
@@ -2,13 +2,25 @@ import { ButtonV1 as Button } from '@fluentui-react-native/button';
 import { Text } from '@fluentui-react-native/experimental-text';
 import { Icon, SvgIconProps } from '@fluentui-react-native/icon';
 import * as React from 'react';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 import { commonTestStyles, stackStyle } from '../Common/styles';
 import TestSvg from './test.svg';
 
 const CustomText = Text.customize({ fontSize: 'header', color: 'hotpink' });
 const CustomButton = Button.customize({ backgroundColor: 'pink' });
 const CustomIconButton = Button.customize({ iconColor: 'yellow' });
+const ComposedButton = Button.compose({
+  slots: {
+    root: View,
+    icon: Icon,
+    content: CustomText,
+  },
+  slotProps: {
+    content: {
+      style: { marginTop: -1, marginBottom: 1, marginStart: 0, marginEnd: -2 },
+    },
+  },
+});
 const svgProps: SvgIconProps = {
   src: TestSvg,
   viewBox: '0 0 500 500',
@@ -16,25 +28,14 @@ const svgProps: SvgIconProps = {
 
 export const ButtonHOCTest: React.FunctionComponent = () => {
   const buttonRef = React.useRef(null);
-  const ComposedButton = Button.compose({
-    slots: {
-      root: View,
-      icon: Icon,
-      content: CustomText,
-    },
-    slotProps: {
-      content: {
-        style: { marginTop: -1, marginBottom: 1, marginStart: 0, marginEnd: -2 },
-      },
-    },
-  });
+  const svgIconsEnabled = ['ios', 'macos', 'win32', 'android'].includes(Platform.OS as string);
 
   return (
     <View style={stackStyle}>
       <CustomButton style={commonTestStyles.vmargin} componentRef={buttonRef}>
         Customized Button with ref
       </CustomButton>
-      <CustomIconButton icon={{ svgSource: svgProps }}>Customized Icon Button</CustomIconButton>
+      {svgIconsEnabled && <CustomIconButton icon={{ svgSource: svgProps }}>Customized Icon Button</CustomIconButton>}
       <Button
         style={commonTestStyles.vmargin}
         onClick={() => {

--- a/apps/fluent-tester/src/FluentTester/TestComponents/Button/ButtonHOCTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Button/ButtonHOCTestSection.tsx
@@ -1,14 +1,21 @@
 import { ButtonV1 as Button } from '@fluentui-react-native/button';
 import { Text } from '@fluentui-react-native/experimental-text';
-import { Icon } from '@fluentui-react-native/icon';
+import { Icon, SvgIconProps } from '@fluentui-react-native/icon';
 import * as React from 'react';
 import { View } from 'react-native';
 import { commonTestStyles, stackStyle } from '../Common/styles';
+import TestSvg from './test.svg';
+
+const CustomText = Text.customize({ fontSize: 'header', color: 'hotpink' });
+const CustomButton = Button.customize({ backgroundColor: 'pink' });
+const CustomIconButton = Button.customize({ iconColor: 'yellow' });
+const svgProps: SvgIconProps = {
+  src: TestSvg,
+  viewBox: '0 0 500 500',
+};
 
 export const ButtonHOCTest: React.FunctionComponent = () => {
   const buttonRef = React.useRef(null);
-  const CustomText = Text.customize({ fontSize: 'header', color: 'hotpink' });
-  const CustomButton = Button.customize({ backgroundColor: 'pink' });
   const ComposedButton = Button.compose({
     slots: {
       root: View,
@@ -27,6 +34,7 @@ export const ButtonHOCTest: React.FunctionComponent = () => {
       <CustomButton style={commonTestStyles.vmargin} componentRef={buttonRef}>
         Customized Button with ref
       </CustomButton>
+      <CustomIconButton icon={{ svgSource: svgProps }}>Customized Icon Button</CustomIconButton>
       <Button
         style={commonTestStyles.vmargin}
         onClick={() => {

--- a/apps/fluent-tester/src/FluentTester/TestComponents/Button/ButtonSizeTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Button/ButtonSizeTestSection.tsx
@@ -11,12 +11,12 @@ export const ButtonSizeTest: React.FunctionComponent = () => {
     viewBox: '0 0 500 500',
   };
   const svgIconsEnabled = ['ios', 'macos', 'win32', 'android'].includes(Platform.OS as string);
-
+  const CustomButton = Button.customize({ iconColor: 'yellow' });
   return (
     <View style={[stackStyle, commonTestStyles.view]}>
       {svgIconsEnabled && (
         <>
-          <Button
+          <CustomButton
             iconOnly
             size="small"
             icon={{ svgSource: svgProps }}

--- a/apps/fluent-tester/src/FluentTester/TestComponents/Button/ButtonSizeTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Button/ButtonSizeTestSection.tsx
@@ -11,12 +11,11 @@ export const ButtonSizeTest: React.FunctionComponent = () => {
     viewBox: '0 0 500 500',
   };
   const svgIconsEnabled = ['ios', 'macos', 'win32', 'android'].includes(Platform.OS as string);
-  const CustomButton = Button.customize({ iconColor: 'yellow' });
   return (
     <View style={[stackStyle, commonTestStyles.view]}>
       {svgIconsEnabled && (
         <>
-          <CustomButton
+          <Button
             iconOnly
             size="small"
             icon={{ svgSource: svgProps }}

--- a/change/@fluentui-react-native-button-c0a4f925-17b9-4752-91b0-b77d167605c2.json
+++ b/change/@fluentui-react-native-button-c0a4f925-17b9-4752-91b0-b77d167605c2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix iconColor token being no-op",
+  "packageName": "@fluentui-react-native/button",
+  "email": "amchiu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-1e25a118-685c-4e84-93cc-9ed90cf464f8.json
+++ b/change/@fluentui-react-native-tester-1e25a118-685c-4e84-93cc-9ed90cf464f8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix iconColor token being no-op",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "amchiu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Button/src/Button.styling.ts
+++ b/packages/components/Button/src/Button.styling.ts
@@ -61,9 +61,7 @@ export const stylingSettings: UseStylingOptions<ButtonProps, ButtonSlotProps, Bu
     ),
     icon: buildProps(
       (tokens: ButtonTokens) => ({
-        style: {
-          tintColor: tokens.iconColor,
-        },
+        color: tokens.iconColor,
         height: tokens.iconSize,
         width: tokens.iconSize,
       }),


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS
- [X] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This change corrects the mapping of the `color` prop in iconProps.

### Verification

Added a custom button as a test case, verified the token works for SVGs, font icons, and PNGs.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
