### PR TITLE
Disable hovered visuals on loading buttons

### DIFF
--- a/change/@fluentui-react-native-button-651b581f-3500-4153-b8de-55c7453e8e33.json
+++ b/change/@fluentui-react-native-button-651b581f-3500-4153-b8de-55c7453e8e33.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Disable hovered visuals on loading buttons",
+  "packageName": "@fluentui-react-native/button",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-interactive-hooks-3bea016d-93bf-4230-854a-ff7174b8787b.json
+++ b/change/@fluentui-react-native-interactive-hooks-3bea016d-93bf-4230-854a-ff7174b8787b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Disable hovered visuals on loading buttons",
+  "packageName": "@fluentui-react-native/interactive-hooks",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Button/src/Button.tsx
+++ b/packages/components/Button/src/Button.tsx
@@ -27,6 +27,7 @@ export const buttonLookup = (layer: string, state: IPressableState, userProps: B
     (!userProps['size'] && layer === getDefaultSize()) ||
     layer === userProps['shape'] ||
     (!userProps['shape'] && layer === 'rounded') ||
+    (layer === 'hovered' && state[layer] && !userProps.loading) ||
     (layer === 'hasContent' && !userProps.iconOnly) ||
     (layer === 'hasIconAfter' && (userProps.icon || userProps.loading) && userProps.iconPosition === 'after') ||
     (layer === 'hasIconBefore' && (userProps.icon || userProps.loading) && (!userProps.iconPosition || userProps.iconPosition === 'before'))

--- a/packages/utils/interactive-hooks/src/Pressability/Pressability.ts
+++ b/packages/utils/interactive-hooks/src/Pressability/Pressability.ts
@@ -395,8 +395,7 @@ export class Pressability {
         ? null
         : {
             onMouseEnter: (event: MouseEvent): void => {
-              const { disabled } = this._config;
-              if (!disabled && isHoverEnabled()) {
+              if (isHoverEnabled()) {
                 this._isHovered = true;
                 this._cancelHoverOutDelayTimeout();
                 const { onHoverIn } = this._config;


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

Follow up to #1587. Updating Button to not have hovered visual state when loading prop is set.
Undoing change to Pressibility done, as well.

### Verification

Tested with native local changes on the Button test page.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
