### PR TITLE
Fix badge package dependencies

### DIFF
--- a/change/@fluentui-react-native-badge-d88ddb5e-de04-443a-b77b-70a57c7fa72e.json
+++ b/change/@fluentui-react-native-badge-d88ddb5e-de04-443a-b77b-70a57c7fa72e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix badge package dependency",
+  "packageName": "@fluentui-react-native/badge",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Badge/package.json
+++ b/packages/experimental/Badge/package.json
@@ -31,7 +31,6 @@
     "@fluentui-react-native/interactive-hooks": "^0.13.3",
     "@fluentui-react-native/theme-tokens": "^0.12.0",
     "@fluentui-react-native/tokens": "^0.11.6",
-    "@fluentui-react-native/use-styling": "^0.8.2",
     "react-native-svg": "^12.1.1"
   },
   "devDependencies": {

--- a/packages/experimental/Badge/package.json
+++ b/packages/experimental/Badge/package.json
@@ -31,7 +31,7 @@
     "@fluentui-react-native/interactive-hooks": "^0.13.3",
     "@fluentui-react-native/theme-tokens": "^0.12.0",
     "@fluentui-react-native/tokens": "^0.11.6",
-    "@fluentui-react-native/use-styling": "^0.8.0",
+    "@fluentui-react-native/use-styling": "^0.8.2",
     "react-native-svg": "^12.1.1"
   },
   "devDependencies": {

--- a/packages/experimental/Badge/src/BadgeColorTokens.ts
+++ b/packages/experimental/Badge/src/BadgeColorTokens.ts
@@ -1,8 +1,7 @@
-import { Theme } from '@fluentui-react-native/framework';
-import { TokenSettings } from '@fluentui-react-native/use-styling';
+import { Theme, TokenSettings } from '@fluentui-react-native/framework';
 import { BadgeTokens } from './Badge.types';
 
-export const defaultBadgeColorTokens: TokenSettings<BadgeTokens, Theme> = (t: Theme) =>
+export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
   ({
     filled: {
       backgroundColor: t.colors.brandedBackground,

--- a/packages/experimental/Badge/src/BadgeTokens.ts
+++ b/packages/experimental/Badge/src/BadgeTokens.ts
@@ -1,9 +1,8 @@
-import { Theme } from '@fluentui-react-native/framework';
+import { TokenSettings } from '@fluentui-react-native/framework';
 import { globalTokens } from '@fluentui-react-native/theme-tokens';
-import { TokenSettings } from '@fluentui-react-native/use-styling';
 import { BadgeTokens } from './Badge.types';
 
-export const defaultBadgeTokens: TokenSettings<BadgeTokens, Theme> = () =>
+export const defaultBadgeTokens: TokenSettings<BadgeTokens> = () =>
   ({
     iconSize: 5,
     borderWidth: globalTokens.stroke.width.thin,


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Okay maybe we can fix this beachball issue once and for all.

Running `beachball bump --verbose` gave:

"@fluentui-react-native/badge needs to be bumped because @fluentui-react-native/use-styling ^0.8.0 -> ^0.8.2"

"...Wait, but we haven't updated `use-styling` at all recently????"
Turns out the dependency version listed in the `badge` package was older than the version in our `use-styling` package. As for why it didn't fix the dependency for us, no clue.

This change actually removes the dependency from the badge package as the `TokenSettings` we import from `use-styling` is exported by the `framework` package as well (it assumes the `Theme` type is being used, so less typing for us, too). I took this chance to consolidate this dependency to make the list shorter.

### Verification

Code builds as expected. `beachball bump` does not list the badge package as needing a bump anymore. As for whether publish will succeed, time will tell.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
