### PR TITLE
ContextualMenu macOS: Improve lifecycle management

### DIFF
--- a/apps/macos/src/Podfile.lock
+++ b/apps/macos/src/Podfile.lock
@@ -9,17 +9,17 @@ PODS:
     - React-Core (= 0.64.29)
     - React-jsi (= 0.64.29)
     - ReactCommon/turbomodule/core (= 0.64.29)
-  - FRNAvatar (0.14.5):
+  - FRNAvatar (0.14.8):
     - MicrosoftFluentUI (= 0.3.0)
     - MicrosoftFluentUI/Avatar_ios (= 0.3.0)
     - React
-  - FRNCallout (0.19.28):
+  - FRNCallout (0.19.32):
     - React
-  - FRNCheckbox (0.9.0):
+  - FRNCheckbox (0.10.4):
     - React
-  - FRNMenuButton (0.7.35):
+  - FRNMenuButton (0.7.39):
     - React
-  - FRNRadioButton (0.14.24):
+  - FRNRadioButton (0.14.28):
     - React
   - glog (0.3.5)
   - MicrosoftFluentUI (0.3.0):
@@ -94,7 +94,7 @@ PODS:
     - boost-for-react-native
     - DoubleConversion
     - glog
-  - RCTFocusZone (0.9.5):
+  - RCTFocusZone (0.9.9):
     - React
   - RCTRequired (0.64.29)
   - RCTTypeSafety (0.64.29):
@@ -344,7 +344,7 @@ PODS:
     - React-cxxreact (= 0.64.29)
     - React-jsi (= 0.64.29)
     - React-perflogger (= 0.64.29)
-  - ReactTestApp-DevSupport (1.1.4):
+  - ReactTestApp-DevSupport (1.2.0):
     - React-Core
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
@@ -485,19 +485,19 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native-macos/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost-for-react-native: d5ad1140010aa8cb622323a781ecbeab4425d19a
-  DoubleConversion: 0ea4559a49682230337df966e735d6cc7760108e
+  boost-for-react-native: 8f7c9ecfe357664c072ffbe2432569667cbf1f1b
+  DoubleConversion: ed15e075aa758ac0e4c1f8b830bd4e4d40d669e8
   FBLazyVector: 829631c3f7fe7e9a8177011898ecd324f2ceeb4a
   FBReactNativeSpec: 4de01e4efb3b170c85f000696514071b3748a222
-  FRNAvatar: bf720e2693804f2bdd60258313ede00e7219c6b3
-  FRNCallout: 05fae661484019536fc969067b9bb02d01e1c445
-  FRNCheckbox: a3bb79d732c588c6a0ca063986719ac3f14bd7f1
-  FRNMenuButton: 23ddf190403745c538e164affbc5c9adfde365f0
-  FRNRadioButton: 05e5b2e131e340e4a452a7b39aba5ddb77f9a752
-  glog: 0dc7efada961c0793012970b60faebbd58b0decb
+  FRNAvatar: 6d619c9cfaff54cbce08c064c582229fff9678c3
+  FRNCallout: 6106e9875a5a5efe85f83bffdf9111e71b6a6025
+  FRNCheckbox: f2ca924e1d4f833475d17ad0e6d100bc98ff8f82
+  FRNMenuButton: f5f6af94a34f65aace6cbeea60c63b3a44edc5fa
+  FRNRadioButton: ad1db52c48c37c72454b08029ae564fa8f4bea56
+  glog: 42c4bf47024808486e90b25ea9e5ac3959047641
   MicrosoftFluentUI: b98d877a2122804132365aa167944f58ef4adb69
   RCT-Folly: b3998425a8ee9f695f57a204dc494534246f0fe9
-  RCTFocusZone: 2b8ec6bd28dcde87fe50f8ed8b31e091a2f6aaf1
+  RCTFocusZone: b03631501bd89d3b264ae4ef56ab4f70c9a2d731
   RCTRequired: 4faed4f4e7677ee3608201a95f85505a828f5a37
   RCTTypeSafety: 52197108479b90693ad1b58d27295c81e2dd151f
   React: cce411cee511f86ba6819bd7e14419488e5ca8f2
@@ -520,7 +520,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: 8306ee340eaec9de278d6746f4d3b22ea21d973e
   React-runtimeexecutor: c613c28c921a1d8409c6ecd215b20f56319a7482
   ReactCommon: 2bd9e562df8a08ad11c933450ac30a1ff8a1e922
