### PR TITLE
Update react-native-test-app to pick up latest security fixes

### DIFF
--- a/.ado/xcconfig/publish_overrides.xcconfig
+++ b/.ado/xcconfig/publish_overrides.xcconfig
@@ -12,3 +12,9 @@ ONLY_ACTIVE_ARCH=NO
 
 // Specify the exact Swift version used for reproducibility
 SWIFT_VERSION = 5.0
+
+// Turn off Sanitizers for Release Builds
+CLANG_ADDRESS_SANITIZER = NO
+CLANG_UNDEFINED_BEHAVIOR_SANITIZER = NO
+
+

--- a/.ado/xcconfig/publish_overrides.xcconfig
+++ b/.ado/xcconfig/publish_overrides.xcconfig
@@ -12,6 +12,3 @@ ONLY_ACTIVE_ARCH=NO
 
 // Specify the exact Swift version used for reproducibility
 SWIFT_VERSION = 5.0
-
-// Turn off ASAN for ship builds
-ENABLE_ADDRESS_SANITIZER = NO

--- a/apps/android/package.json
+++ b/apps/android/package.json
@@ -42,7 +42,7 @@
     "flow-bin": "^0.113.0",
     "metro-react-native-babel-preset": "^0.66.2",
     "react-native-svg-transformer": "^1.0.0",
-    "react-native-test-app": "^1.1.1",
+    "react-native-test-app": "^1.1.4",
     "react-test-renderer": "17.0.1"
   },
   "jest": {

--- a/apps/ios/package.json
+++ b/apps/ios/package.json
@@ -41,7 +41,7 @@
     "metro-config": "^0.66.2",
     "metro-react-native-babel-preset": "^0.66.2",
     "react-native-svg-transformer": "^1.0.0",
-    "react-native-test-app": "^1.1.1",
+    "react-native-test-app": "^1.1.4",
     "react-test-renderer": "17.0.1"
   },
   "jest": {

--- a/apps/ios/src/Podfile.lock
+++ b/apps/ios/src/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
     - React-Core (= 0.64.3)
     - React-jsi (= 0.64.3)
     - ReactCommon/turbomodule/core (= 0.64.3)
-  - FRNAvatar (0.14.3):
+  - FRNAvatar (0.14.5):
     - MicrosoftFluentUI (= 0.3.0)
     - MicrosoftFluentUI/Avatar_ios (= 0.3.0)
     - React
@@ -433,7 +433,7 @@ PODS:
     - React-cxxreact (= 0.64.3)
     - React-jsi (= 0.64.3)
     - React-perflogger (= 0.64.3)
-  - ReactTestApp-DevSupport (1.0.12):
+  - ReactTestApp-DevSupport (1.1.4):
     - React-Core
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
@@ -565,7 +565,7 @@ SPEC CHECKSUMS:
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: c71c5917ec0ad2de41d5d06a5855f6d5eda06971
   FBReactNativeSpec: 96e0ac3698e5ebbc3aab6e67bcd98508c0767abc
-  FRNAvatar: 5e1b7c6304d4132046a9dd77e1b8da2f0bf7fb20
+  FRNAvatar: bf720e2693804f2bdd60258313ede00e7219c6b3
   FRNDatePicker: 58e321df06792fd68b4e0e3e1844a916652fa172
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   MicrosoftFluentUI: b98d877a2122804132365aa167944f58ef4adb69
@@ -594,7 +594,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: c7f845861e79eae13dc1e8217a3cf47a3945b504
   React-runtimeexecutor: 493d9abb8b23c3f84e19ae221eeba92cadcb70dc
   ReactCommon: 8fea6422328e2fc093e25c9fac67adbcf0f04fb4
-  ReactTestApp-DevSupport: 5c964974cab58dfc9ce22a36ddb3924fc97518fa
+  ReactTestApp-DevSupport: 5b0a4857ecf70fa107d040d204a6af374c5f49e9
   ReactTestApp-Resources: 51437f32bf317329a7c9ca3f68e3a4cc952567ba
   RNSVG: 551acb6562324b1d52a4e0758f7ca0ec234e278f
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52

--- a/apps/macos/package.json
+++ b/apps/macos/package.json
@@ -48,7 +48,7 @@
     "metro-config": "^0.66.2",
     "metro-react-native-babel-preset": "^0.66.2",
     "react-native-svg-transformer": "^1.0.0",
-    "react-native-test-app": "^1.1.1",
+    "react-native-test-app": "^1.1.4",
     "react-test-renderer": "17.0.1",
     "ts-node": "^8.10.1",
     "tsconfig-paths": "^3.9.0",

--- a/apps/macos/src/Podfile.lock
+++ b/apps/macos/src/Podfile.lock
@@ -1,25 +1,25 @@
 PODS:
   - boost-for-react-native (1.63.0)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.64.27)
