### PR TITLE
Update checkbox documentation

### DIFF
--- a/change/@fluentui-react-native-checkbox-f7b98823-4fae-4ea7-8d73-44cb7d726ea1.json
+++ b/change/@fluentui-react-native-checkbox-f7b98823-4fae-4ea7-8d73-44cb7d726ea1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update checkbox documentation for MacOS",
+  "packageName": "@fluentui-react-native/checkbox",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Checkbox/README.md
+++ b/packages/components/Checkbox/README.md
@@ -2,7 +2,9 @@
 
 A cross-platform Checkbox component using the Fluent Design System.
 
-Supported Platforms: Android, iOS, macOS, web, windows, win32
+Checkbox V1 supported platformsL win32
+
+Checkbox V0 Supported Platforms: Android, iOS, macOS, web, windows, win32
 
 Note that on iOS, the more common control to use is a Switch
 https://developer.apple.com/design/human-interface-guidelines/ios/controls/switches/

--- a/packages/components/Checkbox/SPEC.md
+++ b/packages/components/Checkbox/SPEC.md
@@ -1,7 +1,6 @@
 # Checkbox
 
-_Not available on MacOS_
-Please use Checkbox V0 under the deprecated folder until further notice.
+**Not available on MacOS** - Please use Checkbox V0 under the deprecated folder until further notice.
 
 In the short term, the new `Checkbox` control is named `CheckboxV1` while it clashes with the existing older control. Once we deprecate the old control, it will be renamed to `Checkbox`. It may be useful to rename the control to `Checkbox` using the import syntax to simplify the rename:
 

--- a/packages/components/Checkbox/SPEC.md
+++ b/packages/components/Checkbox/SPEC.md
@@ -1,5 +1,8 @@
 # Checkbox
 
+_Not available on MacOS_
+Please use Checkbox V0 under the deprecated folder until further notice.
+
 In the short term, the new `Checkbox` control is named `CheckboxV1` while it clashes with the existing older control. Once we deprecate the old control, it will be renamed to `Checkbox`. It may be useful to rename the control to `Checkbox` using the import syntax to simplify the rename:
 
 ```ts

--- a/packages/components/Checkbox/SPEC.md
+++ b/packages/components/Checkbox/SPEC.md
@@ -1,6 +1,6 @@
 # Checkbox
 
-**Not available on MacOS** - Please use Checkbox V0 under the deprecated folder until further notice.
+**Not available on MacOS** - Please use `import { Checkbox } from @'fluentui-react-native/checkbox'` and ignore the deprecation message until further notice.
 
 In the short term, the new `Checkbox` control is named `CheckboxV1` while it clashes with the existing older control. Once we deprecate the old control, it will be renamed to `Checkbox`. It may be useful to rename the control to `Checkbox` using the import syntax to simplify the rename:
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Small addition to documentation to make it clear that Checkbox V1 is not available on macOS.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
