### PR TITLE
(macOS) FocusZone: Handle Nested Focus Zones

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/FocusZone/FocusZoneTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/FocusZone/FocusZoneTest.tsx
@@ -4,7 +4,7 @@ import { FocusZone, Text, FocusZoneDirection, Checkbox } from '@fluentui/react-n
 import { ButtonV1 as Button, ButtonProps } from '@fluentui-react-native/button';
 import { Test, TestSection, PlatformStatus } from '../Test';
 import { FOCUSZONE_TESTPAGE } from './consts';
-import { focusZoneTestStyles, GridButton, stackStyleFocusZone, nes, SubheaderText } from './styles';
+import { focusZoneTestStyles, GridButton, stackStyleFocusZone, SubheaderText } from './styles';
 import { commonTestStyles } from '../Common/styles';
 import { Stack } from '@fluentui-react-native/stack';
 import { MenuButton, MenuButtonItemProps } from '@fluentui-react-native/experimental-menu-button';

--- a/apps/fluent-tester/src/FluentTester/TestComponents/FocusZone/FocusZoneTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/FocusZone/FocusZoneTest.tsx
@@ -4,7 +4,7 @@ import { FocusZone, Text, FocusZoneDirection, Checkbox } from '@fluentui/react-n
 import { ButtonV1 as Button, ButtonProps } from '@fluentui-react-native/button';
 import { Test, TestSection, PlatformStatus } from '../Test';
 import { FOCUSZONE_TESTPAGE } from './consts';
-import { focusZoneTestStyles, GridButton, stackStyleFocusZone, SubheaderText } from './styles';
+import { focusZoneTestStyles, GridButton, stackStyleFocusZone, nes, SubheaderText } from './styles';
 import { commonTestStyles } from '../Common/styles';
 import { Stack } from '@fluentui-react-native/stack';
 import { MenuButton, MenuButtonItemProps } from '@fluentui-react-native/experimental-menu-button';
@@ -15,7 +15,6 @@ const ListOfCheckboxes: React.FunctionComponent = () => {
       <Checkbox label="Option A" />
       <Checkbox label="Option B" />
       <Checkbox label="Option C" />
-      <Checkbox label="Option D" />
     </React.Fragment>
   );
 };