-  - FBReactNativeSpec (0.64.27):
+  - FBLazyVector (0.64.28)
+  - FBReactNativeSpec (0.64.28):
     - RCT-Folly (= 2020.01.13.00)
-    - RCTRequired (= 0.64.27)
-    - RCTTypeSafety (= 0.64.27)
-    - React-Core (= 0.64.27)
-    - React-jsi (= 0.64.27)
-    - ReactCommon/turbomodule/core (= 0.64.27)
-  - FRNAvatar (0.14.3):
+    - RCTRequired (= 0.64.28)
+    - RCTTypeSafety (= 0.64.28)
+    - React-Core (= 0.64.28)
+    - React-jsi (= 0.64.28)
+    - ReactCommon/turbomodule/core (= 0.64.28)
+  - FRNAvatar (0.14.5):
     - MicrosoftFluentUI (= 0.3.0)
     - MicrosoftFluentUI/Avatar_ios (= 0.3.0)
     - React
-  - FRNCallout (0.19.24):
+  - FRNCallout (0.19.27):
     - React
-  - FRNCheckbox (0.6.6):
+  - FRNCheckbox (0.7.0):
     - React
-  - FRNMenuButton (0.7.28):
+  - FRNMenuButton (0.7.34):
     - React
-  - FRNRadioButton (0.14.20):
+  - FRNRadioButton (0.14.23):
     - React
   - glog (0.3.5)
   - MicrosoftFluentUI (0.3.0):
@@ -94,261 +94,261 @@ PODS:
     - boost-for-react-native
     - DoubleConversion
     - glog
-  - RCTFocusZone (0.9.1):
+  - RCTFocusZone (0.9.4):
     - React