-  ReactTestApp-DevSupport: 5b0a4857ecf70fa107d040d204a6af374c5f49e9
+  ReactTestApp-DevSupport: e45da8435821fcbd42bb96e21a43aa593efe2a6e
   ReactTestApp-Resources: 320923a3635f7bf90caa1a28fd29765b577888d9
   RNCPicker: f6c760d4b314585ff35165d8640d7917ae30afb1
   RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8

--- a/change/@fluentui-react-native-callout-e72a332a-2f4c-4499-b481-9d0143323acc.json
+++ b/change/@fluentui-react-native-callout-e72a332a-2f4c-4499-b481-9d0143323acc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "ContextualMenu macOS: Improve lifecycle management",
+  "packageName": "@fluentui-react-native/callout",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-contextual-menu-d467986d-d33b-4c06-a3ff-5462d1f7edd4.json
+++ b/change/@fluentui-react-native-contextual-menu-d467986d-d33b-4c06-a3ff-5462d1f7edd4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "ContextualMenu macOS: Improve lifecycle management",
+  "packageName": "@fluentui-react-native/contextual-menu",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Callout/macos/Callout.swift
+++ b/packages/components/Callout/macos/Callout.swift
@@ -361,20 +361,12 @@ class CalloutView: RCTView, CalloutWindowLifeCycleDelegate {
 		if let parentWindow = self.window {
 			parentWindow.addChildWindow(window, ordered: .above)
 		}
-		if (self.window as? CalloutWindow != nil) {
-			window.isSubwindow = true
-		}
-
 		return window
 	}()
 	
 	private var mouseEventMonitor = GuardedEventMonitor()
 	
 	private var isCalloutWindowShown = false
-	
-	deinit {
-		if (calloutWindow.isSubwindow) {}
-	}
 }
 
 /// React Native macOS uses a flipped coordinate space by default. Let's stay consistent and

--- a/packages/components/Callout/macos/Callout.swift
+++ b/packages/components/Callout/macos/Callout.swift
@@ -82,39 +82,39 @@ class CalloutView: RCTView, CalloutWindowLifeCycleDelegate {
 		guard !isCalloutWindowShown else {
 			return
 		}
-		
+
 		updateCalloutFrameToAnchor()
 		calloutWindow.makeKeyAndOrderFront(self)
 		
 		// Dismiss the Callout if the window is no longer active.
 		NotificationCenter.default.addObserver(self, selector: #selector(dismissCallout), name: NSApplication.didResignActiveNotification, object: nil)
-		
+
 		mouseEventMonitor.addLocalMonitorForEvents(matching: .leftMouseUp, handler: { [weak self] (event) -> NSEvent? in
 			guard let clickedWindow = event.window else {
-   				return event
-   			}
-   
-   			var shouldDismissCallout = true
-   
-   			// Did the click happened in our own window?
-   			if (clickedWindow.isEqual(to: self) ) {
-   				shouldDismissCallout = false
-   
-   			// Are we a child window of a Callout (e.g: a ContextualMenu submenu), where the click happened in our parent?
-   			} else if (clickedWindow.isEqual(to: self?.calloutWindow.parent as? CalloutWindow)) {
-   				shouldDismissCallout = false
-   
-   			// Did the click happened in any of our child windows (e.g: our submenus)?
-   			} else if (self?.calloutWindow.childWindows?.contains(clickedWindow) ?? false) {
-   				shouldDismissCallout = false
-   			}
-   
-   			if (shouldDismissCallout) {
-   				self?.dismissCallout()
-   			}
-   
-   			return event
-   		})
+					return event
+				}
+
+				var shouldDismissCallout = true
+
+				// Did the click happened in our own window?
+				if (clickedWindow.isEqual(to: self) ) {
+					shouldDismissCallout = false
+	
+				// Are we a child window of a Callout (e.g: a ContextualMenu submenu), where the click happened in our parent?
+				} else if (clickedWindow.isEqual(to: self?.calloutWindow.parent as? CalloutWindow)) {
+					shouldDismissCallout = false
+
+				// Did the click happened in any of our child windows (e.g: our submenus)?
+				} else if (self?.calloutWindow.childWindows?.contains(clickedWindow) ?? false) {
+					shouldDismissCallout = false
+				}
+	
+				if (shouldDismissCallout) {
+					self?.dismissCallout()
+				}
+
+				return event
+			})
 		
 		isCalloutWindowShown = true
 		
