### PR TITLE
Change files

### DIFF
--- a/change/@fluentui-react-native-badge-2b112d9c-56c5-4351-8ad3-a9402ad0cddd.json
+++ b/change/@fluentui-react-native-badge-2b112d9c-56c5-4351-8ad3-a9402ad0cddd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bump version due to mismatched publish",
+  "packageName": "@fluentui-react-native/badge",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "none"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Bump version of `@fluentui-react-native/badge` 0.13 is already published.

### Verification

N/A

### Pull request checklist

N/A