-  - RCTRequired (0.64.27)
-  - RCTTypeSafety (0.64.27):
-    - FBLazyVector (= 0.64.27)
+  - RCTRequired (0.64.28)
+  - RCTTypeSafety (0.64.28):
+    - FBLazyVector (= 0.64.28)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTRequired (= 0.64.27)
-    - React-Core (= 0.64.27)
-  - React (0.64.27):
-    - React-Core (= 0.64.27)
-    - React-Core/DevSupport (= 0.64.27)
-    - React-Core/RCTWebSocket (= 0.64.27)
-    - React-RCTActionSheet (= 0.64.27)
-    - React-RCTAnimation (= 0.64.27)
-    - React-RCTBlob (= 0.64.27)
-    - React-RCTImage (= 0.64.27)
-    - React-RCTLinking (= 0.64.27)
-    - React-RCTNetwork (= 0.64.27)
-    - React-RCTSettings (= 0.64.27)
-    - React-RCTText (= 0.64.27)
-    - React-RCTVibration (= 0.64.27)
-  - React-callinvoker (0.64.27)
-  - React-Core (0.64.27):
+    - RCTRequired (= 0.64.28)
+    - React-Core (= 0.64.28)
+  - React (0.64.28):
+    - React-Core (= 0.64.28)
+    - React-Core/DevSupport (= 0.64.28)
+    - React-Core/RCTWebSocket (= 0.64.28)
+    - React-RCTActionSheet (= 0.64.28)
+    - React-RCTAnimation (= 0.64.28)
+    - React-RCTBlob (= 0.64.28)
+    - React-RCTImage (= 0.64.28)
+    - React-RCTLinking (= 0.64.28)
+    - React-RCTNetwork (= 0.64.28)
+    - React-RCTSettings (= 0.64.28)
+    - React-RCTText (= 0.64.28)
+    - React-RCTVibration (= 0.64.28)
+  - React-callinvoker (0.64.28)
+  - React-Core (0.64.28):
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.64.27)
-    - React-cxxreact (= 0.64.27)
-    - React-jsi (= 0.64.27)
-    - React-jsiexecutor (= 0.64.27)
-    - React-perflogger (= 0.64.27)
+    - React-Core/Default (= 0.64.28)
+    - React-cxxreact (= 0.64.28)
+    - React-jsi (= 0.64.28)
+    - React-jsiexecutor (= 0.64.28)
+    - React-perflogger (= 0.64.28)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.64.27):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default
-    - React-cxxreact (= 0.64.27)
-    - React-jsi (= 0.64.27)
-    - React-jsiexecutor (= 0.64.27)
-    - React-perflogger (= 0.64.27)
-    - Yoga
-  - React-Core/Default (0.64.27):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-cxxreact (= 0.64.27)
-    - React-jsi (= 0.64.27)
-    - React-jsiexecutor (= 0.64.27)
-    - React-perflogger (= 0.64.27)
-    - Yoga
-  - React-Core/DevSupport (0.64.27):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.64.27)
-    - React-Core/RCTWebSocket (= 0.64.27)
-    - React-cxxreact (= 0.64.27)
-    - React-jsi (= 0.64.27)
-    - React-jsiexecutor (= 0.64.27)
-    - React-jsinspector (= 0.64.27)
-    - React-perflogger (= 0.64.27)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.64.27):
+  - React-Core/CoreModulesHeaders (0.64.28):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.27)
-    - React-jsi (= 0.64.27)
-    - React-jsiexecutor (= 0.64.27)
-    - React-perflogger (= 0.64.27)
+    - React-cxxreact (= 0.64.28)
+    - React-jsi (= 0.64.28)
+    - React-jsiexecutor (= 0.64.28)
+    - React-perflogger (= 0.64.28)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.64.27):
+  - React-Core/Default (0.64.28):
+    - glog
+    - RCT-Folly (= 2020.01.13.00)
+    - React-cxxreact (= 0.64.28)
+    - React-jsi (= 0.64.28)
+    - React-jsiexecutor (= 0.64.28)
+    - React-perflogger (= 0.64.28)
+    - Yoga
+  - React-Core/DevSupport (0.64.28):
+    - glog
+    - RCT-Folly (= 2020.01.13.00)
+    - React-Core/Default (= 0.64.28)
+    - React-Core/RCTWebSocket (= 0.64.28)
+    - React-cxxreact (= 0.64.28)
+    - React-jsi (= 0.64.28)
+    - React-jsiexecutor (= 0.64.28)
+    - React-jsinspector (= 0.64.28)
+    - React-perflogger (= 0.64.28)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.64.28):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.27)
-    - React-jsi (= 0.64.27)
-    - React-jsiexecutor (= 0.64.27)
-    - React-perflogger (= 0.64.27)
+    - React-cxxreact (= 0.64.28)
+    - React-jsi (= 0.64.28)
+    - React-jsiexecutor (= 0.64.28)
+    - React-perflogger (= 0.64.28)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.64.27):
+  - React-Core/RCTAnimationHeaders (0.64.28):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.27)
-    - React-jsi (= 0.64.27)
-    - React-jsiexecutor (= 0.64.27)
-    - React-perflogger (= 0.64.27)
+    - React-cxxreact (= 0.64.28)
+    - React-jsi (= 0.64.28)
+    - React-jsiexecutor (= 0.64.28)
+    - React-perflogger (= 0.64.28)
     - Yoga
