### PR TITLE
ActivityIndicator - Don't use customize inside render 

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/ActivityIndicator/ActivityIndicatorTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ActivityIndicator/ActivityIndicatorTest.tsx
@@ -7,37 +7,6 @@ import { Test, TestSection, PlatformStatus } from '../Test';
 import { ACTIVITY_INDICATOR_TESTPAGE } from './consts';
 import { View, Switch } from 'react-native';
 
-const activityIndicatorTest: React.FunctionComponent = () => {
-  /** Customize doesn't do anything
-   * Tried having tokens not be props, but didn't work
-   * Not sure how to test/check where the tokens are passed through other than just looking at the final render
-   */
-  const CustomizedActivityIndicator = ActivityIndicator.customize({
-    activityIndicatorColor: 'orange',
-  });
-  return (
-    <Stack style={stackStyle}>
-      <Text>Extra Small</Text>
-      <ActivityIndicator size="xSmall" />
-      <Text>Small</Text>
-      <ActivityIndicator size="small" />
-      <Text>Medium</Text>
-      <ActivityIndicator size="medium" />
-      <Text>Large</Text>
-      <ActivityIndicator size="large" />
-      <Text>Extra Large</Text>
-      <ActivityIndicator size="xLarge" />
-
-      <Text>Size=xLarge and Line Thickness=large</Text>
-      <ActivityIndicator size="xLarge" lineThickness="large" />
-      <Text>Color props</Text>
-      <ActivityIndicator activityIndicatorColor="orange" accessibilityLabel="orange progressbar" />
-      <Text>Customized Activity Indicator (currently not working)</Text>
-      <CustomizedActivityIndicator />
-    </Stack>
-  );
-};
-
 const basicActivityIndicator: React.FunctionComponent = () => {
   const [animating, setAnimating] = React.useState(true);
   const [hidesWhenStopped, setHidesWhenStopped] = React.useState(true);
@@ -61,9 +30,45 @@ const basicActivityIndicator: React.FunctionComponent = () => {
   );
 };
 
+const activityIndicatorTest: React.FunctionComponent = () => {
+  return (
+    <Stack style={stackStyle}>
+      <Text>Extra Small</Text>
+      <ActivityIndicator size="xSmall" />
+      <Text>Small</Text>
+      <ActivityIndicator size="small" />
+      <Text>Medium</Text>
+      <ActivityIndicator size="medium" />
+      <Text>Large</Text>
+      <ActivityIndicator size="large" />
+      <Text>Extra Large</Text>
+      <ActivityIndicator size="xLarge" />
+
+      <Text>Size=xLarge and Line Thickness=large</Text>
+      <ActivityIndicator size="xLarge" lineThickness="large" />
+      <Text>Color props</Text>
+      <ActivityIndicator activityIndicatorColor="orange" accessibilityLabel="orange progressbar" />
+    </Stack>
+  );
+};
+
+const CustomizedActivityIndicator = ActivityIndicator.customize({
+  activityIndicatorColor: 'orange',
+  size: 'large',
+});
+
+const customizedActivityIndicatorTest: React.FunctionComponent = () => {
+  return (
+    <Stack style={stackStyle}>
+      <Text>Customized Activity Indicator</Text>
+      <CustomizedActivityIndicator />
+    </Stack>
+  );
+};
+
 const activityIndicatorSections: TestSection[] = [
   {
-    name: 'BaseActivityIndicator',
+    name: 'Base ActivityIndicator',
     testID: ACTIVITY_INDICATOR_TESTPAGE,
     component: basicActivityIndicator,
   },
@@ -71,6 +76,11 @@ const activityIndicatorSections: TestSection[] = [
     name: 'ActivityIndicator',
     testID: ACTIVITY_INDICATOR_TESTPAGE,
     component: activityIndicatorTest,
+  },
+  {
+    name: 'Customized ActivityIndicator',
+    testID: ACTIVITY_INDICATOR_TESTPAGE,
+    component: customizedActivityIndicatorTest,
   },
 ];
 

--- a/change/@fluentui-react-native-tester-a287dffd-389f-42bd-9c65-8fee991a6c8f.json
+++ b/change/@fluentui-react-native-tester-a287dffd-389f-42bd-9c65-8fee991a6c8f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix ActivityIndicator customize test",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

This change makes a minor fix to the ActivityIndicator test page, allowing the customize scenario to work. The main thing was to not call `customize` inside a function component. I also re-ordered the test page a bit.

### Verification

Customize works!

![Screen Shot 2022-02-24 at 9 50 24 AM](https://user-images.githubusercontent.com/6722175/155580250-86bd4f7b-5f5c-49dd-9824-a3de130987a5.png)


### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
