### PR TITLE
Add new packages for Menu and Popover

### DIFF
--- a/change/@fluentui-react-native-menu-e9988512-70e4-481e-9b76-fe8e90e1c620.json
+++ b/change/@fluentui-react-native-menu-e9988512-70e4-481e-9b76-fe8e90e1c620.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add empty Menu and Popover packages",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-popover-9148688c-1663-4387-8370-2438ab5044f2.json
+++ b/change/@fluentui-react-native-popover-9148688c-1663-4387-8370-2438ab5044f2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add empty Menu and Popover packages",
+  "packageName": "@fluentui-react-native/popover",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Menu/.eslintrc.js
+++ b/packages/experimental/Menu/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/experimental/Menu/babel.config.js
+++ b/packages/experimental/Menu/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/experimental/Menu/just.config.js
+++ b/packages/experimental/Menu/just.config.js
@@ -1,0 +1,3 @@
+const { preset } = require('@fluentui-react-native/scripts');
+
+preset();

--- a/packages/experimental/Menu/package.json
+++ b/packages/experimental/Menu/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@fluentui-react-native/menu",
+  "version": "0.1.0",
+  "description": "A cross-platform Menu component using the Fluent Design System",
+  "main": "src/index.ts",
+  "module": "src/index.ts",
+  "typings": "lib/index.d.ts",
+  "onPublish": {
+    "main": "lib-commonjs/index.js",
+    "module": "lib/index.js"
+  },
+  "scripts": {
+    "build": "fluentui-scripts build",
+    "clean": "fluentui-scripts clean",
+    "depcheck": "fluentui-scripts depcheck",
+    "just": "fluentui-scripts",
+    "lint": "fluentui-scripts eslint",
+    "test": "fluentui-scripts jest",
+    "update-snapshots": "fluentui-scripts jest -u",
+    "prettier": "fluentui-scripts prettier",
+    "prettier-fix": "fluentui-scripts prettier --fix true"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/fluentui-react-native.git",
+    "directory": "packages/experimental/menu"
+  },
+  "dependencies": {
+    "@fluentui-react-native/adapters": ">=0.8.5 <1.0.0",
+    "@fluentui-react-native/framework": "0.7.22",
+    "tslib": "^2.3.1"
+  },
+  "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
+    "@types/react-native": "^0.64.0",
+    "react-native": "^0.64.3"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.1",
+    "react-native": ">=0.64.3"
+  },
+  "author": "",
+  "license": "MIT"
+}

--- a/packages/experimental/Menu/package.json
+++ b/packages/experimental/Menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/menu",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "A cross-platform Menu component using the Fluent Design System",
   "main": "src/index.ts",
   "module": "src/index.ts",

--- a/packages/experimental/Menu/src/Menu.tsx
+++ b/packages/experimental/Menu/src/Menu.tsx
@@ -1,15 +1,14 @@
 /** @jsx withSlots */
-import { menuName, MenuType } from './Menu.types';
-import { compose } from '@fluentui-react-native/framework';
+import { menuName, MenuProps, MenuTokens } from './Menu.types';
+import { compressible, buildUseTokens, UseTokens } from '@fluentui-react-native/framework';
 
-export const Menu = compose<MenuType>({
-  displayName: menuName,
-  slots: {},
-  useRender: () => {
-    return () => {
-      return null;
-    };
-  },
-});
+const useMenuTokens = buildUseTokens<MenuTokens>(() => ({}), menuName);
+
+export const Menu = compressible<MenuProps, MenuTokens>((_props: MenuProps, _useTokens: UseTokens<MenuTokens>) => {
+  return () => {
+    return null;
+  };
+}, useMenuTokens);
+Menu.displayName = menuName;
 
 export default Menu;

--- a/packages/experimental/Menu/src/Menu.tsx
+++ b/packages/experimental/Menu/src/Menu.tsx
@@ -1,0 +1,15 @@
+/** @jsx withSlots */
+import { menuName, MenuType } from './Menu.types';
+import { compose } from '@fluentui-react-native/framework';
+
+export const Menu = compose<MenuType>({
+  displayName: menuName,
+  slots: {},
+  useRender: () => {
+    return () => {
+      return null;
+    };
+  },
+});
+
+export default Menu;

--- a/packages/experimental/Menu/src/Menu.types.ts
+++ b/packages/experimental/Menu/src/Menu.types.ts
@@ -1,0 +1,18 @@
+import type { IViewProps } from '@fluentui-react-native/adapters';
+
+export const menuName = 'Menu';
+
+export interface MenuTokens {}
+
+export interface MenuProps extends Omit<IViewProps, 'onPress'> {}
+
+export interface MenuState {}
+
+export interface MenuSlotProps {}
+
+export interface MenuType {
+  props: MenuProps;
+  tokens: MenuTokens;
+  slotProps: MenuSlotProps;
+  state: MenuState;
+}

--- a/packages/experimental/Menu/src/index.ts
+++ b/packages/experimental/Menu/src/index.ts
@@ -1,0 +1,1 @@
+export { Menu } from './Menu';

