### PR TITLE
(Apple only) Turn off ASAN when packing the NuGet package

### DIFF
--- a/.ado/xcconfig/publish_overrides.xcconfig
+++ b/.ado/xcconfig/publish_overrides.xcconfig
@@ -12,3 +12,6 @@ ONLY_ACTIVE_ARCH=NO
 
 // Specify the exact Swift version used for reproducibility
 SWIFT_VERSION = 5.0
+
+// Turn off ASAN for ship builds
+ENABLE_ADDRESS_SANITIZER = NO


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

We only want ASAN turned on for debug, not ship.

### Verification

Testing Nuget creation is usually a "check in, make sure publish pipeline worked" kinda job 🤷🏾‍♂️


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