-  - React-Core/RCTImageHeaders (0.64.27):
+  - React-Core/RCTBlobHeaders (0.64.28):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.27)
-    - React-jsi (= 0.64.27)
-    - React-jsiexecutor (= 0.64.27)
-    - React-perflogger (= 0.64.27)
+    - React-cxxreact (= 0.64.28)
+    - React-jsi (= 0.64.28)
+    - React-jsiexecutor (= 0.64.28)
+    - React-perflogger (= 0.64.28)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.64.27):
+  - React-Core/RCTImageHeaders (0.64.28):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.27)
-    - React-jsi (= 0.64.27)
-    - React-jsiexecutor (= 0.64.27)
-    - React-perflogger (= 0.64.27)
+    - React-cxxreact (= 0.64.28)
+    - React-jsi (= 0.64.28)
+    - React-jsiexecutor (= 0.64.28)
+    - React-perflogger (= 0.64.28)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.64.27):
+  - React-Core/RCTLinkingHeaders (0.64.28):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.27)
-    - React-jsi (= 0.64.27)
-    - React-jsiexecutor (= 0.64.27)
-    - React-perflogger (= 0.64.27)
+    - React-cxxreact (= 0.64.28)
+    - React-jsi (= 0.64.28)
+    - React-jsiexecutor (= 0.64.28)
+    - React-perflogger (= 0.64.28)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.64.27):
+  - React-Core/RCTNetworkHeaders (0.64.28):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.27)
-    - React-jsi (= 0.64.27)
-    - React-jsiexecutor (= 0.64.27)
-    - React-perflogger (= 0.64.27)
+    - React-cxxreact (= 0.64.28)
+    - React-jsi (= 0.64.28)
+    - React-jsiexecutor (= 0.64.28)
+    - React-perflogger (= 0.64.28)
     - Yoga
-  - React-Core/RCTTextHeaders (0.64.27):
+  - React-Core/RCTSettingsHeaders (0.64.28):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.27)
-    - React-jsi (= 0.64.27)
-    - React-jsiexecutor (= 0.64.27)
-    - React-perflogger (= 0.64.27)
+    - React-cxxreact (= 0.64.28)
+    - React-jsi (= 0.64.28)
+    - React-jsiexecutor (= 0.64.28)
+    - React-perflogger (= 0.64.28)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.64.27):
+  - React-Core/RCTTextHeaders (0.64.28):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.27)
-    - React-jsi (= 0.64.27)
-    - React-jsiexecutor (= 0.64.27)
-    - React-perflogger (= 0.64.27)
+    - React-cxxreact (= 0.64.28)
+    - React-jsi (= 0.64.28)
+    - React-jsiexecutor (= 0.64.28)
+    - React-perflogger (= 0.64.28)
     - Yoga
-  - React-Core/RCTWebSocket (0.64.27):
+  - React-Core/RCTVibrationHeaders (0.64.28):
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.64.27)
-    - React-cxxreact (= 0.64.27)
-    - React-jsi (= 0.64.27)
-    - React-jsiexecutor (= 0.64.27)
-    - React-perflogger (= 0.64.27)
+    - React-Core/Default
+    - React-cxxreact (= 0.64.28)
+    - React-jsi (= 0.64.28)
+    - React-jsiexecutor (= 0.64.28)
+    - React-perflogger (= 0.64.28)
     - Yoga
