### PR TITLE
Handle FocusZone edge cases

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/FocusZone/FocusZoneTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/FocusZone/FocusZoneTest.tsx
@@ -20,6 +20,35 @@ const ListOfCheckboxes: React.FunctionComponent = () => {
   );
 };
 
+const ListOfDisabledCheckboxes: React.FunctionComponent = () => {
+  return (
+    <React.Fragment>
+      <Checkbox label="Option A" disabled={true} />
+      <Checkbox label="Option B" disabled={true} />
+      <Checkbox label="Option C" disabled={true} />
+      <Checkbox label="Option D" disabled={true} />
+    </React.Fragment>
+  );
+};
+
+const EdgeCasesFocusZone: React.FunctionComponent = () => {
+  return (
+    <View>
+      <FocusZone>
+        <SubheaderText>FocusZone with no focusable elements</SubheaderText>
+        <ListOfDisabledCheckboxes />
+      </FocusZone>
+      <FocusZone>
+        <SubheaderText>FocusZone with no props set</SubheaderText>
+        <ListOfCheckboxes />
+      </FocusZone>
+      <FocusZone>
+        <SubheaderText>FocusZone with no elements</SubheaderText>
+      </FocusZone>
+    </View>
+  );
+};
+
 const FocusZoneListWrapper: React.FunctionComponent = (props) => {
   const buttonProps: ButtonProps = { children: 'Click to Focus', style: { marginVertical: 10 } };
   return (
@@ -219,6 +248,10 @@ const focusZoneSections: TestSection[] = [
   {
     name: 'Customizable FocusZone',
     component: CustomizableFocusZone,
+  },
+  {
+    name: 'FocusZone Edge Cases',
+    component: EdgeCasesFocusZone,
   },
 ];
 

--- a/change/@fluentui-react-native-focus-zone-30240d95-9ba8-45cb-83d7-790aac750224.json
+++ b/change/@fluentui-react-native-focus-zone-30240d95-9ba8-45cb-83d7-790aac750224.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Handle FocusZone edge cases",
+  "packageName": "@fluentui-react-native/focus-zone",
+  "email": "amchiu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-594c41da-3dc6-417d-b5fd-dc4083287a13.json
+++ b/change/@fluentui-react-native-tester-594c41da-3dc6-417d-b5fd-dc4083287a13.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Handle FocusZone edge cases",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "amchiu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/FocusZone/macos/RCTFocusZone.m
+++ b/packages/components/FocusZone/macos/RCTFocusZone.m
@@ -157,10 +157,32 @@ static RCTFocusZone *GetFocusZoneAncestor(NSView *view)
 	return nil;
 }
 
+/// Bypass FocusZone if it's empty or has no focusable elements
+static BOOL ShouldSkipFocusZone(NSView *view)
+{
+    if([view isKindOfClass:[RCTFocusZone class]])
+    {
+        // FocusZone has no elements
+        if ([[view subviews] count] < 1)
+        {
+            return YES;
+        }
+        
+        NSView* keyView = GetFirstKeyViewWithin(view);
+        // FocusZone has no focusable elements
+        if (keyView == nil)
+        {
+            return YES;
+        }
+    }
+
+    return NO;
+}
+
 - (BOOL)acceptsFirstResponder
 {
 	// Accept firstResponder on FocusZone itself in order to reassign it within the FocusZone.
-	return !_disabled;
+    return !_disabled && !ShouldSkipFocusZone(self);
 }
 
 - (BOOL)becomeFirstResponder

--- a/packages/components/FocusZone/macos/RCTFocusZone.m
+++ b/packages/components/FocusZone/macos/RCTFocusZone.m
@@ -49,6 +49,11 @@ static inline CGFloat GetMinDistanceBetweenRectVerticesAndPoint(NSRect rect, NSP
 /// This function does not take into account the geometric position of the view.
 static NSView *GetFirstKeyViewWithin(NSView *parentView)
 {
+    if ([[parentView subviews] count] < 1)
+    {
+        return nil;
+    }
+
 	for (NSView *view in [parentView subviews]) {
 		if ([view canBecomeKeyView]) {
 			return view;
@@ -162,14 +167,8 @@ static BOOL ShouldSkipFocusZone(NSView *view)
 {
     if([view isKindOfClass:[RCTFocusZone class]])
     {
-        // FocusZone has no elements
-        if ([[view subviews] count] < 1)
-        {
-            return YES;
-        }
-        
-        NSView* keyView = GetFirstKeyViewWithin(view);
-        // FocusZone has no focusable elements
+        NSView *keyView = GetFirstKeyViewWithin(view);
+        // FocusZone is empty or has no focusable elements
         if (keyView == nil)
         {
             return YES;
@@ -178,10 +177,10 @@ static BOOL ShouldSkipFocusZone(NSView *view)
 
     return NO;
 }
-
+/// Accept firstResponder on FocusZone itself in order to reassign it within the FocusZone.
 - (BOOL)acceptsFirstResponder
 {
-	// Accept firstResponder on FocusZone itself in order to reassign it within the FocusZone.
+    // Reject first responder if FocusZone is disabled or should be skipped.
     return !_disabled && !ShouldSkipFocusZone(self);
 }
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Currently, keyboard navigation breaks when these two cases happen:
1. FocusZone is empty
2. FocusZone has no focusable elements

That's because `becomeFirstReesponder` is false when a nil key view is being passed in which causes the key view loop to get reset.

Let's handle said edge cases by rejecting firstResponder if FocusZone is empty or has no focusable elements.

### Verification
Added new test cases and traversed through (forward & backward directions) them in the FocusZone test page.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [X] Documentation and examples
- [X] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
