### PR TITLE
Migrate release pipeline to office/iss to be compliant

### DIFF
--- a/.ado/azure-pipelines.publish.yml
+++ b/.ado/azure-pipelines.publish.yml
@@ -17,16 +17,21 @@ parameters:
   displayName: Skip Git Push
   type: boolean
   default: false
+- name: skipNugetPublish
+  displayName: Skip Nuget Publish
+  type: boolean
+  default: false
 
 variables:
-  - group: 'NPM and Github Secrets'
+  - group: 'FluentUI React Native Secrets'
+  - group: InfoSec-SecurityResults
+  - name: tags
+    value: production,externalfacing
 
 jobs:
   - job: NPMPublish
     displayName: NPM Publish
-    pool:
-      vmImage: 'ubuntu-latest'
-
+    pool: Azure-Pipelines-EO-Ubuntu20.04-Office
     steps:
       - task: NodeTool@0
         inputs:
@@ -62,30 +67,38 @@ jobs:
         displayName: 📒 Generate Manifest Npm
         inputs:
           BuildDropPath: $(System.DefaultWorkingDirectory)
-     
+
       - task: PublishPipelineArtifact@1
         displayName: 📒 Publish Manifest Npm
         inputs:
           artifactName: SBom-Npm-$(System.JobAttempt)
           targetPath: $(System.DefaultWorkingDirectory)/_manifest
 
+      - task: ComponentGovernanceComponentDetection@0
+
   - job: NuGetPublish
     displayName: NuGet Publish
     pool:
       vmImage: 'macos-11'
       demands: ['xcode', 'sh', 'npm']
+    variables:
+      - name: BUILDSECMON_OPT_IN
+        value: true
     timeoutInMinutes: 90 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 
     steps:
       - template: templates/apple-nuget-publish.yml
+        parameters:
+          skipNugetPublish: ${{ parameters.skipNugetPublish }}
 
   - job: Win32NuGetPublish
     displayName: Win32 FluentTester NuGet Publish
-    pool:
-      vmImage: 'windows-2019'
+    pool: OE-OfficePublic
     timeoutInMinutes: 90 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 
     steps:
       - template: templates/win32-nuget-publish.yml
+        parameters:
+          skipNugetPublish: ${{ parameters.skipNugetPublish }}

--- a/.ado/azure-pipelines.yml
+++ b/.ado/azure-pipelines.yml
@@ -9,8 +9,7 @@ jobs:
   # time consuming they don't need to run on every CI pass, instead do a dedicated JS loop to make the platform specific tests start quicker
   - job: BuildAndBundle
     displayName: Build, test, and bundle JavaScript
-    pool:
-      vmImage: 'ubuntu-latest'
+    pool: cxe-ubuntu-20-04-small
     timeoutInMinutes: 60 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 
@@ -39,8 +38,7 @@ jobs:
   # Windows bundling and end to end testing
   - job: WindowsPR
     displayName: Windows PR
-    pool:
-      vmImage: 'windows-2019'
+    pool: cxe-windows-2019-small
     timeoutInMinutes: 60 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 
@@ -59,8 +57,7 @@ jobs:
   # Win32 bundling and end to end testing
   - job: Win32PR
     displayName: Win32 PR
-    pool:
-      vmImage: 'windows-2019'
+    pool: cxe-windows-2019-small
     timeoutInMinutes: 60
     cancelTimeoutInMinutes: 5
 
@@ -155,8 +152,7 @@ jobs:
   # Dedicated task to make sure link on repo are functional.
   - job: TestLinks
     displayName: Test repo links
-    pool:
-      vmImage: 'ubuntu-latest'
+    pool: cxe-ubuntu-20-04-small
     timeoutInMinutes: 60 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 

--- a/.ado/azure-pipelines.yml
+++ b/.ado/azure-pipelines.yml
@@ -9,7 +9,8 @@ jobs:
   # time consuming they don't need to run on every CI pass, instead do a dedicated JS loop to make the platform specific tests start quicker
   - job: BuildAndBundle
     displayName: Build, test, and bundle JavaScript
-    pool: cxe-ubuntu-20-04-small
+    pool:
+      vmImage: 'ubuntu-latest'
     timeoutInMinutes: 60 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 
@@ -38,7 +39,8 @@ jobs:
   # Windows bundling and end to end testing
   - job: WindowsPR
     displayName: Windows PR
-    pool: cxe-windows-2019-small
+    pool:
+      vmImage: 'windows-2019'
     timeoutInMinutes: 60 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 
@@ -57,7 +59,8 @@ jobs:
   # Win32 bundling and end to end testing
   - job: Win32PR
     displayName: Win32 PR