-  - React-CoreModules (0.64.27):
-    - FBReactNativeSpec (= 0.64.27)
+  - React-Core/RCTWebSocket (0.64.28):
+    - glog
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.64.27)
-    - React-Core/CoreModulesHeaders (= 0.64.27)
-    - React-jsi (= 0.64.27)
-    - React-RCTImage (= 0.64.27)
-    - ReactCommon/turbomodule/core (= 0.64.27)
-  - React-cxxreact (0.64.27):
+    - React-Core/Default (= 0.64.28)
+    - React-cxxreact (= 0.64.28)
+    - React-jsi (= 0.64.28)
+    - React-jsiexecutor (= 0.64.28)
+    - React-perflogger (= 0.64.28)
+    - Yoga
+  - React-CoreModules (0.64.28):
+    - FBReactNativeSpec (= 0.64.28)
+    - RCT-Folly (= 2020.01.13.00)
+    - RCTTypeSafety (= 0.64.28)
+    - React-Core/CoreModulesHeaders (= 0.64.28)
+    - React-jsi (= 0.64.28)
+    - React-RCTImage (= 0.64.28)
+    - ReactCommon/turbomodule/core (= 0.64.28)
+  - React-cxxreact (0.64.28):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.64.27)
-    - React-jsi (= 0.64.27)
-    - React-jsinspector (= 0.64.27)
-    - React-perflogger (= 0.64.27)
-    - React-runtimeexecutor (= 0.64.27)
-  - React-jsi (0.64.27):
+    - React-callinvoker (= 0.64.28)
+    - React-jsi (= 0.64.28)
+    - React-jsinspector (= 0.64.28)
+    - React-perflogger (= 0.64.28)
+    - React-runtimeexecutor (= 0.64.28)
+  - React-jsi (0.64.28):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-jsi/Default (= 0.64.27)
-  - React-jsi/Default (0.64.27):
+    - React-jsi/Default (= 0.64.28)
+  - React-jsi/Default (0.64.28):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-  - React-jsiexecutor (0.64.27):
+  - React-jsiexecutor (0.64.28):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-cxxreact (= 0.64.27)
-    - React-jsi (= 0.64.27)
-    - React-perflogger (= 0.64.27)
-  - React-jsinspector (0.64.27)
-  - React-perflogger (0.64.27)
-  - React-RCTActionSheet (0.64.27):
-    - React-Core/RCTActionSheetHeaders (= 0.64.27)
-  - React-RCTAnimation (0.64.27):
-    - FBReactNativeSpec (= 0.64.27)
+    - React-cxxreact (= 0.64.28)
+    - React-jsi (= 0.64.28)
+    - React-perflogger (= 0.64.28)
+  - React-jsinspector (0.64.28)
+  - React-perflogger (0.64.28)
+  - React-RCTActionSheet (0.64.28):
+    - React-Core/RCTActionSheetHeaders (= 0.64.28)
+  - React-RCTAnimation (0.64.28):
+    - FBReactNativeSpec (= 0.64.28)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.64.27)
-    - React-Core/RCTAnimationHeaders (= 0.64.27)
-    - React-jsi (= 0.64.27)
-    - ReactCommon/turbomodule/core (= 0.64.27)
-  - React-RCTBlob (0.64.27):
-    - FBReactNativeSpec (= 0.64.27)
+    - RCTTypeSafety (= 0.64.28)
+    - React-Core/RCTAnimationHeaders (= 0.64.28)
+    - React-jsi (= 0.64.28)
+    - ReactCommon/turbomodule/core (= 0.64.28)
+  - React-RCTBlob (0.64.28):
+    - FBReactNativeSpec (= 0.64.28)
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/RCTBlobHeaders (= 0.64.27)
-    - React-Core/RCTWebSocket (= 0.64.27)
-    - React-jsi (= 0.64.27)
-    - React-RCTNetwork (= 0.64.27)
-    - ReactCommon/turbomodule/core (= 0.64.27)
-  - React-RCTImage (0.64.27):
-    - FBReactNativeSpec (= 0.64.27)
+    - React-Core/RCTBlobHeaders (= 0.64.28)
+    - React-Core/RCTWebSocket (= 0.64.28)
+    - React-jsi (= 0.64.28)
+    - React-RCTNetwork (= 0.64.28)
+    - ReactCommon/turbomodule/core (= 0.64.28)
+  - React-RCTImage (0.64.28):
+    - FBReactNativeSpec (= 0.64.28)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.64.27)
-    - React-Core/RCTImageHeaders (= 0.64.27)
-    - React-jsi (= 0.64.27)
-    - React-RCTNetwork (= 0.64.27)
-    - ReactCommon/turbomodule/core (= 0.64.27)
-  - React-RCTLinking (0.64.27):
-    - FBReactNativeSpec (= 0.64.27)
-    - React-Core/RCTLinkingHeaders (= 0.64.27)
-    - React-jsi (= 0.64.27)
-    - ReactCommon/turbomodule/core (= 0.64.27)
-  - React-RCTNetwork (0.64.27):
-    - FBReactNativeSpec (= 0.64.27)
+    - RCTTypeSafety (= 0.64.28)
+    - React-Core/RCTImageHeaders (= 0.64.28)
+    - React-jsi (= 0.64.28)
+    - React-RCTNetwork (= 0.64.28)
+    - ReactCommon/turbomodule/core (= 0.64.28)
+  - React-RCTLinking (0.64.28):
+    - FBReactNativeSpec (= 0.64.28)
+    - React-Core/RCTLinkingHeaders (= 0.64.28)
+    - React-jsi (= 0.64.28)
+    - ReactCommon/turbomodule/core (= 0.64.28)
+  - React-RCTNetwork (0.64.28):
+    - FBReactNativeSpec (= 0.64.28)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.64.27)
-    - React-Core/RCTNetworkHeaders (= 0.64.27)
-    - React-jsi (= 0.64.27)
-    - ReactCommon/turbomodule/core (= 0.64.27)
-  - React-RCTSettings (0.64.27):
-    - FBReactNativeSpec (= 0.64.27)
+    - RCTTypeSafety (= 0.64.28)
+    - React-Core/RCTNetworkHeaders (= 0.64.28)
+    - React-jsi (= 0.64.28)
+    - ReactCommon/turbomodule/core (= 0.64.28)
+  - React-RCTSettings (0.64.28):
+    - FBReactNativeSpec (= 0.64.28)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.64.27)
-    - React-Core/RCTSettingsHeaders (= 0.64.27)
-    - React-jsi (= 0.64.27)
-    - ReactCommon/turbomodule/core (= 0.64.27)
-  - React-RCTText (0.64.27):
-    - React-Core/RCTTextHeaders (= 0.64.27)
-  - React-RCTVibration (0.64.27):
-    - FBReactNativeSpec (= 0.64.27)
+    - RCTTypeSafety (= 0.64.28)
+    - React-Core/RCTSettingsHeaders (= 0.64.28)
+    - React-jsi (= 0.64.28)
+    - ReactCommon/turbomodule/core (= 0.64.28)
+  - React-RCTText (0.64.28):
+    - React-Core/RCTTextHeaders (= 0.64.28)
+  - React-RCTVibration (0.64.28):
+    - FBReactNativeSpec (= 0.64.28)
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/RCTVibrationHeaders (= 0.64.27)
-    - React-jsi (= 0.64.27)
-    - ReactCommon/turbomodule/core (= 0.64.27)
-  - React-runtimeexecutor (0.64.27):
-    - React-jsi (= 0.64.27)
-  - ReactCommon/turbomodule/core (0.64.27):
+    - React-Core/RCTVibrationHeaders (= 0.64.28)
+    - React-jsi (= 0.64.28)
+    - ReactCommon/turbomodule/core (= 0.64.28)
+  - React-runtimeexecutor (0.64.28):
+    - React-jsi (= 0.64.28)
+  - ReactCommon/turbomodule/core (0.64.28):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.64.27)
-    - React-Core (= 0.64.27)
-    - React-cxxreact (= 0.64.27)
-    - React-jsi (= 0.64.27)
-    - React-perflogger (= 0.64.27)
-  - ReactTestApp-DevSupport (1.0.12):
+    - React-callinvoker (= 0.64.28)
+    - React-Core (= 0.64.28)
+    - React-cxxreact (= 0.64.28)
+    - React-jsi (= 0.64.28)
+    - React-perflogger (= 0.64.28)
+  - ReactTestApp-DevSupport (1.1.4):
     - React-Core
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
-  - RNCPicker (1.16.8):
+  - RNCPicker (2.3.0):
     - React-Core
   - RNSVG (12.1.1):
     - React
