### PR TITLE
Remove SvgCssUri reference

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/Svg/SvgTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Svg/SvgTest.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { StyleSheet, Switch, Text, View } from 'react-native';
 import { Separator } from '@fluentui/react-native';
-import { Circle, Defs, G, Line, Path, Polygon, LinearGradient, RadialGradient, Rect, Stop, Svg, SvgCssUri, Use } from 'react-native-svg';
+import { Circle, Defs, G, Line, Path, Polygon, LinearGradient, RadialGradient, Rect, Stop, Svg, SvgUri, Use } from 'react-native-svg';
 import TestSvg from './Assets/accessible-icon-brands.svg';
 import { SVG_TESTPAGE } from './consts';
 import { Test, TestSection, PlatformStatus } from '../Test';
@@ -124,7 +124,7 @@ const RemoteSvgTest: React.FunctionComponent = () => {
 
   return (
     <View>
-      <SvgCssUri
+      <SvgUri
         style={styles.svg}
         viewBox="0 0 200 200"
         width="100"
@@ -132,7 +132,7 @@ const RemoteSvgTest: React.FunctionComponent = () => {
         uri="https://upload.wikimedia.org/wikipedia/commons/8/84/Example.svg"
       />
       {shouldShowLocalNetwork && (
-        <SvgCssUri
+        <SvgUri
           x="50"
           y="50"
           viewBox="0 0 500 500"

--- a/change/@fluentui-react-native-tester-595510f0-416e-4e6a-aad6-226aa5cd6796.json
+++ b/change/@fluentui-react-native-tester-595510f0-416e-4e6a-aad6-226aa5cd6796.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Use SvgUri instead of SvgCssUri",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This change sets us up to remove a bunch of code from rn-svg which will (eventually?) become optional and reduce bundle size. If we want we can try to force it out of the resolver ourselves.

### Verification

Booted tester and ensured that the SVG still appears. Since the linked SVG is not using the styles tag, we should be fine here.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