-    pool: cxe-windows-2019-small
+    pool:
+      vmImage: 'windows-2019'
     timeoutInMinutes: 60
     cancelTimeoutInMinutes: 5
 

--- a/.ado/templates/apple-nuget-publish.yml
+++ b/.ado/templates/apple-nuget-publish.yml
@@ -1,3 +1,9 @@
+parameters:
+  - name: skipNugetPublish
+    displayName: Skip Nuget Publish
+    type: boolean
+    default: false
+
 steps:
   - checkout: self
     persistCredentials: true
@@ -83,11 +89,14 @@ steps:
       packagesToPack: 'package.nuspec'
       buildProperties: buildNumber=$(sanitizedBuildNumber);commitId=$(Build.SourceVersion);repoUri=$(Build.Repository.Uri)
 
+  - task: ComponentGovernanceComponentDetection@0
+
   # push the package package
   - task: NuGetCommand@2
     displayName: 'NuGet push'
+    condition: not(${{ parameters.skipNugetPublish }})
     inputs:
       command: push
       packagesToPush: '$(Build.ArtifactStagingDirectory)/Microsoft.FluentUI.ReactNative.*.nupkg'
-      nuGetFeedType: external
-      publishFeedCredentials: react-native
+      publishVstsFeed: Office
+

--- a/.ado/templates/win32-nuget-publish.yml
+++ b/.ado/templates/win32-nuget-publish.yml
@@ -1,3 +1,9 @@
+parameters:
+  - name: skipNugetPublish
+    displayName: Skip Nuget Publish
+    type: boolean
+    default: false
+
 steps:
   - checkout: self
     persistCredentials: true
@@ -33,11 +39,13 @@ steps:
       artifactName: SBom-FluentTester-$(System.JobAttempt)
       targetPath: $(System.DefaultWorkingDirectory)/_manifest
 
+  - task: ComponentGovernanceComponentDetection@0
+
   # Push the NuGet package
   - task: NuGetCommand@2
     displayName: 'NuGet push'
+    condition: not(${{ parameters.skipNugetPublish }})
     inputs:
       command: push
       packagesToPush: '$(Build.ArtifactStagingDirectory)/Microsoft.FluentUI.FluentTesterWin32.nupkg'
-      nuGetFeedType: external
-      publishFeedCredentials: react-native
+      publishVstsFeed: Office

--- a/GuardianCustomConfiguration.json
+++ b/GuardianCustomConfiguration.json
@@ -1,0 +1,17 @@
+{
+  "Enabled": true,
+  "Tools": {
+    "ESLint": {
+      "Enabled": true,
+      "Inputs": {
+        "Configuration": "recommended",
+        "Parser": "@typescript-eslint/parser",
+        "ParserOptions": "sourceType:script\necmaVersion:2017",
+        "CustomEnvironments": true,
+        "EnvironmentsBrowser": true,
+        "EnvironmentsEs6": true,
+        "EnvironmentsNode": true
+      }
+    }
+  }
+}

--- a/scripts/typescript-compatibility-build.yml
+++ b/scripts/typescript-compatibility-build.yml
@@ -11,13 +11,12 @@ variables:
     value: https://github.com/Microsoft/ui-fabric-ts-validation.git
   - name: NodeVersion
     value: '10.x'
-  - name: VmImage
-    value: 'Ubuntu 16.04'
+  - name: UbuntuPool
+    value: 'cxe-ubuntu-20-04-small'
 
 jobs:
   - job: Build
-    pool:
-      vmImage: $(VmImage)
+    pool: $(UbuntuPool)
     timeoutInMinutes: 60
     steps:
       - checkout: self
@@ -66,8 +65,7 @@ jobs:
     dependsOn: Build
     condition: succeeded()
     timeoutInMinutes: 60
-    pool:
-      vmImage: $(VmImage)
+    pool: $(UbuntuPool)
     strategy:
       maxParallel: 1
       matrix:
@@ -143,8 +141,7 @@ jobs:
     dependsOn: Compatibility
     condition: always()
     timeoutInMinutes: 60
-    pool:
-      vmImage: $(VmImage)
+    pool: $(UbuntuPool)
     steps:
       # Download build library
       - task: DownloadBuildArtifacts@0


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [X] macOS
- [X] win32 (Office)
- [x] windows
- [x] android

### Description of changes

This updates the release pipeline to be compliant.
It will move it from: [ms/ui-fabric-react-native](https://dev.azure.com/ms/ui-fabric-react-native/_build?definitionId=229) to: [office/iss](https://dev.azure.com/office/ISS/_build?definitionId=18514)


### Verification

Tested with private branch.

### Pull request checklist

This PR has considered (when applicable):
- [X] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