@@ -487,45 +487,45 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost-for-react-native: d5ad1140010aa8cb622323a781ecbeab4425d19a
   DoubleConversion: 0ea4559a49682230337df966e735d6cc7760108e
-  FBLazyVector: 5a2f9592b6a73a6058558956d167bb1ad684c7c2
-  FBReactNativeSpec: e14a8fb710a1e079c75627f0f8f6aeabaef5af1a
-  FRNAvatar: 5e1b7c6304d4132046a9dd77e1b8da2f0bf7fb20
-  FRNCallout: f630a150300e75873ee7720282521d45cc22e8ef
-  FRNCheckbox: d719a3829edc668be92dbca91e5a2fae661ee21f
-  FRNMenuButton: 883ee1d20e834c439c3a2a3bd972b538816f5793
-  FRNRadioButton: 65320d631c04b2dca92befff11b741e3ba82dc03
+  FBLazyVector: 858890de7b2b63c0ae2f3fc7fb1d182fcbad393a
+  FBReactNativeSpec: 5423c76e7b05f046a4a683aa38c77dd6c8dcf67e
+  FRNAvatar: bf720e2693804f2bdd60258313ede00e7219c6b3
+  FRNCallout: 3ae719b5125759c232664f6a19a3b6f08bdcd4a2
+  FRNCheckbox: 8e60f9b87a452026f7838789fe4c1c199baeeef4
+  FRNMenuButton: 2280e468e760ead9726994a6384516984677ba38
+  FRNRadioButton: 88ad9ca942b85eaebca36e4dae462e48d8682d56
   glog: 0dc7efada961c0793012970b60faebbd58b0decb
   MicrosoftFluentUI: b98d877a2122804132365aa167944f58ef4adb69
   RCT-Folly: b3998425a8ee9f695f57a204dc494534246f0fe9
