### PR TITLE
Remove border for subtle buttons in high contrast mode

### DIFF
--- a/change/@fluentui-react-native-apple-theme-a4a9f540-0752-4c6b-ae43-d4f6091bdbd6.json
+++ b/change/@fluentui-react-native-apple-theme-a4a9f540-0752-4c6b-ae43-d4f6091bdbd6.json
@@ -1,0 +1,10 @@
+{
+  "type": "patch",
+  "comment": {
+    "title": "",
+    "value": ""
+  },
+  "packageName": "@fluentui-react-native/apple-theme",
+  "email": "amchiu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/theming/apple-theme/src/appleColors.macos.ts
+++ b/packages/theming/apple-theme/src/appleColors.macos.ts
@@ -412,7 +412,7 @@ export function fallbackApplePalette(): ThemeColorDefinition {
     defaultDisabledIcon: fluentUIApple.neutralForeground3, //GH:728 Icon doesn't support PlatformColor
 
     ghostBackground: 'transparent',
-    ghostBorder: fluentUIApple.transparentStroke,
+    ghostBorder: 'transparent',
     ghostContent: fluentUIApple.communicationBlue,
     ghostIcon: fluentUIApple.communicationBlue,
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Previously, the subtle button design was inspired by the icon-only button in Docstage. I then recently discovered the "More themes" (in PPT) / "More Templates"(in Word) also in Docstage, that seems like a closer example of the subtle button. Therefore, let's update its alias token to reflect that.

![image](https://user-images.githubusercontent.com/67026167/157323120-72a934dd-e642-481c-ad7b-b633c147ac91.png)


### Verification

Validated in light / dark / high contrast light / high contrast dark.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