@@ -26,14 +25,13 @@ const ListOfDisabledCheckboxes: React.FunctionComponent = () => {
       <Checkbox label="Option A" disabled={true} />
       <Checkbox label="Option B" disabled={true} />
       <Checkbox label="Option C" disabled={true} />
-      <Checkbox label="Option D" disabled={true} />
     </React.Fragment>
   );
 };
 
 const EdgeCasesFocusZone: React.FunctionComponent = () => {
   return (
-    <View>
+    <Stack style={stackStyleFocusZone}>
       <FocusZone>
         <SubheaderText>FocusZone with no focusable elements</SubheaderText>
         <ListOfDisabledCheckboxes />
@@ -45,7 +43,28 @@ const EdgeCasesFocusZone: React.FunctionComponent = () => {
       <FocusZone>
         <SubheaderText>FocusZone with no elements</SubheaderText>
       </FocusZone>
-    </View>
+      <SubheaderText>Nested FocusZones</SubheaderText>
+      <Button>Outside Focus Zone</Button>
+      <Text>Parent FocusZone</Text>
+      <View style={focusZoneTestStyles.nestedFocusZoneStyle}>
+        <FocusZone>
+          <Text>Inner FocusZone 1</Text>
+          <View style={focusZoneTestStyles.nestedFocusZoneStyle}>
+            <FocusZone>
+              <ListOfCheckboxes />
+            </FocusZone>
+          </View>
+          <Text>Inner FocusZone 2</Text>
+          <View style={focusZoneTestStyles.nestedFocusZoneStyle}>
+            <FocusZone>
+              <ListOfCheckboxes />
+            </FocusZone>
+          </View>
+          <Button>Inside Focus Zone</Button>
+        </FocusZone>
+      </View>
+      <Button>Outside Focus Zone</Button>
+    </Stack>
   );
 };
 

--- a/apps/fluent-tester/src/FluentTester/TestComponents/FocusZone/FocusZoneTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/FocusZone/FocusZoneTest.tsx
@@ -50,14 +50,24 @@ const EdgeCasesFocusZone: React.FunctionComponent = () => {
         <FocusZone>
           <Text>Inner FocusZone 1</Text>
           <View style={focusZoneTestStyles.nestedFocusZoneStyle}>
-            <FocusZone>
-              <ListOfCheckboxes />
+            <FocusZone focusZoneDirection="horizontal">
+              <View style={focusZoneTestStyles.focusZoneContainer}>
+                {GridOfButtons({
+                  gridWidth: 3,
+                  gridHeight: 1,
+                })}
+              </View>
             </FocusZone>
           </View>
           <Text>Inner FocusZone 2</Text>
           <View style={focusZoneTestStyles.nestedFocusZoneStyle}>
-            <FocusZone>
-              <ListOfCheckboxes />
+            <FocusZone focusZoneDirection="horizontal">
+              <View style={focusZoneTestStyles.focusZoneContainer}>
+                {GridOfButtons({
+                  gridWidth: 3,
+                  gridHeight: 1,
+                })}
+              </View>
             </FocusZone>
           </View>
           <Button>Inside Focus Zone</Button>

--- a/apps/fluent-tester/src/FluentTester/TestComponents/FocusZone/styles.ts
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/FocusZone/styles.ts
@@ -17,7 +17,8 @@ export const focusZoneTestStyles = StyleSheet.create({
   },
   nestedFocusZoneStyle: {
     borderWidth: 1,
-    padding: 10,
+    padding: 8,
+    margin: 8,
   },
   focusZoneButton: {
     height: 50,

--- a/apps/fluent-tester/src/FluentTester/TestComponents/FocusZone/styles.ts
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/FocusZone/styles.ts
@@ -15,6 +15,10 @@ export const focusZoneTestStyles = StyleSheet.create({
     justifyContent: 'space-evenly',
     padding: 4,
   },
+  nestedFocusZoneStyle: {
+    borderWidth: 1,
+    padding: 10,
+  },
   focusZoneButton: {
     height: 50,
     width: 50,

--- a/apps/macos/src/Podfile.lock
+++ b/apps/macos/src/Podfile.lock
@@ -9,17 +9,17 @@ PODS:
     - React-Core (= 0.64.30)
     - React-jsi (= 0.64.30)
     - ReactCommon/turbomodule/core (= 0.64.30)
-  - FRNAvatar (0.14.11):
+  - FRNAvatar (0.14.12):
     - MicrosoftFluentUI (= 0.3.0)
     - MicrosoftFluentUI/Avatar_ios (= 0.3.0)
     - React
-  - FRNCallout (0.19.38):
+  - FRNCallout (0.19.39):
     - React
-  - FRNCheckbox (0.10.9):
+  - FRNCheckbox (0.10.10):
     - React
-  - FRNMenuButton (0.7.45):
+  - FRNMenuButton (0.7.48):
     - React
-  - FRNRadioButton (0.14.34):
+  - FRNRadioButton (0.14.36):
     - React
   - glog (0.3.5)
   - MicrosoftFluentUI (0.3.0):
@@ -94,7 +94,7 @@ PODS:
     - boost-for-react-native
     - DoubleConversion
     - glog
-  - RCTFocusZone (0.9.14):
+  - RCTFocusZone (0.9.16):
     - React
   - RCTRequired (0.64.30)
   - RCTTypeSafety (0.64.30):
@@ -489,15 +489,15 @@ SPEC CHECKSUMS:
   DoubleConversion: 0ea4559a49682230337df966e735d6cc7760108e
   FBLazyVector: 8a96f324df8c1bc4e2f7e2163d704ec364f0bc6c
   FBReactNativeSpec: 52bfb636413dc06cf5a57b63f60ef41b5dd9f8c6
-  FRNAvatar: b07d7b17a456112b838d785b602c204a86387221
-  FRNCallout: d872c7ba99c8ffcbbc6f61a930c30f79aef5668a
-  FRNCheckbox: 99e42ac1a8b7c42e449f10ae9e6778dd2a0f04f2
-  FRNMenuButton: 463b050240bfd7cf0efc64b55f56ce03dc800d3f
-  FRNRadioButton: 2452fff884c7608e644bbf14bcc561b71f8f78f5
+  FRNAvatar: 39533725b0070c27460bace57391f2daf85680bb
+  FRNCallout: 3bc6c0d8a8df47054fbe9e84a21180c3153e0214
+  FRNCheckbox: 20f99d5804c5c87e1309c1ceecd3ca790f1f4e87
+  FRNMenuButton: f225ac8082af451a12a4f05904f127fa9fb1f22a
+  FRNRadioButton: f7717a67caf728c2a5f62676a1e0c8c9a0bbe388
   glog: 0dc7efada961c0793012970b60faebbd58b0decb
   MicrosoftFluentUI: b98d877a2122804132365aa167944f58ef4adb69
   RCT-Folly: b3998425a8ee9f695f57a204dc494534246f0fe9
-  RCTFocusZone: 6d93f2727b66840b0446c1cc4edf47e7fb8ecf10
+  RCTFocusZone: 4fef47c6807d3323adf4aa24b64232ccad7c2026
   RCTRequired: 8903667b081ec6b4b870c6b25ff1038eef62db0d
   RCTTypeSafety: 061b065a52bcd68ca38755bc56784a4889659625
   React: a3c80fce87768d4553ebe658746219431483b620

--- a/apps/macos/src/Podfile.lock
+++ b/apps/macos/src/Podfile.lock
@@ -1,25 +1,25 @@
 PODS:
   - boost-for-react-native (1.63.0)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.64.29)
-  - FBReactNativeSpec (0.64.29):
+  - FBLazyVector (0.64.30)
+  - FBReactNativeSpec (0.64.30):
     - RCT-Folly (= 2020.01.13.00)
-    - RCTRequired (= 0.64.29)
-    - RCTTypeSafety (= 0.64.29)
-    - React-Core (= 0.64.29)
-    - React-jsi (= 0.64.29)
-    - ReactCommon/turbomodule/core (= 0.64.29)
-  - FRNAvatar (0.14.8):
+    - RCTRequired (= 0.64.30)
+    - RCTTypeSafety (= 0.64.30)
+    - React-Core (= 0.64.30)
+    - React-jsi (= 0.64.30)
+    - ReactCommon/turbomodule/core (= 0.64.30)
+  - FRNAvatar (0.14.11):
     - MicrosoftFluentUI (= 0.3.0)
     - MicrosoftFluentUI/Avatar_ios (= 0.3.0)
     - React
-  - FRNCallout (0.19.33):
+  - FRNCallout (0.19.38):
     - React
-  - FRNCheckbox (0.10.4):
+  - FRNCheckbox (0.10.9):
     - React
-  - FRNMenuButton (0.7.40):
+  - FRNMenuButton (0.7.45):
     - React
-  - FRNRadioButton (0.14.28):
+  - FRNRadioButton (0.14.34):
     - React
   - glog (0.3.5)
   - MicrosoftFluentUI (0.3.0):
@@ -94,257 +94,257 @@ PODS:
     - boost-for-react-native
     - DoubleConversion
     - glog
-  - RCTFocusZone (0.9.9):
+  - RCTFocusZone (0.9.14):
     - React
-  - RCTRequired (0.64.29)
-  - RCTTypeSafety (0.64.29):
-    - FBLazyVector (= 0.64.29)
+  - RCTRequired (0.64.30)
+  - RCTTypeSafety (0.64.30):
+    - FBLazyVector (= 0.64.30)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTRequired (= 0.64.29)
-    - React-Core (= 0.64.29)
-  - React (0.64.29):
-    - React-Core (= 0.64.29)
-    - React-Core/DevSupport (= 0.64.29)
-    - React-Core/RCTWebSocket (= 0.64.29)
-    - React-RCTActionSheet (= 0.64.29)
-    - React-RCTAnimation (= 0.64.29)
-    - React-RCTBlob (= 0.64.29)
-    - React-RCTImage (= 0.64.29)
-    - React-RCTLinking (= 0.64.29)
-    - React-RCTNetwork (= 0.64.29)
-    - React-RCTSettings (= 0.64.29)
-    - React-RCTText (= 0.64.29)
-    - React-RCTVibration (= 0.64.29)
-  - React-callinvoker (0.64.29)
-  - React-Core (0.64.29):
+    - RCTRequired (= 0.64.30)
+    - React-Core (= 0.64.30)
+  - React (0.64.30):
+    - React-Core (= 0.64.30)
+    - React-Core/DevSupport (= 0.64.30)
+    - React-Core/RCTWebSocket (= 0.64.30)
+    - React-RCTActionSheet (= 0.64.30)
+    - React-RCTAnimation (= 0.64.30)
+    - React-RCTBlob (= 0.64.30)
+    - React-RCTImage (= 0.64.30)
+    - React-RCTLinking (= 0.64.30)
+    - React-RCTNetwork (= 0.64.30)
+    - React-RCTSettings (= 0.64.30)
+    - React-RCTText (= 0.64.30)
+    - React-RCTVibration (= 0.64.30)
+  - React-callinvoker (0.64.30)
+  - React-Core (0.64.30):
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.64.29)
-    - React-cxxreact (= 0.64.29)
-    - React-jsi (= 0.64.29)
-    - React-jsiexecutor (= 0.64.29)
-    - React-perflogger (= 0.64.29)
+    - React-Core/Default (= 0.64.30)
+    - React-cxxreact (= 0.64.30)
+    - React-jsi (= 0.64.30)
+    - React-jsiexecutor (= 0.64.30)
+    - React-perflogger (= 0.64.30)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.64.29):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default
-    - React-cxxreact (= 0.64.29)
-    - React-jsi (= 0.64.29)
-    - React-jsiexecutor (= 0.64.29)
-    - React-perflogger (= 0.64.29)
-    - Yoga
-  - React-Core/Default (0.64.29):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-cxxreact (= 0.64.29)
-    - React-jsi (= 0.64.29)
-    - React-jsiexecutor (= 0.64.29)
-    - React-perflogger (= 0.64.29)
-    - Yoga
-  - React-Core/DevSupport (0.64.29):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.64.29)
-    - React-Core/RCTWebSocket (= 0.64.29)
-    - React-cxxreact (= 0.64.29)
-    - React-jsi (= 0.64.29)
-    - React-jsiexecutor (= 0.64.29)
-    - React-jsinspector (= 0.64.29)
-    - React-perflogger (= 0.64.29)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.64.29):
+  - React-Core/CoreModulesHeaders (0.64.30):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.29)
-    - React-jsi (= 0.64.29)
-    - React-jsiexecutor (= 0.64.29)
-    - React-perflogger (= 0.64.29)
+    - React-cxxreact (= 0.64.30)
+    - React-jsi (= 0.64.30)
+    - React-jsiexecutor (= 0.64.30)
+    - React-perflogger (= 0.64.30)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.64.29):
+  - React-Core/Default (0.64.30):
+    - glog
+    - RCT-Folly (= 2020.01.13.00)
+    - React-cxxreact (= 0.64.30)
+    - React-jsi (= 0.64.30)
+    - React-jsiexecutor (= 0.64.30)
+    - React-perflogger (= 0.64.30)
+    - Yoga
+  - React-Core/DevSupport (0.64.30):
+    - glog
+    - RCT-Folly (= 2020.01.13.00)
+    - React-Core/Default (= 0.64.30)
+    - React-Core/RCTWebSocket (= 0.64.30)
+    - React-cxxreact (= 0.64.30)
+    - React-jsi (= 0.64.30)
+    - React-jsiexecutor (= 0.64.30)
+    - React-jsinspector (= 0.64.30)
+    - React-perflogger (= 0.64.30)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.64.30):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.29)
-    - React-jsi (= 0.64.29)
-    - React-jsiexecutor (= 0.64.29)
-    - React-perflogger (= 0.64.29)
+    - React-cxxreact (= 0.64.30)
+    - React-jsi (= 0.64.30)
+    - React-jsiexecutor (= 0.64.30)
+    - React-perflogger (= 0.64.30)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.64.29):
+  - React-Core/RCTAnimationHeaders (0.64.30):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.29)
-    - React-jsi (= 0.64.29)
-    - React-jsiexecutor (= 0.64.29)
-    - React-perflogger (= 0.64.29)
+    - React-cxxreact (= 0.64.30)
+    - React-jsi (= 0.64.30)
+    - React-jsiexecutor (= 0.64.30)
+    - React-perflogger (= 0.64.30)
     - Yoga