--- a/packages/experimental/Menu/tsconfig.json
+++ b/packages/experimental/Menu/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
+  "compilerOptions": {
+    "importHelpers": true,
+    "outDir": "lib",
+    "types": ["node", "jest"]
+  },
+  "include": ["src"]
+}

--- a/packages/experimental/Popover/.eslintrc.js
+++ b/packages/experimental/Popover/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/experimental/Popover/babel.config.js
+++ b/packages/experimental/Popover/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/experimental/Popover/just.config.js
+++ b/packages/experimental/Popover/just.config.js
@@ -1,0 +1,3 @@
+const { preset } = require('@fluentui-react-native/scripts');
+
+preset();

--- a/packages/experimental/Popover/package.json
+++ b/packages/experimental/Popover/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@fluentui-react-native/popover",
+  "version": "0.1.0",
+  "description": "A cross-platform Popover component using the Fluent Design System",
+  "main": "src/index.ts",
+  "module": "src/index.ts",
+  "typings": "lib/index.d.ts",
+  "onPublish": {
+    "main": "lib-commonjs/index.js",
+    "module": "lib/index.js"
+  },
+  "scripts": {
+    "build": "fluentui-scripts build",
+    "clean": "fluentui-scripts clean",
+    "depcheck": "fluentui-scripts depcheck",
+    "just": "fluentui-scripts",
+    "lint": "fluentui-scripts eslint",
+    "test": "fluentui-scripts jest",
+    "update-snapshots": "fluentui-scripts jest -u",
+    "prettier": "fluentui-scripts prettier",
+    "prettier-fix": "fluentui-scripts prettier --fix true"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/fluentui-react-native.git",
+    "directory": "packages/experimental/popover"
+  },
+  "dependencies": {
+    "@fluentui-react-native/adapters": ">=0.8.5 <1.0.0",
+    "@fluentui-react-native/framework": "0.7.22",
+    "tslib": "^2.3.1"
+  },
+  "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
+    "@types/react-native": "^0.64.0",
+    "react-native": "^0.64.3"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.1",
+    "react-native": ">=0.64.3"
+  },
+  "author": "",
+  "license": "MIT"
+}

--- a/packages/experimental/Popover/package.json
+++ b/packages/experimental/Popover/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/popover",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "A cross-platform Popover component using the Fluent Design System",
   "main": "src/index.ts",
   "module": "src/index.ts",

--- a/packages/experimental/Popover/src/Popover.tsx
+++ b/packages/experimental/Popover/src/Popover.tsx
@@ -1,0 +1,15 @@
+/** @jsx withSlots */
+import { popoverName, PopoverType } from './Popover.types';
+import { compose } from '@fluentui-react-native/framework';
+
+export const Popover = compose<PopoverType>({
+  displayName: popoverName,
+  slots: {},
+  useRender: () => {
+    return () => {
+      return null;
+    };
+  },
+});
+
+export default Popover;

--- a/packages/experimental/Popover/src/Popover.tsx
+++ b/packages/experimental/Popover/src/Popover.tsx
@@ -1,15 +1,14 @@
 /** @jsx withSlots */
-import { popoverName, PopoverType } from './Popover.types';
-import { compose } from '@fluentui-react-native/framework';
+import { popoverName, PopoverProps, PopoverTokens } from './Popover.types';
+import { compressible, buildUseTokens, UseTokens } from '@fluentui-react-native/framework';
 
-export const Popover = compose<PopoverType>({
-  displayName: popoverName,
-  slots: {},
-  useRender: () => {
-    return () => {
-      return null;
-    };
-  },
-});
+const usePopoverTokens = buildUseTokens<PopoverTokens>(() => ({}), popoverName);
+
+export const Popover = compressible<PopoverProps, PopoverTokens>((_props: PopoverProps, _useTokens: UseTokens<PopoverTokens>) => {
+  return () => {
+    return null;
+  };
+}, usePopoverTokens);
+Popover.displayName = popoverName;
 
 export default Popover;

--- a/packages/experimental/Popover/src/Popover.types.ts
+++ b/packages/experimental/Popover/src/Popover.types.ts
@@ -1,0 +1,18 @@
+import type { IViewProps } from '@fluentui-react-native/adapters';
+
+export const popoverName = 'Popover';
+
+export interface PopoverTokens {}
+
+export interface PopoverProps extends Omit<IViewProps, 'onPress'> {}
+
+export interface PopoverState {}
+
+export interface PopoverSlotProps {}
+
+export interface PopoverType {
+  props: PopoverProps;
+  tokens: PopoverTokens;
+  slotProps: PopoverSlotProps;
+  state: PopoverState;
+}

--- a/packages/experimental/Popover/src/index.ts
+++ b/packages/experimental/Popover/src/index.ts
@@ -1,0 +1,1 @@
+export { Popover } from './Popover';

--- a/packages/experimental/Popover/tsconfig.json
+++ b/packages/experimental/Popover/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
+  "compilerOptions": {
+    "importHelpers": true,
+    "outDir": "lib",
+    "types": ["node", "jest"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Adding empty components for Menu and Popover in the experimental folder to lay groundwork for the new components.

### Verification

Build passes

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
