### PR TITLE
Add required prop to Checkbox V1

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/CheckboxExperimental/CheckboxTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/CheckboxExperimental/CheckboxTest.tsx
@@ -23,6 +23,7 @@ const basicCheckbox: React.FunctionComponent = () => {
       <Checkbox label="Checkbox will display a tooltip" tooltip="This is a tooltip" />
       <Checkbox label="A circular checkbox" shape="circular" />
       <Checkbox label="A checkbox with label placed before" labelPosition="before" />
+      <Checkbox label="A required checkbox" required />
     </View>
   );
 };
@@ -58,6 +59,7 @@ const otherCheckbox: React.FunctionComponent = () => {
         labelPosition="before"
         checked={Boolean(isCheckedControlled2)}
       />
+      <Checkbox label="A required checkbox with other required text" required="**" />
     </View>
   );
 };

--- a/change/@fluentui-react-native-experimental-checkbox-de28a0a5-c73d-4636-bd65-9555888551c9.json
+++ b/change/@fluentui-react-native-experimental-checkbox-de28a0a5-c73d-4636-bd65-9555888551c9.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Implement required prop",
+  "packageName": "@fluentui-react-native/experimental-checkbox",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-text-161b8d7f-5b42-4b7d-8e8c-da63e4dd93d0.json
+++ b/change/@fluentui-react-native-experimental-text-161b8d7f-5b42-4b7d-8e8c-da63e4dd93d0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add snapshot and fix runtime error",
+  "packageName": "@fluentui-react-native/experimental-text",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-65520d3f-f2f4-49a4-887e-05c053dfb573.json
+++ b/change/@fluentui-react-native-tester-65520d3f-f2f4-49a4-887e-05c053dfb573.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add tests and fix bugs",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-theme-tokens-d4981b7e-8fac-47af-be8a-8da6d4f33ab5.json
+++ b/change/@fluentui-react-native-theme-tokens-d4981b7e-8fac-47af-be8a-8da6d4f33ab5.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "New alias tokens",
+  "packageName": "@fluentui-react-native/theme-tokens",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-theme-types-a5ff344e-35ee-4e6e-8d34-25ea7ca2bf8e.json
+++ b/change/@fluentui-react-native-theme-types-a5ff344e-35ee-4e6e-8d34-25ea7ca2bf8e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "New alias tokens",
+  "packageName": "@fluentui-react-native/theme-types",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-theming-utils-9d6704fd-eaeb-4c87-ad9e-3996371c806b.json
+++ b/change/@fluentui-react-native-theming-utils-9d6704fd-eaeb-4c87-ad9e-3996371c806b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "New alias tokens",
+  "packageName": "@fluentui-react-native/theming-utils",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Checkbox/MIGRATION.md
+++ b/packages/experimental/Checkbox/MIGRATION.md
@@ -69,6 +69,7 @@ The FURN Checkbox cannot be used in place of a FluentUI React Checkbox - these b
 ### Props unchanged
 
 - `labelPosition`
+- `required`
 - `shape`
 - `size`
 
@@ -78,7 +79,7 @@ No `Checkbox` specific renames.
 
 ### Prop differences due to technical differences and limitations
 
-- `onChange` does not pass native event info due to typing difficulties.
+- `onChange` passes a different type for the native event
 
 ### Other Prop differences
 

--- a/packages/experimental/Checkbox/SPEC.md
+++ b/packages/experimental/Checkbox/SPEC.md
@@ -64,6 +64,7 @@ The `Checkbox` control has three slots, or parts. The slots behave as follows:
 
 - `root` - The outer container representing the `Checkbox` itself that wraps everything passed via the `children` prop.
 - `label` - If specified, renders text describing the checkbox either before or after the `checkbox` as specified by the `labelPosition` prop.
+- `required` - If specified, renders text that denotes a checkbox as required after `label`.
 - `checkbox` - The box which visually represents the checkbox.
 - `checkmark` - A checkmark icon which shows whether the checkbox is in a checked state.
 