-  - React-Core/RCTImageHeaders (0.64.29):
+  - React-Core/RCTBlobHeaders (0.64.30):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.29)
-    - React-jsi (= 0.64.29)
-    - React-jsiexecutor (= 0.64.29)
-    - React-perflogger (= 0.64.29)
+    - React-cxxreact (= 0.64.30)
+    - React-jsi (= 0.64.30)
+    - React-jsiexecutor (= 0.64.30)
+    - React-perflogger (= 0.64.30)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.64.29):
+  - React-Core/RCTImageHeaders (0.64.30):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.29)
-    - React-jsi (= 0.64.29)
-    - React-jsiexecutor (= 0.64.29)
-    - React-perflogger (= 0.64.29)
+    - React-cxxreact (= 0.64.30)
+    - React-jsi (= 0.64.30)
+    - React-jsiexecutor (= 0.64.30)
+    - React-perflogger (= 0.64.30)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.64.29):
+  - React-Core/RCTLinkingHeaders (0.64.30):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.29)
-    - React-jsi (= 0.64.29)
-    - React-jsiexecutor (= 0.64.29)
-    - React-perflogger (= 0.64.29)
+    - React-cxxreact (= 0.64.30)
+    - React-jsi (= 0.64.30)
+    - React-jsiexecutor (= 0.64.30)
+    - React-perflogger (= 0.64.30)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.64.29):
+  - React-Core/RCTNetworkHeaders (0.64.30):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.29)
-    - React-jsi (= 0.64.29)
-    - React-jsiexecutor (= 0.64.29)
-    - React-perflogger (= 0.64.29)
+    - React-cxxreact (= 0.64.30)
+    - React-jsi (= 0.64.30)
+    - React-jsiexecutor (= 0.64.30)
+    - React-perflogger (= 0.64.30)
     - Yoga
