### PR TITLE
Fix link to rnx-kit documentation

### DIFF
--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -72,7 +72,7 @@ Bump `reactNativeVersion`, and run `yarn rnx-dep-check --write`. This command
 will ensure that all relevant packages are bumped correctly.
 
 You can read more about this tool here:
-[`@rnx-kit/dep-check` design document](https://github.com/microsoft/rnx-kit/blob/main/packages/dep-check/DESIGN.md)
+[`@rnx-kit/dep-check` design document](https://github.com/microsoft/rnx-kit/blob/main/docsite/docs/architecture/dependency-management.md)
 
 ## Debugging
 

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -51,7 +51,7 @@ Bump `reactNativeVersion`, and run `yarn rnx-dep-check --write`. This command
 will ensure that all relevant packages are bumped correctly.
 
 You can read more about this tool here:
-[`@rnx-kit/dep-check` design document](https://github.com/microsoft/rnx-kit/blob/main/packages/dep-check/DESIGN.md)
+[`@rnx-kit/dep-check` design document](https://github.com/microsoft/rnx-kit/blob/main/docsite/docs/architecture/dependency-management.md)
 
 ## Debugging
 

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -60,7 +60,7 @@ Bump `reactNativeVersion`, and run `yarn rnx-dep-check --write`. This command
 will ensure that all relevant packages are bumped correctly.
 
 You can read more about this tool here:
-[`@rnx-kit/dep-check` design document](https://github.com/microsoft/rnx-kit/blob/main/packages/dep-check/DESIGN.md)
+[`@rnx-kit/dep-check` design document](https://github.com/microsoft/rnx-kit/blob/main/docsite/docs/architecture/dependency-management.md)
 
 ## Troubleshooting
 

--- a/apps/win32/README.md
+++ b/apps/win32/README.md
@@ -104,4 +104,4 @@ Bump `reactNativeVersion`, and run `yarn rnx-dep-check --write`. This command
 will ensure that all relevant packages are bumped correctly.
 
 You can read more about this tool here:
-[`@rnx-kit/dep-check` design document](https://github.com/microsoft/rnx-kit/blob/main/packages/dep-check/DESIGN.md)
+[`@rnx-kit/dep-check` design document](https://github.com/microsoft/rnx-kit/blob/main/docsite/docs/architecture/dependency-management.md)

--- a/apps/windows/README.md
+++ b/apps/windows/README.md
@@ -49,7 +49,7 @@ Bump `reactNativeVersion`, and run `yarn rnx-dep-check --write`. This command
 will ensure that all relevant packages are bumped correctly.
 
 You can read more about this tool here:
-[`@rnx-kit/dep-check` design document](https://github.com/microsoft/rnx-kit/blob/main/packages/dep-check/DESIGN.md)
+[`@rnx-kit/dep-check` design document](https://github.com/microsoft/rnx-kit/blob/main/docsite/docs/architecture/dependency-management.md)
 
 ## Troubleshooting
 

--- a/change/@fluentui-react-native-tester-win32-cc6acf7b-6694-4aaf-8a1e-942b3c6d34ea.json
+++ b/change/@fluentui-react-native-tester-win32-cc6acf7b-6694-4aaf-8a1e-942b3c6d34ea.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Some more link fixes",
+  "packageName": "@fluentui-react-native/tester-win32",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

rnx-kit did some restructuring of their docs which causes some failures on our repo.

### Verification

CI will verify

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
