### PR TITLE
Fix asserts in FURN tester for Icon and SVG

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/Icon/IconTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Icon/IconTest.tsx
@@ -53,6 +53,7 @@ const Icons: React.FunctionComponent = () => {
   const showFontIcons = true;
   const showSvgIcons = true;
   const showRasterIcons = true;
+  const shouldShowDataUri = Platform.OS !== 'android' && Platform.OS !== ('win32' as any);
 
   return (
     <View>
@@ -63,7 +64,7 @@ const Icons: React.FunctionComponent = () => {
             // We've seen some issues getting Font Awesome to link properly on Apple platforms in the FURN test app specifically.
             // This shouldn't be an issue in other apps, though, so keeping this icon Windows-only for now is an easy workaround.
             // When Android support comes, the platform check can be adjusted accordingly.
-            Platform.OS == 'windows' ? <Icon fontSource={fontCustomFontProps} width={100} height={100} color="purple" /> : null
+            Platform.OS === 'windows' ? <Icon fontSource={fontCustomFontProps} width={100} height={100} color="purple" /> : null
           }
           <Icon fontSource={fontBuiltInProps} width={100} height={100} color="#060" />
         </View>
@@ -74,7 +75,7 @@ const Icons: React.FunctionComponent = () => {
           <Icon svgSource={svgProps} width={100} height={100} color="orange" />
           {
             // TODO: Causes TypeError: Network request failed on Android
-            Platform.OS == 'android' ? null : <Icon svgSource={svgD20DataUriProps} width={100} height={100} color="#7a7" />
+            shouldShowDataUri ? <Icon svgSource={svgD20DataUriProps} width={100} height={100} color="#7a7" /> : null
           }
           <Icon svgSource={svgUriProps} width={100} height={100} color="red" />
         </View>

--- a/apps/fluent-tester/src/FluentTester/TestComponents/Svg/SvgTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Svg/SvgTest.tsx
@@ -119,7 +119,7 @@ const BundledSvgTest: React.FunctionComponent = () => {
 };
 
 const RemoteSvgTest: React.FunctionComponent = () => {
-  // Temporarily stop testing this case until it can be either more robust or removed
+  // GH#1596: Temporarily stop testing this case until it can be either more robust or removed
   const shouldShowLocalNetwork = false;
 
   return (

--- a/apps/fluent-tester/src/FluentTester/TestComponents/Svg/SvgTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Svg/SvgTest.tsx
@@ -17,6 +17,7 @@ const RectTest: React.FunctionComponent = () => {
   const [useColorA, setUseColorA] = React.useState(false);
   const colorA = 'red';
   const colorB = 'green';
+
   return (
     <React.Fragment>
       <View style={{ flexDirection: 'row', alignItems: 'center' }}>
@@ -118,6 +119,9 @@ const BundledSvgTest: React.FunctionComponent = () => {
 };
 
 const RemoteSvgTest: React.FunctionComponent = () => {
+  // Temporarily stop testing this case until it can be either more robust or removed
+  const shouldShowLocalNetwork = false;
+
   return (
     <View>
       <SvgCssUri
@@ -127,15 +131,17 @@ const RemoteSvgTest: React.FunctionComponent = () => {
         height="100"
         uri="https://upload.wikimedia.org/wikipedia/commons/8/84/Example.svg"
       />
-      <SvgCssUri
-        x="50"
-        y="50"
-        viewBox="0 0 500 500"
-        style={styles.svg}
-        width="100"
-        height="100"
-        uri="http://10.122.222.112:8080/accessible-icon-brands.svg"
-      />
+      {shouldShowLocalNetwork && (
+        <SvgCssUri
+          x="50"
+          y="50"
+          viewBox="0 0 500 500"
+          style={styles.svg}
+          width="100"
+          height="100"
+          uri="http://10.122.222.112:8080/accessible-icon-brands.svg"
+        />
+      )}
     </View>
   );
 };

--- a/apps/win32/wdio.conf.js
+++ b/apps/win32/wdio.conf.js
@@ -12,7 +12,7 @@ const jasmineDefaultTimeout = 45000; // 45 seconds for Jasmine test timeout
 exports.config = {
   runner: 'local', // Where should your test be launched
   specs: ['../fluent-tester/src/E2E/**/specs/*.win.ts'],
-  exclude: ['../fluent-tester/src/E2E/Shimmer/specs/*.win.ts', '../fluent-tester/src/E2E/Icon/specs/*.win.ts'],
+  exclude: ['../fluent-tester/src/E2E/Shimmer/specs/*.win.ts'],
 
   maxInstances: 30,
   capabilities: [

--- a/change/@fluentui-react-native-tester-ef444ac2-47de-4bde-87d9-1e38906e9aca.json
+++ b/change/@fluentui-react-native-tester-ef444ac2-47de-4bde-87d9-1e38906e9aca.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix asserting tests",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-win32-5f3ac323-0980-4c56-9275-f812f83bf5b5.json
+++ b/change/@fluentui-react-native-tester-win32-5f3ac323-0980-4c56-9275-f812f83bf5b5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Run Icon test",
+  "packageName": "@fluentui-react-native/tester-win32",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

The Icon and SVG test pages show asserts. This change prevents those components from being rendered (either on win32 or at all). I'm following up with @warren-ms on whether they should be fixed or deleted.

This PR also reenables the icon E2E tests

### Verification

CI

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