-  - React-Core/RCTTextHeaders (0.64.29):
+  - React-Core/RCTSettingsHeaders (0.64.30):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.29)
-    - React-jsi (= 0.64.29)
-    - React-jsiexecutor (= 0.64.29)
-    - React-perflogger (= 0.64.29)
+    - React-cxxreact (= 0.64.30)
+    - React-jsi (= 0.64.30)
+    - React-jsiexecutor (= 0.64.30)
+    - React-perflogger (= 0.64.30)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.64.29):
+  - React-Core/RCTTextHeaders (0.64.30):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.29)
-    - React-jsi (= 0.64.29)
-    - React-jsiexecutor (= 0.64.29)
-    - React-perflogger (= 0.64.29)
+    - React-cxxreact (= 0.64.30)
+    - React-jsi (= 0.64.30)
+    - React-jsiexecutor (= 0.64.30)
+    - React-perflogger (= 0.64.30)
     - Yoga
-  - React-Core/RCTWebSocket (0.64.29):
+  - React-Core/RCTVibrationHeaders (0.64.30):
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.64.29)
-    - React-cxxreact (= 0.64.29)
-    - React-jsi (= 0.64.29)
-    - React-jsiexecutor (= 0.64.29)
-    - React-perflogger (= 0.64.29)
+    - React-Core/Default
+    - React-cxxreact (= 0.64.30)
+    - React-jsi (= 0.64.30)
+    - React-jsiexecutor (= 0.64.30)
+    - React-perflogger (= 0.64.30)
     - Yoga