@@ -113,6 +114,11 @@ export interface CheckboxProps extends Omit<IViewProps, 'onPress'> {
    * Callback that is called when the checked value has changed.
    */
   onChange?: (e: InteractionEvent, isChecked: boolean) => void;
+
+  /**
+   * If true, adds an asterisk which denotes that this checkbox is required. Can also be set a custom string.
+   */
+  required?: boolean | string;
 
   /**
    * The shape of the checkbox. Can be either (rounded) square or circular.
@@ -180,6 +186,16 @@ export interface CheckboxTokens extends FontTokens, IForegroundColorTokens, IBac
    * Height and width of the checkmark icon.
    */
   checkmarkSize?: number;
+
+  /**
+   * Color of the text that denotes that the checkbox is required
+   */
+  requiredColor?: ColorValue;
+
+  /**
+   * Amount of padding between the end of the label and the start of the required text
+   */
+  requiredPadding?: ViewStyle['padding'];
 
   /**
    * The amount of spacing between an icon and the content when iconPosition is set to 'before', in pixels

--- a/packages/experimental/Checkbox/src/Checkbox.styling.ts
+++ b/packages/experimental/Checkbox/src/Checkbox.styling.ts
@@ -67,6 +67,12 @@ export const stylingSettings: UseStylingOptions<CheckboxProps, CheckboxSlotProps
       }),
       ['checkmarkColor', 'checkmarkSize', 'checkmarkOpacity'],
     ),
+    required: buildProps(
+      (tokens: CheckboxTokens) => ({
+        style: { color: tokens.requiredColor, paddingStart: tokens.requiredPadding },
+      }),
+      ['requiredColor', 'requiredPadding'],
+    ),
   },
 };
 

--- a/packages/experimental/Checkbox/src/Checkbox.styling.ts
+++ b/packages/experimental/Checkbox/src/Checkbox.styling.ts
@@ -68,10 +68,10 @@ export const stylingSettings: UseStylingOptions<CheckboxProps, CheckboxSlotProps
       ['checkmarkColor', 'checkmarkSize', 'checkmarkOpacity'],
     ),
     required: buildProps(
-      (tokens: CheckboxTokens) => ({
-        style: { color: tokens.requiredColor, paddingStart: tokens.requiredPadding },
+      (tokens: CheckboxTokens, theme: Theme) => ({
+        style: { color: tokens.requiredColor, paddingStart: tokens.requiredPadding, ...fontStyles.from(tokens, theme) },
       }),
-      ['requiredColor', 'requiredPadding'],
+      ['requiredColor', 'requiredPadding', ...fontStyles.keys],
     ),
   },
 };

--- a/packages/experimental/Checkbox/src/Checkbox.tsx
+++ b/packages/experimental/Checkbox/src/Checkbox.tsx
@@ -1,4 +1,5 @@
 /** @jsx withSlots */
+import * as React from 'react';
 import { View } from 'react-native';
 import { checkboxName, CheckboxType, CheckboxProps } from './Checkbox.types';
 import { Text } from '@fluentui-react-native/experimental-text';
@@ -36,7 +37,12 @@ export const Checkbox = compose<CheckboxType>({
 
       return (
         <Slots.root {...mergedProps}>
-          {Checkbox.state.labelIsBefore && <Slots.label key="label">{label}</Slots.label>}
+          {Checkbox.state.labelIsBefore && (
+            <React.Fragment>
+              <Slots.label key="label">{label}</Slots.label>
+              {!!required && <Slots.required>{typeof required === 'string' ? required : '*'}</Slots.required>}
+            </React.Fragment>
+          )}
           <Slots.checkbox>
             <Slots.checkmark key="checkmark" viewBox="0 0 11 8">
               <Path
@@ -46,10 +52,10 @@ export const Checkbox = compose<CheckboxType>({
             </Slots.checkmark>
           </Slots.checkbox>
           {!Checkbox.state.labelIsBefore && (
-            <Slots.label key="label">
-              {label}
-              <Slots.required>{!!required && typeof required === 'string' ? required : '*'}</Slots.required>
-            </Slots.label>
+            <React.Fragment>
+              <Slots.label key="label">{label}</Slots.label>
+              {!!required && <Slots.required>{typeof required === 'string' ? required : '*'}</Slots.required>}
+            </React.Fragment>
           )}
         </Slots.root>
       );

--- a/packages/experimental/Checkbox/src/Checkbox.tsx
+++ b/packages/experimental/Checkbox/src/Checkbox.tsx
@@ -15,6 +15,7 @@ export const Checkbox = compose<CheckboxType>({
     checkbox: View,
     checkmark: Svg,
     label: Text,
+    required: Text,
   },
   render: (userProps: CheckboxProps, useSlots: UseSlots<CheckboxType>) => {
     // configure props and state for checkbox based on user props
@@ -31,7 +32,7 @@ export const Checkbox = compose<CheckboxType>({
     );
     // now return the handler for finishing render
     return (final: CheckboxProps) => {
-      const { label, ...mergedProps } = mergeProps(Checkbox.props, final);
+      const { label, required, ...mergedProps } = mergeProps(Checkbox.props, final);
 
       return (
         <Slots.root {...mergedProps}>
@@ -44,7 +45,12 @@ export const Checkbox = compose<CheckboxType>({
               />
             </Slots.checkmark>
           </Slots.checkbox>
-          {!Checkbox.state.labelIsBefore && <Slots.label key="label">{label}</Slots.label>}
+          {!Checkbox.state.labelIsBefore && (
+            <Slots.label key="label">
+              {label}
+              <Slots.required>{!!required && typeof required === 'string' ? required : '*'}</Slots.required>
+            </Slots.label>
+          )}
         </Slots.root>
       );
     };

--- a/packages/experimental/Checkbox/src/Checkbox.types.ts
+++ b/packages/experimental/Checkbox/src/Checkbox.types.ts
@@ -52,7 +52,14 @@ export interface CheckboxTokens extends FontTokens, IForegroundColorTokens, IBac
    */
   checkmarkSize?: number;
 
+  /**
+   * Color of the text that denotes that the checkbox is required
+   */
   requiredColor?: ColorValue;
+
+  /**
+   * Amount of padding between the end of the label and the start of the required text
+   */
   requiredPadding?: ViewStyle['padding'];
 
   /**

--- a/packages/experimental/Checkbox/src/Checkbox.types.ts
+++ b/packages/experimental/Checkbox/src/Checkbox.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ColorValue } from 'react-native';
+import { ColorValue, ViewStyle } from 'react-native';
 import { FontTokens, IBorderTokens, IForegroundColorTokens, IBackgroundColorTokens, LayoutTokens } from '@fluentui-react-native/tokens';
 import { IFocusable, IPressableState } from '@fluentui-react-native/interactive-hooks';
 import type { ITextProps, IViewProps } from '@fluentui-react-native/adapters';
@@ -51,6 +51,9 @@ export interface CheckboxTokens extends FontTokens, IForegroundColorTokens, IBac
    * Height and width of the checkmark icon.
    */
   checkmarkSize?: number;
+
+  requiredColor?: ColorValue;
+  requiredPadding?: ViewStyle['padding'];
 
   /**
    * The amount of spacing between an icon and the content when iconPosition is set to 'before', in pixels
@@ -118,6 +121,11 @@ export interface CheckboxProps extends Omit<IViewProps, 'onPress'> {
   onChange?: (e: InteractionEvent, isChecked: boolean) => void;
 
   /**
+   * If true, adds an asterisk which denotes that this checkbox is required. Can also be set a custom string.
+   */
+  required?: boolean | string;
+
+  /**
    * The shape of the checkbox. Can be either (rounded) square or circular.
    *
    * @default square
@@ -161,8 +169,9 @@ export interface CheckboxInfo {
 export interface CheckboxSlotProps {
   root: React.PropsWithRef<IViewProps>;
   checkbox: IViewProps;
-  checkmark?: SvgProps;
+  checkmark: SvgProps;
   label: ITextProps;
+  required: ITextProps;
 }
 
 export interface CheckboxType {

--- a/packages/experimental/Checkbox/src/CheckboxTokens.ts
+++ b/packages/experimental/Checkbox/src/CheckboxTokens.ts
@@ -5,6 +5,8 @@ import { CheckboxTokens } from './Checkbox.types';
 
 export const defaultCheckboxTokens: TokenSettings<CheckboxTokens, Theme> = (t: Theme) =>
   ({
+    requiredColor: t.colors.redForeground1,
+    requiredPadding: globalTokens.spacing.s,
     medium: {
       borderRadius: globalTokens.corner.radius.small,
       checkboxBorderWidth: globalTokens.stroke.width.thin,

--- a/packages/experimental/Checkbox/src/CheckboxTokens.win32.ts
+++ b/packages/experimental/Checkbox/src/CheckboxTokens.win32.ts
@@ -5,6 +5,8 @@ import { CheckboxTokens } from './Checkbox.types';
 
 export const defaultCheckboxTokens: TokenSettings<CheckboxTokens, Theme> = (t: Theme) =>
   ({
+    requiredColor: t.colors.redForeground1,
+    requiredPadding: globalTokens.spacing.s,
     medium: {
       borderRadius: globalTokens.corner.radius.small,
       checkboxBorderWidth: globalTokens.stroke.width.thin,

--- a/packages/experimental/Checkbox/src/CheckboxTokens.windows.ts
+++ b/packages/experimental/Checkbox/src/CheckboxTokens.windows.ts
@@ -5,6 +5,8 @@ import { CheckboxTokens } from './Checkbox.types';
 
 export const defaultCheckboxTokens: TokenSettings<CheckboxTokens, Theme> = (t: Theme) =>
   ({
+    requiredColor: t.colors.redForeground1,
+    requiredPadding: globalTokens.spacing.s,
     medium: {
       borderRadius: globalTokens.corner.radius.small,
       checkboxBorderWidth: globalTokens.stroke.width.thin,

--- a/packages/experimental/Checkbox/src/__tests__/Checkbox.test.tsx
+++ b/packages/experimental/Checkbox/src/__tests__/Checkbox.test.tsx
@@ -65,6 +65,7 @@ describe('Checkbox component tests', () => {
         checkbox: View,
         checkmark: Svg,
         label: Text,
+        required: Text,
       },
     });
     const tree = renderer.create(<ComposedCheckbox>Composed Button with RNText</ComposedCheckbox>).toJSON();

--- a/packages/experimental/Checkbox/src/__tests__/Checkbox.test.tsx
+++ b/packages/experimental/Checkbox/src/__tests__/Checkbox.test.tsx
@@ -27,6 +27,7 @@ describe('Checkbox component tests', () => {
           disabled
           shape="circular"
           size="large"
+          required
         />,
       )
       .toJSON();

--- a/packages/experimental/Checkbox/src/__tests__/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/experimental/Checkbox/src/__tests__/__snapshots__/Checkbox.test.tsx.snap
@@ -64,6 +64,20 @@ exports[`Checkbox component tests Checkbox all props 1`] = `
   >
     All Props Checkbox
   </Text>
+  <Text
+    style={
+      Object {
+        "color": "#690a19",
+        "fontFamily": "Segoe UI",
+        "fontSize": 14,
+        "fontWeight": "400",
+        "margin": 0,
+        "paddingStart": 8,
+      }
+    }
+  >
+    *
+  </Text>
   <View
     style={
       Object {

--- a/packages/experimental/Checkbox/src/__tests__/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/experimental/Checkbox/src/__tests__/__snapshots__/Checkbox.test.tsx.snap
@@ -63,7 +63,6 @@ exports[`Checkbox component tests Checkbox all props 1`] = `
     }
   >
     All Props Checkbox
-
   </Text>
   <Text
     style={

--- a/packages/experimental/Checkbox/src/__tests__/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/experimental/Checkbox/src/__tests__/__snapshots__/Checkbox.test.tsx.snap
@@ -63,6 +63,7 @@ exports[`Checkbox component tests Checkbox all props 1`] = `
     }
   >
     All Props Checkbox
+
   </Text>
   <Text
     style={

--- a/packages/experimental/Text/src/Text.tsx
+++ b/packages/experimental/Text/src/Text.tsx
@@ -77,7 +77,7 @@ export const Text = compressible<TextProps, TextTokens>((props: TextProps, useTo
 
   // return a continuation function that allows this text to be compressed
   return (extra: TextProps, children: React.ReactNode) => {
-    const mergedProps = { ...rest, ...extra, style: mergeStyles(tokenStyle, props.style, extra.style) };
+    const mergedProps = { ...rest, ...extra, style: mergeStyles(tokenStyle, props.style, extra?.style) };
     return <RNText {...mergedProps}>{children}</RNText>;
   };
 }, useTextTokens);

--- a/packages/theming/theme-tokens/src/generated/black/reactnative/tokens-aliases.json
+++ b/packages/theming/theme-tokens/src/generated/black/reactnative/tokens-aliases.json
@@ -217,13 +217,16 @@
     "fillColorRest": "#750b1c"
   },
   "redBorder1": {
-    "fillColorRest": "#750b1c"
+    "strokeColorRest": "#750b1c",
+    "strokeWidth": 1
   },
   "redBorder2": {
-    "fillColorRest": "#962f3f"
+    "strokeColorRest": "#962f3f",
+    "strokeWidth": 1
   },
   "redBorderActive": {
-    "fillColorRest": "#ac4f5e"
+    "strokeColorRest": "#ac4f5e",
+    "strokeWidth": 1
   },
   "redForeground1": {
     "fillColorRest": "#ac4f5e"

--- a/packages/theming/theme-tokens/src/generated/black/reactnative/tokens-aliases.json
+++ b/packages/theming/theme-tokens/src/generated/black/reactnative/tokens-aliases.json
@@ -207,6 +207,33 @@
     "strokeColorRest": "#424242",
     "strokeWidth": 1
   },
+  "redBackground1": {
+    "fillColorRest": "#230308"
+  },
+  "redBackground2": {
+    "fillColorRest": "#420610"
+  },
+  "redBackground3": {
+    "fillColorRest": "#750b1c"
+  },
+  "redBorder1": {
+    "fillColorRest": "#750b1c"
+  },
+  "redBorder2": {
+    "fillColorRest": "#962f3f"
+  },
+  "redBorderActive": {
+    "fillColorRest": "#ac4f5e"
+  },
+  "redForeground1": {
+    "fillColorRest": "#ac4f5e"
+  },
+  "redForeground2": {
+    "fillColorRest": "#d69ca5"
+  },
+  "redForeground3": {
+    "fillColorRest": "#962f3f"
+  },
   "strokeFocus1": {
     "strokeColorRest": "#000000",
     "strokeWidth": 1

--- a/packages/theming/theme-tokens/src/generated/colorful/reactnative/tokens-aliases.json
+++ b/packages/theming/theme-tokens/src/generated/colorful/reactnative/tokens-aliases.json
@@ -217,13 +217,16 @@
     "fillColorRest": "#750b1c"
   },
   "redBorder1": {
-    "fillColorRest": "#d69ca5"
+    "strokeColorRest": "#d69ca5",
+    "strokeWidth": 1
   },
   "redBorder2": {
-    "fillColorRest": "#750b1c"
+    "strokeColorRest": "#750b1c",
+    "strokeWidth": 1
   },
   "redBorderActive": {
-    "fillColorRest": "#750b1c"
+    "strokeColorRest": "#750b1c",
+    "strokeWidth": 1
   },
   "redForeground1": {
     "fillColorRest": "#690a19"

--- a/packages/theming/theme-tokens/src/generated/colorful/reactnative/tokens-aliases.json
+++ b/packages/theming/theme-tokens/src/generated/colorful/reactnative/tokens-aliases.json
@@ -207,6 +207,33 @@
     "strokeColorRest": "#e0e0e0",
     "strokeWidth": 1
   },
+  "redBackground1": {
+    "fillColorRest": "#f9f0f2"
+  },
+  "redBackground2": {
+    "fillColorRest": "#d69ca5"
+  },
+  "redBackground3": {
+    "fillColorRest": "#750b1c"
+  },
+  "redBorder1": {
+    "fillColorRest": "#d69ca5"
+  },
+  "redBorder2": {
+    "fillColorRest": "#750b1c"
+  },
+  "redBorderActive": {
+    "fillColorRest": "#750b1c"
+  },
+  "redForeground1": {
+    "fillColorRest": "#690a19"
+  },
+  "redForeground2": {
+    "fillColorRest": "#420610"
+  },
+  "redForeground3": {
+    "fillColorRest": "#750b1c"
+  },
   "strokeFocus1": {
     "strokeColorRest": "#ffffff",
     "strokeWidth": 1

--- a/packages/theming/theme-tokens/src/generated/dark-high-contrast-macos/reactnative/tokens-aliases.json
+++ b/packages/theming/theme-tokens/src/generated/dark-high-contrast-macos/reactnative/tokens-aliases.json
@@ -222,6 +222,33 @@
     "strokeColorRest": "#525252",
     "strokeWidth": 1
   },
+  "redBackground1": {
+    "fillColorRest": "#230308"
+  },
+  "redBackground2": {
+    "fillColorRest": "#420610"
+  },
+  "redBackground3": {
+    "fillColorRest": "#750b1c"
+  },
+  "redBorder1": {
+    "fillColorRest": "#750b1c"
+  },
+  "redBorder2": {
+    "fillColorRest": "#962f3f"
+  },
+  "redBorderActive": {
+    "fillColorRest": "#ac4f5e"
+  },
+  "redForeground1": {
+    "fillColorRest": "#ac4f5e"
+  },
+  "redForeground2": {
+    "fillColorRest": "#d69ca5"
+  },
+  "redForeground3": {
+    "fillColorRest": "#962f3f"
+  },
   "strokeFocus1": {
     "strokeColorRest": "#000000",
     "strokeWidth": 1

--- a/packages/theming/theme-tokens/src/generated/dark-high-contrast-macos/reactnative/tokens-aliases.json
+++ b/packages/theming/theme-tokens/src/generated/dark-high-contrast-macos/reactnative/tokens-aliases.json
@@ -232,13 +232,16 @@
     "fillColorRest": "#750b1c"
   },
   "redBorder1": {
-    "fillColorRest": "#750b1c"
+    "strokeColorRest": "#750b1c",
+    "strokeWidth": 1
   },
   "redBorder2": {
-    "fillColorRest": "#962f3f"
+    "strokeColorRest": "#962f3f",
+    "strokeWidth": 1
   },
   "redBorderActive": {
-    "fillColorRest": "#ac4f5e"
+    "strokeColorRest": "#ac4f5e",
+    "strokeWidth": 1
   },
   "redForeground1": {
     "fillColorRest": "#ac4f5e"

--- a/packages/theming/theme-tokens/src/generated/dark-macos/reactnative/tokens-aliases.json
+++ b/packages/theming/theme-tokens/src/generated/dark-macos/reactnative/tokens-aliases.json
@@ -218,6 +218,33 @@
     "strokeColorRest": "#525252",
     "strokeWidth": 1
   },
+  "redBackground1": {
+    "fillColorRest": "#230308"
+  },
+  "redBackground2": {
+    "fillColorRest": "#420610"
+  },
+  "redBackground3": {
+    "fillColorRest": "#750b1c"
+  },
+  "redBorder1": {
+    "fillColorRest": "#750b1c"
+  },
+  "redBorder2": {
+    "fillColorRest": "#962f3f"
+  },
+  "redBorderActive": {
+    "fillColorRest": "#ac4f5e"
+  },
+  "redForeground1": {
+    "fillColorRest": "#ac4f5e"
+  },
+  "redForeground2": {
+    "fillColorRest": "#d69ca5"
+  },
+  "redForeground3": {
+    "fillColorRest": "#962f3f"
+  },
   "strokeFocus1": {
     "strokeColorRest": "#000000",
     "strokeWidth": 1

--- a/packages/theming/theme-tokens/src/generated/dark-macos/reactnative/tokens-aliases.json
+++ b/packages/theming/theme-tokens/src/generated/dark-macos/reactnative/tokens-aliases.json
@@ -228,13 +228,16 @@
     "fillColorRest": "#750b1c"
   },
   "redBorder1": {
-    "fillColorRest": "#750b1c"
+    "strokeColorRest": "#750b1c",
+    "strokeWidth": 1
   },
   "redBorder2": {
-    "fillColorRest": "#962f3f"
+    "strokeColorRest": "#962f3f",
+    "strokeWidth": 1
   },
   "redBorderActive": {
-    "fillColorRest": "#ac4f5e"
+    "strokeColorRest": "#ac4f5e",
+    "strokeWidth": 1
   },
   "redForeground1": {
     "fillColorRest": "#ac4f5e"

--- a/packages/theming/theme-tokens/src/generated/dark/reactnative/tokens-aliases.json
+++ b/packages/theming/theme-tokens/src/generated/dark/reactnative/tokens-aliases.json
@@ -217,13 +217,16 @@
     "fillColorRest": "#750b1c"
   },
   "redBorder1": {
-    "fillColorRest": "#750b1c"
+    "strokeColorRest": "#750b1c",
+    "strokeWidth": 1
   },
   "redBorder2": {
-    "fillColorRest": "#962f3f"
+    "strokeColorRest": "#962f3f",
+    "strokeWidth": 1
   },
   "redBorderActive": {
-    "fillColorRest": "#ac4f5e"
+    "strokeColorRest": "#ac4f5e",
+    "strokeWidth": 1
   },
   "redForeground1": {
     "fillColorRest": "#ac4f5e"

--- a/packages/theming/theme-tokens/src/generated/dark/reactnative/tokens-aliases.json
+++ b/packages/theming/theme-tokens/src/generated/dark/reactnative/tokens-aliases.json
@@ -207,6 +207,33 @@
     "strokeColorRest": "#424242",
     "strokeWidth": 1
   },
+  "redBackground1": {
+    "fillColorRest": "#230308"
+  },
+  "redBackground2": {
+    "fillColorRest": "#420610"
+  },
+  "redBackground3": {
+    "fillColorRest": "#750b1c"
+  },
+  "redBorder1": {
+    "fillColorRest": "#750b1c"
+  },
+  "redBorder2": {
+    "fillColorRest": "#962f3f"
+  },
+  "redBorderActive": {
+    "fillColorRest": "#ac4f5e"
+  },
+  "redForeground1": {
+    "fillColorRest": "#ac4f5e"
+  },
+  "redForeground2": {
+    "fillColorRest": "#d69ca5"
+  },
+  "redForeground3": {
+    "fillColorRest": "#962f3f"
+  },
   "strokeFocus1": {
     "strokeColorRest": "#000000",
     "strokeWidth": 1

--- a/packages/theming/theme-tokens/src/generated/darkGray/reactnative/tokens-aliases.json
+++ b/packages/theming/theme-tokens/src/generated/darkGray/reactnative/tokens-aliases.json
@@ -207,6 +207,36 @@
     "strokeColorRest": "#474747",
     "strokeWidth": 1
   },
+  "redBackground1": {
+    "fillColorRest": "#230308"
+  },
+  "redBackground2": {
+    "fillColorRest": "#420610"
+  },
+  "redBackground3": {
+    "fillColorRest": "#750b1c"
+  },
+  "redBorder1": {
+    "strokeColorRest": "#750b1c",
+    "strokeWidth": 1
+  },
+  "redBorder2": {
+    "strokeColorRest": "#962f3f",
+    "strokeWidth": 1
+  },
+  "redBorderActive": {
+    "strokeColorRest": "#ac4f5e",
+    "strokeWidth": 1
+  },
+  "redForeground1": {
+    "fillColorRest": "#ac4f5e"
+  },
+  "redForeground2": {
+    "fillColorRest": "#d69ca5"
+  },
+  "redForeground3": {
+    "fillColorRest": "#962f3f"
+  },
   "strokeFocus1": {
     "strokeColorRest": "#000000",
     "strokeWidth": 1

--- a/packages/theming/theme-tokens/src/generated/highContrast/reactnative/tokens-aliases.json
+++ b/packages/theming/theme-tokens/src/generated/highContrast/reactnative/tokens-aliases.json
@@ -207,6 +207,33 @@
     "strokeColorRest": "PlatformColor(GrayText)",
     "strokeWidth": 1
   },
+  "redBackground1": {
+    "fillColorRest": "PlatformColor(ButtonFace)"
+  },
+  "redBackground2": {
+    "fillColorRest": "PlatformColor(Window)"
+  },
+  "redBackground3": {
+    "fillColorRest": "PlatformColor(ButtonFace)"
+  },
+  "redBorder1": {
+    "fillColorRest": "PlatformColor(WindowText)"
+  },
+  "redBorder2": {
+    "fillColorRest": "PlatformColor(WindowText)"
+  },
+  "redBorderActive": {
+    "fillColorRest": "PlatformColor(Highlight)"
+  },
+  "redForeground1": {
+    "fillColorRest": "PlatformColor(ButtonText)"
+  },
+  "redForeground2": {
+    "fillColorRest": "PlatformColor(WindowText)"
+  },
+  "redForeground3": {
+    "fillColorRest": "PlatformColor(WindowText)"
+  },
   "strokeFocus1": {
     "strokeColorRest": "PlatformColor(Window)",
     "strokeWidth": 1

--- a/packages/theming/theme-tokens/src/generated/highContrast/reactnative/tokens-aliases.json
+++ b/packages/theming/theme-tokens/src/generated/highContrast/reactnative/tokens-aliases.json
@@ -217,13 +217,16 @@
     "fillColorRest": "PlatformColor(ButtonFace)"
   },
   "redBorder1": {
-    "fillColorRest": "PlatformColor(WindowText)"
+    "strokeColorRest": "PlatformColor(WindowText)",
+    "strokeWidth": 1
   },
   "redBorder2": {
-    "fillColorRest": "PlatformColor(WindowText)"
+    "strokeColorRest": "PlatformColor(WindowText)",
+    "strokeWidth": 1
   },
   "redBorderActive": {
-    "fillColorRest": "PlatformColor(Highlight)"
+    "strokeColorRest": "PlatformColor(Highlight)",
+    "strokeWidth": 1
   },
   "redForeground1": {
     "fillColorRest": "PlatformColor(ButtonText)"

--- a/packages/theming/theme-tokens/src/generated/light-high-contrast-macos/reactnative/tokens-aliases.json
+++ b/packages/theming/theme-tokens/src/generated/light-high-contrast-macos/reactnative/tokens-aliases.json
@@ -23,7 +23,7 @@
     "fillColorRest": "#0078d4",
     "fillColorHover": "#106ebe",
     "fillColorPressed": "#106ebe",
-    "fillColorDisabled": "#ebebeb",
+    "fillColorDisabled": "#d1d1d1",
     "fillColorSelected": "#005a9e"
   },
   "brandBackground2": {
@@ -134,7 +134,8 @@
     "fillColorRest": "#e6e6e6"
   },
   "neutralBackgroundDisabled": {
-    "fillColorRest": "#d1d1d1",
+    "fillColorRest": "#f0f0f0",
+    "fillColorPressed": "#d1d1d1",
     "fillColorSelected": "PlatformColor(Window)"
   },
   "neutralBackgroundInverted": {
@@ -220,6 +221,33 @@
   "neutralStrokeDisabled": {
     "strokeColorRest": "#e0e0e0",
     "strokeWidth": 1
+  },
+  "redBackground1": {
+    "fillColorRest": "#f9f0f2"
+  },
+  "redBackground2": {
+    "fillColorRest": "#d69ca5"
+  },
+  "redBackground3": {
+    "fillColorRest": "#750b1c"
+  },
+  "redBorder1": {
+    "fillColorRest": "#d69ca5"
+  },
+  "redBorder2": {
+    "fillColorRest": "#750b1c"
+  },
+  "redBorderActive": {
+    "fillColorRest": "#750b1c"
+  },
+  "redForeground1": {
+    "fillColorRest": "#690a19"
+  },
+  "redForeground2": {
+    "fillColorRest": "#420610"
+  },
+  "redForeground3": {
+    "fillColorRest": "#750b1c"
   },
   "strokeFocus1": {
     "strokeColorRest": "#ffffff",

--- a/packages/theming/theme-tokens/src/generated/light-high-contrast-macos/reactnative/tokens-aliases.json
+++ b/packages/theming/theme-tokens/src/generated/light-high-contrast-macos/reactnative/tokens-aliases.json
@@ -232,13 +232,16 @@
     "fillColorRest": "#750b1c"
   },
   "redBorder1": {
-    "fillColorRest": "#d69ca5"
+    "strokeColorRest": "#d69ca5",
+    "strokeWidth": 1
   },
   "redBorder2": {
-    "fillColorRest": "#750b1c"
+    "strokeColorRest": "#750b1c",
+    "strokeWidth": 1
   },
   "redBorderActive": {
-    "fillColorRest": "#750b1c"
+    "strokeColorRest": "#750b1c",
+    "strokeWidth": 1
   },
   "redForeground1": {
     "fillColorRest": "#690a19"

--- a/packages/theming/theme-tokens/src/generated/light-macos/reactnative/tokens-aliases.json
+++ b/packages/theming/theme-tokens/src/generated/light-macos/reactnative/tokens-aliases.json
@@ -228,13 +228,16 @@
     "fillColorRest": "#750b1c"
   },
   "redBorder1": {
-    "fillColorRest": "#d69ca5"
+    "strokeColorRest": "#d69ca5",
+    "strokeWidth": 1
   },
   "redBorder2": {
-    "fillColorRest": "#750b1c"
+    "strokeColorRest": "#750b1c",
+    "strokeWidth": 1
   },
   "redBorderActive": {
-    "fillColorRest": "#750b1c"
+    "strokeColorRest": "#750b1c",
+    "strokeWidth": 1
   },
   "redForeground1": {
     "fillColorRest": "#690a19"

--- a/packages/theming/theme-tokens/src/generated/light-macos/reactnative/tokens-aliases.json
+++ b/packages/theming/theme-tokens/src/generated/light-macos/reactnative/tokens-aliases.json
@@ -134,7 +134,8 @@
     "fillColorRest": "#e6e6e6"
   },
   "neutralBackgroundDisabled": {
-    "fillColorRest": "#d1d1d1"
+    "fillColorRest": "#f0f0f0",
+    "fillColorPressed": "#d1d1d1"
   },
   "neutralBackgroundInverted": {
     "fillColorRest": "#616161"
@@ -216,6 +217,33 @@
   "neutralStrokeDisabled": {
     "strokeColorRest": "#e0e0e0",
     "strokeWidth": 1
+  },
+  "redBackground1": {
+    "fillColorRest": "#f9f0f2"
+  },
+  "redBackground2": {
+    "fillColorRest": "#d69ca5"
+  },
+  "redBackground3": {
+    "fillColorRest": "#750b1c"
+  },
+  "redBorder1": {
+    "fillColorRest": "#d69ca5"
+  },
+  "redBorder2": {
+    "fillColorRest": "#750b1c"
+  },
+  "redBorderActive": {
+    "fillColorRest": "#750b1c"
+  },
+  "redForeground1": {
+    "fillColorRest": "#690a19"
+  },
+  "redForeground2": {
+    "fillColorRest": "#420610"
+  },
+  "redForeground3": {
+    "fillColorRest": "#750b1c"
   },
   "strokeFocus1": {
     "strokeColorRest": "#ffffff",

--- a/packages/theming/theme-tokens/src/generated/light/reactnative/tokens-aliases.json
+++ b/packages/theming/theme-tokens/src/generated/light/reactnative/tokens-aliases.json
@@ -217,13 +217,16 @@
     "fillColorRest": "#750b1c"
   },
   "redBorder1": {
-    "fillColorRest": "#d69ca5"
+    "strokeColorRest": "#d69ca5",
+    "strokeWidth": 1
   },
   "redBorder2": {
-    "fillColorRest": "#750b1c"
+    "strokeColorRest": "#750b1c",
+    "strokeWidth": 1
   },
   "redBorderActive": {
-    "fillColorRest": "#750b1c"
+    "strokeColorRest": "#750b1c",
+    "strokeWidth": 1
   },
   "redForeground1": {
     "fillColorRest": "#690a19"

--- a/packages/theming/theme-tokens/src/generated/light/reactnative/tokens-aliases.json
+++ b/packages/theming/theme-tokens/src/generated/light/reactnative/tokens-aliases.json
@@ -207,6 +207,33 @@
     "strokeColorRest": "#e0e0e0",
     "strokeWidth": 1
   },
+  "redBackground1": {
+    "fillColorRest": "#f9f0f2"
+  },
+  "redBackground2": {
+    "fillColorRest": "#d69ca5"
+  },
+  "redBackground3": {
+    "fillColorRest": "#750b1c"
+  },
+  "redBorder1": {
+    "fillColorRest": "#d69ca5"
+  },
+  "redBorder2": {
+    "fillColorRest": "#750b1c"
+  },
+  "redBorderActive": {
+    "fillColorRest": "#750b1c"
+  },
+  "redForeground1": {
+    "fillColorRest": "#690a19"
+  },
+  "redForeground2": {
+    "fillColorRest": "#420610"
+  },
+  "redForeground3": {
+    "fillColorRest": "#750b1c"
+  },
   "strokeFocus1": {
     "strokeColorRest": "#ffffff",
     "strokeWidth": 1

--- a/packages/theming/theme-tokens/src/pipeline-input/token-input-dark.json
+++ b/packages/theming/theme-tokens/src/pipeline-input/token-input-dark.json
@@ -391,24 +391,27 @@
       }
     },
     "RedBorderActive": {
-      "Fill": {
+      "Stroke": {
         "Color": {
           "Rest": { "aliasOf": "Global.Color.DarkRed.Tint30" }
-        }
+        },
+        "Width": { "aliasOf": "Global.Stroke.Width.Thin" }
       }
     },
     "RedBorder1": {
-      "Fill": {
+      "Stroke": {
         "Color": {
           "Rest": { "aliasOf": "Global.Color.DarkRed.Primary" }
-        }
+        },
+        "Width": { "aliasOf": "Global.Stroke.Width.Thin" }
       }
     },
     "RedBorder2": {
-      "Fill": {
+      "Stroke": {
         "Color": {
           "Rest": { "aliasOf": "Global.Color.DarkRed.Tint20" }
-        }
+        },
+        "Width": { "aliasOf": "Global.Stroke.Width.Thin" }
       }
     }
   }

--- a/packages/theming/theme-tokens/src/pipeline-input/token-input-dark.json
+++ b/packages/theming/theme-tokens/src/pipeline-input/token-input-dark.json
@@ -347,6 +347,69 @@
         },
         "Width": { "aliasOf": "Global.Stroke.Width.Thin" }
       }
+    },
+    "RedBackground1": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.DarkRed.Shade40" }
+        }
+      }
+    },
+    "RedBackground2": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.DarkRed.Shade30" }
+        }
+      }
+    },
+    "RedBackground3": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.DarkRed.Primary" }
+        }
+      }
+    },
+    "RedForeground1": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.DarkRed.Tint30" }
+        }
+      }
+    },
+    "RedForeground2": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.DarkRed.Tint40" }
+        }
+      }
+    },
+    "RedForeground3": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.DarkRed.Tint20" }
+        }
+      }
+    },
+    "RedBorderActive": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.DarkRed.Tint30" }
+        }
+      }
+    },
+    "RedBorder1": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.DarkRed.Primary" }
+        }
+      }
+    },
+    "RedBorder2": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.DarkRed.Tint20" }
+        }
+      }
     }
   }
 }

--- a/packages/theming/theme-tokens/src/pipeline-input/token-input-darkgray.json
+++ b/packages/theming/theme-tokens/src/pipeline-input/token-input-darkgray.json
@@ -347,6 +347,72 @@
         },
         "Width": { "aliasOf": "Global.Stroke.Width.Thin" }
       }
+    },
+    "RedBackground1": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.DarkRed.Shade40" }
+        }
+      }
+    },
+    "RedBackground2": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.DarkRed.Shade30" }
+        }
+      }
+    },
+    "RedBackground3": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.DarkRed.Primary" }
+        }
+      }
+    },
+    "RedForeground1": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.DarkRed.Tint30" }
+        }
+      }
+    },
+    "RedForeground2": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.DarkRed.Tint40" }
+        }
+      }
+    },
+    "RedForeground3": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.DarkRed.Tint20" }
+        }
+      }
+    },
+    "RedBorderActive": {
+      "Stroke": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.DarkRed.Tint30" }
+        },
+        "Width": { "aliasOf": "Global.Stroke.Width.Thin" }
+      }
+    },
+    "RedBorder1": {
+      "Stroke": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.DarkRed.Primary" }
+        },
+        "Width": { "aliasOf": "Global.Stroke.Width.Thin" }
+      }
+    },
+    "RedBorder2": {
+      "Stroke": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.DarkRed.Tint20" }
+        },
+        "Width": { "aliasOf": "Global.Stroke.Width.Thin" }
+      }
     }
   }
 }

--- a/packages/theming/theme-tokens/src/pipeline-input/token-input-highContrast.json
+++ b/packages/theming/theme-tokens/src/pipeline-input/token-input-highContrast.json
@@ -391,24 +391,27 @@
       }
     },
     "RedBorderActive": {
-      "Fill": {
+      "Stroke": {
         "Color": {
           "Rest": { "aliasOf": "Global.Color.HC.Highlight" }
-        }
+        },
+        "Width": { "aliasOf": "Global.Stroke.Width.Thin" }
       }
     },
     "RedBorder1": {
-      "Fill": {
+      "Stroke": {
         "Color": {
           "Rest": { "aliasOf": "Global.Color.HC.CanvasText" }
-        }
+        },
+        "Width": { "aliasOf": "Global.Stroke.Width.Thin" }
       }
     },
     "RedBorder2": {
-      "Fill": {
+      "Stroke": {
         "Color": {
           "Rest": { "aliasOf": "Global.Color.HC.CanvasText" }
-        }
+        },
+        "Width": { "aliasOf": "Global.Stroke.Width.Thin" }
       }
     }
   }

--- a/packages/theming/theme-tokens/src/pipeline-input/token-input-highContrast.json
+++ b/packages/theming/theme-tokens/src/pipeline-input/token-input-highContrast.json
@@ -347,6 +347,69 @@
         },
         "Width": { "aliasOf": "Global.Stroke.Width.Thin" }
       }
+    },
+    "RedBackground1": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.HC.ButtonFace" }
+        }
+      }
+    },
+    "RedBackground2": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.HC.Canvas" }
+        }
+      }
+    },
+    "RedBackground3": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.HC.ButtonFace" }
+        }
+      }
+    },
+    "RedForeground1": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.HC.ButtonText" }
+        }
+      }
+    },
+    "RedForeground2": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.HC.CanvasText" }
+        }
+      }
+    },
+    "RedForeground3": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.HC.CanvasText" }
+        }
+      }
+    },
+    "RedBorderActive": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.HC.Highlight" }
+        }
+      }
+    },
+    "RedBorder1": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.HC.CanvasText" }
+        }
+      }
+    },
+    "RedBorder2": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.HC.CanvasText" }
+        }
+      }
     }
   }
 }

--- a/packages/theming/theme-tokens/src/pipeline-input/token-input-light.json
+++ b/packages/theming/theme-tokens/src/pipeline-input/token-input-light.json
@@ -347,6 +347,69 @@
         },
         "Width": { "aliasOf": "Global.Stroke.Width.Thin" }
       }
+    },
+    "RedBackground1": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.DarkRed.Tint60" }
+        }
+      }
+    },
+    "RedBackground2": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.DarkRed.Tint40" }
+        }
+      }
+    },
+    "RedBackground3": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.DarkRed.Primary" }
+        }
+      }
+    },
+    "RedForeground1": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.DarkRed.Shade10" }
+        }
+      }
+    },
+    "RedForeground2": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.DarkRed.Shade30" }
+        }
+      }
+    },
+    "RedForeground3": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.DarkRed.Primary" }
+        }
+      }
+    },
+    "RedBorderActive": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.DarkRed.Primary" }
+        }
+      }
+    },
+    "RedBorder1": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.DarkRed.Tint40" }
+        }
+      }
+    },
+    "RedBorder2": {
+      "Fill": {
+        "Color": {
+          "Rest": { "aliasOf": "Global.Color.DarkRed.Primary" }
+        }
+      }
     }
   }
 }

--- a/packages/theming/theme-tokens/src/pipeline-input/token-input-light.json
+++ b/packages/theming/theme-tokens/src/pipeline-input/token-input-light.json
@@ -391,24 +391,27 @@
       }
     },
     "RedBorderActive": {
-      "Fill": {
+      "Stroke": {
         "Color": {
           "Rest": { "aliasOf": "Global.Color.DarkRed.Primary" }
-        }
+        },
+        "Width": { "aliasOf": "Global.Stroke.Width.Thin" }
       }
     },
     "RedBorder1": {
-      "Fill": {
+      "Stroke": {
         "Color": {
           "Rest": { "aliasOf": "Global.Color.DarkRed.Tint40" }
-        }
+        },
+        "Width": { "aliasOf": "Global.Stroke.Width.Thin" }
       }
     },
     "RedBorder2": {
-      "Fill": {
+      "Stroke": {
         "Color": {
           "Rest": { "aliasOf": "Global.Color.DarkRed.Primary" }
-        }
+        },
+        "Width": { "aliasOf": "Global.Stroke.Width.Thin" }
       }
     }
   }

--- a/packages/theming/theme-types/src/Color.types.ts
+++ b/packages/theming/theme-types/src/Color.types.ts
@@ -567,6 +567,16 @@ export interface AliasColorTokens {
 
   strokeFocus1: ColorValue;
   strokeFocus2: ColorValue;
+
+  redBackground1: ColorValue;
+  redBackground2: ColorValue;
+  redBackground3: ColorValue;
+  redForeground1: ColorValue;
+  redForeground2: ColorValue;
+  redForeground3: ColorValue;
+  redBorderActive: ColorValue;
+  redBorder1: ColorValue;
+  redBorder2: ColorValue;
 }
 
 /**

--- a/packages/theming/theming-utils/src/mapPipelineToTheme.ts
+++ b/packages/theming/theming-utils/src/mapPipelineToTheme.ts
@@ -118,5 +118,15 @@ export function mapPipelineToTheme(pipelineOutput: any): AliasColorTokens {
 
     strokeFocus1: pipelineOutput.strokeFocus1.strokeColorRest,
     strokeFocus2: pipelineOutput.strokeFocus2.strokeColorRest,
+
+    redBackground1: pipelineOutput.redBackground1.fillColorRest,
+    redBackground2: pipelineOutput.redBackground2.fillColorRest,
+    redBackground3: pipelineOutput.redBackground3.fillColorRest,
+    redForeground1: pipelineOutput.redForeground1.fillColorRest,
+    redForeground2: pipelineOutput.redBackground2.fillColorRest,
+    redForeground3: pipelineOutput.redBackground3.fillColorRest,
+    redBorderActive: pipelineOutput.redBorderActive.strokeColorRest,
+    redBorder1: pipelineOutput.redBorder1.strokeColorRest,
+    redBorder2: pipelineOutput.redBorder2.strokeColorRest,
   };
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

Adding new required prop to Checkbox. This prop is a boolean or string. If string, the string value will replace the default string of * to denote that a checkbox is required.
This also required adding new alias tokens to the light/dark/HC files, as the required color is based off of the redForground1 token.

### Verification

![image](https://user-images.githubusercontent.com/4602628/156467081-a407e854-6af7-424a-81ae-f7973e5718b8.png)
![image](https://user-images.githubusercontent.com/4602628/156467105-94c62970-e296-4eda-b537-3a62d634253d.png)

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