-  RCTFocusZone: 8863e667134a0376fa9eec20165c414eb70fab87
-  RCTRequired: 476b7e9b6fe8f6795b3c2a32613eda0f2bf70659
-  RCTTypeSafety: 8a74abf2ade4e1e464831b6d63f80b89107fc069
-  React: fbab5f0bbf2f3fdc47b20d6f8fb1f9dda7814053
-  React-callinvoker: 5da8f570452f13cf7e5faf216092f5da82da3d11
-  React-Core: 7d84e349d0ca6e14693175ac5aeb72371433d977
-  React-CoreModules: 64e9eaf3e56585233b99ddcdab4eeda0f3947b33
-  React-cxxreact: 4318977ebf4b4bdf9d1db19deb079121659925dd
-  React-jsi: d57227c937e7658c0d565370790124c23c793f35
-  React-jsiexecutor: c3d1155f35163d8c077b6767dad18a41913e3dcd
-  React-jsinspector: 6593643f36af11dab5f53396df73cb2284fd5c9a
-  React-perflogger: fdfe29e7772de8ffb6f2839f10380c985bca4687
-  React-RCTActionSheet: 53bce013367652e49dbb128a4236f76973264710
-  React-RCTAnimation: f431c95d12262f7690137d8d5071b12eede8af62
-  React-RCTBlob: 88a533c439c2f02d45d8fdbba14d3cf54737e778
-  React-RCTImage: a6305a92c166c5f8be14c2624918eb84b8c93651
-  React-RCTLinking: ab6174291d7568071f8511a4d4d78eedf16b976e
-  React-RCTNetwork: 74d93063da8eca72f153e82a65308c7b3efc37f3
-  React-RCTSettings: 66c9324eb471c4b718784c39e0aaff90164ddcbf
-  React-RCTText: 7f9a1d29e7fe6279e9bc9eec6d447a0d45f392de
-  React-RCTVibration: 027f7cf1e570a3e851dfceda2dbbd635af623ca0
-  React-runtimeexecutor: 80e779465c0d81aa5bd7b571ea2981cf7e86cf34
-  ReactCommon: 9dd2d2d804057ebba91603459b31c6f03a25c51c
-  ReactTestApp-DevSupport: 5c964974cab58dfc9ce22a36ddb3924fc97518fa
+  RCTFocusZone: f50f241517e338202e8cc0c13d77d48556771acd
+  RCTRequired: 41485be07075359f8bdd676cb97d95fbe78da57a
+  RCTTypeSafety: a667b15c1aece833c22107f8c1befafe198578dc
+  React: c9bda8a828ec496382f010689ece7c7c3cc61300
+  React-callinvoker: c20656fcb0f2dadd624c378b5513b4aadf73577c
+  React-Core: 4519d591066e8ac1b35f25e021daedf7314588bc
+  React-CoreModules: 207b578ee51eb9d12e0e60ec372cd4aa9d896a78
+  React-cxxreact: 99e12cef71e39373186c8de0726c33737238c66c
+  React-jsi: f3263478ea3b475ad889e810da71927fa1b9edf9
+  React-jsiexecutor: 20d43e2efc353d7bafdf2f0de7ddef490a33d12c
+  React-jsinspector: d5036f9c81ea07c47ef5b038f1ffefc3e2fef303
+  React-perflogger: cbb82810e2a5091f6bbdfe4da8b4345b47c5eea5
+  React-RCTActionSheet: bbc189471f0d0d9a13a526496fffa74f768fab42
+  React-RCTAnimation: 8c1ab49272c406aedd18a5e8bcefea03751644ec
+  React-RCTBlob: 108ef63c57bf540a4c300b2e8faef09cdddd0336
+  React-RCTImage: b805a9517159ebff95ba1932e1ad35aba4f0fdd8
+  React-RCTLinking: c7d1920f0b67db2d0f46d5e4c12c59ed6e5ea228
+  React-RCTNetwork: 91406f440ab39bc061b087654bed3c6a777a2bd1
+  React-RCTSettings: fbf6322063cacddc8178b98c573e68729875577a
+  React-RCTText: 57234c37974f70b7aff8690bf559993747a86ced
+  React-RCTVibration: 5ffea3e841e30c648eaec122769386f8b0268c53
+  React-runtimeexecutor: c09cb41d99971ed9a380e75aa3e599df4b74a58e
+  ReactCommon: 1dd1c94f0ad9b909d0b874d7d3482f74d51d30f8
+  ReactTestApp-DevSupport: 5b0a4857ecf70fa107d040d204a6af374c5f49e9
   ReactTestApp-Resources: 320923a3635f7bf90caa1a28fd29765b577888d9