-  - React-CoreModules (0.64.29):
-    - FBReactNativeSpec (= 0.64.29)
+  - React-Core/RCTWebSocket (0.64.30):
+    - glog
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.64.29)
-    - React-Core/CoreModulesHeaders (= 0.64.29)
-    - React-jsi (= 0.64.29)
-    - React-RCTImage (= 0.64.29)
-    - ReactCommon/turbomodule/core (= 0.64.29)
-  - React-cxxreact (0.64.29):
+    - React-Core/Default (= 0.64.30)
+    - React-cxxreact (= 0.64.30)
+    - React-jsi (= 0.64.30)
+    - React-jsiexecutor (= 0.64.30)
+    - React-perflogger (= 0.64.30)
+    - Yoga
+  - React-CoreModules (0.64.30):
+    - FBReactNativeSpec (= 0.64.30)
+    - RCT-Folly (= 2020.01.13.00)
+    - RCTTypeSafety (= 0.64.30)
+    - React-Core/CoreModulesHeaders (= 0.64.30)
+    - React-jsi (= 0.64.30)
+    - React-RCTImage (= 0.64.30)
+    - ReactCommon/turbomodule/core (= 0.64.30)
+  - React-cxxreact (0.64.30):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.64.29)
-    - React-jsi (= 0.64.29)
-    - React-jsinspector (= 0.64.29)
-    - React-perflogger (= 0.64.29)
-    - React-runtimeexecutor (= 0.64.29)
-  - React-jsi (0.64.29):
+    - React-callinvoker (= 0.64.30)
+    - React-jsi (= 0.64.30)
+    - React-jsinspector (= 0.64.30)
+    - React-perflogger (= 0.64.30)
+    - React-runtimeexecutor (= 0.64.30)
+  - React-jsi (0.64.30):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-jsi/Default (= 0.64.29)
-  - React-jsi/Default (0.64.29):
+    - React-jsi/Default (= 0.64.30)
+  - React-jsi/Default (0.64.30):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-  - React-jsiexecutor (0.64.29):
+  - React-jsiexecutor (0.64.30):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-cxxreact (= 0.64.29)
-    - React-jsi (= 0.64.29)
-    - React-perflogger (= 0.64.29)
-  - React-jsinspector (0.64.29)
-  - React-perflogger (0.64.29)
-  - React-RCTActionSheet (0.64.29):
-    - React-Core/RCTActionSheetHeaders (= 0.64.29)
-  - React-RCTAnimation (0.64.29):
-    - FBReactNativeSpec (= 0.64.29)
+    - React-cxxreact (= 0.64.30)
+    - React-jsi (= 0.64.30)
+    - React-perflogger (= 0.64.30)
+  - React-jsinspector (0.64.30)
+  - React-perflogger (0.64.30)
+  - React-RCTActionSheet (0.64.30):
+    - React-Core/RCTActionSheetHeaders (= 0.64.30)
+  - React-RCTAnimation (0.64.30):
+    - FBReactNativeSpec (= 0.64.30)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.64.29)
-    - React-Core/RCTAnimationHeaders (= 0.64.29)
-    - React-jsi (= 0.64.29)
-    - ReactCommon/turbomodule/core (= 0.64.29)
-  - React-RCTBlob (0.64.29):
-    - FBReactNativeSpec (= 0.64.29)
+    - RCTTypeSafety (= 0.64.30)
+    - React-Core/RCTAnimationHeaders (= 0.64.30)
+    - React-jsi (= 0.64.30)
+    - ReactCommon/turbomodule/core (= 0.64.30)
+  - React-RCTBlob (0.64.30):
+    - FBReactNativeSpec (= 0.64.30)
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/RCTBlobHeaders (= 0.64.29)
-    - React-Core/RCTWebSocket (= 0.64.29)
-    - React-jsi (= 0.64.29)
-    - React-RCTNetwork (= 0.64.29)
-    - ReactCommon/turbomodule/core (= 0.64.29)
-  - React-RCTImage (0.64.29):
-    - FBReactNativeSpec (= 0.64.29)
+    - React-Core/RCTBlobHeaders (= 0.64.30)
+    - React-Core/RCTWebSocket (= 0.64.30)
+    - React-jsi (= 0.64.30)
+    - React-RCTNetwork (= 0.64.30)
+    - ReactCommon/turbomodule/core (= 0.64.30)
+  - React-RCTImage (0.64.30):
+    - FBReactNativeSpec (= 0.64.30)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.64.29)
-    - React-Core/RCTImageHeaders (= 0.64.29)
-    - React-jsi (= 0.64.29)
-    - React-RCTNetwork (= 0.64.29)
-    - ReactCommon/turbomodule/core (= 0.64.29)
-  - React-RCTLinking (0.64.29):
-    - FBReactNativeSpec (= 0.64.29)
-    - React-Core/RCTLinkingHeaders (= 0.64.29)
-    - React-jsi (= 0.64.29)
-    - ReactCommon/turbomodule/core (= 0.64.29)
-  - React-RCTNetwork (0.64.29):
-    - FBReactNativeSpec (= 0.64.29)
+    - RCTTypeSafety (= 0.64.30)
+    - React-Core/RCTImageHeaders (= 0.64.30)
+    - React-jsi (= 0.64.30)
+    - React-RCTNetwork (= 0.64.30)
+    - ReactCommon/turbomodule/core (= 0.64.30)
+  - React-RCTLinking (0.64.30):
+    - FBReactNativeSpec (= 0.64.30)
+    - React-Core/RCTLinkingHeaders (= 0.64.30)
+    - React-jsi (= 0.64.30)
+    - ReactCommon/turbomodule/core (= 0.64.30)
+  - React-RCTNetwork (0.64.30):
+    - FBReactNativeSpec (= 0.64.30)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.64.29)
-    - React-Core/RCTNetworkHeaders (= 0.64.29)
-    - React-jsi (= 0.64.29)
-    - ReactCommon/turbomodule/core (= 0.64.29)
-  - React-RCTSettings (0.64.29):
-    - FBReactNativeSpec (= 0.64.29)
+    - RCTTypeSafety (= 0.64.30)
+    - React-Core/RCTNetworkHeaders (= 0.64.30)
+    - React-jsi (= 0.64.30)
+    - ReactCommon/turbomodule/core (= 0.64.30)
+  - React-RCTSettings (0.64.30):
+    - FBReactNativeSpec (= 0.64.30)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.64.29)
-    - React-Core/RCTSettingsHeaders (= 0.64.29)
-    - React-jsi (= 0.64.29)
-    - ReactCommon/turbomodule/core (= 0.64.29)
-  - React-RCTText (0.64.29):
-    - React-Core/RCTTextHeaders (= 0.64.29)
-  - React-RCTVibration (0.64.29):
-    - FBReactNativeSpec (= 0.64.29)
+    - RCTTypeSafety (= 0.64.30)
+    - React-Core/RCTSettingsHeaders (= 0.64.30)
+    - React-jsi (= 0.64.30)
+    - ReactCommon/turbomodule/core (= 0.64.30)
+  - React-RCTText (0.64.30):
+    - React-Core/RCTTextHeaders (= 0.64.30)
+  - React-RCTVibration (0.64.30):
+    - FBReactNativeSpec (= 0.64.30)
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/RCTVibrationHeaders (= 0.64.29)
-    - React-jsi (= 0.64.29)
-    - ReactCommon/turbomodule/core (= 0.64.29)
-  - React-runtimeexecutor (0.64.29):
-    - React-jsi (= 0.64.29)
-  - ReactCommon/turbomodule/core (0.64.29):
+    - React-Core/RCTVibrationHeaders (= 0.64.30)
+    - React-jsi (= 0.64.30)
+    - ReactCommon/turbomodule/core (= 0.64.30)
+  - React-runtimeexecutor (0.64.30):
+    - React-jsi (= 0.64.30)
+  - ReactCommon/turbomodule/core (0.64.30):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.64.29)
-    - React-Core (= 0.64.29)
-    - React-cxxreact (= 0.64.29)
-    - React-jsi (= 0.64.29)
-    - React-perflogger (= 0.64.29)
-  - ReactTestApp-DevSupport (1.2.1):
+    - React-callinvoker (= 0.64.30)
+    - React-Core (= 0.64.30)
+    - React-cxxreact (= 0.64.30)
+    - React-jsi (= 0.64.30)
+    - React-perflogger (= 0.64.30)
+  - ReactTestApp-DevSupport (1.3.6):
     - React-Core
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
@@ -487,45 +487,45 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost-for-react-native: d5ad1140010aa8cb622323a781ecbeab4425d19a
   DoubleConversion: 0ea4559a49682230337df966e735d6cc7760108e
