### PR TITLE
Change `circular` to `shape` on CheckboxV1

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/CheckboxExperimental/CheckboxTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/CheckboxExperimental/CheckboxTest.tsx
@@ -20,8 +20,8 @@ const basicCheckbox: React.FunctionComponent = () => {
       <Checkbox label="Disabled checkbox" disabled />
       <Checkbox label="Disabled checked checkbox" defaultChecked disabled />
       <Checkbox label="Checkbox will display a tooltip" tooltip="This is a tooltip" />
-      <Checkbox label="A circular checkbox" circular />
-      <Checkbox label="A circular checkbox" labelPosition="before" />
+      <Checkbox label="A circular checkbox" shape="circular" />
+      <Checkbox label="A checkbox with label placed before" labelPosition="before" />
     </View>
   );
 };
@@ -106,7 +106,12 @@ const tokenCheckbox: React.FunctionComponent = () => {
   return (
     <View>
       <HoverCheckbox label="A checkbox with checkmark visible on hover" onChange={onChangeUncontrolled} defaultChecked={false} />
-      <CircleColorCheckbox label="A circular token-customized checkbox" circular onChange={onChangeUncontrolled} defaultChecked={true} />
+      <CircleColorCheckbox
+        label="A circular token-customized checkbox"
+        shape="circular"
+        onChange={onChangeUncontrolled}
+        defaultChecked={true}
+      />
       <BlueCheckbox
         label="Token-customized checkbox. Customizable below."
         onChange={onChangeUncontrolled}

--- a/change/@fluentui-react-native-experimental-checkbox-59911dbf-ba2f-45b7-ab96-d3471f3b4b81.json
+++ b/change/@fluentui-react-native-experimental-checkbox-59911dbf-ba2f-45b7-ab96-d3471f3b4b81.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Change circular to shape prop",
+  "packageName": "@fluentui-react-native/experimental-checkbox",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-1f59eac3-e963-4ae0-b93a-2be0b45a8947.json
+++ b/change/@fluentui-react-native-tester-1f59eac3-e963-4ae0-b93a-2be0b45a8947.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Change circular to shape prop",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Checkbox/MIGRATION.md
+++ b/packages/experimental/Checkbox/MIGRATION.md
@@ -68,8 +68,8 @@ The FURN Checkbox cannot be used in place of a FluentUI React Checkbox - these b
 
 ### Props unchanged
 
-- `circular`
 - `labelPosition`
+- `shape`
 - `size`
 
 ### Props renamed to align with ReactNative

--- a/packages/experimental/Checkbox/SPEC.md
+++ b/packages/experimental/Checkbox/SPEC.md
@@ -14,7 +14,7 @@ Basic examples:
 
 ```jsx
 <Checkbox label="Example Checkbox" />
-<Checkbox label="Large Circular Checkbox" circular size="large" />
+<Checkbox label="Large Circular Checkbox" shape="circular" size="large" />
 <Checkbox label="Controlled Checkbox" onChange={onChangeFunction} checked={checked} />
 ```
 
@@ -39,7 +39,7 @@ Win32:
 ![Checkbox with circular appearance on win32 example](./assets/Checkbox_circular_example_win32.png)
 
 ```jsx
-<Checkbox label="Circular Checkbox" circular />
+<Checkbox label="Circular Checkbox" shape="circular" />
 ```
 
 ## Variants
@@ -48,9 +48,9 @@ Win32:
 
 The `Checkbox` control supports the `unchecked` and `checked` appearances. It does _not_ support a `intermediate` or `mixed` appearance.
 
-### Circular
+### Shapes
 
-The `Checkbox` control supports a `circular` shape variant.
+The `Checkbox` control supports a rounded `square` (default) and `circular` shape variants.
 
 ### Sizes
 

--- a/packages/experimental/Checkbox/SPEC.md
+++ b/packages/experimental/Checkbox/SPEC.md
@@ -82,13 +82,6 @@ export interface CheckboxProps extends Omit<IViewProps, 'onPress'> {
   checked?: boolean;
 
   /**
-   * Allows you to set the checkbox to have circular styling.
-   *
-   * @platform Android, iOS, windows, win32
-   */
-  circular?: boolean;
-
-  /**
    * A RefObject to access the IFocusable interface. Use this to access the public methods and properties of the component.
    */
   componentRef?: React.RefObject<IFocusable>;
@@ -120,6 +113,14 @@ export interface CheckboxProps extends Omit<IViewProps, 'onPress'> {
    * Callback that is called when the checked value has changed.
    */
   onChange?: (isChecked: boolean) => void;
+
+  /**
+   * The shape of the checkbox. Can be either (rounded) square or circular.
+   *
+   * @default square
+   * @platform Android, iOS, windows, win32
+   */
+  shape?: CheckboxShape;
 
   /** Sets style of checkbox to a preset size style.
    * @default 'medium'

--- a/packages/experimental/Checkbox/src/Checkbox.tsx
+++ b/packages/experimental/Checkbox/src/Checkbox.tsx
@@ -23,7 +23,11 @@ export const Checkbox = compose<CheckboxType>({
     const Slots = useSlots(
       userProps,
       (layer) =>
-        Checkbox.state[layer] || userProps[layer] || layer === userProps['size'] || (!userProps['size'] && layer === getDefaultSize()),
+        Checkbox.state[layer] ||
+        userProps[layer] ||
+        layer === userProps['shape'] ||
+        layer === userProps['size'] ||
+        (!userProps['size'] && layer === getDefaultSize()),
     );
     // now return the handler for finishing render
     return (final: CheckboxProps) => {

--- a/packages/experimental/Checkbox/src/Checkbox.types.ts
+++ b/packages/experimental/Checkbox/src/Checkbox.types.ts
@@ -7,6 +7,7 @@ import { SvgProps } from 'react-native-svg';
 
 export const checkboxName = 'Checkbox';
 export type CheckboxSize = 'medium' | 'large';
+export type CheckboxShape = 'circular' | 'square';
 
 export interface CheckboxTokens extends FontTokens, IForegroundColorTokens, IBackgroundColorTokens, IBorderTokens, LayoutTokens {
   /**
@@ -83,13 +84,6 @@ export interface CheckboxProps extends Omit<IViewProps, 'onPress'> {
   checked?: boolean;
 
   /**
-   * Allows you to set the checkbox to have circular styling.
-   *
-   * @platform Android, iOS, windows, win32
-   */
-  circular?: boolean;
-
-  /**
    * A RefObject to access the IFocusable interface. Use this to access the public methods and properties of the component.
    */
   componentRef?: React.RefObject<IFocusable>;
@@ -121,6 +115,14 @@ export interface CheckboxProps extends Omit<IViewProps, 'onPress'> {
    * Callback that is called when the checked value has changed.
    */
   onChange?: (isChecked: boolean) => void;
+
+  /**
+   * The shape of the checkbox. Can be either (rounded) square or circular.
+   *
+   * @default square
+   * @platform Android, iOS, windows, win32
+   */
+  shape?: CheckboxShape;
 
   /** Sets style of checkbox to a preset size style.
    * @default 'medium'

--- a/packages/experimental/Checkbox/src/__tests__/Checkbox.test.tsx
+++ b/packages/experimental/Checkbox/src/__tests__/Checkbox.test.tsx
@@ -24,7 +24,7 @@ describe('Checkbox component tests', () => {
           defaultChecked={true}
           labelPosition="before"
           disabled
-          circular
+          shape="circular"
           size="large"
         />,
       )

--- a/packages/experimental/Checkbox/src/__tests__/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/experimental/Checkbox/src/__tests__/__snapshots__/Checkbox.test.tsx.snap
@@ -18,7 +18,6 @@ exports[`Checkbox component tests Checkbox all props 1`] = `
     }
   }
   accessible={true}
-  circular={true}
   defaultChecked={true}
   disabled={true}
   enableFocusRing={true}
@@ -36,6 +35,7 @@ exports[`Checkbox component tests Checkbox all props 1`] = `
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
+  shape="circular"
   size="large"
   style={
     Object {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This prop change is to align with FluentUI's similar recent change: https://github.com/microsoft/fluentui/pull/21834

### Verification

Render snapshot of circular checkbox did not change other than the prop being renamed.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
