### PR TITLE
Avatar props

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/Avatar/BasicAvatar.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Avatar/BasicAvatar.tsx
@@ -4,11 +4,10 @@ import {
   AvatarSizes,
   AvatarColor,
   JSAvatar,
-  AvatarPresence,
   AvatarActive,
   AvatarActiveAppearance,
 } from '@fluentui-react-native/experimental-avatar';
-import { PresenceBadgeStatuses } from '@fluentui-react-native/badge';
+import { PresenceBadgeStatuses, PresenceBadgeStatus } from '@fluentui-react-native/badge';
 import { Switch, View, Text, Picker, ColorValue } from 'react-native';
 import { satyaPhotoUrl, undefinedText } from './../PersonaCoin/styles';
 import { commonTestStyles as commonStyles } from '../Common/styles';
@@ -46,7 +45,7 @@ const allColors: WithUndefined<AvatarColor>[] = [
   'brown',
 ];
 
-const allPresences: WithUndefined<AvatarPresence>[] = [undefinedText, ...PresenceBadgeStatuses];
+const allPresences: WithUndefined<PresenceBadgeStatus>[] = [undefinedText, ...PresenceBadgeStatuses];
 
 const StyledPicker = (props) => {
   const { prompt, selected, onChange, collection } = props;
@@ -69,7 +68,7 @@ export const StandardUsage: FunctionComponent = () => {
   const [activeAppearance, setActiveAppearance] = useState<AvatarActiveAppearance>('ring');
   const [imageSize, setImageSize] = useState<WithUndefined<AvatarSize>>('size72');
   const [coinColor, setCoinColor] = useState<WithUndefined<AvatarColor>>('brass');
-  const [presence, setPresence] = useState<WithUndefined<AvatarPresence>>('available');
+  const [presence, setPresence] = useState<WithUndefined<PresenceBadgeStatus>>('available');
 
   const onActiveChange = useCallback((value) => setActive(value), []);
   const onActiveAppearanceChange = useCallback((value) => setActiveAppearance(value), []);
@@ -114,9 +113,9 @@ export const StandardUsage: FunctionComponent = () => {
         size={imageSize === undefinedText ? undefined : imageSize}
         initials="SN"
         shape={isSquare ? 'square' : 'circular'}
-        imageDescription="Photo of Satya Nadella"
-        presence={presence === undefinedText ? undefined : presence}
-        imageUrl={showImage ? satyaPhotoUrl : undefined}
+        accessibilityLabel="Photo of Satya Nadella"
+        badge={{ status: presence === undefinedText ? undefined : presence }}
+        src={showImage ? satyaPhotoUrl : undefined}
         coinColorFluent={coinColor === undefinedText ? undefined : coinColor}
       />
     </View>

--- a/apps/fluent-tester/src/FluentTester/TestComponents/Avatar/CustomizedAvatar.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Avatar/CustomizedAvatar.tsx
@@ -135,9 +135,9 @@ export const CustomizeUsage: React.FunctionComponent = () => {
         active="active"
         activeAppearance="ring"
         initials="SB"
-        imageDescription="Former CEO of Microsoft"
-        presence="blocked"
-        imageUrl={showImage ? steveBallmerPhotoUrl : undefined}
+        accessibilityLabel="Former CEO of Microsoft"
+        badge={{ status: 'blocked' }}
+        src={showImage ? steveBallmerPhotoUrl : undefined}
         ring={
           showRing
             ? {

--- a/apps/fluent-tester/src/FluentTester/TestComponents/Badge/BadgeTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Badge/BadgeTest.tsx
@@ -69,8 +69,8 @@ export const BasicBadge: React.FunctionComponent = () => {
         <>
           <Text>Presence Badge</Text>
           <PresenceBadge status="available" size="largest" />
-          <PresenceBadge status="available" isOutOfOffice={true} size="large" />
-          <PresenceBadge status="doNotDisturb" isOutOfOffice={true} />
+          <PresenceBadge status="available" outOfOffice={true} size="large" />
+          <PresenceBadge status="doNotDisturb" outOfOffice={true} />
           <PresenceBadge status="away" size="small" />
           <PresenceBadge status="busy" size="smallest" />
           <PresenceBadge status="offline" />

--- a/apps/fluent-tester/src/FluentTester/TestComponents/Badge/BadgeTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Badge/BadgeTest.tsx
@@ -68,14 +68,14 @@ export const BasicBadge: React.FunctionComponent = () => {
       {svgIconsEnabled && (
         <>
           <Text>Presence Badge</Text>
-          <PresenceBadge presence="available" size="largest" />
-          <PresenceBadge presence="available" isOutOfOffice={true} size="large" />
-          <PresenceBadge presence="doNotDisturb" isOutOfOffice={true} />
-          <PresenceBadge presence="away" size="small" />
-          <PresenceBadge presence="busy" size="smallest" />
-          <PresenceBadge presence="offline" />
-          <PresenceBadge presence="outOfOffice" />
-          <PresenceBadge presence="away" />
+          <PresenceBadge status="available" size="largest" />
+          <PresenceBadge status="available" isOutOfOffice={true} size="large" />
+          <PresenceBadge status="doNotDisturb" isOutOfOffice={true} />
+          <PresenceBadge status="away" size="small" />
+          <PresenceBadge status="busy" size="smallest" />
+          <PresenceBadge status="offline" />
+          <PresenceBadge status="outOfOffice" />
+          <PresenceBadge status="away" />
         </>
       )}
     </View>

--- a/change/@fluentui-react-native-badge-3c099784-4079-4eac-ba1f-7588874ea64a.json
+++ b/change/@fluentui-react-native-badge-3c099784-4079-4eac-ba1f-7588874ea64a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Changed props according to the spec",
+  "packageName": "@fluentui-react-native/badge",
+  "email": "v.kozova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-avatar-e8c6e0ab-f04f-4c1f-9cfa-c3f8d5037562.json
+++ b/change/@fluentui-react-native-experimental-avatar-e8c6e0ab-f04f-4c1f-9cfa-c3f8d5037562.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Changed props according to the spec",
+  "packageName": "@fluentui-react-native/experimental-avatar",
+  "email": "v.kozova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-9d70ce71-cf45-4d32-99c5-cb526aa8aaca.json
+++ b/change/@fluentui-react-native-tester-9d70ce71-cf45-4d32-99c5-cb526aa8aaca.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Changed props according to the spec",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "v.kozova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Avatar/src/JSAvatar.styling.ts
+++ b/packages/experimental/Avatar/src/JSAvatar.styling.ts
@@ -70,7 +70,7 @@ export const stylingSettings: UseStylingOptions<JSAvatarProps, AvatarSlotProps, 
       },
       ['coinColorFluent', 'backgroundColor', 'physicalSize', ...borderStyles.keys],
     ),
-    photo: buildProps(
+    image: buildProps(
       (tokens: JSAvatarTokens) => {
         const { physicalSize } = calculateEffectiveSizes(tokens);
 
@@ -125,28 +125,6 @@ export const stylingSettings: UseStylingOptions<JSAvatarProps, AvatarSlotProps, 
         };
       },
       ['physicalSize', 'ring', 'physicalSize', ...borderStyles.keys],
-    ),
-    glow: buildProps(
-      (tokens: JSAvatarTokens, theme: Theme) => {
-        const { physicalSize } = calculateEffectiveSizes(tokens);
-        const ringConfig = getRingConfig(physicalSize);
-
-        const glowColor = tokens.ringColor;
-        return {
-          style: {
-            borderStyle: 'solid',
-            borderColor: glowColor,
-            borderWidth: ringConfig.stroke - ringConfig.innerStroke,
-            width: ringConfig.size,
-            height: ringConfig.size,
-            position: 'absolute',
-            top: -ringConfig.stroke * 2,
-            left: -ringConfig.stroke * 2,
-            ...borderStyles.from(tokens, theme),
-          },
-        };
-      },
-      ['physicalSize', 'ring', ...borderStyles.keys],
     ),
   },
 };

--- a/packages/experimental/Avatar/src/JSAvatar.styling.ts
+++ b/packages/experimental/Avatar/src/JSAvatar.styling.ts
@@ -126,5 +126,11 @@ export const stylingSettings: UseStylingOptions<JSAvatarProps, AvatarSlotProps, 
       },
       ['physicalSize', 'ring', 'physicalSize', ...borderStyles.keys],
     ),
+    badge: buildProps((_tokens: JSAvatarTokens) => {
+      return {
+        size: 'medium',
+        shape: 'circular',
+      };
+    }, []),
   },
 };

