### PR TITLE
Implement target behavior for Menu

### DIFF
--- a/apps/fluent-tester/src/FluentTester/testPages.macos.ts
+++ b/apps/fluent-tester/src/FluentTester/testPages.macos.ts
@@ -25,6 +25,7 @@ import { HOMEPAGE_EXPERIMENTAL_TABS_BUTTON, ExperimentalTabsTest } from './TestC
 import { HOMEPAGE_EXPERIMENTAL_TEXT_BUTTON, TextExperimentalTest } from './TestComponents/TextExperimental';
 import { ExperimentalMenuButtonTest, HOMEPAGE_EXPERIMENTAL_MENU_BUTTON } from './TestComponents/MenuButtonExperimental';
 import { ActivityIndicatorTest, HOMEPAGE_ACTIVITY_INDICATOR_BUTTON } from './TestComponents/ActivityIndicator';
+import { HOMEPAGE_MENU_BUTTON, MenuTest } from './TestComponents/Menu';
 
 export const tests: TestDescription[] = [
   {
@@ -96,6 +97,11 @@ export const tests: TestDescription[] = [
     name: 'Link Test',
     component: LinkTest,
     testPage: HOMEPAGE_LINK_BUTTON,
+  },
+  {
+    name: 'Menu Test',
+    component: MenuTest,
+    testPage: HOMEPAGE_MENU_BUTTON,
   },
   {
     name: 'MenuButton Test',

--- a/change/@fluentui-react-native-menu-73c93440-5bf7-4d4d-8624-e261b190ba0c.json
+++ b/change/@fluentui-react-native-menu-73c93440-5bf7-4d4d-8624-e261b190ba0c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Implement target behavior",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-bb504533-3afb-480e-afb5-121b628a1e0d.json
+++ b/change/@fluentui-react-native-tester-bb504533-3afb-480e-afb5-121b628a1e0d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add Menu to MacOS test page",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Menu/src/Menu/Menu.tsx
+++ b/packages/experimental/Menu/src/Menu/Menu.tsx
@@ -13,7 +13,7 @@ export const Menu = stagedComponent((props: MenuProps) => {
     const childrenArray = React.Children.toArray(children) as React.ReactElement[];
 
     if (__DEV__) {
-      if (childrenArray.length === 2) {
+      if (childrenArray.length !== 2) {
         // eslint-disable-next-line no-console
         console.warn('Menu must contain two children');
       }

--- a/packages/experimental/Menu/src/Menu/Menu.types.ts
+++ b/packages/experimental/Menu/src/Menu/Menu.types.ts
@@ -1,4 +1,5 @@
 import type { IViewProps } from '@fluentui-react-native/adapters';
+import React from 'react';
 
 export const menuName = 'Menu';
 
@@ -8,4 +9,5 @@ export interface MenuProps extends Omit<IViewProps, 'onPress'> {
 
 export interface MenuState extends MenuProps {
   setOpen: (isOpen: boolean) => void;
+  triggerRef: React.RefObject<React.Component>;
 }

--- a/packages/experimental/Menu/src/Menu/useMenu.ts
+++ b/packages/experimental/Menu/src/Menu/useMenu.ts
@@ -3,10 +3,12 @@ import { MenuProps, MenuState } from './Menu.types';
 
 export const useMenu = (props: MenuProps): MenuState => {
   const [open, setOpen] = useMenuOpenState(props);
+  const triggerRef = React.useRef(null);
 
   return {
     open,
     setOpen,
+    triggerRef,
   };
 };
 

--- a/packages/experimental/Menu/src/Menu/useMenuContextValue.ts
+++ b/packages/experimental/Menu/src/Menu/useMenuContextValue.ts
@@ -2,5 +2,5 @@ import { MenuContextValue } from '../context/menuContext';
 import { MenuState } from './Menu.types';
 
 export const useMenuContextValue = (state: MenuState): MenuContextValue => {
-  return { open: state.open, setOpen: state.setOpen };
+  return { open: state.open, setOpen: state.setOpen, triggerRef: state.triggerRef };
 };

--- a/packages/experimental/Menu/src/MenuPopover/MenuPopover.tsx
+++ b/packages/experimental/Menu/src/MenuPopover/MenuPopover.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { stagedComponent } from '@fluentui-react-native/framework';
 import { Callout } from '@fluentui-react-native/callout';
 import { menuPopoverName, MenuPopoverProps } from './MenuPopover.types';
-import { useMenuContext } from '../context/menuContext';
+import { useMenuPopover } from './useMenuPopover';
 
-export const MenuPopover = stagedComponent((_props: MenuPopoverProps) => {
-  const context = useMenuContext();
+export const MenuPopover = stagedComponent((props: MenuPopoverProps) => {
+  const state = useMenuPopover(props);
 
   return (_rest: MenuPopoverProps, children: React.ReactNode) => {
-    return context.open && <Callout>{children}</Callout>;
+    return <Callout target={state.triggerRef}>{children}</Callout>;
   };
 });
 MenuPopover.displayName = menuPopoverName;

--- a/packages/experimental/Menu/src/MenuPopover/MenuPopover.types.ts
+++ b/packages/experimental/Menu/src/MenuPopover/MenuPopover.types.ts
@@ -4,4 +4,6 @@ export const menuPopoverName = 'MenuPopover';
 
 export interface MenuPopoverProps extends Omit<IViewProps, 'onPress'> {}
 
-export interface MenuPopoverState {}
+export interface MenuPopoverState {
+  triggerRef: React.RefObject<React.Component>;
+}

--- a/packages/experimental/Menu/src/MenuPopover/useMenuPopover.ts
+++ b/packages/experimental/Menu/src/MenuPopover/useMenuPopover.ts
@@ -1,0 +1,10 @@
+import { useMenuContext } from '../context/menuContext';
+import { MenuPopoverProps, MenuPopoverState } from './MenuPopover.types';
+
+export const useMenuPopover = (_props: MenuPopoverProps): MenuPopoverState => {
+  const context = useMenuContext();
+
+  const triggerRef = context.triggerRef;
+
+  return { triggerRef };
+};

--- a/packages/experimental/Menu/src/MenuTrigger/useMenuTrigger.ts
+++ b/packages/experimental/Menu/src/MenuTrigger/useMenuTrigger.ts
@@ -7,10 +7,11 @@ export const useMenuTrigger = (_props: MenuTriggerProps) => {
 
   const setOpen = context.setOpen;
   const open = context.open;
+  const triggerRef = context.triggerRef;
 
   const onClick = (_e: InteractionEvent) => {
     setOpen(!open);
   };
 
-  return { onClick };
+  return { onClick, componentRef: triggerRef };
 };

--- a/packages/experimental/Menu/src/context/menuContext.ts
+++ b/packages/experimental/Menu/src/context/menuContext.ts
@@ -9,6 +9,7 @@ export type MenuContextValue = MenuState;
 export const MenuContext = React.createContext<MenuContextValue>({
   open: false,
   setOpen: () => false,
+  triggerRef: null,
 });
 
 export const MenuProvider = MenuContext.Provider;


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Adding target behavior to Menu. This change sets up setting a ref on the MenuTrigger and then using that ref as the target on the Callout in MenuPopover

### Verification

![menu_target](https://user-images.githubusercontent.com/4602628/164817828-06ed68e6-093d-4709-a8c4-f69a89565a19.gif)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
