### PR TITLE
ContextualMenu - Only show scrollbars if we specify maxHeight/maxWidth

### DIFF
--- a/apps/macos/src/Podfile.lock
+++ b/apps/macos/src/Podfile.lock
@@ -9,17 +9,17 @@ PODS:
     - React-Core (= 0.64.30)
     - React-jsi (= 0.64.30)
     - ReactCommon/turbomodule/core (= 0.64.30)
-  - FRNAvatar (0.14.12):
+  - FRNAvatar (0.14.15):
     - MicrosoftFluentUI (= 0.3.0)
     - MicrosoftFluentUI/Avatar_ios (= 0.3.0)
     - React
-  - FRNCallout (0.19.39):
+  - FRNCallout (0.19.43):
     - React
-  - FRNCheckbox (0.10.11):
+  - FRNCheckbox (0.10.16):
     - React
-  - FRNMenuButton (0.7.49):
+  - FRNMenuButton (0.7.55):
     - React
-  - FRNRadioButton (0.14.37):
+  - FRNRadioButton (0.14.42):
     - React
   - glog (0.3.5)
   - MicrosoftFluentUI (0.3.0):
@@ -94,7 +94,7 @@ PODS:
     - boost-for-react-native
     - DoubleConversion
     - glog
-  - RCTFocusZone (0.9.17):
+  - RCTFocusZone (0.9.22):
     - React
   - RCTRequired (0.64.30)
   - RCTTypeSafety (0.64.30):
@@ -344,11 +344,11 @@ PODS:
     - React-cxxreact (= 0.64.30)
     - React-jsi (= 0.64.30)
     - React-perflogger (= 0.64.30)
-  - ReactTestApp-DevSupport (1.3.6):
+  - ReactTestApp-DevSupport (1.3.7):
     - React-Core
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
-  - RNCPicker (2.4.0):
+  - RNCPicker (2.4.1):
     - React-Core
   - RNSVG (12.3.0):
     - React-Core
@@ -489,15 +489,15 @@ SPEC CHECKSUMS:
   DoubleConversion: 0ea4559a49682230337df966e735d6cc7760108e
   FBLazyVector: 8a96f324df8c1bc4e2f7e2163d704ec364f0bc6c
   FBReactNativeSpec: 52bfb636413dc06cf5a57b63f60ef41b5dd9f8c6
-  FRNAvatar: 39533725b0070c27460bace57391f2daf85680bb
-  FRNCallout: 3bc6c0d8a8df47054fbe9e84a21180c3153e0214
-  FRNCheckbox: 8e4115b57fd90b3595a61b03bc5fd5932c212923
-  FRNMenuButton: a6265ff9898da3d80ee5e761f51432139febd8df
-  FRNRadioButton: 28ef3c2ca4f460f37dfb155845160f4cdcdbd54d
+  FRNAvatar: c2ad92e454278c4ecff55e705224eb1368e8ddda
+  FRNCallout: c6a13a3e22b95d0c0db395e8f9eb75e484b59b0c
+  FRNCheckbox: fee69e9e776074b8337578984f620a5081ff1a19
+  FRNMenuButton: 97bda376b4af6780a01094195e4efe44fce3e0a2
+  FRNRadioButton: 47ab47b5c340c970d66c9498d85802bd4c111eaf
   glog: 0dc7efada961c0793012970b60faebbd58b0decb
   MicrosoftFluentUI: b98d877a2122804132365aa167944f58ef4adb69
   RCT-Folly: b3998425a8ee9f695f57a204dc494534246f0fe9
-  RCTFocusZone: 4b693eb7a64661325e9045e3d1f211befdc8e961
+  RCTFocusZone: 85fe6e7e4f5fa510df280ee975a0be08fb7edee1
   RCTRequired: 8903667b081ec6b4b870c6b25ff1038eef62db0d
   RCTTypeSafety: 061b065a52bcd68ca38755bc56784a4889659625
   React: a3c80fce87768d4553ebe658746219431483b620
@@ -520,9 +520,9 @@ SPEC CHECKSUMS:
   React-RCTVibration: 42a79e144eb66f2f1baa0d361c68d1e977046861
   React-runtimeexecutor: f151eec4a900bddc9f127df64a66a01275d3acf8
   ReactCommon: 0665778a9e30416d3bff636251a34d1e93ee59af
