### PR TITLE
Add native event info to onChange in Checkbox V1 and onClick for Button V1

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/Button/ButtonHOCTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Button/ButtonHOCTestSection.tsx
@@ -38,7 +38,8 @@ export const ButtonHOCTest: React.FunctionComponent = () => {
       {svgIconsEnabled && <CustomIconButton icon={{ svgSource: svgProps }}>Customized Icon Button</CustomIconButton>}
       <Button
         style={commonTestStyles.vmargin}
-        onClick={() => {
+        onClick={(e) => {
+          console.log(e.timeStamp);
           if (buttonRef.current) {
             buttonRef.current.focus();
           }

--- a/apps/fluent-tester/src/FluentTester/TestComponents/Button/ButtonHOCTestSection.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Button/ButtonHOCTestSection.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { Platform, View } from 'react-native';
 import { commonTestStyles, stackStyle } from '../Common/styles';
 import TestSvg from './test.svg';
+import { InteractionEvent, isGestureResponderEvent } from '@fluentui-react-native/interactive-hooks';
 
 const CustomText = Text.customize({ fontSize: 'header', color: 'hotpink' });
 const CustomButton = Button.customize({ backgroundColor: 'pink' });
@@ -38,8 +39,13 @@ export const ButtonHOCTest: React.FunctionComponent = () => {
       {svgIconsEnabled && <CustomIconButton icon={{ svgSource: svgProps }}>Customized Icon Button</CustomIconButton>}
       <Button
         style={commonTestStyles.vmargin}
-        onClick={(e) => {
+        onClick={(e: InteractionEvent) => {
           console.log(e.timeStamp);
+
+          if (isGestureResponderEvent(e)) {
+            console.log('I was clicked!');
+          }
+
           if (buttonRef.current) {
             buttonRef.current.focus();
           }

--- a/apps/fluent-tester/src/FluentTester/TestComponents/CheckboxExperimental/CheckboxTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/CheckboxExperimental/CheckboxTest.tsx
@@ -3,12 +3,12 @@ import { EXPERIMENTAL_CHECKBOX_TESTPAGE } from './consts';
 import { Test, TestSection, PlatformStatus } from '../Test';
 import { Checkbox } from '@fluentui-react-native/experimental-checkbox';
 import { useTheme } from '@fluentui-react-native/theme-types';
-import { View, TextInput, TextStyle, AccessibilityActionEvent, GestureResponderEvent } from 'react-native';
+import { View, TextInput, TextStyle } from 'react-native';
 import { commonTestStyles as commonStyles } from '../Common/styles';
 import { E2ECheckboxExperimentalTest } from './E2ECheckboxExperimentalTest';
-import { KeyPressEvent } from '@fluentui-react-native/interactive-hooks';
+import { CallbackEvent } from '@fluentui-react-native/interactive-hooks';
 
-function onChangeUncontrolled(_e: GestureResponderEvent | KeyPressEvent | AccessibilityActionEvent, isChecked: boolean) {
+function onChangeUncontrolled(_e: CallbackEvent, isChecked: boolean) {
   console.log(isChecked);
 }
 

--- a/apps/fluent-tester/src/FluentTester/TestComponents/CheckboxExperimental/CheckboxTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/CheckboxExperimental/CheckboxTest.tsx
@@ -6,9 +6,9 @@ import { useTheme } from '@fluentui-react-native/theme-types';
 import { View, TextInput, TextStyle } from 'react-native';
 import { commonTestStyles as commonStyles } from '../Common/styles';
 import { E2ECheckboxExperimentalTest } from './E2ECheckboxExperimentalTest';
-import { CallbackEvent } from '@fluentui-react-native/interactive-hooks';
+import { InteractionEvent } from '@fluentui-react-native/interactive-hooks';
 
-function onChangeUncontrolled(_e: CallbackEvent, isChecked: boolean) {
+function onChangeUncontrolled(_e: InteractionEvent, isChecked: boolean) {
   console.log(isChecked);
 }
 

--- a/apps/fluent-tester/src/FluentTester/TestComponents/CheckboxExperimental/CheckboxTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/CheckboxExperimental/CheckboxTest.tsx
@@ -3,11 +3,12 @@ import { EXPERIMENTAL_CHECKBOX_TESTPAGE } from './consts';
 import { Test, TestSection, PlatformStatus } from '../Test';
 import { Checkbox } from '@fluentui-react-native/experimental-checkbox';
 import { useTheme } from '@fluentui-react-native/theme-types';
-import { View, TextInput, TextStyle } from 'react-native';
+import { View, TextInput, TextStyle, AccessibilityActionEvent, GestureResponderEvent } from 'react-native';
 import { commonTestStyles as commonStyles } from '../Common/styles';
 import { E2ECheckboxExperimentalTest } from './E2ECheckboxExperimentalTest';
+import { KeyPressEvent } from '@fluentui-react-native/interactive-hooks';
 
-function onChangeUncontrolled(isChecked: boolean) {
+function onChangeUncontrolled(_e: GestureResponderEvent | KeyPressEvent | AccessibilityActionEvent, isChecked: boolean) {
   console.log(isChecked);
 }
 

--- a/apps/fluent-tester/src/FluentTester/TestComponents/CheckboxExperimental/E2ECheckboxExperimentalTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/CheckboxExperimental/E2ECheckboxExperimentalTest.tsx
@@ -16,7 +16,7 @@ export const E2ECheckboxExperimentalTest: React.FunctionComponent = () => {
   const [checkboxPressed, setCheckboxPressed] = React.useState(false);
 
   const onClick = React.useCallback(
-    (checked) => {
+    (_e, checked) => {
       setCheckboxPressed(checked);
     },
     [setCheckboxPressed],

--- a/change/@fluentui-react-native-button-7d327a27-d505-4da3-aaad-872375a50741.json
+++ b/change/@fluentui-react-native-button-7d327a27-d505-4da3-aaad-872375a50741.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add native event to button onClick",
+  "packageName": "@fluentui-react-native/button",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-checkbox-7c713537-1714-460b-a4bd-9cd28a107afa.json
+++ b/change/@fluentui-react-native-experimental-checkbox-7c713537-1714-460b-a4bd-9cd28a107afa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix types",
+  "packageName": "@fluentui-react-native/experimental-checkbox",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-checkbox-7c713537-1714-460b-a4bd-9cd28a107afa.json
+++ b/change/@fluentui-react-native-experimental-checkbox-7c713537-1714-460b-a4bd-9cd28a107afa.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
+  "type": "minor",
   "comment": "Fix types",
   "packageName": "@fluentui-react-native/experimental-checkbox",
   "email": "ruaraki@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "minor"
 }

--- a/change/@fluentui-react-native-interactive-hooks-e7a94dc8-7e08-4f57-9845-53f22d8da563.json
+++ b/change/@fluentui-react-native-interactive-hooks-e7a94dc8-7e08-4f57-9845-53f22d8da563.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Set up initial native event passing",
+  "packageName": "@fluentui-react-native/interactive-hooks",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-ff085262-bb6e-4f5f-8c6f-1beb0e840391.json
+++ b/change/@fluentui-react-native-tester-ff085262-bb6e-4f5f-8c6f-1beb0e840391.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix types",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Button/SPEC.md
+++ b/packages/components/Button/SPEC.md
@@ -136,7 +136,7 @@ export interface ButtonProps extends Omit<IWithPressableOptions<ViewProps>, 'onP
   /**
    * A callback to call on button click event
    */
-  onClick?: (e: CallbackEvent) => void;
+  onClick?: (e: InteractionEvent) => void;
 
   /**
    * A button can be rounded, circular, or square.

--- a/packages/components/Button/SPEC.md
+++ b/packages/components/Button/SPEC.md
@@ -136,7 +136,7 @@ export interface ButtonProps extends Omit<IWithPressableOptions<ViewProps>, 'onP
   /**
    * A callback to call on button click event
    */
-  onClick?: (e: [CallbackEvent](../../utils/interactive-hooks/src/events.types.ts)) => void;
+  onClick?: (e: CallbackEvent) => void;
 
   /**
    * A button can be rounded, circular, or square.

--- a/packages/components/Button/SPEC.md
+++ b/packages/components/Button/SPEC.md
@@ -136,7 +136,7 @@ export interface ButtonProps extends Omit<IWithPressableOptions<ViewProps>, 'onP
   /**
    * A callback to call on button click event
    */
-  onClick?: (e: GestureResponderEvent | KeyPressEvent | AccessibilityActionEvent) => void;
+  onClick?: (e: CallbackEvent) => void;
 
   /**
    * A button can be rounded, circular, or square.

--- a/packages/components/Button/SPEC.md
+++ b/packages/components/Button/SPEC.md
@@ -134,6 +134,11 @@ export interface ButtonProps extends Omit<IWithPressableOptions<ViewProps>, 'onP
   loading?: boolean;
 
   /**
+   * A callback to call on button click event
+   */
+  onClick?: (e: GestureResponderEvent | KeyPressEvent | AccessibilityActionEvent) => void;
+
+  /**
    * A button can be rounded, circular, or square.
    * @default 'rounded'
    */
@@ -149,11 +154,6 @@ export interface ButtonProps extends Omit<IWithPressableOptions<ViewProps>, 'onP
    * Text that should show in a tooltip when the user hovers over a button.
    */
   tooltip?: string;
-
-  /**
-   * A callback to call on button click event
-   */
-  onClick?: () => void;
 }
 ```
 

--- a/packages/components/Button/SPEC.md
+++ b/packages/components/Button/SPEC.md
@@ -136,7 +136,7 @@ export interface ButtonProps extends Omit<IWithPressableOptions<ViewProps>, 'onP
   /**
    * A callback to call on button click event
    */
-  onClick?: (e: CallbackEvent) => void;
+  onClick?: (e: [CallbackEvent](../../utils/interactive-hooks/src/events.types.ts)) => void;
 
   /**
    * A button can be rounded, circular, or square.

--- a/packages/components/Button/src/Button.types.ts
+++ b/packages/components/Button/src/Button.types.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { ViewProps, ViewStyle, ColorValue } from 'react-native';
+import { ViewProps, ViewStyle, ColorValue, GestureResponderEvent, AccessibilityActionEvent } from 'react-native';
 import { TextProps } from '@fluentui-react-native/experimental-text';
 import { FontTokens, IBorderTokens, IColorTokens, IShadowTokens, LayoutTokens } from '@fluentui-react-native/tokens';
-import { IFocusable, IPressableHooks, IWithPressableOptions } from '@fluentui-react-native/interactive-hooks';
+import { IFocusable, IPressableHooks, IWithPressableOptions, KeyPressEvent } from '@fluentui-react-native/interactive-hooks';
 import { IconProps, IconSourcesType } from '@fluentui-react-native/icon';
 import { IViewProps } from '@fluentui-react-native/adapters';
 
@@ -89,7 +89,7 @@ export interface ButtonCoreProps extends Omit<IWithPressableOptions<ViewProps>, 
   /**
    * A callback to call on button click event
    */
-  onClick?: () => void;
+  onClick?: (e: GestureResponderEvent | KeyPressEvent | AccessibilityActionEvent) => void;
 
   /**
    * Text that should show in a tooltip when the user hovers over a button.

--- a/packages/components/Button/src/Button.types.ts
+++ b/packages/components/Button/src/Button.types.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { ViewProps, ViewStyle, ColorValue } from 'react-native';
 import { TextProps } from '@fluentui-react-native/experimental-text';
 import { FontTokens, IBorderTokens, IColorTokens, IShadowTokens, LayoutTokens } from '@fluentui-react-native/tokens';
-import { IFocusable, IPressableHooks, IWithPressableOptions, CallbackEvent } from '@fluentui-react-native/interactive-hooks';
+import { IFocusable, IPressableHooks, IWithPressableOptions, InteractionEvent } from '@fluentui-react-native/interactive-hooks';
 import { IconProps, IconSourcesType } from '@fluentui-react-native/icon';
 import { IViewProps } from '@fluentui-react-native/adapters';
 
@@ -89,7 +89,7 @@ export interface ButtonCoreProps extends Omit<IWithPressableOptions<ViewProps>, 
   /**
    * A callback to call on button click event
    */
-  onClick?: (e: CallbackEvent) => void;
+  onClick?: (e: InteractionEvent) => void;
 
   /**
    * Text that should show in a tooltip when the user hovers over a button.

--- a/packages/components/Button/src/Button.types.ts
+++ b/packages/components/Button/src/Button.types.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { ViewProps, ViewStyle, ColorValue, GestureResponderEvent, AccessibilityActionEvent } from 'react-native';
+import { ViewProps, ViewStyle, ColorValue } from 'react-native';
 import { TextProps } from '@fluentui-react-native/experimental-text';
 import { FontTokens, IBorderTokens, IColorTokens, IShadowTokens, LayoutTokens } from '@fluentui-react-native/tokens';
-import { IFocusable, IPressableHooks, IWithPressableOptions, KeyPressEvent } from '@fluentui-react-native/interactive-hooks';
+import { IFocusable, IPressableHooks, IWithPressableOptions, CallbackEvent } from '@fluentui-react-native/interactive-hooks';
 import { IconProps, IconSourcesType } from '@fluentui-react-native/icon';
 import { IViewProps } from '@fluentui-react-native/adapters';
 
@@ -89,7 +89,7 @@ export interface ButtonCoreProps extends Omit<IWithPressableOptions<ViewProps>, 
   /**
    * A callback to call on button click event
    */
-  onClick?: (e: GestureResponderEvent | KeyPressEvent | AccessibilityActionEvent) => void;
+  onClick?: (e: CallbackEvent) => void;
 
   /**
    * Text that should show in a tooltip when the user hovers over a button.

--- a/packages/components/Button/src/ToggleButton/useToggleButton.ts
+++ b/packages/components/Button/src/ToggleButton/useToggleButton.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ToggleButtonProps, ToggleButtonState } from './ToggleButton.types';
 import { useButton } from '../useButton';
-import { useAsToggle } from '@fluentui-react-native/interactive-hooks';
+import { useAsToggleWithEvent } from '@fluentui-react-native/interactive-hooks';
 import { memoize } from '@fluentui-react-native/framework';
 import { AccessibilityState } from 'react-native';
 
@@ -13,7 +13,7 @@ export const useToggleButton = (props: ToggleButtonProps): ToggleButtonState => 
   if (defaultChecked != undefined && checked != undefined) {
     console.warn('defaultChecked and checked are mutually exclusive to one another. Use one or the other.');
   }
-  const [checkedValue, toggle] = useAsToggle(defaultChecked, checked, onClick);
+  const [checkedValue, toggle] = useAsToggleWithEvent(defaultChecked, checked, onClick);
   const accessibilityActionsProp = accessibilityActions
     ? [...defaultAccessibilityActions, ...accessibilityActions]
     : defaultAccessibilityActions;
@@ -21,7 +21,7 @@ export const useToggleButton = (props: ToggleButtonProps): ToggleButtonState => 
     (event) => {
       switch (event.nativeEvent.actionName) {
         case 'Toggle':
-          toggle();
+          toggle(event);
           break;
       }
       onAccessibilityAction && onAccessibilityAction(event);

--- a/packages/experimental/Checkbox/SPEC.md
+++ b/packages/experimental/Checkbox/SPEC.md
@@ -119,7 +119,7 @@ export interface CheckboxProps extends Omit<IViewProps, 'onPress'> {
   /**
    * Callback that is called when the checked value has changed.
    */
-  onChange?: (e: CallbackEvent, isChecked: boolean) => void;
+  onChange?: (e: InteractionEvent, isChecked: boolean) => void;
 
   /** Sets style of checkbox to a preset size style.
    * @default 'medium'

--- a/packages/experimental/Checkbox/SPEC.md
+++ b/packages/experimental/Checkbox/SPEC.md
@@ -119,7 +119,7 @@ export interface CheckboxProps extends Omit<IViewProps, 'onPress'> {
   /**
    * Callback that is called when the checked value has changed.
    */
-  onChange?: (e: GestureResponderEvent | KeyPressEvent | AccessibilityActionEvent, isChecked: boolean) => void;
+  onChange?: (e: CallbackEvent, isChecked: boolean) => void;
 
   /** Sets style of checkbox to a preset size style.
    * @default 'medium'

--- a/packages/experimental/Checkbox/SPEC.md
+++ b/packages/experimental/Checkbox/SPEC.md
@@ -119,7 +119,7 @@ export interface CheckboxProps extends Omit<IViewProps, 'onPress'> {
   /**
    * Callback that is called when the checked value has changed.
    */
-  onChange?: (isChecked: boolean) => void;
+  onChange?: (e: GestureResponderEvent | KeyPressEvent | AccessibilityActionEvent, isChecked: boolean) => void;
 
   /** Sets style of checkbox to a preset size style.
    * @default 'medium'

--- a/packages/experimental/Checkbox/SPEC.md
+++ b/packages/experimental/Checkbox/SPEC.md
@@ -119,7 +119,7 @@ export interface CheckboxProps extends Omit<IViewProps, 'onPress'> {
   /**
    * Callback that is called when the checked value has changed.
    */
-  onChange?: (e: CallbackEvent, isChecked: boolean) => void;
+  onChange?: (e: [CallbackEvent](../../utils/interactive-hooks/src/events.types.ts), isChecked: boolean) => void;
 
   /** Sets style of checkbox to a preset size style.
    * @default 'medium'

--- a/packages/experimental/Checkbox/SPEC.md
+++ b/packages/experimental/Checkbox/SPEC.md
@@ -119,7 +119,7 @@ export interface CheckboxProps extends Omit<IViewProps, 'onPress'> {
   /**
    * Callback that is called when the checked value has changed.
    */
-  onChange?: (e: [CallbackEvent](../../utils/interactive-hooks/src/events.types.ts), isChecked: boolean) => void;
+  onChange?: (e: CallbackEvent, isChecked: boolean) => void;
 
   /** Sets style of checkbox to a preset size style.
    * @default 'medium'

--- a/packages/experimental/Checkbox/src/Checkbox.macos.tsx
+++ b/packages/experimental/Checkbox/src/Checkbox.macos.tsx
@@ -33,7 +33,7 @@ export const Checkbox = compose<CheckboxTypeMacOS>({
     const { onChange, ...restOfUserProps } = props;
     const onPress = (e: any) => {
       if (onChange != null) {
-        onChange(e.nativeEvent.isChecked);
+        onChange(e, e.nativeEvent.isChecked);
       }
     };
     const rootProps = { ...restOfUserProps };

--- a/packages/experimental/Checkbox/src/Checkbox.types.ts
+++ b/packages/experimental/Checkbox/src/Checkbox.types.ts
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { ColorValue } from 'react-native';
+import { AccessibilityActionEvent, ColorValue, GestureResponderEvent } from 'react-native';
 import { FontTokens, IBorderTokens, IForegroundColorTokens, IBackgroundColorTokens, LayoutTokens } from '@fluentui-react-native/tokens';
 import { IFocusable, IPressableState } from '@fluentui-react-native/interactive-hooks';
 import type { ITextProps, IViewProps } from '@fluentui-react-native/adapters';
 import { SvgProps } from 'react-native-svg';
+import { KeyPressEvent } from '@fluentui-react-native/interactive-hooks';
 
 export const checkboxName = 'Checkbox';
 export type CheckboxSize = 'medium' | 'large';
@@ -120,7 +121,7 @@ export interface CheckboxProps extends Omit<IViewProps, 'onPress'> {
   /**
    * Callback that is called when the checked value has changed.
    */
-  onChange?: (e: any, isChecked: boolean) => void;
+  onChange?: (e: GestureResponderEvent | KeyPressEvent | AccessibilityActionEvent, isChecked: boolean) => void;
 
   /** Sets style of checkbox to a preset size style.
    * @default 'medium'

--- a/packages/experimental/Checkbox/src/Checkbox.types.ts
+++ b/packages/experimental/Checkbox/src/Checkbox.types.ts
@@ -4,7 +4,7 @@ import { FontTokens, IBorderTokens, IForegroundColorTokens, IBackgroundColorToke
 import { IFocusable, IPressableState } from '@fluentui-react-native/interactive-hooks';
 import type { ITextProps, IViewProps } from '@fluentui-react-native/adapters';
 import { SvgProps } from 'react-native-svg';
-import { CallbackEvent } from '@fluentui-react-native/interactive-hooks';
+import { InteractionEvent } from '@fluentui-react-native/interactive-hooks';
 
 export const checkboxName = 'Checkbox';
 export type CheckboxSize = 'medium' | 'large';
@@ -121,7 +121,7 @@ export interface CheckboxProps extends Omit<IViewProps, 'onPress'> {
   /**
    * Callback that is called when the checked value has changed.
    */
-  onChange?: (e: CallbackEvent, isChecked: boolean) => void;
+  onChange?: (e: InteractionEvent, isChecked: boolean) => void;
 
   /** Sets style of checkbox to a preset size style.
    * @default 'medium'

--- a/packages/experimental/Checkbox/src/Checkbox.types.ts
+++ b/packages/experimental/Checkbox/src/Checkbox.types.ts
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import { AccessibilityActionEvent, ColorValue, GestureResponderEvent } from 'react-native';
+import { ColorValue } from 'react-native';
 import { FontTokens, IBorderTokens, IForegroundColorTokens, IBackgroundColorTokens, LayoutTokens } from '@fluentui-react-native/tokens';
 import { IFocusable, IPressableState } from '@fluentui-react-native/interactive-hooks';
 import type { ITextProps, IViewProps } from '@fluentui-react-native/adapters';
 import { SvgProps } from 'react-native-svg';
-import { KeyPressEvent } from '@fluentui-react-native/interactive-hooks';
+import { CallbackEvent } from '@fluentui-react-native/interactive-hooks';
 
 export const checkboxName = 'Checkbox';
 export type CheckboxSize = 'medium' | 'large';
@@ -121,7 +121,7 @@ export interface CheckboxProps extends Omit<IViewProps, 'onPress'> {
   /**
    * Callback that is called when the checked value has changed.
    */
-  onChange?: (e: GestureResponderEvent | KeyPressEvent | AccessibilityActionEvent, isChecked: boolean) => void;
+  onChange?: (e: CallbackEvent, isChecked: boolean) => void;
 
   /** Sets style of checkbox to a preset size style.
    * @default 'medium'

--- a/packages/experimental/Checkbox/src/Checkbox.types.ts
+++ b/packages/experimental/Checkbox/src/Checkbox.types.ts
@@ -120,7 +120,7 @@ export interface CheckboxProps extends Omit<IViewProps, 'onPress'> {
   /**
    * Callback that is called when the checked value has changed.
    */
-  onChange?: (isChecked: boolean) => void;
+  onChange?: (e: any, isChecked: boolean) => void;
 
   /** Sets style of checkbox to a preset size style.
    * @default 'medium'

--- a/packages/experimental/Checkbox/src/__tests__/Checkbox.test.tsx
+++ b/packages/experimental/Checkbox/src/__tests__/Checkbox.test.tsx
@@ -2,11 +2,11 @@ import * as React from 'react';
 import { Checkbox } from '../Checkbox';
 import * as renderer from 'react-test-renderer';
 import { checkRenderConsistency, checkReRender } from '@fluentui-react-native/test-tools';
-import { AccessibilityActionEvent, AccessibilityActionName, GestureResponderEvent, Text, View } from 'react-native';
+import { AccessibilityActionName, Text, View } from 'react-native';
 import { Svg } from 'react-native-svg';
-import { KeyPressEvent } from '@fluentui-react-native/interactive-hooks';
+import { CallbackEvent } from '@fluentui-react-native/interactive-hooks';
 
-function onChange(_e: GestureResponderEvent | KeyPressEvent | AccessibilityActionEvent, isChecked: boolean) {
+function onChange(_e: CallbackEvent, isChecked: boolean) {
   console.log(isChecked);
 }
 

--- a/packages/experimental/Checkbox/src/__tests__/Checkbox.test.tsx
+++ b/packages/experimental/Checkbox/src/__tests__/Checkbox.test.tsx
@@ -4,9 +4,9 @@ import * as renderer from 'react-test-renderer';
 import { checkRenderConsistency, checkReRender } from '@fluentui-react-native/test-tools';
 import { AccessibilityActionName, Text, View } from 'react-native';
 import { Svg } from 'react-native-svg';
-import { CallbackEvent } from '@fluentui-react-native/interactive-hooks';
+import { InteractionEvent } from '@fluentui-react-native/interactive-hooks';
 
-function onChange(_e: CallbackEvent, isChecked: boolean) {
+function onChange(_e: InteractionEvent, isChecked: boolean) {
   console.log(isChecked);
 }
 

--- a/packages/experimental/Checkbox/src/__tests__/Checkbox.test.tsx
+++ b/packages/experimental/Checkbox/src/__tests__/Checkbox.test.tsx
@@ -2,10 +2,11 @@ import * as React from 'react';
 import { Checkbox } from '../Checkbox';
 import * as renderer from 'react-test-renderer';
 import { checkRenderConsistency, checkReRender } from '@fluentui-react-native/test-tools';
-import { AccessibilityActionName, Text, View } from 'react-native';
+import { AccessibilityActionEvent, AccessibilityActionName, GestureResponderEvent, Text, View } from 'react-native';
 import { Svg } from 'react-native-svg';
+import { KeyPressEvent } from '@fluentui-react-native/interactive-hooks';
 
-function onChange(isChecked: boolean) {
+function onChange(_e: GestureResponderEvent | KeyPressEvent | AccessibilityActionEvent, isChecked: boolean) {
   console.log(isChecked);
 }
 

--- a/packages/experimental/Checkbox/src/useCheckbox.ts
+++ b/packages/experimental/Checkbox/src/useCheckbox.ts
@@ -4,7 +4,7 @@ import {
   useKeyProps,
   useOnPressWithFocus,
   useViewCommandFocus,
-  useAsToggle,
+  useAsToggleWithEvent,
 } from '@fluentui-react-native/interactive-hooks';
 import { CheckboxProps, CheckboxInfo, CheckboxState } from './Checkbox.types';
 import { IPressableProps } from '@fluentui-react-native/pressable';
@@ -44,7 +44,7 @@ export const useCheckbox = (props: CheckboxProps): CheckboxInfo => {
   }
 
   // Re-usable hook for toggle components.
-  const [isChecked, toggleChecked] = useAsToggle(defaultChecked, checked, onChange);
+  const [isChecked, toggleChecked] = useAsToggleWithEvent(defaultChecked, checked, onChange);
 
   // Ensure focus is placed on checkbox after click
   const toggleCheckedWithFocus = useOnPressWithFocus(componentRef, toggleChecked);
@@ -71,7 +71,7 @@ export const useCheckbox = (props: CheckboxProps): CheckboxInfo => {
     (event: AccessibilityActionEvent) => {
       switch (event.nativeEvent.actionName) {
         case 'Toggle':
-          toggleChecked();
+          toggleChecked(event);
           break;
       }
       onAccessibilityAction && onAccessibilityAction(event);

--- a/packages/utils/interactive-hooks/jest.config.js
+++ b/packages/utils/interactive-hooks/jest.config.js
@@ -1,0 +1,2 @@
+const { configureJest } = require('@fluentui-react-native/scripts');
+module.exports = configureJest();

--- a/packages/utils/interactive-hooks/package.json
+++ b/packages/utils/interactive-hooks/package.json
@@ -35,6 +35,7 @@
     "@fluentui-react-native/icon": "0.11.9",
     "@office-iss/react-native-win32": "^0.64.8",
     "@types/invariant": "^2.2.0",
+    "@types/jest": "^26.0.0",
     "@types/react": "^17.0.2",
     "@types/react-native": "^0.64.0",
     "@fluentui-react-native/scripts": "^0.1.1",

--- a/packages/utils/interactive-hooks/src/events.types.test.ts
+++ b/packages/utils/interactive-hooks/src/events.types.test.ts
@@ -1,0 +1,79 @@
+import { AccessibilityActionEvent, GestureResponderEvent } from 'react-native';
+import { KeyPressEvent } from './Pressability/CoreEventTypes';
+import { isAccessibilityActionEvent, isGestureResponderEvent, isKeyPressEvent } from './events.types';
+
+const createMockEvent = (nativeEvent) => {
+  return {
+    nativeEvent: nativeEvent,
+    currentTarget: 1,
+    target: 1,
+    bubbles: false,
+    cancelable: true,
+    defaultPrevented: false,
+    eventPhase: 0,
+    isTrusted: false,
+    preventDefault: () => {
+      /* empty for test*/
+    },
+    isDefaultPrevented: () => {
+      return false;
+    },
+    stopPropagation: () => {
+      /* empty for test*/
+    },
+    isPropagationStopped: () => {
+      return true;
+    },
+    persist: () => {
+      /* empty for test*/
+    },
+    timeStamp: 0,
+    type: '',
+  };
+};
+
+const mockGestureEvent: GestureResponderEvent = createMockEvent({
+  changedTouches: [],
+  identifier: '',
+  locationX: 0,
+  locationY: 0,
+  pageX: 0,
+  pageY: 0,
+  target: '',
+  timestamp: 0,
+  touches: [],
+});
+
+const mockKeyPressEvent: KeyPressEvent = createMockEvent({
+  key: 'enter',
+});
+
+const mockAccessibilityEvent: AccessibilityActionEvent = createMockEvent({
+  actionName: 'longpress',
+});
+
+describe('InteractionEvent type guard tests', () => {
+  it('has correct output from isGestureResponderEvent when input is type GestureResponderEvent', () => {
+    expect(isGestureResponderEvent(mockGestureEvent)).toBeTruthy();
+  });
+
+  it('has correct output from isGestureResponderEvent when input is not type GestureResponderEvent', () => {
+    expect(isGestureResponderEvent(mockAccessibilityEvent)).toBeFalsy();
+  });
+
+  it('has correct output from isKeyPressEvent when input is type KeyPressEvent', () => {
+    expect(isKeyPressEvent(mockKeyPressEvent)).toBeTruthy();
+  });
+
+  it('has correct output from isKeyPressEvent when input is not type KeyPressEvent', () => {
+    expect(isKeyPressEvent(mockGestureEvent)).toBeFalsy();
+  });
+
+  it('has correct output from isAccessibilityActionEvent when input is type AccessibilityActionEvent', () => {
+    expect(isAccessibilityActionEvent(mockAccessibilityEvent)).toBeTruthy();
+  });
+
+  it('has correct output from isAccessibilityActionEvent when input is not type AccessibilityActionEvent', () => {
+    expect(isAccessibilityActionEvent(mockGestureEvent)).toBeFalsy();
+  });
+});

--- a/packages/utils/interactive-hooks/src/events.types.ts
+++ b/packages/utils/interactive-hooks/src/events.types.ts
@@ -1,4 +1,28 @@
 import { AccessibilityActionEvent, GestureResponderEvent } from 'react-native';
-import { KeyPressEvent } from '.';
+import { KeyPressEvent } from './Pressability/CoreEventTypes';
 
 export type InteractionEvent = GestureResponderEvent | KeyPressEvent | AccessibilityActionEvent;
+
+export const isGestureResponderEvent = (e: InteractionEvent): e is GestureResponderEvent => {
+  if ('touches' in e.nativeEvent) {
+    return true;
+  }
+
+  return false;
+};
+
+export const isKeyPressEvent = (e: InteractionEvent): e is KeyPressEvent => {
+  if ('key' in e.nativeEvent) {
+    return true;
+  }
+
+  return false;
+};
+
+export const isAccessibilityActionEvent = (e: InteractionEvent): e is AccessibilityActionEvent => {
+  if ('actionName' in e.nativeEvent) {
+    return true;
+  }
+
+  return false;
+};

--- a/packages/utils/interactive-hooks/src/events.types.ts
+++ b/packages/utils/interactive-hooks/src/events.types.ts
@@ -1,4 +1,4 @@
 import { AccessibilityActionEvent, GestureResponderEvent } from 'react-native';
 import { KeyPressEvent } from '.';
 
-export type CallbackEvent = GestureResponderEvent | KeyPressEvent | AccessibilityActionEvent;
+export type InteractionEvent = GestureResponderEvent | KeyPressEvent | AccessibilityActionEvent;

--- a/packages/utils/interactive-hooks/src/events.types.ts
+++ b/packages/utils/interactive-hooks/src/events.types.ts
@@ -1,0 +1,4 @@
+import { AccessibilityActionEvent, GestureResponderEvent } from 'react-native';
+import { KeyPressEvent } from '.';
+
+export type CallbackEvent = GestureResponderEvent | KeyPressEvent | AccessibilityActionEvent;

--- a/packages/utils/interactive-hooks/src/index.ts
+++ b/packages/utils/interactive-hooks/src/index.ts
@@ -5,6 +5,7 @@ export * from './useViewCommandFocus';
 export * from './useSelectedKey.hooks';
 export * from './useIconProps.hooks';
 export * from './useAsToggle';
+export * from './useAsToggleWithEvent';
 export * from './Pressability/Pressability.types';
 export * from './Pressability/InternalTypes';
 export * from './Pressability/CoreEventTypes';

--- a/packages/utils/interactive-hooks/src/index.ts
+++ b/packages/utils/interactive-hooks/src/index.ts
@@ -1,3 +1,4 @@
+export * from './events.types';
 export * from './useAsPressable.types';
 export * from './useAsPressable';
 export * from './usePressability';

--- a/packages/utils/interactive-hooks/src/useAsToggleWithEvent.ts
+++ b/packages/utils/interactive-hooks/src/useAsToggleWithEvent.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { CallbackEvent } from '.';
+import { InteractionEvent } from '.';
 
-export type OnToggleWithEventCallback = (e: CallbackEvent, value?: boolean) => void;
-export type OnChangeWithEventCallback = (e: CallbackEvent) => void;
+export type OnToggleWithEventCallback = (e: InteractionEvent, value?: boolean) => void;
+export type OnChangeWithEventCallback = (e: InteractionEvent) => void;
 
 /* Re-usable hook for toggle components.
  * This hook configures the checked state, the callback to toggle the component

--- a/packages/utils/interactive-hooks/src/useAsToggleWithEvent.ts
+++ b/packages/utils/interactive-hooks/src/useAsToggleWithEvent.ts
@@ -1,9 +1,8 @@
 import * as React from 'react';
-import { AccessibilityActionEvent, GestureResponderEvent } from 'react-native';
-import { KeyPressEvent } from '.';
+import { CallbackEvent } from '.';
 
-export type OnToggleWithEventCallback = (e: GestureResponderEvent | KeyPressEvent | AccessibilityActionEvent, value?: boolean) => void;
-export type OnChangeWithEventCallback = (e: GestureResponderEvent | KeyPressEvent | AccessibilityActionEvent) => void;
+export type OnToggleWithEventCallback = (e: CallbackEvent, value?: boolean) => void;
+export type OnChangeWithEventCallback = (e: CallbackEvent) => void;
 
 /* Re-usable hook for toggle components.
  * This hook configures the checked state, the callback to toggle the component

--- a/packages/utils/interactive-hooks/src/useAsToggleWithEvent.ts
+++ b/packages/utils/interactive-hooks/src/useAsToggleWithEvent.ts
@@ -1,7 +1,9 @@
 import * as React from 'react';
+import { AccessibilityActionEvent, GestureResponderEvent } from 'react-native';
+import { KeyPressEvent } from '.';
 
-export type OnToggleWithEventCallback = (e: any, value?: boolean) => void;
-export type OnChangeWithEventCallback = (e: any) => void;
+export type OnToggleWithEventCallback = (e: GestureResponderEvent | KeyPressEvent | AccessibilityActionEvent, value?: boolean) => void;
+export type OnChangeWithEventCallback = (e: GestureResponderEvent | KeyPressEvent | AccessibilityActionEvent) => void;
 
 /* Re-usable hook for toggle components.
  * This hook configures the checked state, the callback to toggle the component

--- a/packages/utils/interactive-hooks/src/useAsToggleWithEvent.ts
+++ b/packages/utils/interactive-hooks/src/useAsToggleWithEvent.ts
@@ -1,0 +1,33 @@
+import * as React from 'react';
+
+export type OnToggleWithEventCallback = (e: any, value?: boolean) => void;
+export type OnChangeWithEventCallback = (e: any) => void;
+
+/* Re-usable hook for toggle components.
+ * This hook configures the checked state, the callback to toggle the component
+ * It handles the controlled/uncontrolled functionality of the toggle component.
+ *
+ * PROPS:  defaultChecked - Default checked state. Mutually exclusive to ‘checked’. This should come from userProps
+ *         checked - Checked state. Mutually exclusive to 'defaultChecked'. This should come from userProps
+ *         userCallback() - Callback provided by userProps when the checked (toggle) state changes
+ * RETURNS:
+ *         onChange() - Callback to toggle the component
+ *         state.isChecked - Whether or not component is currently checked or selected
+ */
+export function useAsToggleWithEvent(
+  defaultChecked?: boolean,
+  checked?: boolean,
+  userCallback?: OnToggleWithEventCallback,
+): [boolean, OnChangeWithEventCallback] {
+  const [isChecked, setChecked] = React.useState(defaultChecked ?? checked);
+
+  const onChange = React.useCallback(
+    (e: any) => {
+      userCallback && userCallback(e, !isChecked);
+      setChecked(!isChecked);
+    },
+    [isChecked, setChecked],
+  );
+
+  return [checked ?? isChecked, onChange];
+}

--- a/packages/utils/interactive-hooks/src/useOnPressWithFocus.ts
+++ b/packages/utils/interactive-hooks/src/useOnPressWithFocus.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { GestureResponderEvent } from 'react-native';
 
-export type OnPressCallback = (args?: GestureResponderEvent) => void;
+export type OnPressCallback = (args: GestureResponderEvent) => void;
 export type OnPressWithFocusCallback = (args: GestureResponderEvent) => void;
 
 /* Re-usable hook for pressable components.

--- a/packages/utils/interactive-hooks/src/useOnPressWithFocus.ts
+++ b/packages/utils/interactive-hooks/src/useOnPressWithFocus.ts
@@ -1,7 +1,8 @@
 import * as React from 'react';
+import { GestureResponderEvent } from 'react-native';
 
-export type OnPressCallback = (args?: any) => void;
-export type OnPressWithFocusCallback = () => void;
+export type OnPressCallback = (args?: GestureResponderEvent) => void;
+export type OnPressWithFocusCallback = (args: GestureResponderEvent) => void;
 
 /* Re-usable hook for pressable components.
  * This hook sets focus on a component after onPress behavior.

--- a/packages/utils/interactive-hooks/tsconfig.json
+++ b/packages/utils/interactive-hooks/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@fluentui-react-native/scripts/tsconfig.json",
   "compilerOptions": {
     "importHelpers": true,
-    "outDir": "lib"
+    "outDir": "lib",
+    "types": ["node", "jest"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Changing the signature of the onChange and onClick callbacks to have an e (event) arg. This arg is one of types GestureResponderEvent, KeyEvent, or AccessibilityActionEvent, since we use this callback to respond to all 3 of click, key press, and accessibility invocations.

This allows users to get information about the events that come through and has the bonus of aligning our API to FluentUI JS better.

## Verification

Build passes, UTs pass. Tested on tester and ensured that event information is being filled in correctly.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