--- a/packages/experimental/Avatar/src/JSAvatar.tsx
+++ b/packages/experimental/Avatar/src/JSAvatar.tsx
@@ -41,7 +41,7 @@ export const JSAvatar = compose<JSAvatarType>({
     const Slots = useSlots(userProps, (layer) => avatarLookup(layer, avatar.state, userProps));
 
     return (final: JSAvatarProps) => {
-      const { activeAppearance, children, image, badge, ...mergedProps } = mergeProps(avatar.props, final);
+      const { activeAppearance, initials, image, badge, ...mergedProps } = mergeProps(avatar.props, final);
       const { showRing, transparentRing } = avatar.state;
 
       return (
@@ -50,7 +50,7 @@ export const JSAvatar = compose<JSAvatarType>({
             <Slots.image {...image} />
           ) : (
             <Slots.initialsBackground>
-              <Slots.initials>{children}</Slots.initials>
+              <Slots.initials>{initials}</Slots.initials>
             </Slots.initialsBackground>
           )}
           {showRing && !transparentRing && <Slots.ring />}

--- a/packages/experimental/Avatar/src/JSAvatar.tsx
+++ b/packages/experimental/Avatar/src/JSAvatar.tsx
@@ -34,6 +34,7 @@ export const JSAvatar = compose<JSAvatarType>({
     initialsBackground: View,
     icon: Image,
     ring: View,
+    badge: PresenceBadge,
   },
   useRender: (userProps: JSAvatarProps, useSlots: UseSlots<JSAvatarType>) => {
     const avatar = useAvatar(userProps);
@@ -53,7 +54,7 @@ export const JSAvatar = compose<JSAvatarType>({
             </Slots.initialsBackground>
           )}
           {showRing && !transparentRing && <Slots.ring />}
-          <PresenceBadge {...badge} />
+          <Slots.badge {...badge} />
         </Slots.root>
       );
     };

--- a/packages/experimental/Avatar/src/JSAvatar.tsx
+++ b/packages/experimental/Avatar/src/JSAvatar.tsx
@@ -29,33 +29,31 @@ export const JSAvatar = compose<JSAvatarType>({
   ...stylingSettings,
   slots: {
     root: View,
-    photo: Image,
+    image: Image,
     initials: Text,
     initialsBackground: View,
     icon: Image,
     ring: View,
-    glow: View,
   },
   useRender: (userProps: JSAvatarProps, useSlots: UseSlots<JSAvatarType>) => {
     const avatar = useAvatar(userProps);
     const Slots = useSlots(userProps, (layer) => avatarLookup(layer, avatar.state, userProps));
 
     return (final: JSAvatarProps) => {
-      const { children, accessibilityLabel, presence, activeAppearance, isOutOfOffice, ...mergedProps } = mergeProps(avatar.props, final);
-      const { personaPhotoSource, showRing, transparentRing } = avatar.state;
+      const { activeAppearance, children, image, badge, ...mergedProps } = mergeProps(avatar.props, final);
+      const { showRing, transparentRing } = avatar.state;
 
       return (
         <Slots.root {...mergedProps}>
-          {personaPhotoSource ? (
-            <Slots.photo accessibilityLabel={accessibilityLabel} source={personaPhotoSource} />
+          {image.source ? (
+            <Slots.image {...image} />
           ) : (
             <Slots.initialsBackground>
               <Slots.initials>{children}</Slots.initials>
             </Slots.initialsBackground>
           )}
           {showRing && !transparentRing && <Slots.ring />}
-          {activeAppearance === 'glow' && <Slots.glow />}
-          <PresenceBadge size="small" shape="circular" presence={presence} isOutOfOffice={isOutOfOffice} />
+          <PresenceBadge {...badge} />
         </Slots.root>
       );
     };

--- a/packages/experimental/Avatar/src/JSAvatar.types.ts
+++ b/packages/experimental/Avatar/src/JSAvatar.types.ts
@@ -1,7 +1,7 @@
 import type { IViewProps } from '@fluentui-react-native/adapters';
-import { ImageProps, ViewProps, ImageURISource, TextProps, ColorValue } from 'react-native';
+import { ImageProps, ViewProps, TextProps, ColorValue } from 'react-native';
 import { IBackgroundColorTokens, IForegroundColorTokens, IBorderTokens } from '@fluentui-react-native/tokens';
-import { Presence } from '@fluentui-react-native/badge';
+import { PresenceBadgeProps } from '@fluentui-react-native/badge';
 
 export const JSAvatarName = 'Avatar';
 export const AvatarSizes = [
@@ -48,8 +48,6 @@ export type AvatarColor =
   | 'platinum'
   | 'steel'
   | 'brown';
-
-export type AvatarPresence = Presence;
 export interface RingConfig {
   accent?: boolean;
   transparent?: boolean;
@@ -68,22 +66,21 @@ export interface AvatarConfigurableProps {
 export interface JSAvatarProps extends IViewProps, AvatarConfigurableProps {
   active?: AvatarActive;
   activeAppearance?: AvatarActiveAppearance;
-  imageUrl?: string;
-  imageDescription?: string;
+  image?: ImageProps;
+  src?: string;
   initials?: string;
-  presence?: AvatarPresence;
-  isOutOfOffice?: boolean;
+  name?: string;
   shape?: AvatarShape;
+  badge?: PresenceBadgeProps;
 }
 
 export interface AvatarSlotProps {
   root: ViewProps;
-  photo: ImageProps;
+  image: ImageProps;
   initials: TextProps;
   initialsBackground: ViewProps;
   icon: ImageProps;
   ring: ViewProps;
-  glow: ViewProps;
 }
 
 export type IconAlignment = 'start' | 'center' | 'end';
@@ -105,7 +102,6 @@ export interface JSAvatarTokens extends IBackgroundColorTokens, IForegroundColor
 }
 
 export interface JSAvatarState {
-  personaPhotoSource: ImageURISource | undefined;
   showRing: boolean;
   transparentRing: boolean;
 }

--- a/packages/experimental/Avatar/src/JSAvatar.types.ts
+++ b/packages/experimental/Avatar/src/JSAvatar.types.ts
@@ -1,7 +1,7 @@
 import type { IViewProps } from '@fluentui-react-native/adapters';
 import { ImageProps, ViewProps, TextProps, ColorValue } from 'react-native';
 import { IBackgroundColorTokens, IForegroundColorTokens, IBorderTokens } from '@fluentui-react-native/tokens';
-import { PresenceBadgeProps } from '@fluentui-react-native/badge';
+import { BadgeProps, PresenceBadgeProps } from '@fluentui-react-native/badge';
 
 export const JSAvatarName = 'Avatar';
 export const AvatarSizes = [
@@ -81,6 +81,7 @@ export interface AvatarSlotProps {
   initialsBackground: ViewProps;
   icon: ImageProps;
   ring: ViewProps;
+  badge: BadgeProps;
 }
 
 export type IconAlignment = 'start' | 'center' | 'end';

--- a/packages/experimental/Avatar/src/useAvatar.ts
+++ b/packages/experimental/Avatar/src/useAvatar.ts
@@ -21,7 +21,6 @@ export const useAvatar = (props: JSAvatarProps): AvatarInfo => {
 
   const badgeProps: PresenceBadgeProps = {
     size: 'small',
-    shape: 'circular',
     ...badge,
   };
 

--- a/packages/experimental/Avatar/src/useAvatar.ts
+++ b/packages/experimental/Avatar/src/useAvatar.ts
@@ -9,7 +9,7 @@ import { PresenceBadgeProps } from '@fluentui-react-native/badge';
  * @returns configured props and state for FURN Avatar
  */
 export const useAvatar = (props: JSAvatarProps): AvatarInfo => {
-  const { active, accessibilityLabel, activeAppearance, badge, src, initials, ring, shape, ...rest } = props;
+  const { active, accessibilityLabel, activeAppearance, badge, src, ring, shape, ...rest } = props;
 
   const showRing = active === 'active' && activeAppearance === 'ring';
   const transparentRing = !!ring?.transparent;
@@ -31,7 +31,6 @@ export const useAvatar = (props: JSAvatarProps): AvatarInfo => {
 
   return {
     props: {
-      children: initials,
       shape: shape || 'circular',
       ...rest,
       active,

--- a/packages/experimental/Avatar/src/useAvatar.ts
+++ b/packages/experimental/Avatar/src/useAvatar.ts
@@ -1,4 +1,6 @@
 import { JSAvatarProps, AvatarInfo, JSAvatarState } from './JSAvatar.types';
+import { ImageProps, ImageSourcePropType } from 'react-native';
+import { PresenceBadgeProps } from '@fluentui-react-native/badge';
 /**
  * Re-usable hook for FURN Avatar.
  * This hook configures Avatar props and state for FURN Avatar.
@@ -7,34 +9,36 @@ import { JSAvatarProps, AvatarInfo, JSAvatarState } from './JSAvatar.types';
  * @returns configured props and state for FURN Avatar
  */
 export const useAvatar = (props: JSAvatarProps): AvatarInfo => {
-  const { imageUrl, imageDescription, initials, isOutOfOffice, presence, ring, shape, active, activeAppearance, ...rest } = props;
-
-  const personaPhotoSource =
-    imageUrl === undefined
-      ? undefined
-      : {
-          uri: imageUrl,
-        };
+  const { active, accessibilityLabel, activeAppearance, badge, src, initials, ring, shape, ...rest } = props;
 
   const showRing = active === 'active' && activeAppearance === 'ring';
   const transparentRing = !!ring?.transparent;
 
+  const imageProps: ImageProps = {
+    accessibilityLabel,
+    source: src ? ({ uri: src } as ImageSourcePropType) : undefined,
+  };
+
+  const badgeProps: PresenceBadgeProps = {
+    size: 'small',
+    shape: 'circular',
+    ...badge,
+  };
+
   const state: JSAvatarState = {
-    personaPhotoSource,
     showRing,
     transparentRing,
   };
 
   return {
     props: {
-      isOutOfOffice: isOutOfOffice || false,
-      presence: presence || 'available',
       children: initials,
-      accessibilityLabel: imageDescription,
       shape: shape || 'circular',
       ...rest,
       active,
       activeAppearance,
+      image: imageProps,
+      badge: badgeProps,
     },
     state: {
       ...state,

--- a/packages/experimental/Badge/src/PresenceBadge/PresenceBadge.tsx
+++ b/packages/experimental/Badge/src/PresenceBadge/PresenceBadge.tsx
@@ -1,7 +1,7 @@
 /** @jsx withSlots */
 import { View } from 'react-native';
 import { badgeLookup } from '../Badge';
-import { presenceBadgeName, PresenceBadgeType, PresenceBadgeProps, Presence } from './PresenceBadge.types';
+import { presenceBadgeName, PresenceBadgeType, PresenceBadgeProps, PresenceBadgeStatus } from './PresenceBadge.types';
 import { BadgeSize } from '../Badge.types';
 import { compose, withSlots, mergeProps, UseSlots } from '@fluentui-react-native/framework';
 import { presenceIconPaths } from './presenceIconPaths';
@@ -9,8 +9,8 @@ import { SvgXml } from 'react-native-svg';
 import { useBadge } from '../useBadge';
 import { stylingSettings } from './PresenceBadge.styling';
 
-function getIconPath(presence: Presence, isOutOfOffice: boolean) {
-  switch (presence) {
+function getIconPath(status: PresenceBadgeStatus, isOutOfOffice: boolean) {
+  switch (status) {
     case 'available':
     default:
       return isOutOfOffice ? presenceIconPaths.availableOutOfOffice : presenceIconPaths.available;
@@ -52,15 +52,17 @@ export const PresenceBadge = compose<PresenceBadgeType>({
     root: View,
   },
   useRender: (userProps: PresenceBadgeProps, useSlots: UseSlots<PresenceBadgeType>) => {
-    const badge = useBadge(userProps);
-    const size = getIconSize(userProps.size || 'medium');
-    const iconXml = `<svg width="${size}" height="${size}" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-      ${getIconPath(userProps.presence, userProps.isOutOfOffice)}
-    </svg>`;
-    const Slots = useSlots(userProps, (layer) => badgeLookup(layer, userProps));
+    const badge = useBadge(userProps) as PresenceBadgeProps;
+    const Slots = useSlots(badge, (layer) => badgeLookup(layer, badge));
 
     return (final: PresenceBadgeProps) => {
-      const { ...mergedProps } = mergeProps(badge, final);
+      const { size, status, isOutOfOffice, ...mergedProps } = mergeProps(badge, final);
+      const badgeSize = getIconSize(size);
+      const outOfOffice = isOutOfOffice || false;
+      const iconXml = `<svg width="${badgeSize}" height="${badgeSize}" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+        ${getIconPath(status, outOfOffice)}
+      </svg>`;
+
       return (
         <Slots.root {...mergedProps}>
           <SvgXml xml={iconXml} />

--- a/packages/experimental/Badge/src/PresenceBadge/PresenceBadge.tsx
+++ b/packages/experimental/Badge/src/PresenceBadge/PresenceBadge.tsx
@@ -56,11 +56,11 @@ export const PresenceBadge = compose<PresenceBadgeType>({
     const Slots = useSlots(badge, (layer) => badgeLookup(layer, badge));
 
     return (final: PresenceBadgeProps) => {
-      const { size, status, isOutOfOffice, ...mergedProps } = mergeProps(badge, final);
+      const { size, status, outOfOffice, ...mergedProps } = mergeProps(badge, final);
       const badgeSize = getIconSize(size);
-      const outOfOffice = isOutOfOffice || false;
+      const isOutOfOffice = outOfOffice || false;
       const iconXml = `<svg width="${badgeSize}" height="${badgeSize}" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-        ${getIconPath(status, outOfOffice)}
+        ${getIconPath(status, isOutOfOffice)}
       </svg>`;
 
       return (

--- a/packages/experimental/Badge/src/PresenceBadge/PresenceBadge.types.ts
+++ b/packages/experimental/Badge/src/PresenceBadge/PresenceBadge.types.ts
@@ -3,11 +3,11 @@ import { BadgeCoreTokens } from '../Badge.types';
 
 export const presenceBadgeName = 'PresenceBadge';
 export const PresenceBadgeStatuses = ['doNotDisturb', 'busy', 'unknown', 'blocked', 'outOfOffice', 'away', 'available', 'offline'] as const;
-export type Presence = typeof PresenceBadgeStatuses[number];
+export type PresenceBadgeStatus = typeof PresenceBadgeStatuses[number];
 
 export interface PresenceBadgeTokens extends BadgeCoreTokens {}
 export interface PresenceBadgeProps extends BadgeCoreProps {
-  presence?: Presence;
+  status?: PresenceBadgeStatus;
   isOutOfOffice?: boolean;
 }
 

--- a/packages/experimental/Badge/src/PresenceBadge/PresenceBadge.types.ts
+++ b/packages/experimental/Badge/src/PresenceBadge/PresenceBadge.types.ts
@@ -8,7 +8,7 @@ export type PresenceBadgeStatus = typeof PresenceBadgeStatuses[number];
 export interface PresenceBadgeTokens extends BadgeCoreTokens {}
 export interface PresenceBadgeProps extends BadgeCoreProps {
   status?: PresenceBadgeStatus;
-  isOutOfOffice?: boolean;
+  outOfOffice?: boolean;
 }
 
 export interface PresenceBadgeSlotProps extends Omit<BadgeSlotProps, 'text' | 'icon'> {}

--- a/packages/experimental/Badge/src/__tests__/__snapshots__/Badge.test.tsx.snap
+++ b/packages/experimental/Badge/src/__tests__/__snapshots__/Badge.test.tsx.snap
@@ -56,6 +56,7 @@ exports[`Badge component tests Badge all props 1`] = `
 
 exports[`Badge component tests Badge tokens 1`] = `
 <View
+  size="medium"
   style={
     Object {
       "alignItems": "center",
@@ -94,6 +95,7 @@ exports[`Badge component tests Badge tokens 1`] = `
 
 exports[`Badge component tests Empty Badge 1`] = `
 <View
+  size="medium"
   style={
     Object {
       "alignItems": "center",

--- a/packages/experimental/Badge/src/index.ts
+++ b/packages/experimental/Badge/src/index.ts
@@ -12,4 +12,4 @@ export type {
 } from './Badge.types';
 export { Badge, CompressibleBadge, badgeLookup } from './Badge';
 export { PresenceBadge, presenceBadgeName, PresenceBadgeStatuses } from './PresenceBadge';
-export type { Presence, PresenceBadgeProps, PresenceBadgeSlotProps, PresenceBadgeType } from './PresenceBadge';
+export type { PresenceBadgeStatus, PresenceBadgeProps, PresenceBadgeSlotProps, PresenceBadgeType } from './PresenceBadge';

--- a/packages/experimental/Badge/src/useBadge.ts
+++ b/packages/experimental/Badge/src/useBadge.ts
@@ -1,10 +1,12 @@
 import { BadgeProps } from './Badge.types';
 
 export const useBadge = (props: BadgeProps): BadgeProps => {
-  const { iconPosition, ...rest } = props;
+  if (!props) return {};
+  const { iconPosition = 'before', size = 'medium', ...rest } = props;
 
   return {
-    iconPosition: iconPosition || 'before',
+    iconPosition: iconPosition,
+    size,
     ...rest,
   };
 };


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
Updated props according to the spec.
**Notes/questions:**
1. Web uses image as a slot. They have image as a separate component. I've only renamed it.
2. Removed glow because glow and shadow won't be implemented while this stage. This glow code was from PersonaCoin component. Anyway, it would be rewritten.

**Issue:** userProps are undefined on the first stage of render when adding badge as a slot. Because of that styling uses default parameters.

### Verification
Ran tests and checked manually

### Pull request checklist

This PR has considered (when applicable):
- [X] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