-  FBLazyVector: 829631c3f7fe7e9a8177011898ecd324f2ceeb4a
-  FBReactNativeSpec: 4de01e4efb3b170c85f000696514071b3748a222
-  FRNAvatar: 6d619c9cfaff54cbce08c064c582229fff9678c3
-  FRNCallout: 6621cadadd5f342db37ce4c219d1bfc702df8413
-  FRNCheckbox: f2ca924e1d4f833475d17ad0e6d100bc98ff8f82
-  FRNMenuButton: 60f6cbda6975e3c8556655586da22be92f230fc7
-  FRNRadioButton: ad1db52c48c37c72454b08029ae564fa8f4bea56
+  FBLazyVector: 8a96f324df8c1bc4e2f7e2163d704ec364f0bc6c
+  FBReactNativeSpec: 52bfb636413dc06cf5a57b63f60ef41b5dd9f8c6
+  FRNAvatar: b07d7b17a456112b838d785b602c204a86387221
+  FRNCallout: d872c7ba99c8ffcbbc6f61a930c30f79aef5668a
+  FRNCheckbox: 99e42ac1a8b7c42e449f10ae9e6778dd2a0f04f2
+  FRNMenuButton: 463b050240bfd7cf0efc64b55f56ce03dc800d3f
+  FRNRadioButton: 2452fff884c7608e644bbf14bcc561b71f8f78f5
   glog: 0dc7efada961c0793012970b60faebbd58b0decb
   MicrosoftFluentUI: b98d877a2122804132365aa167944f58ef4adb69
   RCT-Folly: b3998425a8ee9f695f57a204dc494534246f0fe9