@@ -369,39 +369,6 @@ class CalloutView: RCTView, CalloutWindowLifeCycleDelegate {
 	private var isCalloutWindowShown = false
 }
 
-/// React Native macOS uses a flipped coordinate space by default. Let's stay consistent and
-/// ensure any views hosting React Native views are also flipped. This helps RCTTouchHandler
-/// register clicks in the right location.
-private class FlippedVisualEffectView: NSVisualEffectView {
-	override var isFlipped: Bool {
-		return true
-	}
-}
 
-
-/// NSEvent localMonitors are an _old_ API that requires you to do some  memory management yourself.
-/// You _must_ call `removeMonitor`exactly once per monitor created from. This helper class enforces
-/// that with the use of an extra boolean to track whether we have already allocated/released our monitor.
-/// https://developer.apple.com/documentation/appkit/nsevent/1533709-removemonitor
-private class GuardedEventMonitor: Any {
-	
-	private var isMonitorAllocated = false
-	private var allocatedMonitor: Any?
-	
-	
-	func addLocalMonitorForEvents(matching mask: NSEvent.EventTypeMask, handler block: @escaping (NSEvent) -> NSEvent?) {
-		if (!isMonitorAllocated) {
-			allocatedMonitor = NSEvent.addLocalMonitorForEvents(matching: mask, handler: block)
-			isMonitorAllocated = true
-		}
-	}
-	
-	func removeMonitor() {
-		if (isMonitorAllocated) {
-			NSEvent.removeMonitor(allocatedMonitor as Any)
-			isMonitorAllocated = false
-		}
-	}
-}
 
 private var calloutWindowCornerRadius: CGFloat = 5.0

--- a/packages/components/Callout/macos/Callout.swift
+++ b/packages/components/Callout/macos/Callout.swift
@@ -26,9 +26,9 @@ class CalloutView: RCTView, CalloutWindowLifeCycleDelegate {
 		}
 	}
 
-	@objc public var onShow: RCTBubblingEventBlock?
+	@objc public var onShow: RCTDirectEventBlock?
 
-	@objc public var onDismiss: RCTBubblingEventBlock?
+	@objc public var onDismiss: RCTDirectEventBlock?
 
 	public weak var bridge: RCTBridge?
 
