### PR TITLE
FocusZone macOS: Handle edge case where FocusZone has no elements

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/FocusZone/FocusZoneTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/FocusZone/FocusZoneTest.tsx
@@ -51,6 +51,9 @@ const DirectionalFocusZone: React.FunctionComponent = () => {
         <Checkbox label="Option D" />
       </FocusZone>
       <Button content="Outside FocusZone" />
+      <Text variant="headerSemibold">FocusZone with no elements</Text>
+      <FocusZone></FocusZone>
+      <Button content="Outside FocusZone" />
     </View>
   );
 };

--- a/change/@fluentui-react-native-focus-zone-3fe5bc1e-2a0c-4cbf-bdca-12b02be0e803.json
+++ b/change/@fluentui-react-native-focus-zone-3fe5bc1e-2a0c-4cbf-bdca-12b02be0e803.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix for FocusZone",
+  "packageName": "@fluentui-react-native/focus-zone",
+  "email": "amchiu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-1b7c37c9-ebf6-4c8b-9d1c-6c00f632509f.json
+++ b/change/@fluentui-react-native-tester-1b7c37c9-ebf6-4c8b-9d1c-6c00f632509f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix for FocusZone",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "amchiu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/FocusZone/macos/RCTFocusZone.m
+++ b/packages/components/FocusZone/macos/RCTFocusZone.m
@@ -157,10 +157,11 @@ static RCTFocusZone *GetFocusZoneAncestor(NSView *view)
 	return nil;
 }
 
+/// Accept firstResponder on FocusZone itself in order to reassign it within the FocusZone.
 - (BOOL)acceptsFirstResponder
 {
-	// Accept firstResponder on FocusZone itself in order to reassign it within the FocusZone.
-	return !_disabled;
+    // Accept firstResponder if FocusZone has at least one element and is not disabled.
+    return !_disabled && !([[self subviews] count]  < 1);
 }
 
 - (BOOL)becomeFirstResponder


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Currently, keyboard navigation breaks when there's an empty FocusZone in a view, that's because a nil key view is being passed in `becomeFirstResponder` that causes the key view loop to reset. This change fixes that by rejecting `acceptsFirstResponder` if the subview count of the current view is less than one.

Note: This logic will break if there are non-focusable elements inside a FocusZone.

### Verification
Added a test case for an empty FocusZone and traversed through (forward & backward directions) all test cases in the FocusZone test page. 


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