-  RCTFocusZone: b03631501bd89d3b264ae4ef56ab4f70c9a2d731
-  RCTRequired: 4faed4f4e7677ee3608201a95f85505a828f5a37
-  RCTTypeSafety: 52197108479b90693ad1b58d27295c81e2dd151f
-  React: cce411cee511f86ba6819bd7e14419488e5ca8f2
-  React-callinvoker: 08e100f6304c974875efae9595cc7ee515c3cfa8
-  React-Core: 75a41506df9ca07dc701af1f55d50d4318061c97
-  React-CoreModules: 8691f242ef6dab56cc4ed851933039d274d6f048
-  React-cxxreact: 8d628163b27f24533f9b23d0fc0eb0bc9913214b
-  React-jsi: 31ed10746c36748368372cb289a66e6d7a0902a5
-  React-jsiexecutor: d1790edb4148fb29d17d826d982c8a108a003a08
-  React-jsinspector: f69021291833f1cd7faa0a7e9864faba31adb5a0
-  React-perflogger: 824957ddfc695e682fa516837fa9a2fea779ef80
-  React-RCTActionSheet: 8d376c9d63077ead01cf2b72cf03f9e89f2eec3a
-  React-RCTAnimation: d73e1c0a2556cb797dfd864391a52051467a10c7
-  React-RCTBlob: a40ce305d2f7cbede63e173eb4e9ec594ae5f1ba
-  React-RCTImage: cc89f18edff9ee347dd119f87e50a5ba199b1d33
-  React-RCTLinking: b184b56b3a6e2ce811b8a267f53be6c67d8b6ae1
-  React-RCTNetwork: 868a7fe83f70eafe93cd4d4e30562a9823504bef
-  React-RCTSettings: f5bb95ffd953bccfbc2383b2175dd31fbe2c7395
-  React-RCTText: 9944b6e9a906596e67b174eab8d6f9078010f705
-  React-RCTVibration: 8306ee340eaec9de278d6746f4d3b22ea21d973e
-  React-runtimeexecutor: c613c28c921a1d8409c6ecd215b20f56319a7482
-  ReactCommon: 2bd9e562df8a08ad11c933450ac30a1ff8a1e922
-  ReactTestApp-DevSupport: 12b1db9658a28f0f13272d7e4d68d2439130dd93
+  RCTFocusZone: 6d93f2727b66840b0446c1cc4edf47e7fb8ecf10
+  RCTRequired: 8903667b081ec6b4b870c6b25ff1038eef62db0d
+  RCTTypeSafety: 061b065a52bcd68ca38755bc56784a4889659625
+  React: a3c80fce87768d4553ebe658746219431483b620
+  React-callinvoker: 9700f10472bbe91aec1fd1aecdbaf20c79c416eb
+  React-Core: 5b76e8f9f31298918d937c8b991ca76b9c60bc0b
+  React-CoreModules: 52f7694f8b8b95eab784795252611798fdae0db0
+  React-cxxreact: 11ca86ce6b6f974bf45d0aef9a4eb2ce1b709856
+  React-jsi: 760affd655f33e7ba1d241ba3bc9d52cb7a77995
+  React-jsiexecutor: e6fabffa8a04b7c6a6c109ee2ba04296c83b1e62
+  React-jsinspector: 0abcd8b7f0a3729aac619e882bfc4cc2fe21b3d0
+  React-perflogger: f89af03aacb08a0743a674dc399d72f56a30c7dd
+  React-RCTActionSheet: 06978e883c6bcc34b8b593f5592cc52c369597f3
+  React-RCTAnimation: 6da3c1909bd89bdb6c0501d69e8956671805ead5
+  React-RCTBlob: 07d15c05b915f184e0425d86b482e492670e9ebc
+  React-RCTImage: 893f79f8c0ab69abf302b93b6c7925b1f6433505
+  React-RCTLinking: 9d6048af5ff49314663e353838f7471a966d9579
+  React-RCTNetwork: 4857c35ed55c577adaf7a8b8498af1320b056c9c
+  React-RCTSettings: 9a237b3f39f6c1cc1c66275f760d80f3dd180ef9
+  React-RCTText: a65d9088fc0073af243745c5157ca32b270a8fb1
+  React-RCTVibration: 42a79e144eb66f2f1baa0d361c68d1e977046861
+  React-runtimeexecutor: f151eec4a900bddc9f127df64a66a01275d3acf8
+  ReactCommon: 0665778a9e30416d3bff636251a34d1e93ee59af
+  ReactTestApp-DevSupport: 01831bc572cff28e1ca4b54f32215e8f9f54bb29
   ReactTestApp-Resources: 320923a3635f7bf90caa1a28fd29765b577888d9
   RNCPicker: 6d5d64e7b90c240c779ee0938ec433c11e2dd758
   RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8
   SwiftLint: 6bc52a21f0fd44cab9aa2dc8e534fb9f5e3ec507