-  RNCPicker: 0991c56da7815c0cf946d6f63cf920b25296e5f6
+  RNCPicker: c796ddf16cd93e980a5a5642eebcee9eb9da1e76
   RNSVG: 551acb6562324b1d52a4e0758f7ca0ec234e278f
   SwiftLint: 6bc52a21f0fd44cab9aa2dc8e534fb9f5e3ec507
-  Yoga: d40948211a16713378654fe5d445c25048030bda
+  Yoga: acff05ee0ca761a1ce1dcd6b53476706c74c9ae6
 
 PODFILE CHECKSUM: 568704fb95966cf7ad6daa54a1d36eb2d5c3bba6
 

--- a/apps/windows/package.json
+++ b/apps/windows/package.json
@@ -45,7 +45,7 @@
     "flow-bin": "^0.113.0",
     "metro-config": "^0.66.2",
     "metro-react-native-babel-preset": "^0.66.2",
-    "react-native-test-app": "^1.1.1",
+    "react-native-test-app": "^1.1.4",
     "react-test-renderer": "17.0.1",
     "rimraf": "~3.0.2",
     "ts-node": "^8.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12440,10 +12440,10 @@ react-native-svg@^12.1.1:
     css-select "^2.1.0"
     css-tree "^1.0.0-alpha.39"
 
-react-native-test-app@^1.1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/react-native-test-app/-/react-native-test-app-1.1.3.tgz#82c4fa8033c14304ebbc286c3486617670fd4ddd"
-  integrity sha512-grNSLV1tOJbciHzzLV34UQpYxlAkNJZ9NsG5XcJurD8ZQ6d2nunmGWGK97whRCG3to6JMHPDfeWq/O3IWUdOfg==
+react-native-test-app@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/react-native-test-app/-/react-native-test-app-1.1.4.tgz#a959e5d847079cbaa290c6ef6174db52ecadcac5"
+  integrity sha512-DiMCRgVEJn9WS0oefwIxdb4aylTAfx6kKf+E6G1xRS/fZN3zR7BwQ7eVsihtijESi9BL2kAjF7LHU79uAUZNlQ==
   dependencies:
     ajv "^8.0.0"
     chalk "^4.1.0"


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [ ] win32 (Office)
- [x] windows
- [x] android

### Description of changes

(Apple only) RNTA version 1.1.4 updates it's xcconfigs so that the Address Sanitizer (ASAN) and Udefined Behavior Sanitizer (UBSAN) are OFF for release builds. We need this for downstream consumption. By updating our dependency, we can also remove one of our xcconfig flags where we hardcoded ASAN as off for release.

### Verification

CI 

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
