### PR TITLE
Use ButtonV1 in FluentTester

### DIFF
--- a/apps/fluent-tester/src/FluentTester/FluentTester.tsx
+++ b/apps/fluent-tester/src/FluentTester/FluentTester.tsx
@@ -1,6 +1,6 @@
 import { Theme } from '@fluentui-react-native/framework';
 import { FocusTrapZone, Separator, Text } from '@fluentui/react-native';
-import { Button } from '@fluentui-react-native/experimental-button';
+import { ButtonV1 as Button } from '@fluentui-react-native/button';
 import { themedStyleSheet } from '@fluentui-react-native/themed-stylesheet';
 import * as React from 'react';
 import { ScrollView, View, Text as RNText, Platform, SafeAreaView, BackHandler } from 'react-native';

--- a/change/@fluentui-react-native-tester-0b6582c9-4486-410e-8caa-c8157b166b41.json
+++ b/change/@fluentui-react-native-tester-0b6582c9-4486-410e-8caa-c8157b166b41.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Use ButtonV1 in FluentTester",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
Updated button import

### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Updated FluentTester to use v1 button

### Verification

Not tested - no visible changes

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