@@ -79,14 +79,68 @@ class CalloutView: RCTView, CalloutWindowLifeCycleDelegate {
 	// MARK: Private methods
 
 	private func showCallout() {
+		guard !isCalloutWindowShown else {
+			return
+		}
+		
 		updateCalloutFrameToAnchor()
 		calloutWindow.makeKeyAndOrderFront(self)
+		
+		// Dismiss the Callout if the window is no longer active.
+		NotificationCenter.default.addObserver(self, selector: #selector(dismissCallout), name: NSApplication.didResignActiveNotification, object: nil)
+		
+		mouseEventMonitor.addLocalMonitorForEvents(matching: .leftMouseUp, handler: { [weak self] (event) -> NSEvent? in
+			guard let clickedWindow = event.window else {
+   				return event
+   			}
+   
+   			var shouldDismissCallout = true
+   
+   			// Did the click happened in our own window?
+   			if (clickedWindow.isEqual(to: self) ) {
+   				shouldDismissCallout = false
+   
+   			// Are we a child window of a Callout (e.g: a ContextualMenu submenu), where the click happened in our parent?
+   			} else if (clickedWindow.isEqual(to: self?.calloutWindow.parent as? CalloutWindow)) {
+   				shouldDismissCallout = false
+   
+   			// Did the click happened in any of our child windows (e.g: our submenus)?
+   			} else if (self?.calloutWindow.childWindows?.contains(clickedWindow) ?? false) {
+   				shouldDismissCallout = false
+   			}
+   
+   			if (shouldDismissCallout) {
+   				self?.dismissCallout()
+   			}
+   
+   			return event
+   		})
+		
+		isCalloutWindowShown = true
+		
 		onShowCallout()
 	}
 
-	private func dismissCallout() {
-		calloutWindow.close()
-		onDismissCallout()
+	@objc private func dismissCallout() {
+		guard isCalloutWindowShown else {
+			return
+		}
+
+		// Dismiss any children Callouts (I.E: Submenus) first
+		if let childWindows = calloutWindow.childWindows {
+			for childWindow in childWindows {
+				if let childCallout = childWindow as? CalloutWindow {
+					childCallout.dismissCallout()
+				}
+			}
+		}
+
+		calloutWindow.dismissCallout()
+
+		NotificationCenter.default.removeObserver(self)
+		mouseEventMonitor.removeMonitor()
+		
+		isCalloutWindowShown = false
 	}
 
 	/// Sets the frame of the Callout Window (in screen coordinates to be off of the Anchor on the preferred edge
@@ -307,9 +361,20 @@ class CalloutView: RCTView, CalloutWindowLifeCycleDelegate {
 		if let parentWindow = self.window {
 			parentWindow.addChildWindow(window, ordered: .above)
 		}
+		if (self.window as? CalloutWindow != nil) {
+			window.isSubwindow = true
+		}
 
 		return window
 	}()
+	
+	private var mouseEventMonitor = GuardedEventMonitor()
+	
+	private var isCalloutWindowShown = false
+	
+	deinit {
+		if (calloutWindow.isSubwindow) {}
+	}
 }
 
 /// React Native macOS uses a flipped coordinate space by default. Let's stay consistent and
@@ -318,6 +383,32 @@ class CalloutView: RCTView, CalloutWindowLifeCycleDelegate {
 private class FlippedVisualEffectView: NSVisualEffectView {
 	override var isFlipped: Bool {
 		return true
+	}
+}
+
+
+/// NSEvent localMonitors are an _old_ API that requires you to do some  memory management yourself.
+/// You _must_ call `removeMonitor`exactly once per monitor created from. This helper class enforces
+/// that with the use of an extra boolean to track whether we have already allocated/released our monitor.
+/// https://developer.apple.com/documentation/appkit/nsevent/1533709-removemonitor
+private class GuardedEventMonitor: Any {
+	
+	private var isMonitorAllocated = false
+	private var allocatedMonitor: Any?
+	
+	
+	func addLocalMonitorForEvents(matching mask: NSEvent.EventTypeMask, handler block: @escaping (NSEvent) -> NSEvent?) {
+		if (!isMonitorAllocated) {
+			allocatedMonitor = NSEvent.addLocalMonitorForEvents(matching: mask, handler: block)
+			isMonitorAllocated = true
+		}
+	}
+	
+	func removeMonitor() {
+		if (isMonitorAllocated) {
+			NSEvent.removeMonitor(allocatedMonitor as Any)
+			isMonitorAllocated = false
+		}
 	}
 }
 

--- a/packages/components/Callout/macos/CalloutWindow.swift
+++ b/packages/components/Callout/macos/CalloutWindow.swift
@@ -7,14 +7,10 @@ protocol CalloutWindowLifeCycleDelegate: AnyObject {
 }
 
 class CalloutWindow: NSWindow {
-
-	public var isSubwindow = false
-	
 	weak var lifeCycleDelegate: CalloutWindowLifeCycleDelegate?
 
 	override init(contentRect: NSRect, styleMask style: NSWindow.StyleMask, backing backingStoreType: NSWindow.BackingStoreType, defer flag: Bool) {
 		super.init(contentRect: contentRect, styleMask: style, backing: backingStoreType, defer: flag)
-		isReleasedWhenClosed = false
 
 		styleMask = .borderless
 		level = .popUpMenu
@@ -38,11 +34,7 @@ class CalloutWindow: NSWindow {
 
 	@objc public func dismissCallout() {
 		lifeCycleDelegate?.calloutWillDismiss(window: self)
-		close()
-	}
-	
-	deinit {
-		if (isSubwindow) {}
+		orderOut(self)
 	}
 }
 

--- a/packages/components/Callout/macos/FRNCalloutManager.m
+++ b/packages/components/Callout/macos/FRNCalloutManager.m
@@ -42,8 +42,8 @@ RCT_EXPORT_VIEW_PROPERTY(anchorRect, screenRect)
 
 RCT_EXPORT_VIEW_PROPERTY(directionalHint, NSRectEdge)
 
-RCT_EXPORT_VIEW_PROPERTY(onShow, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onShow, RCTDirectEventBlock)
 
-RCT_EXPORT_VIEW_PROPERTY(onDismiss, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onDismiss, RCTDirectEventBlock)
 
 @end

--- a/packages/components/Callout/macos/FlippedVisualEffectView.swift
+++ b/packages/components/Callout/macos/FlippedVisualEffectView.swift
@@ -1,0 +1,8 @@
+/// React Native macOS uses a flipped coordinate space by default. Let's stay consistent and
+/// ensure any views hosting React Native views are also flipped. This helps RCTTouchHandler
+/// register clicks in the right location.
+internal class FlippedVisualEffectView: NSVisualEffectView {
+	override var isFlipped: Bool {
+		return true
+	}
+}

--- a/packages/components/Callout/macos/GuardedEventMonitor.swift
+++ b/packages/components/Callout/macos/GuardedEventMonitor.swift
@@ -1,0 +1,30 @@
+
+
+/// NSEvent localMonitors are an _old_ API that requires you to do some  memory management yourself.
+/// You _must_ call `removeMonitor`exactly once per monitor created from. This helper class enforces
+/// that with the use of an extra boolean to track whether we have already allocated/released our monitor.
+/// https://developer.apple.com/documentation/appkit/nsevent/1533709-removemonitor
+internal class GuardedEventMonitor: Any {
+	
+	private var isMonitorAllocated = false
+	private var allocatedMonitor: Any?
+	
+	
+	func addLocalMonitorForEvents(matching mask: NSEvent.EventTypeMask, handler block: @escaping (NSEvent) -> NSEvent?) {
+		if (!isMonitorAllocated) {
+			allocatedMonitor = NSEvent.addLocalMonitorForEvents(matching: mask, handler: block)
+			isMonitorAllocated = true
+		}
+	}
+	
+	func removeMonitor() {
+		if (isMonitorAllocated) {
+			NSEvent.removeMonitor(allocatedMonitor as Any)
+			isMonitorAllocated = false
+		}
+	}
+	
+	deinit {
+		removeMonitor()
+	}
+}

--- a/packages/components/ContextualMenu/src/Submenu.tsx
+++ b/packages/components/ContextualMenu/src/Submenu.tsx
@@ -85,13 +85,6 @@ export const Submenu = compose<SubmenuType>({
     // Explicitly override onKeyDown to override the native windows behavior of moving focus with arrow keys.
     const onKeyDownProps = useKeyDownProps(dismissWithArrowKey, 'ArrowLeft', 'ArrowRight');
 
-    const containerPropsWin32: IViewProps = {
-      accessible: shouldFocusOnContainer,
-      focusable: shouldFocusOnContainer && containerFocus,
-      onBlur: toggleContainerFocus,
-      style: { maxHeight: maxHeight, width: maxWidth },
-    };
-
     const slotProps = mergeSettings<SubmenuSlotProps>(styleProps, {
       root: {
         ...rest,
@@ -101,7 +94,10 @@ export const Submenu = compose<SubmenuType>({
       },
       container: {
         ...onKeyDownProps,
-        ...(Platform.OS === ('win32' as string) && { containerPropsWin32 }),
+        accessible: shouldFocusOnContainer,
+        focusable: shouldFocusOnContainer && containerFocus,
+        onBlur: toggleContainerFocus,
+        style: { maxHeight: maxHeight, width: maxWidth },
       },
       scrollView: {
         contentContainerStyle: {

--- a/packages/components/ContextualMenu/src/Submenu.tsx
+++ b/packages/components/ContextualMenu/src/Submenu.tsx
@@ -10,7 +10,6 @@ import { backgroundColorTokens, borderTokens } from '@fluentui-react-native/toke
 import { Callout } from '@fluentui-react-native/callout';
 import { ISlots, withSlots } from '@uifabricshared/foundation-composable';
 import { CMContext } from './ContextualMenu';
-import { IViewProps } from '@fluentui-react-native/adapters';
 import { FocusZone } from '@fluentui-react-native/focus-zone';
 
 export const Submenu = compose<SubmenuType>({

--- a/packages/components/ContextualMenu/src/SubmenuItem.types.ts
+++ b/packages/components/ContextualMenu/src/SubmenuItem.types.ts
@@ -6,7 +6,7 @@ import { ContextualMenuItemProps, ContextualMenuItemTokens, ContextualMenuItemSt
 import { IconProps } from '@fluentui-react-native/icon';
 import { XmlProps } from 'react-native-svg';
 
-export const submenuItemName = 'submenuItem';
+export const submenuItemName = 'SubmenuItem';
 export interface SubmenuItemTokens extends ContextualMenuItemTokens {
   chevronColor?: string;
 }


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

We had a bug in ContextualMenu for macOS where you could end up in a weird state if you open/close/reopen a menu:
![image](https://user-images.githubusercontent.com/6722175/158913423-e92d33b8-a9ae-4c4f-812d-7b32f8cf8ade.png)

After... a LOT of debugging, I found out the solution was to make sure on the native side (`Callout.swift`) we dismiss our CalloutWindows' subwindows (submenus) before itself. Along the way, I made a lot of changes/improvements to the object lifecycle of Callout / CalloutWindow / their NSEvent monitors. I shall describe the changes below:

1.  NSEventMonitor improvements. 

We create an [NSEvent localMonitor](https://developer.apple.com/documentation/appkit/nsevent/1534971-addlocalmonitorforeventsmatching) to watch for clicks outside the CalloutWindow & it's children that should dismiss the Callout. The API is quite old, and if you read the fine print for [removeMonitor](https://developer.apple.com/documentation/appkit/nsevent/1533709-removemonitor), you **must** call `removeMonitor` only once per `addLocalMonitor` call, or else you can run into an over-release. This is true with ARC, and with Swift. Even doing an `if let monitor = mouseEventMonitor` check could cause a BAD_ACCESS crash if `monitor` was already released. 

To get around this, I created a private helper class `guardedEventMonitor` which keeps track of whether we allocated a monitor already or not, to prevent against an over release. It's pretty simple, but has worked well!

2. Move most CalloutWindow presentation management to CalloutView

We have a "proxy" CalloutView that owns a CalloutWindow, and forwards it's props / children to the window. As our API is currently written, as long as CalloutView is alive and allocated, CalloutWindow should be as well. Previously,  both CalloutView and CalloutWindow could dismiss CalloutWindow. CalloutView would listen for if JS wanted to dismiss the Callout, while CalloutWindow listened for mouse/keyboard/app-did-resign-active events that should dismiss the CalloutWindow. This got a little confusing for the flow of what methods / callbacks were invoked each time a window is dismissed. This led to bugs where the mouseEventMonitor would still be active and listening for mouse events, even if the Callout was dismissed. Worse, we could forget to remove them, and have new monitors allocated every time we opened a new Callout 😢 .

To simplify this, I moved as much of the Callout show/dismissal responsibility to the CalloutView as possible. This meant moving the NSEventMonitor from _CalloutWindow_ to _CalloutView_. We now also only allocate and remove the monitor while the window is shown, so that they don't lie around after we close the window. I also moved the `NSApplication.didResignActiveNotification` notification listener to CalloutView, and remove it in DismissCallout. 

The one thing I could not move was `cancelOperation` which listens for the "Escape" key press to dismiss the Callout. That has to stay in CalloutWindow.

3. Dismiss Children Callout windows first

This is the one that actually fixed the bug. If we dismissed the top level Callout _before_ the children, then the children CalloutViews/CalloutWindows would not de-allocate. This meant the child window (in our case a submenu) would stick around hidden, and not show up till the next time you opened the menu. 

The fix was simple: in `CalloutView.dismissCallout()`, dismiss all your children Callouts _before_ you dismiss yourself and voila! Everything is fixed! 😁 

Other minor fixes:

- Renamed displayName: submenuItem -> SubmenuItem
    - Every other display name was capitalized, and this affects what shows up in the React tree.  Felt like a simple typo
- Made onShow/onDismiss direct events
    - Now that I know the difference, these don't feel like they should be bubbling events. 
- Support more submenu props
    - Totally just forgot to do this earlier. More reason to not duplicate Menu/Submenu and MenuItem/SubmenuItem code..

### Verification

For the simple case of the bug: I can open/close submenus as much as I want and they don't show up on top of the main menu anymore!

https://user-images.githubusercontent.com/6722175/158916366-2199bfc8-cd70-42fd-97b7-f21e00015fc5.mov

For the complex case of lifecyle management, I put _ a lot_ of breakpoints  to trace order flow. I set them to print a message in console, and continue execution. The video below does a good job of showing the order flow. The important thing is: no step is hit twice or skipped, ensuring we don't have zombie event monitors or zombie windows laying around. 

https://user-images.githubusercontent.com/6722175/158916326-b8995532-8fd3-4679-b33f-c9bcf485e071.mov

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
