### PR TITLE
Add "tooltip" to macOS adapters

### DIFF
--- a/change/@fluentui-react-native-adapters-ece3bdba-f62a-4663-ba78-fdbf8745865e.json
+++ b/change/@fluentui-react-native-adapters-ece3bdba-f62a-4663-ba78-fdbf8745865e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Pass tooltip to React Native macOS components",
+  "packageName": "@fluentui-react-native/adapters",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/utils/adapters/src/adapters.macos.ts
+++ b/packages/utils/adapters/src/adapters.macos.ts
@@ -95,6 +95,7 @@ const _textMask: IFilterMask<ITextProps> = {
   style: true,
   suppressHighlighting: true,
   testID: true,
+  tooltip: true,
 };
 
 const _imageMask: IFilterMask<IImageProps> = {
@@ -135,6 +136,7 @@ const _imageMask: IFilterMask<IImageProps> = {
   source: true,
   style: true,
   testID: true,
+  tooltip: true,
 };
 
 export function filterViewProps(propName: string): boolean {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

"tooltip" was not one of the props in the macOS adapters. This meant FURN Text for example, didn't set tooltip. This change should fix that. 

### Verification

Tested setting tooltip on FURN Text on macOS

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
