### PR TITLE
Checkbox refactor followup

### DIFF
--- a/change/@fluentui-react-native-experimental-checkbox-7aadfe29-6d8f-4dfe-a016-c692b6483362.json
+++ b/change/@fluentui-react-native-experimental-checkbox-7aadfe29-6d8f-4dfe-a016-c692b6483362.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Refactor component",
+  "packageName": "@fluentui-react-native/experimental-checkbox",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Checkbox/src/Checkbox.tsx
+++ b/packages/experimental/Checkbox/src/Checkbox.tsx
@@ -34,15 +34,16 @@ export const Checkbox = compose<CheckboxType>({
     // now return the handler for finishing render
     return (final: CheckboxProps) => {
       const { label, required, ...mergedProps } = mergeProps(Checkbox.props, final);
+      const labelComponent = (
+        <React.Fragment>
+          <Slots.label key="label">{label}</Slots.label>
+          {!!required && <Slots.required>{typeof required === 'string' ? required : '*'}</Slots.required>}
+        </React.Fragment>
+      );
 
       return (
         <Slots.root {...mergedProps}>
-          {Checkbox.state.labelIsBefore && (
-            <React.Fragment>
-              <Slots.label key="label">{label}</Slots.label>
-              {!!required && <Slots.required>{typeof required === 'string' ? required : '*'}</Slots.required>}
-            </React.Fragment>
-          )}
+          {Checkbox.state.labelIsBefore && labelComponent}
           <Slots.checkbox>
             <Slots.checkmark key="checkmark" viewBox="0 0 11 8">
               <Path
@@ -51,12 +52,7 @@ export const Checkbox = compose<CheckboxType>({
               />
             </Slots.checkmark>
           </Slots.checkbox>
-          {!Checkbox.state.labelIsBefore && (
-            <React.Fragment>
-              <Slots.label key="label">{label}</Slots.label>
-              {!!required && <Slots.required>{typeof required === 'string' ? required : '*'}</Slots.required>}
-            </React.Fragment>
-          )}
+          {!Checkbox.state.labelIsBefore && labelComponent}
         </Slots.root>
       );
     };


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Follow up to #1492. Moved out label portion of render to its own variable.

### Verification

Ran tests and booted tester

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