-  ReactTestApp-DevSupport: 01831bc572cff28e1ca4b54f32215e8f9f54bb29
+  ReactTestApp-DevSupport: 184027604fa0bff24e3467092ba799c2fc6be16f
   ReactTestApp-Resources: 320923a3635f7bf90caa1a28fd29765b577888d9
-  RNCPicker: 6d5d64e7b90c240c779ee0938ec433c11e2dd758
+  RNCPicker: abc646b53a3d28ccfa3232c927a0ca52e0cf024d
   RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8
   SwiftLint: 6bc52a21f0fd44cab9aa2dc8e534fb9f5e3ec507
   Yoga: 1ea22d438a06b78c080c477ecadd4eae4c4907f4

--- a/change/@fluentui-react-native-contextual-menu-c0553191-c5b8-4558-a6b8-0d9648927f3d.json
+++ b/change/@fluentui-react-native-contextual-menu-c0553191-c5b8-4558-a6b8-0d9648927f3d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Only show the scrollbars if we need them",
+  "packageName": "@fluentui-react-native/contextual-menu",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/ContextualMenu/src/ContextualMenu.tsx
+++ b/packages/components/ContextualMenu/src/ContextualMenu.tsx
@@ -89,7 +89,8 @@ export const ContextualMenu = compose<ContextualMenuType>({
           flexDirection: 'column',
           flexGrow: 1,
         },
-        showsVerticalScrollIndicator: true,
+        showsVerticalScrollIndicator: maxHeight != undefined,
+        showsHorizontalScrollIndicator: maxWidth != undefined,
       },
       focusZone: {
         enableFocusRing: false,

--- a/packages/components/ContextualMenu/src/Submenu.tsx
+++ b/packages/components/ContextualMenu/src/Submenu.tsx
@@ -103,7 +103,8 @@ export const Submenu = compose<SubmenuType>({
           flexDirection: 'column',
           flexGrow: 1,
         },
-        showsVerticalScrollIndicator: true,
+        showsVerticalScrollIndicator: maxHeight != undefined,
+        showsHorizontalScrollIndicator: maxWidth != undefined,
       },
       focusZone: {
         componentRef: focusZoneRef,

--- a/packages/components/ContextualMenu/src/__tests__/__snapshots__/ContextualMenu.test.tsx.snap
+++ b/packages/components/ContextualMenu/src/__tests__/__snapshots__/ContextualMenu.test.tsx.snap
@@ -34,7 +34,8 @@ exports[`ContextualMenu default props 1`] = `
           "flexGrow": 1,
         }
       }
-      showsVerticalScrollIndicator={true}
+      showsHorizontalScrollIndicator={false}
+      showsVerticalScrollIndicator={false}
     >
       <View />
     </RCTScrollView>


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Note: This PR requires https://github.com/microsoft/react-native-macos/pull/1135 to land and get back ported as a prerequisite

On macOS, there are 2 types of scrollbars that you can switch between in user preferences:
- Legacy: Scrollbars that appear at the trailing end of the content view in a dedicated space. 
- Overlay: iOS style scrollbars that are overlaid on top of the content view.

The former legacy style scrollbars add some margins to the scroll views' shadow view in order to account for the scroll bars. There is a race condition during layout of our ContextualMenu where the margins may show up even if we don't have a need for the scrollbars because all the content is visible. This was rather awkward, and a pretty big visual bug in ContextualMenu.

https://user-images.githubusercontent.com/6722175/165080842-e47d5364-a865-4267-8e82-e4e9127a3433.mov

We can fix this by telling ContextualMenu to only show scroll bars when we need them, AKA, when the user specified a maxHeight for vertical scrollbars, or maxWidth for horizontal scrollbars. 

### Verification

I tested a few different menus on our ContextualMenu test page, including one that wants a scrollbar and one that doesn't. Apart from that very last submenu, things seem to be laying out correctly. 

https://user-images.githubusercontent.com/6722175/165081373-b244bc1f-803c-433a-ab9d-78f7289bfa27.mov


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
