### PR TITLE
chore: enable no-export-all on index files

### DIFF
--- a/apps/fluent-tester/src/index.ts
+++ b/apps/fluent-tester/src/index.ts
@@ -1,1 +1,1 @@
-export * from './FluentTester';
+export { FluentTesterApp } from './FluentTester';

--- a/change/@fluentui-react-native-adapters-c264b16f-5068-43f6-a8d0-c48bca3b27ff.json
+++ b/change/@fluentui-react-native-adapters-c264b16f-5068-43f6-a8d0-c48bca3b27ff.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@fluentui-react-native/adapters",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-android-theme-a6f695a1-357d-4208-826d-e9ea9911e58a.json
+++ b/change/@fluentui-react-native-android-theme-a6f695a1-357d-4208-826d-e9ea9911e58a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@fluentui-react-native/android-theme",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-apple-theme-f29e773b-de04-4872-9e01-6997bf7fffc9.json
+++ b/change/@fluentui-react-native-apple-theme-f29e773b-de04-4872-9e01-6997bf7fffc9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@fluentui-react-native/apple-theme",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-badge-269e93da-e28d-4479-8133-86b2f648448f.json
+++ b/change/@fluentui-react-native-badge-269e93da-e28d-4479-8133-86b2f648448f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@fluentui-react-native/badge",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-button-0bdbd2ea-265c-411d-a2eb-439fdfdffc40.json
+++ b/change/@fluentui-react-native-button-0bdbd2ea-265c-411d-a2eb-439fdfdffc40.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@fluentui-react-native/button",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-callout-39dbe27a-fe89-4c21-8637-74a74bdb7f94.json
+++ b/change/@fluentui-react-native-callout-39dbe27a-fe89-4c21-8637-74a74bdb7f94.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@fluentui-react-native/callout",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-checkbox-c3dfe0ed-d0b1-4f7e-b079-b503c87db6aa.json
+++ b/change/@fluentui-react-native-checkbox-c3dfe0ed-d0b1-4f7e-b079-b503c87db6aa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@fluentui-react-native/checkbox",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-component-cache-6bd65df2-be45-496a-b624-a31bb2d838e4.json
+++ b/change/@fluentui-react-native-component-cache-6bd65df2-be45-496a-b624-a31bb2d838e4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@fluentui-react-native/component-cache",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-contextual-menu-d05aef40-d25d-4a9b-a748-d4d84bd2e6f8.json
+++ b/change/@fluentui-react-native-contextual-menu-d05aef40-d25d-4a9b-a748-d4d84bd2e6f8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@fluentui-react-native/contextual-menu",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-default-theme-5e87aa71-b3c0-46c5-ae55-64b9a2d62e55.json
+++ b/change/@fluentui-react-native-default-theme-5e87aa71-b3c0-46c5-ae55-64b9a2d62e55.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@fluentui-react-native/default-theme",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-menu-button-2cadcb44-58f4-4e3a-ae38-b044adc37e85.json
+++ b/change/@fluentui-react-native-experimental-menu-button-2cadcb44-58f4-4e3a-ae38-b044adc37e85.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@fluentui-react-native/experimental-menu-button",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-tabs-3e06ea22-a6d7-4b8e-aa23-4aa9381366cd.json
+++ b/change/@fluentui-react-native-experimental-tabs-3e06ea22-a6d7-4b8e-aa23-4aa9381366cd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@fluentui-react-native/experimental-tabs",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-text-45c62fb3-e6cf-4c8b-ab94-4ab2983614dc.json
+++ b/change/@fluentui-react-native-experimental-text-45c62fb3-e6cf-4c8b-ab94-4ab2983614dc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@fluentui-react-native/experimental-text",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-focus-trap-zone-7db16ee7-0550-48fe-bdaa-4a15d300e00e.json
+++ b/change/@fluentui-react-native-focus-trap-zone-7db16ee7-0550-48fe-bdaa-4a15d300e00e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@fluentui-react-native/focus-trap-zone",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-focus-zone-f576086b-c2d0-4455-8564-2deb495018db.json
+++ b/change/@fluentui-react-native-focus-zone-f576086b-c2d0-4455-8564-2deb495018db.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@fluentui-react-native/focus-zone",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-framework-c8d966ae-5506-404c-80e2-7a99375f1698.json
+++ b/change/@fluentui-react-native-framework-c8d966ae-5506-404c-80e2-7a99375f1698.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@fluentui-react-native/framework",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-immutable-merge-0a6ac0d9-d9d8-40ae-b48d-f8c056bc93a7.json
+++ b/change/@fluentui-react-native-immutable-merge-0a6ac0d9-d9d8-40ae-b48d-f8c056bc93a7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@fluentui-react-native/immutable-merge",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-interactive-hooks-9db2dd97-939b-40b2-8ca4-acadaea1439a.json
+++ b/change/@fluentui-react-native-interactive-hooks-9db2dd97-939b-40b2-8ca4-acadaea1439a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@fluentui-react-native/interactive-hooks",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-link-38dbd523-5708-44f2-b168-5906f0b92301.json
+++ b/change/@fluentui-react-native-link-38dbd523-5708-44f2-b168-5906f0b92301.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@fluentui-react-native/link",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-menu-button-c99833f3-83f4-43a0-af4a-93850c3e1c23.json
+++ b/change/@fluentui-react-native-menu-button-c99833f3-83f4-43a0-af4a-93850c3e1c23.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@fluentui-react-native/menu-button",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-persona-coin-f384e636-42a8-4ad8-a1d8-6cc2526c04b7.json
+++ b/change/@fluentui-react-native-persona-coin-f384e636-42a8-4ad8-a1d8-6cc2526c04b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@fluentui-react-native/persona-coin",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-persona-e1e26eb9-a5d9-4fbc-9618-ba0d4e40acca.json
+++ b/change/@fluentui-react-native-persona-e1e26eb9-a5d9-4fbc-9618-ba0d4e40acca.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@fluentui-react-native/persona",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-pressable-dac8a792-7bf8-4b5b-b233-2ad35f4a2ec0.json
+++ b/change/@fluentui-react-native-pressable-dac8a792-7bf8-4b5b-b233-2ad35f4a2ec0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@fluentui-react-native/pressable",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-radio-group-a865c0cd-ee8b-49da-8a76-3fcb36ec0887.json
+++ b/change/@fluentui-react-native-radio-group-a865c0cd-ee8b-49da-8a76-3fcb36ec0887.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@fluentui-react-native/radio-group",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-separator-b86f1d5c-aa84-477e-8ed7-17d64ecae9cc.json
+++ b/change/@fluentui-react-native-separator-b86f1d5c-aa84-477e-8ed7-17d64ecae9cc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@fluentui-react-native/separator",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-stack-09f353ac-6db3-4bd4-8964-0d45fa9cf94d.json
+++ b/change/@fluentui-react-native-stack-09f353ac-6db3-4bd4-8964-0d45fa9cf94d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@fluentui-react-native/stack",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-styling-utils-5955233d-3521-43c6-97c7-10315cd372a1.json
+++ b/change/@fluentui-react-native-styling-utils-5955233d-3521-43c6-97c7-10315cd372a1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@fluentui-react-native/styling-utils",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tabs-a8e1c110-b4c2-4b63-b332-2ed7635830cc.json
+++ b/change/@fluentui-react-native-tabs-a8e1c110-b4c2-4b63-b332-2ed7635830cc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@fluentui-react-native/tabs",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-4f742d35-59b9-40f0-8124-eabde92ab01b.json
+++ b/change/@fluentui-react-native-tester-4f742d35-59b9-40f0-8124-eabde92ab01b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-text-ed556faf-92df-41e3-9ff2-7bb3eedfeabb.json
+++ b/change/@fluentui-react-native-text-ed556faf-92df-41e3-9ff2-7bb3eedfeabb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@fluentui-react-native/text",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-theme-types-616d914e-0616-4e92-bf9e-b190b69118d0.json
+++ b/change/@fluentui-react-native-theme-types-616d914e-0616-4e92-bf9e-b190b69118d0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@fluentui-react-native/theme-types",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-themed-stylesheet-f49cf969-6044-4f38-8003-626495c819a2.json
+++ b/change/@fluentui-react-native-themed-stylesheet-f49cf969-6044-4f38-8003-626495c819a2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@fluentui-react-native/themed-stylesheet",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-theming-utils-c5b0d75f-4ad0-47e2-ba7f-777e57b21e21.json
+++ b/change/@fluentui-react-native-theming-utils-c5b0d75f-4ad0-47e2-ba7f-777e57b21e21.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@fluentui-react-native/theming-utils",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tokens-3e381150-dce9-4dfd-aede-e5fcc13f89c2.json
+++ b/change/@fluentui-react-native-tokens-3e381150-dce9-4dfd-aede-e5fcc13f89c2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@fluentui-react-native/tokens",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-win32-theme-b881e3aa-0f7f-470c-8950-5b96d430b8cb.json
+++ b/change/@fluentui-react-native-win32-theme-b881e3aa-0f7f-470c-8950-5b96d430b8cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@fluentui-react-native/win32-theme",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabricshared-foundation-composable-5d8eac0e-2510-4d7d-a099-079583cb6f17.json
+++ b/change/@uifabricshared-foundation-composable-5d8eac0e-2510-4d7d-a099-079583cb6f17.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@uifabricshared/foundation-composable",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabricshared-foundation-compose-c7ba3b99-ec8f-4d99-ae55-244a355a7605.json
+++ b/change/@uifabricshared-foundation-compose-c7ba3b99-ec8f-4d99-ae55-244a355a7605.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@uifabricshared/foundation-compose",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabricshared-foundation-settings-2cf3bc18-8605-4fd5-8f8a-fc5eda2b8ae4.json
+++ b/change/@uifabricshared-foundation-settings-2cf3bc18-8605-4fd5-8f8a-fc5eda2b8ae4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@uifabricshared/foundation-settings",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabricshared-theme-registry-68f6ca2b-4810-4b29-bf19-1d56c34b5ff1.json
+++ b/change/@uifabricshared-theme-registry-68f6ca2b-4810-4b29-bf19-1d56c34b5ff1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@uifabricshared/theme-registry",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabricshared-themed-settings-61749554-a666-446d-b6fc-58536ae5f733.json
+++ b/change/@uifabricshared-themed-settings-61749554-a666-446d-b6fc-58536ae5f733.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@uifabricshared/themed-settings",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabricshared-theming-ramp-6c6e2f12-7896-424b-a1b2-371a654b56ef.json
+++ b/change/@uifabricshared-theming-ramp-6c6e2f12-7896-424b-a1b2-371a654b56ef.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@uifabricshared/theming-ramp",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabricshared-theming-react-native-0dc320a8-2155-4488-abd4-74f65ff32941.json
+++ b/change/@uifabricshared-theming-react-native-0dc320a8-2155-4488-abd4-74f65ff32941.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ban `export *` in index files for better tree-shakeability",
+  "packageName": "@uifabricshared/theming-react-native",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Button/src/index.ts
+++ b/packages/components/Button/src/index.ts
@@ -1,7 +1,16 @@
-export * from './deprecated/Button.types';
-export * from './deprecated/Button';
-export * from './deprecated/PrimaryButton';
-export * from './deprecated/StealthButton';
+export { buttonName } from './deprecated/Button.types';
+export type {
+  IButtonInfo,
+  IButtonProps,
+  IButtonRenderData,
+  IButtonSlotProps,
+  IButtonState,
+  IButtonTokens,
+  IButtonType,
+} from './deprecated/Button.types';
+export { Button } from './deprecated/Button';
+export { PrimaryButton } from './deprecated/PrimaryButton';
+export { StealthButton } from './deprecated/StealthButton';
 export {
   buttonName as buttonNameV1,
   ButtonSize,
@@ -16,6 +25,9 @@ export {
   ButtonType,
 } from './Button.types';
 export { Button as ButtonV1 } from './Button';
-export * from './CompoundButton';
-export * from './FAB';
-export * from './ToggleButton';
+export { CompoundButton, compoundButtonName } from './CompoundButton';
+export type { CompoundButtonProps, CompoundButtonSlotProps, CompoundButtonTokens, CompoundButtonType } from './CompoundButton';
+export { FAB, fabName } from './FAB';
+export type { FABType } from './FAB';
+export { ToggleButton, toggleButtonName } from './ToggleButton';
+export type { ToggleButtonProps, ToggleButtonSlotProps, ToggleButtonState, ToggleButtonTokens, ToggleButtonType } from './ToggleButton';

--- a/packages/components/Callout/src/index.ts
+++ b/packages/components/Callout/src/index.ts
@@ -1,2 +1,12 @@
-export * from './Callout.types';
-export * from './Callout';
+export { calloutName } from './Callout.types';
+export type {
+  DirectionalHint,
+  DismissBehaviors,
+  ICalloutProps,
+  ICalloutRenderData,
+  ICalloutSlotProps,
+  ICalloutTokens,
+  ICalloutType,
+  RestoreFocusEvent,
+} from './Callout.types';
+export { Callout } from './Callout';

--- a/packages/components/Checkbox/src/index.ts
+++ b/packages/components/Checkbox/src/index.ts
@@ -1,2 +1,10 @@
-export * from './Checkbox.types';
-export * from './Checkbox';
+export { checkboxName } from './Checkbox.types';
+export type {
+  ICheckboxProps,
+  ICheckboxRenderData,
+  ICheckboxSlotProps,
+  ICheckboxState,
+  ICheckboxTokens,
+  ICheckboxType,
+} from './Checkbox.types';
+export { Checkbox } from './Checkbox';

--- a/packages/components/ContextualMenu/src/index.ts
+++ b/packages/components/ContextualMenu/src/index.ts
@@ -1,8 +1,34 @@
-export * from './ContextualMenu.types';
-export * from './ContextualMenu';
-export * from './ContextualMenuItem.types';
-export * from './ContextualMenuItem';
-export * from './Submenu.types';
-export * from './Submenu';
-export * from './SubmenuItem.types';
-export * from './SubmenuItem';
+export { contextualMenuName } from './ContextualMenu.types';
+export type {
+  ContextualMenuContext,
+  ContextualMenuProps,
+  ContextualMenuRenderData,
+  ContextualMenuSlotProps,
+  ContextualMenuState,
+  ContextualMenuTokens,
+  ContextualMenuType,
+} from './ContextualMenu.types';
+export { CMContext, ContextualMenu } from './ContextualMenu';
+export { contextualMenuItemName } from './ContextualMenuItem.types';
+export type {
+  ContextualMenuItemProps,
+  ContextualMenuItemRenderData,
+  ContextualMenuItemSlotProps,
+  ContextualMenuItemState,
+  ContextualMenuItemTokens,
+  ContextualMenuItemType,
+} from './ContextualMenuItem.types';
+export { ContextualMenuItem } from './ContextualMenuItem';
+export { submenuName } from './Submenu.types';
+export type { SubmenuProps, SubmenuRenderData, SubmenuSlotProps, SubmenuState, SubmenuTokens, SubmenuType } from './Submenu.types';
+export { Submenu } from './Submenu';
+export { submenuItemName } from './SubmenuItem.types';
+export type {
+  SubmenuItemProps,
+  SubmenuItemRenderData,
+  SubmenuItemSlotProps,
+  SubmenuItemState,
+  SubmenuItemTokens,
+  SubmenuItemType,
+} from './SubmenuItem.types';
+export { SubmenuItem } from './SubmenuItem';

--- a/packages/components/FocusTrapZone/src/index.ts
+++ b/packages/components/FocusTrapZone/src/index.ts
@@ -1,2 +1,2 @@
-export * from './FocusTrapZone.types';
-export * from './FocusTrapZone';
+export type { IFocusTrapZoneProps, IFocusTrapZoneSlotProps, IFocusTrapZoneType } from './FocusTrapZone.types';
+export { FocusTrapZone, filterOutComponentRef } from './FocusTrapZone';

--- a/packages/components/FocusZone/src/index.ts
+++ b/packages/components/FocusZone/src/index.ts
@@ -1,2 +1,13 @@
-export * from './FocusZone.types';
-export * from './FocusZone';
+export { focusZoneName } from './FocusZone.types';
+export type {
+  FocusZoneDirection,
+  FocusZoneProps,
+  FocusZoneRenderData,
+  FocusZoneSlotProps,
+  FocusZoneState,
+  FocusZoneTokens,
+  FocusZoneType,
+  NativeProps,
+  NavigateAtEnd,
+} from './FocusZone.types';
+export { FocusZone } from './FocusZone';

--- a/packages/components/Link/src/index.ts
+++ b/packages/components/Link/src/index.ts
@@ -1,2 +1,14 @@
-export * from './Link.types';
-export * from './Link';
+export { linkName } from './Link.types';
+export type {
+  ILinkInfo,
+  ILinkOptions,
+  ILinkProps,
+  ILinkRenderData,
+  ILinkSlotProps,
+  ILinkState,
+  ILinkTokens,
+  ILinkType,
+  IWithLinkOptions,
+} from './Link.types';
+export { Link, useAsLink } from './Link';
+export type { ILinkHooks } from './Link';

--- a/packages/components/MenuButton/src/index.ts
+++ b/packages/components/MenuButton/src/index.ts
@@ -1,2 +1,12 @@
-export * from './MenuButton.types';
-export * from './MenuButton';
+export { MenuButtonName } from './MenuButton.types';
+export type {
+  MenuButtonContext,
+  MenuButtonItemProps,
+  MenuButtonProps,
+  MenuButtonRenderData,
+  MenuButtonSlotProps,
+  MenuButtonState,
+  MenuButtonTokens,
+  MenuButtonType,
+} from './MenuButton.types';
+export { MenuButton } from './MenuButton';

--- a/packages/components/Persona/src/index.ts
+++ b/packages/components/Persona/src/index.ts
@@ -1,2 +1,3 @@
-export * from './Persona';
-export * from './Persona.types';
+export { Persona } from './Persona';
+export { personaName } from './Persona.types';
+export type { IPersonaProps, IPersonaRenderData, IPersonaSlotProps, IPersonaState, IPersonaTokens, IPersonaType } from './Persona.types';

--- a/packages/components/PersonaCoin/src/index.ts
+++ b/packages/components/PersonaCoin/src/index.ts
@@ -1,3 +1,19 @@
-export * from './PersonaCoin';
-export * from './PersonaCoin.types';
-export * from './PersonaCoin.tokens.root';
+export { PersonaCoin } from './PersonaCoin';
+export { personaCoinName } from './PersonaCoin.types';
+export type {
+  IPersonaCoinProps,
+  IPersonaCoinRenderData,
+  IPersonaCoinSlotProps,
+  IPersonaCoinState,
+  IPersonaCoinTokens,
+  IPersonaCoinType,
+  IPersonaConfigurableProps,
+  IconAlignment,
+  PersonaCoinColor,
+  PersonaCoinFluentColor,
+  PersonaPresence,
+  PersonaSize,
+  RingConfig,
+  RingThickness,
+} from './PersonaCoin.types';
+export { buildRootStyles } from './PersonaCoin.tokens.root';

--- a/packages/components/Pressable/src/index.ts
+++ b/packages/components/Pressable/src/index.ts
@@ -1,2 +1,2 @@
-export * from './Pressable.props';
-export * from './Pressable';
+export type { IChildAsFunction, IPressableProps, IPressableType, IRenderChild, IRenderStyle } from './Pressable.props';
+export { Pressable } from './Pressable';

--- a/packages/components/RadioGroup/src/index.ts
+++ b/packages/components/RadioGroup/src/index.ts
@@ -1,4 +1,20 @@
-export * from './RadioButton';
-export * from './RadioButton.types';
-export * from './RadioGroup';
-export * from './RadioGroup.types';
+export { RadioButton } from './RadioButton';
+export { radioButtonName } from './RadioButton.types';
+export type {
+  IRadioButtonProps,
+  IRadioButtonRenderData,
+  IRadioButtonSlotProps,
+  IRadioButtonTokens,
+  IRadioButtonType,
+} from './RadioButton.types';
+export { RadioGroup, RadioGroupContext } from './RadioGroup';
+export { radioGroupName } from './RadioGroup.types';
+export type {
+  IRadioGroupContext,
+  IRadioGroupProps,
+  IRadioGroupRenderData,
+  IRadioGroupSlotProps,
+  IRadioGroupState,
+  IRadioGroupTokens,
+  IRadioGroupType,
+} from './RadioGroup.types';

--- a/packages/components/Separator/src/index.ts
+++ b/packages/components/Separator/src/index.ts
@@ -1,2 +1,2 @@
-export * from './Separator.types';
-export * from './Separator';
+export type { SeparatorProps, SeparatorTokens, SeparatorType } from './Separator.types';
+export { Separator, separatorName } from './Separator';

--- a/packages/components/Stack/src/index.ts
+++ b/packages/components/Stack/src/index.ts
@@ -1,4 +1,6 @@
-export * from './StackItem/StackItem.types';
-export * from './StackItem/StackItem';
-export * from './Stack.types';
-export * from './Stack';
+export { stackItemName } from './StackItem/StackItem.types';
+export type { IStackItemProps, IStackItemTokens, IStackItemType } from './StackItem/StackItem.types';
+export { StackItem } from './StackItem/StackItem';
+export { stackName } from './Stack.types';
+export type { Alignment, IStackProps, IStackRenderData, IStackSlotProps, IStackStatics, IStackTokens, IStackType } from './Stack.types';
+export { Stack } from './Stack';

--- a/packages/components/Tabs/src/index.ts
+++ b/packages/components/Tabs/src/index.ts
@@ -1,4 +1,14 @@
-export * from './Tabs';
-export * from './Tabs.types';
-export * from './TabsItem';
-export * from './TabsItem.types';
+export { Tabs, TabsContext } from './Tabs';
+export { tabsName } from './Tabs.types';
+export type { TabsContextData, TabsInfo, TabsProps, TabsRenderData, TabsSlotProps, TabsState, TabsTokens, TabsType } from './Tabs.types';
+export { TabsItem } from './TabsItem';
+export { tabsItemName } from './TabsItem.types';
+export type {
+  TabsItemInfo,
+  TabsItemProps,
+  TabsItemRenderData,
+  TabsItemSlotProps,
+  TabsItemState,
+  TabsItemTokens,
+  TabsItemType,
+} from './TabsItem.types';

--- a/packages/components/text/src/index.ts
+++ b/packages/components/text/src/index.ts
@@ -1,2 +1,3 @@
-export * from './Text.types';
-export * from './Text';
+export { textName } from './Text.types';
+export type { ITextProps, ITextType } from './Text.types';
+export { Text } from './Text';

--- a/packages/deprecated/foundation-composable/src/index.ts
+++ b/packages/deprecated/foundation-composable/src/index.ts
@@ -1,3 +1,25 @@
-export * from './Composable.types';
-export * from './Composable';
-export * from './slots';
+export type {
+  AsObject,
+  IComposable,
+  IComposableDefinition,
+  IComposableType,
+  IComposableTypecast,
+  IDefineUsePrepareProps,
+  IDefineUseStyling,
+  IExtractProps,
+  IExtractSlotProps,
+  IExtractState,
+  INativeSlotType,
+  IPartialSlotDefinitions,
+  IPropFilter,
+  IRenderData,
+  ISlotDefinitions,
+  ISlotWithFilter,
+  ISlots,
+  IUsePrepareProps,
+  IUseStyling,
+  IWithComposable,
+  RequireObject,
+} from './Composable.types';
+export { atomic, atomicRender, atomicUsePrepareProps, composable } from './Composable';
+export { renderSlot, withSlots } from './slots';

--- a/packages/deprecated/foundation-compose/src/index.ts
+++ b/packages/deprecated/foundation-compose/src/index.ts
@@ -1,3 +1,15 @@
-export * from './compose.types';
-export * from './compose';
+export type {
+  IComposeOptions,
+  IComposeReturnType,
+  IComposeSettings,
+  IComposeType,
+  IComposeTypecast,
+  IDefineComposeSettings,
+  IDefineUseComposeStyling,
+  IExtractStatics,
+  IExtractTokens,
+  IStylingSettings,
+  IUseComposeStyling,
+} from './compose.types';
+export { compose } from './compose';
 export { initializeStyling } from './useStyling';

--- a/packages/deprecated/foundation-settings/src/index.ts
+++ b/packages/deprecated/foundation-settings/src/index.ts
@@ -1,2 +1,11 @@
-export * from './Settings.types';
-export * from './Settings';
+export type {
+  IComponentSettings,
+  IComponentSettingsCollection,
+  IOverrideFunction,
+  IOverrideLookup,
+  IOverrideMask,
+  IPartialSlotProps,
+  ISlotProps,
+  IWithTokens,
+} from './Settings.types';
+export { getActiveOverrides, mergeSettings, mergeSettingsCollection, resolveSettingsOverrides, slotPropsFromSettings } from './Settings';

--- a/packages/deprecated/theme-registry/src/index.ts
+++ b/packages/deprecated/theme-registry/src/index.ts
@@ -1,2 +1,2 @@
-export * from './Registry.types';
-export * from './Registry';
+export type { IProcessTheme, IResolveTheme, IThemeEventListener, IThemeRegistry } from './Registry.types';
+export { createThemeRegistry } from './Registry';

--- a/packages/deprecated/themed-settings/src/index.ts
+++ b/packages/deprecated/themed-settings/src/index.ts
@@ -1,2 +1,2 @@
-export * from './CustomSettings.types';
-export * from './CustomSettings';
+export type { IGetSettingsFromTheme, ISettingsEntry, ISettingsFromTheme } from './CustomSettings.types';
+export { getThemedSettings, mergeBaseSettings } from './CustomSettings';

--- a/packages/deprecated/theming-ramp/src/index.ts
+++ b/packages/deprecated/theming-ramp/src/index.ts
@@ -1,5 +1,5 @@
-export * from './SettingsWorker';
-export * from './Theme';
+export { getSettings, returnAsSlotProps } from './SettingsWorker';
+export { resolvePartialTheme } from './Theme';
 export {
   OfficePalette,
   Palette as IPalette,

--- a/packages/deprecated/theming-react-native/src/index.ts
+++ b/packages/deprecated/theming-react-native/src/index.ts
@@ -1,8 +1,10 @@
 export { addThemeRegistryListener, removeThemeRegistryListener, setTheme, getTheme, augmentPlatformTheme } from './Global';
-export * from './Theme.types';
+export { IPartialTheme, ITheme } from './Theme.types';
+export type { IThemeDefinition, ThemeRegistry } from './Theme.types';
 export { IThemeLayerProps, ThemeLayer } from './ThemeLayer';
-export * from './platform';
-export * from './ThemeProvider';
-export * from './ThemeProvider.types';
-export * from './ThemeContext';
-export * from './NativeModule';
+export { createPlatformThemeRegistry } from './platform';
+export { ThemeProvider } from './ThemeProvider';
+export type { IThemeProviderProps } from './ThemeProvider.types';
+export { ThemeContext, ThemeRegistryContext, useTheme, useThemeRegistry } from './ThemeContext';
+export { ThemingModuleHelper, getHostSettingsWin32 } from './NativeModule';
+export type { IEventEmitter, IHostSettingsWin32, IPlatformThemeDefinition, IThemingModuleHelper } from './NativeModule';

--- a/packages/experimental/Badge/src/index.ts
+++ b/packages/experimental/Badge/src/index.ts
@@ -1,3 +1,5 @@
-export * from './Badge.types';
-export * from './Badge';
-export * from './PresenceBadge';
+export { badgeName } from './Badge.types';
+export type { BadgeAppearance, BadgeProps, BadgeShape, BadgeSize, BadgeSlotProps, BadgeTokens, BadgeType } from './Badge.types';
+export { Badge, CompressibleBadge, badgeLookup } from './Badge';
+export { PresenceBadge, presenceBadgeName } from './PresenceBadge';
+export type { Presence, PresenceBadgeProps, PresenceBadgeSlotProps, PresenceBadgeType } from './PresenceBadge';

--- a/packages/experimental/MenuButton/src/index.ts
+++ b/packages/experimental/MenuButton/src/index.ts
@@ -1,2 +1,11 @@
-export * from './MenuButton.types';
-export * from './MenuButton';
+export { menuButtonName } from './MenuButton.types';
+export type {
+  MenuButtonContext,
+  MenuButtonItemProps,
+  MenuButtonProps,
+  MenuButtonSlotProps,
+  MenuButtonState,
+  MenuButtonTokens,
+  MenuButtonType,
+} from './MenuButton.types';
+export { MenuButton } from './MenuButton';

--- a/packages/experimental/Stack/src/index.ts
+++ b/packages/experimental/Stack/src/index.ts
@@ -1,4 +1,6 @@
-export * from './StackItem/StackItem.types';
-export * from './StackItem/StackItem';
-export * from './Stack.types';
-export * from './Stack';
+export { stackItemName } from './StackItem/StackItem.types';
+export type { StackItemProps, StackItemSlotProps, StackItemTokens, StackItemType } from './StackItem/StackItem.types';
+export { StackItem } from './StackItem/StackItem';
+export { stackName } from './Stack.types';
+export type { Alignment, StackProps, StackSlotProps, StackStatics, StackTokenProps, StackTokens, StackType } from './Stack.types';
+export { Stack } from './Stack';

--- a/packages/experimental/Tabs/src/index.ts
+++ b/packages/experimental/Tabs/src/index.ts
@@ -1,4 +1,6 @@
-export * from './TabsItem.types';
-export * from './TabsItem';
-export * from './Tabs.types';
-export * from './Tabs';
+export { tabsItemName } from './TabsItem.types';
+export type { TabItemType, TabsItemInfo, TabsItemProps, TabsItemSlotProps, TabsItemState, TabsItemTokens } from './TabsItem.types';
+export { TabsItem } from './TabsItem';
+export { tabsName } from './Tabs.types';
+export type { TabsContextData, TabsInfo, TabsProps, TabsSlotProps, TabsState, TabsTokens, TabsType } from './Tabs.types';
+export { Tabs, TabsContext } from './Tabs';

--- a/packages/experimental/Text/src/index.ts
+++ b/packages/experimental/Text/src/index.ts
@@ -1,1 +1,2 @@
-export * from './Text';
+export { Text } from './Text';
+export type { TextProps, TextTokens } from './Text';

--- a/packages/framework/component-cache/src/index.ts
+++ b/packages/framework/component-cache/src/index.ts
@@ -1,1 +1,1 @@
-export * from './ensureNativeComponent';
+export { ensureNativeComponent } from './ensureNativeComponent';

--- a/packages/framework/eslint-config-rules/eslintrc.js
+++ b/packages/framework/eslint-config-rules/eslintrc.js
@@ -14,4 +14,12 @@ module.exports = {
     'no-undef': 'off',
     'react/display-name': 'off',
   },
+  overrides: [
+    {
+      files: '**/src/index.{js,ts,tsx}',
+      rules: {
+        '@rnx-kit/no-export-all': ['error', { expand: 'all' }],
+      },
+    },
+  ],
 };

--- a/packages/framework/framework/src/index.ts
+++ b/packages/framework/framework/src/index.ts
@@ -79,8 +79,20 @@ export type {
   Variants,
 } from '@fluentui-react-native/theme-types';
 
-export * from './compose';
-export * from './compressible';
-export * from './useFluentTheme';
-export * from './useStyling';
-export * from './useTokens';
+export { compose } from './compose';
+export type {
+  ComposableComponent,
+  ComposeOptions,
+  ComposeType,
+  ExtractProps,
+  ExtractSlotProps,
+  ExtractStatics,
+  ExtractTokens,
+  UseSlots,
+} from './compose';
+export { compressible } from './compressible';
+export { useFluentTheme } from './useFluentTheme';
+export { HasLayer, TokensThatAreAlsoProps, UseStyling, buildProps, buildUseStyling } from './useStyling';
+export type { BuildProps, TokenSettings, TokensFromTheme, UseStylingOptions } from './useStyling';
+export { applyPropsToTokens, applyTokenLayers, buildUseTokens, customizable, patchTokens } from './useTokens';
+export type { UseTokens } from './useTokens';

--- a/packages/framework/immutable-merge/src/index.ts
+++ b/packages/framework/immutable-merge/src/index.ts
@@ -1,1 +1,2 @@
-export * from './Merge';
+export { immutableMerge, immutableMergeCore, processImmutable } from './Merge';
+export type { BuiltinRecursionHandlers, CustomRecursionHandler, MergeOptions, RecursionHandler, RecursionOption } from './Merge';

--- a/packages/framework/themed-stylesheet/src/index.ts
+++ b/packages/framework/themed-stylesheet/src/index.ts
@@ -1,1 +1,2 @@
-export * from './themedStyleSheet';
+export { themedStyleSheet } from './themedStyleSheet';
+export type { NamedStyles } from './themedStyleSheet';

--- a/packages/theming/android-theme/src/index.ts
+++ b/packages/theming/android-theme/src/index.ts
@@ -1,1 +1,1 @@
-export * from './createAndroidTheme';
+export { createAndroidTheme } from './createAndroidTheme';

--- a/packages/theming/apple-theme/src/index.ts
+++ b/packages/theming/apple-theme/src/index.ts
@@ -1,3 +1,3 @@
-export * from './createAppleTheme';
-export * from './createMacOSAliasTokens';
-export * from './appleHighContrast.macos';
+export { createAppleTheme } from './createAppleTheme';
+export { createMacOSAliasTokens } from './createMacOSAliasTokens';
+export { getIsHighContrast, setIsHighContrast } from './appleHighContrast.macos';

--- a/packages/theming/default-theme/src/index.ts
+++ b/packages/theming/default-theme/src/index.ts
@@ -1,2 +1,2 @@
 export { defaultFluentTheme, defaultFluentDarkTheme } from './defaultTheme';
-export * from './createDefaultTheme';
+export { createDefaultTheme } from './createDefaultTheme';

--- a/packages/theming/theme-types/src/index.ts
+++ b/packages/theming/theme-types/src/index.ts
@@ -1,5 +1,31 @@
-export * from './Color.types';
-export * from './Theme.types';
-export * from './Typography.types';
-export * from './context';
-export * from './palette.types';
+export type {
+  AliasColorTokens,
+  Color,
+  ControlColorTokens,
+  FabricWebPalette,
+  Palette,
+  PaletteBackgroundColors,
+  PaletteTextColors,
+  PartialPalette,
+  ThemeColorDefinition,
+} from './Color.types';
+export type { AppearanceOptions, PartialTheme, Spacing, Theme, ThemeOptions } from './Theme.types';
+export type {
+  FontFamilies,
+  FontFamily,
+  FontFamilyValue,
+  FontSize,
+  FontSizeValuePoints,
+  FontSizes,
+  FontWeight,
+  FontWeightValue,
+  FontWeights,
+  PartialTypography,
+  TextStyling,
+  Typography,
+  Variant,
+  VariantValue,
+  Variants,
+} from './Typography.types';
+export { ThemeContext, useTheme } from './context';
+export type { OfficePalette } from './palette.types';

--- a/packages/theming/theming-utils/src/index.ts
+++ b/packages/theming/theming-utils/src/index.ts
@@ -1,3 +1,3 @@
-export * from './createAliasTokens';
-export * from './getCurrentAppearance';
-export * from './mapPipelineToTheme';
+export { createAliasTokens } from './createAliasTokens';
+export { getCurrentAppearance } from './getCurrentAppearance';
+export { mapPipelineToTheme } from './mapPipelineToTheme';

--- a/packages/theming/win32-theme/src/index.ts
+++ b/packages/theming/win32-theme/src/index.ts
@@ -1,6 +1,15 @@
-export * from './createOfficeTheme';
-export * from './createPartialOfficeTheme';
-export * from './NativeModule/index';
-export * from './paletteFromOfficeColors';
-export * from './createOfficeAliasTokens';
-export * from './createBrandedThemeWithAlias';
+export { createOfficeTheme } from './createOfficeTheme';
+export { createPartialOfficeTheme } from './createPartialOfficeTheme';
+export { fallbackGetPalette, fallbackOfficeModule, getThemingModule } from './NativeModule/index';
+export type {
+  CxxException,
+  IEventEmitter,
+  NativeColorNames,
+  NativeColorRamps,
+  OfficeThemingModule,
+  PlatformDefaultsChangedArgs,
+  PlatformDefaultsChangedCallback,
+} from './NativeModule/index';
+export { paletteFromOfficeColors } from './paletteFromOfficeColors';
+export { createOfficeAliasTokens } from './createOfficeAliasTokens';
+export { createBrandedThemeWithAlias, getCurrentBrandAliasTokens } from './createBrandedThemeWithAlias';

--- a/packages/utils/adapters/src/index.ts
+++ b/packages/utils/adapters/src/index.ts
@@ -1,1 +1,2 @@
-export * from './adapters';
+export { filterImageProps, filterTextProps, filterViewProps } from './adapters';
+export type { IImageProps, ITextProps, IViewProps } from './adapters';

--- a/packages/utils/interactive-hooks/src/index.ts
+++ b/packages/utils/interactive-hooks/src/index.ts
@@ -1,14 +1,62 @@
-export * from './events.types';
-export * from './useAsPressable.types';
-export * from './useAsPressable';
-export * from './usePressability';
-export * from './useViewCommandFocus';
-export * from './useSelectedKey.hooks';
-export * from './useIconProps.hooks';
-export * from './useAsToggle';
-export * from './useAsToggleWithEvent';
-export * from './Pressability/Pressability.types';
-export * from './Pressability/InternalTypes';
-export * from './Pressability/CoreEventTypes';
-export * from './useKeyProps';
-export * from './useOnPressWithFocus';
+export { isAccessibilityActionEvent, isGestureResponderEvent, isKeyPressEvent } from './events.types';
+export type { InteractionEvent } from './events.types';
+export type {
+  IFocusState,
+  IHoverState,
+  IPressState,
+  IPressableHooks,
+  IPressableOptions,
+  IPressableState,
+  IWithPressableEvents,
+  IWithPressableOptions,
+  PressablePropsExtended,
+} from './useAsPressable.types';
+export { useAsPressable, useFocusState, useHoverState, usePressState, usePressableState } from './useAsPressable';
+export { usePressability } from './usePressability';
+export { useViewCommandFocus } from './useViewCommandFocus';
+export type { IFocusable } from './useViewCommandFocus';
+export { useSelectedKey } from './useSelectedKey.hooks';
+export type { onKeySelectCallback } from './useSelectedKey.hooks';
+export { createIconProps } from './useIconProps.hooks';
+export { useAsToggle } from './useAsToggle';
+export type { OnChangeCallback, OnToggleCallback } from './useAsToggle';
+export { useAsToggleWithEvent } from './useAsToggleWithEvent';
+export type { OnChangeWithEventCallback, OnToggleWithEventCallback } from './useAsToggleWithEvent';
+export type {
+  PressabilityConfig,
+  PressabilityEventHandlers,
+  PressableFocusProps,
+  PressableHoverEventProps,
+  PressableHoverProps,
+  PressablePressProps,
+} from './Pressability/Pressability.types';
+export { normalizeRect } from './Pressability/InternalTypes';
+export type {
+  AbstractComponent,
+  ComponentMethods,
+  HostComponent,
+  MeasureInWindowOnSuccessCallback,
+  MeasureLayoutOnSuccessCallback,
+  MeasureOnSuccessCallback,
+  NativeMethods,
+  Rect,
+  RectOrSize,
+} from './Pressability/InternalTypes';
+export type {
+  BlurEvent,
+  FocusEvent,
+  KeyPressEvent,
+  Layout,
+  LayoutEvent,
+  MouseEvent,
+  PressEvent,
+  ResponderSyntheticEvent,
+  ScrollEvent,
+  SyntheticEvent,
+  TextLayout,
+  TextLayoutEvent,
+} from './Pressability/CoreEventTypes';
+export { useKeyCallback, useKeyDownProps, useKeyProps, useKeyUpProps } from './useKeyProps';
+export type { KeyCallback, KeyPressProps } from './useKeyProps';
+export { useOnPressWithFocus } from './useOnPressWithFocus';
+export type { OnPressCallback, OnPressWithFocusCallback } from './useOnPressWithFocus';

--- a/packages/utils/styling/src/index.ts
+++ b/packages/utils/styling/src/index.ts
@@ -1,1 +1,1 @@
-export * from './getMarginAdjustment';
+export { getTextMarginAdjustment } from './getMarginAdjustment';

--- a/packages/utils/test-tools/src/index.ts
+++ b/packages/utils/test-tools/src/index.ts
@@ -1,2 +1,3 @@
-export * from './enzymeTests';
-export * from './mockTheme';
+export { checkReRender, checkRenderConsistency, compareTrees, snapshotPropTree } from './enzymeTests';
+export type { JSXProducer, PropTreeFilter, PropTreeSnapshot } from './enzymeTests';
+export { mockTheme } from './mockTheme';

--- a/packages/utils/tokens/src/index.ts
+++ b/packages/utils/tokens/src/index.ts
@@ -1,6 +1,12 @@
-export * from './border-tokens';
-export * from './color-tokens';
-export * from './text-tokens';
-export * from './layout-tokens';
-export * from './shadow-tokens';
-export * from './tokenBuilder';
+export { borderStyles, borderTokens } from './border-tokens';
+export type { IBorderTokens } from './border-tokens';
+export { backgroundColorTokens, colorTokens, foregroundColorTokens, getPaletteFromTheme } from './color-tokens';
+export type { IBackgroundColorTokens, IColorTokens, IForegroundColorTokens } from './color-tokens';
+export { fontStyles, textTokens } from './text-tokens';
+export type { FontStyleTokens, FontTokens, FontVariantTokens } from './text-tokens';
+export { layoutStyles, layoutTokens } from './layout-tokens';
+export type { LayoutTokens } from './layout-tokens';
+export { shadowStyles, shadowTokens } from './shadow-tokens';
+export type { IShadowTokens } from './shadow-tokens';
+export { tokenBuilder } from './tokenBuilder';
+export type { TokenBuilder } from './tokenBuilder';


### PR DESCRIPTION
Some bundlers, such as esbuild, are not able to tree-shake nested `export *` statements. Fixed them using the `no-export-all` ESLint rule.

### Platforms Impacted

- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Some bundlers, such as esbuild, are not able to tree-shake nested `export *` statements.

The Fluent team has also recently turned this on: https://github.com/microsoft/fluentui/pull/22073

Fixed using the `no-export-all` ESLint rule.

### Verification

Functionally, nothing has changed.