### PR TITLE
Windows tester fixes

### DIFF
--- a/apps/fluent-tester/src/FluentTester/FluentTester.tsx
+++ b/apps/fluent-tester/src/FluentTester/FluentTester.tsx
@@ -1,7 +1,6 @@
 import { Theme } from '@fluentui-react-native/framework';
-import { FocusTrapZone, Separator } from '@fluentui/react-native';
+import { FocusTrapZone, Separator, Text } from '@fluentui/react-native';
 import { Button } from '@fluentui-react-native/experimental-button';
-import { Text } from '@fluentui-react-native/experimental-text';
 import { themedStyleSheet } from '@fluentui-react-native/themed-stylesheet';
 import * as React from 'react';
 import { ScrollView, View, Text as RNText, Platform, SafeAreaView, BackHandler } from 'react-native';

--- a/apps/fluent-tester/src/FluentTester/TestComponents/Badge/BadgeTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Badge/BadgeTest.tsx
@@ -57,10 +57,10 @@ export const BasicBadge: React.FunctionComponent = () => {
           <Badge icon={{ fontSource: { ...fontBuiltInProps }, color: '#fff' }} />
           <Text>Badge with icon and text</Text>
           <Badge appearance="outline" icon={iconProps} />
+          <Text>Customized Badge</Text>
+          <BadgeNoBorder appearance="outline" icon={iconProps} />
         </>
       )}
-      <Text>Customized Badge</Text>
-      <BadgeNoBorder appearance="outline" icon={iconProps} />
       <StyledBadge appearance="outline" text="styled badge" />
       <Text>Compressible badge</Text>
       <CompressibleBadge />

--- a/apps/fluent-tester/src/FluentTester/testPages.windows.ts
+++ b/apps/fluent-tester/src/FluentTester/testPages.windows.ts
@@ -13,7 +13,6 @@ import { HOMEPAGE_THEME_BUTTON, ThemeTest } from './TestComponents/Theme';
 import { HOMEPAGE_TABS_BUTTON, TabsTest } from './TestComponents/Tabs';
 import { HOMEPAGE_EXPERIMENTAL_TABS_BUTTON, ExperimentalTabsTest } from './TestComponents/TabsExperimental';
 import { HOMEPAGE_TOKEN_BUTTON, TokenTest } from './TestComponents/Tokens';
-import { ExpanderTest, HOMEPAGE_EXPANDER_BUTTON } from './TestComponents/Expander';
 import { HOMEPAGE_EXPERIMENTAL_TEXT_BUTTON, TextExperimentalTest } from './TestComponents/TextExperimental';
 import { ActivityIndicatorTest, HOMEPAGE_ACTIVITY_INDICATOR_BUTTON } from './TestComponents/ActivityIndicator';
 
@@ -92,9 +91,10 @@ export const tests = [
     component: TokenTest,
     testPage: HOMEPAGE_TOKEN_BUTTON,
   },
-  {
-    name: 'Expander Test',
-    component: ExpanderTest,
-    testPage: HOMEPAGE_EXPANDER_BUTTON,
-  },
+  // GH##1027 Temporarily disabling while the test doesn't load
+  // {
+  //   name: 'Expander Test',
+  //   component: ExpanderTest,
+  //   testPage: HOMEPAGE_EXPANDER_BUTTON,
+  // },
 ];

--- a/change/@fluentui-react-native-tester-c98b6113-2fde-4ae7-a5d6-7de2f669f98e.json
+++ b/change/@fluentui-react-native-tester-c98b6113-2fde-4ae7-a5d6-7de2f669f98e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix some errors",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [x] windows
- [ ] android

### Description of changes

Making some fixes for the windows tester:

- Revert Text from experimental to the old Text to reduce the errors that show up when you click a test page
- Remove Expander test since it doesn't work
- Fix the Badge test

### Verification

Booted windows tester

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
