### PR TITLE
Fix focused state styling for default button

### DIFF
--- a/change/@fluentui-react-native-apple-theme-fa030c94-fa00-42ee-b866-341f5bbf6175.json
+++ b/change/@fluentui-react-native-apple-theme-fa030c94-fa00-42ee-b866-341f5bbf6175.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix button styling",
+  "packageName": "@fluentui-react-native/apple-theme",
+  "email": "amchiu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/theming/apple-theme/src/appleColors.macos.ts
+++ b/packages/theming/apple-theme/src/appleColors.macos.ts
@@ -396,9 +396,9 @@ export function fallbackApplePalette(): ThemeColorDefinition {
     defaultHoveredContent: fluentUIApple.neutralForeground3,
     defaultHoveredIcon: fluentUIApple.neutralForeground3, //GH:728 Icon doesn't support PlatformColor
 
-    defaultFocusedBackground: fluentUIApple.neutralBackground3,
+    defaultFocusedBackground: fluentUIApple.neutralBackground2,
     defaultFocusedBorder: fluentUIApple.neutralStroke2,
-    defaultFocusedContent: fluentUIApple.neutralForeground3,
+    defaultFocusedContent: fluentUIApple.neutralForeground2,
     defaultFocusedIcon: fluentUIApple.neutralForeground3, //GH:728 Icon doesn't support PlatformColor
 
     defaultPressedBackground: fluentUIApple.neutralBackground2Pressed,


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

There's no UI changes when the system button gets focused, let's update the default button to reflect that.

### Verification
Tested in light + dark + high contrast mode

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