-  Yoga: 605bc07f11a1701de74216328100e35ebc282441
+  Yoga: 1ea22d438a06b78c080c477ecadd4eae4c4907f4
 
 PODFILE CHECKSUM: 568704fb95966cf7ad6daa54a1d36eb2d5c3bba6
 

--- a/change/@fluentui-react-native-focus-zone-2cf3c1a3-b647-44af-8ff9-a7c3066ac0b6.json
+++ b/change/@fluentui-react-native-focus-zone-2cf3c1a3-b647-44af-8ff9-a7c3066ac0b6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add support for nested focus zones",
+  "packageName": "@fluentui-react-native/focus-zone",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-0f1ae3b6-93fd-4d99-ad0b-0d3caed8381d.json
+++ b/change/@fluentui-react-native-tester-0f1ae3b6-93fd-4d99-ad0b-0d3caed8381d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add support for nested focus zones",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Let's say we have a FocusZone that contains many child FocusZones. An example might be a list of cards, where the list is a FocusZone, and each card is a FocusZone. In that scenario, if focus is on an element in an _inner_ FocusZone and we press Tab, we want Focus to move out of the parent, and onto the next element outside the parent FocusZone (aka, the next focusable element outside our list of cards).

As implemented right now, pressing tab would ignore that we might be a nested FocusZone, and put focus on the next card, which itself is inside the parent focus zone.  This is a little hard to describe, so see the demo videos.

### Verification

I added a test to the "Focus Zone edge cases" section of our FocusZone test page that should illustrate it well. 

Before:
Bad, pressing tab in Inner FocusZone 1 moved focus to Inner FocusZone2

https://user-images.githubusercontent.com/6722175/162550912-782bce7d-cd78-426c-88b9-02ea75825c45.mov



After:
Good, Pressing Tab and Shift+Tab while inside any Inner FocusZone moved Focus out of the parent FocusZone.

https://user-images.githubusercontent.com/6722175/162550909-9db7bead-b61f-4c10-9580-44a04d912873.mov



### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
