### PR TITLE
Added colors for Avatar

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/Avatar/BasicAvatar.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Avatar/BasicAvatar.tsx
@@ -3,6 +3,7 @@ import {
   AvatarSize,
   AvatarSizes,
   AvatarColor,
+  AvatarColors,
   JSAvatar,
   AvatarActive,
   AvatarActiveAppearance,
@@ -12,39 +13,14 @@ import { Switch, View, Text, Picker, ColorValue, Platform } from 'react-native';
 import { satyaPhotoUrl, undefinedText } from './../PersonaCoin/styles';
 import { commonTestStyles as commonStyles } from '../Common/styles';
 import { useTheme } from '@fluentui-react-native/theme-types';
-import { JSAvatarTokens } from '@fluentui-react-native/experimental-avatar';
 
 type WithUndefined<T> = T | typeof undefinedText;
 
 const avatarActive: AvatarActive[] = ['unset', 'active', 'inactive'];
+const avatarColors: AvatarColor[] = ['neutral', 'brand', 'colorful', ...AvatarColors];
 const avatarActiveAppearance: AvatarActiveAppearance[] = ['ring', 'shadow', 'glow', 'ring-shadow', 'ring-glow'];
 
 const allSizes: WithUndefined<AvatarSize>[] = [undefinedText, ...AvatarSizes];
-
-const allColors: WithUndefined<AvatarColor>[] = [
-  undefinedText,
-  'cornflower',
-  'blue',
-  'royalBlue',
-  'teal',
-  'forest',
-  'darkGreen',
-  'berry',
-  'hotPink',
-  'grape',
-  'purple',
-  'pumpkin',
-  'red',
-  'burgundy',
-  'orchid',
-  'brass',
-  'darkRed',
-  'beige',
-  'platinum',
-  'steel',
-  'brown',
-];
-
 const allPresences: WithUndefined<PresenceBadgeStatus>[] = [undefinedText, ...PresenceBadgeStatuses];
 
 const StyledPicker = (props) => {
@@ -61,25 +37,23 @@ const StyledPicker = (props) => {
 };
 
 export const StandardUsage: FunctionComponent = () => {
-  const tokens: JSAvatarTokens = {};
   const [isSquare, setSquare] = useState(false);
   const [showImage, setShowImage] = useState(true);
   const [active, setActive] = useState<AvatarActive>('unset');
   const [activeAppearance, setActiveAppearance] = useState<AvatarActiveAppearance>('ring');
   const [imageSize, setImageSize] = useState<WithUndefined<AvatarSize>>('size72');
-  const [coinColor, setCoinColor] = useState<WithUndefined<AvatarColor>>('brass');
   const [presence, setPresence] = useState<WithUndefined<PresenceBadgeStatus>>('available');
+  const [avatarColor, setAvatarColor] = useState<AvatarColor>('brass');
 
   const onActiveChange = useCallback((value) => setActive(value), []);
   const onActiveAppearanceChange = useCallback((value) => setActiveAppearance(value), []);
+  const onAvatarColorChange = useCallback((value) => setAvatarColor(value), []);
   const onSizeChange = useCallback((value) => setImageSize(value), []);
-  const onColorChange = useCallback((value) => setCoinColor(value), []);
+
   const onPresenceChange = useCallback((value) => setPresence(value), []);
 
   const theme = useTheme();
   const textStyles = { color: theme.colors.inputText as ColorValue };
-
-  tokens.backgroundColor = coinColor;
 
   const fontBuiltInProps = {
     fontFamily: 'Arial',
@@ -111,7 +85,7 @@ export const StandardUsage: FunctionComponent = () => {
             collection={avatarActiveAppearance}
           />
         ) : null}
-        <StyledPicker prompt="Coin color" selected={coinColor} onChange={onColorChange} collection={allColors} />
+        <StyledPicker prompt="Avatar Color" selected={avatarColor} onChange={onAvatarColorChange} collection={avatarColors} />
         <StyledPicker prompt="Presence status" selected={presence} onChange={onPresenceChange} collection={allPresences} />
       </View>
 
@@ -124,7 +98,7 @@ export const StandardUsage: FunctionComponent = () => {
         accessibilityLabel="Photo of Satya Nadella"
         badge={{ status: presence === undefinedText ? undefined : presence }}
         src={showImage ? satyaPhotoUrl : undefined}
-        coinColorFluent={coinColor === undefinedText ? undefined : coinColor}
+        avatarColor={avatarColor}
       />
       {svgIconsEnabled && (
         <JSAvatar
@@ -134,7 +108,7 @@ export const StandardUsage: FunctionComponent = () => {
           shape={isSquare ? 'square' : 'circular'}
           accessibilityLabel="Icon"
           icon={{ fontSource: { ...fontBuiltInProps }, color: 'white' }}
-          coinColorFluent={coinColor === undefinedText ? undefined : coinColor}
+          avatarColor={avatarColor}
         />
       )}
     </View>

--- a/apps/fluent-tester/src/FluentTester/TestComponents/Avatar/CustomizedAvatar.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Avatar/CustomizedAvatar.tsx
@@ -13,8 +13,6 @@ export const CustomizeUsage: React.FunctionComponent = () => {
   const [textColor, setTextColor] = React.useState<string>();
   const [size, setSize] = React.useState<number>(96);
   const [iconSize, setIconSize] = React.useState<number>(24);
-  const [iconStrokeWidth, setIconStrokeWidth] = React.useState<number>(2);
-  const [iconStrokeColor, setIconStrokeColor] = React.useState<string>(undefined);
   const [initialsSize, setInitialsSize] = React.useState<number>(14);
   const [horizontalAlignment, setHorizontalAlignment] = React.useState<IconAlignment>();
   const [verticalAlignment, setVerticalAlignment] = React.useState<IconAlignment>();
@@ -36,14 +34,12 @@ export const CustomizeUsage: React.FunctionComponent = () => {
       horizontalIconAlignment: horizontalAlignment,
       verticalIconAlignment: verticalAlignment,
       iconSize: iconSize,
-      iconStrokeWidth: iconStrokeWidth,
-      iconStrokeColor: iconStrokeColor,
       initialsSize: initialsSize,
       width: size,
       height: size,
     };
     return JSAvatar.customize(tokens);
-  }, [coinColor, textColor, horizontalAlignment, verticalAlignment, iconSize, iconStrokeWidth, iconStrokeColor, initialsSize, size]);
+  }, [coinColor, textColor, horizontalAlignment, verticalAlignment, iconSize, initialsSize, size]);
 
   return (
     <View style={commonStyles.root}>
@@ -79,14 +75,6 @@ export const CustomizeUsage: React.FunctionComponent = () => {
             setTextColor(e.nativeEvent.text);
           }}
         />
-        <TextInput
-          style={[commonStyles.textBox, textBoxBorderStyle]}
-          placeholder="Icon stroke color"
-          blurOnSubmit={true}
-          onSubmitEditing={(e) => {
-            setIconStrokeColor(e.nativeEvent.text);
-          }}
-        />
 
         <TextInput
           style={[commonStyles.textBox, textBoxBorderStyle]}
@@ -114,9 +102,6 @@ export const CustomizeUsage: React.FunctionComponent = () => {
 
         <Text>Icon size</Text>
         <Slider minimum={8} maximum={100} initialValue={24} style={commonStyles.vmargin} onChange={setIconSize} />
-
-        <Text>Icon stroke width</Text>
-        <Slider minimum={0} maximum={8} initialValue={2} style={commonStyles.vmargin} onChange={setIconStrokeWidth} />
 
         <Text>Font size</Text>
         <Slider minimum={5} maximum={50} initialValue={14} style={commonStyles.vmargin} onChange={setInitialsSize} />

--- a/change/@fluentui-react-native-experimental-avatar-57267d39-1b9d-4007-88a8-ae3c1249c2ba.json
+++ b/change/@fluentui-react-native-experimental-avatar-57267d39-1b9d-4007-88a8-ae3c1249c2ba.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Changed colors for the Avatar",
+  "packageName": "@fluentui-react-native/experimental-avatar",
+  "email": "v.kozova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-0012185b-a769-466e-9254-a8ba60651fe0.json
+++ b/change/@fluentui-react-native-tester-0012185b-a769-466e-9254-a8ba60651fe0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Changed colors for the Avatar",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "v.kozova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Avatar/src/JSAvatar.helpers.ts
+++ b/packages/experimental/Avatar/src/JSAvatar.helpers.ts
@@ -1,4 +1,3 @@
-import { AvatarColor } from './JSAvatar.types';
 import { globalTokens } from '@fluentui-react-native/theme-tokens';
 
 const sizeAdjustment = {
@@ -12,36 +11,6 @@ export type AvatarSizeConfig = {
   iconStrokeWidth: number;
   initialsSize: number;
 };
-
-const colorTableFluent: { [P in AvatarColor]: string } = {
-  cornflower: globalTokens.color.cornflower.primary,
-  blue: globalTokens.color.blue.primary,
-  royalBlue: globalTokens.color.royalBlue.primary,
-  teal: globalTokens.color.teal.primary,
-  forest: globalTokens.color.forest.primary,
-  darkGreen: globalTokens.color.darkGreen.primary,
-  berry: globalTokens.color.berry.primary,
-  hotPink: globalTokens.color.hotPink.primary,
-  grape: globalTokens.color.grape.primary,
-  purple: globalTokens.color.purple.primary,
-  pumpkin: globalTokens.color.pumpkin.primary,
-  red: globalTokens.color.red.primary,
-  burgundy: globalTokens.color.burgundy.primary,
-  orchid: globalTokens.color.orchid.primary,
-  brass: globalTokens.color.brass.primary,
-  darkRed: globalTokens.color.darkRed.primary,
-  beige: globalTokens.color.beige.primary,
-  platinum: globalTokens.color.platinum.primary,
-  steel: globalTokens.color.steel.primary,
-  brown: globalTokens.color.brown.primary,
-};
-
-/**
- * Converts the AvatarColor into a hex color value
- */
-export function convertCoinColorFluent(coinColor: AvatarColor): string {
-  return colorTableFluent[coinColor];
-}
 
 export function getRingConfig(size: number): any {
   if (size <= 48) {

--- a/packages/experimental/Avatar/src/JSAvatar.styling.ts
+++ b/packages/experimental/Avatar/src/JSAvatar.styling.ts
@@ -1,8 +1,8 @@
-import { JSAvatarName, JSAvatarTokens, AvatarSlotProps, JSAvatarProps } from './JSAvatar.types';
+import { JSAvatarName, JSAvatarTokens, AvatarSlotProps, JSAvatarProps, AvatarColors, AvatarSizes } from './JSAvatar.types';
 import { Theme, UseStylingOptions, buildProps } from '@fluentui-react-native/framework';
 import { defaultJSAvatarTokens } from './JSAvatarTokens';
 import { ViewStyle } from 'react-native';
-import { convertCoinColorFluent, getRingConfig } from './JSAvatar.helpers';
+import { getRingConfig } from './JSAvatar.helpers';
 import { borderStyles } from '@fluentui-react-native/tokens';
 
 const nameMap: { [key: string]: string } = {
@@ -11,23 +11,7 @@ const nameMap: { [key: string]: string } = {
   end: 'flex-end',
 };
 
-export const avatarStates: (keyof JSAvatarTokens)[] = [
-  'circular',
-  'square',
-  'inactive',
-  'size20',
-  'size24',
-  'size28',
-  'size32',
-  'size36',
-  'size40',
-  'size48',
-  'size56',
-  'size64',
-  'size72',
-  'size96',
-  'size120',
-];
+export const avatarStates: (keyof JSAvatarTokens)[] = [...AvatarColors, ...AvatarSizes, 'circular', 'square', 'inactive'];
 
 export const stylingSettings: UseStylingOptions<JSAvatarProps, AvatarSlotProps, JSAvatarTokens> = {
   tokens: [defaultJSAvatarTokens, JSAvatarName],
@@ -35,17 +19,17 @@ export const stylingSettings: UseStylingOptions<JSAvatarProps, AvatarSlotProps, 
   slotProps: {
     root: buildProps(
       (tokens: JSAvatarTokens) => {
-        const { horizontalIconAlignment, verticalIconAlignment } = tokens;
+        const { horizontalIconAlignment, verticalIconAlignment, width, height, avatarOpacity } = tokens;
         return {
           style: {
             flexDirection: 'row',
-            width: tokens.width,
-            height: tokens.height,
+            width: width,
+            height: height,
             justifyContent: nameMap[horizontalIconAlignment || 'end'] as ViewStyle['justifyContent'],
             alignItems: nameMap[verticalIconAlignment || 'end'] as ViewStyle['alignItems'],
             horizontalIconAlignment,
             verticalIconAlignment,
-            opacity: tokens.avatarOpacity,
+            opacity: avatarOpacity,
           },
         };
       },
@@ -56,18 +40,16 @@ export const stylingSettings: UseStylingOptions<JSAvatarProps, AvatarSlotProps, 
         return {
           style: {
             fontSize: tokens.initialsSize,
+            color: tokens.color,
           },
         };
       },
-      ['initialsSize'],
+      ['initialsSize', 'color'],
     ),
     initialsBackground: buildProps(
       (tokens: JSAvatarTokens, theme: Theme) => {
-        const { backgroundColor, coinColorFluent } = tokens;
-        let effectiveBackgroundColor = backgroundColor;
-        if (coinColorFluent) {
-          effectiveBackgroundColor = convertCoinColorFluent(coinColorFluent);
-        }
+        const { backgroundColor } = tokens;
+
         return {
           style: {
             ...borderStyles.from(tokens, theme),
@@ -77,11 +59,11 @@ export const stylingSettings: UseStylingOptions<JSAvatarProps, AvatarSlotProps, 
             alignSelf: 'stretch',
             justifyContent: 'center',
             alignItems: 'center',
-            backgroundColor: effectiveBackgroundColor,
+            backgroundColor: backgroundColor,
           },
         };
       },
-      ['coinColorFluent', 'backgroundColor', 'width', 'height', ...borderStyles.keys],
+      ['backgroundColor', 'width', 'height', ...borderStyles.keys],
     ),
     image: buildProps(
       (tokens: JSAvatarTokens) => {
@@ -110,12 +92,10 @@ export const stylingSettings: UseStylingOptions<JSAvatarProps, AvatarSlotProps, 
     ring: buildProps(
       (tokens: JSAvatarTokens, theme: Theme) => {
         const ringConfig = getRingConfig(tokens.width);
-
-        const ringColor = tokens.ringColor;
         return {
           style: {
             borderStyle: 'solid',
-            borderColor: ringColor,
+            borderColor: tokens.ringColor,
             borderWidth: ringConfig.stroke,
             width: ringConfig.size,
             height: ringConfig.size,
@@ -126,7 +106,7 @@ export const stylingSettings: UseStylingOptions<JSAvatarProps, AvatarSlotProps, 
           },
         };
       },
-      ['width', 'height', ...borderStyles.keys],
+      ['width', 'height', 'ringColor', ...borderStyles.keys],
     ),
     badge: buildProps(
       (tokens: JSAvatarTokens) => {

--- a/packages/experimental/Avatar/src/JSAvatar.tsx
+++ b/packages/experimental/Avatar/src/JSAvatar.tsx
@@ -22,6 +22,8 @@ export const avatarLookup = (layer: string, state: JSAvatarState, userProps: JSA
     userProps[layer] ||
     layer === userProps['shape'] ||
     (!userProps['shape'] && layer === 'circular') ||
+    layer === userProps['avatarColor'] ||
+    (!userProps['avatarColor'] && layer === 'brand') ||
     layer === userProps['size'] ||
     (!userProps['size'] && layer === 'size56') ||
     (userProps.active === 'inactive' && layer === 'inactive')

--- a/packages/experimental/Avatar/src/JSAvatar.types.ts
+++ b/packages/experimental/Avatar/src/JSAvatar.types.ts
@@ -19,36 +19,51 @@ export const AvatarSizes = [
   'size96',
   'size120',
 ] as const;
-export type AvatarSize = typeof AvatarSizes[number];
-
-export type AvatarShape = 'circular' | 'square';
-export type AvatarActive = 'active' | 'inactive' | 'unset';
-export type AvatarActiveAppearance = 'ring' | 'shadow' | 'glow' | 'ring-shadow' | 'ring-glow';
 
 /**
  * Sets color of the avatar when there is no picture. Uses fluent color names
  */
-export type AvatarColor =
-  | 'cornflower'
-  | 'blue'
-  | 'royalBlue'
-  | 'teal'
-  | 'forest'
-  | 'darkGreen'
-  | 'berry'
-  | 'hotPink'
-  | 'grape'
-  | 'purple'
-  | 'pumpkin'
-  | 'red'
-  | 'burgundy'
-  | 'orchid'
-  | 'brass'
-  | 'darkRed'
-  | 'beige'
-  | 'platinum'
-  | 'steel'
-  | 'brown';
+export const AvatarColors = [
+  'darkRed',
+  'cranberry',
+  'red',
+  'pumpkin',
+  'peach',
+  'marigold',
+  'gold',
+  'brass',
+  'brown',
+  'forest',
+  'seafoam',
+  'darkGreen',
+  'lightTeal',
+  'teal',
+  'steel',
+  'blue',
+  'royalBlue',
+  'cornflower',
+  'navy',
+  'lavender',
+  'purple',
+  'grape',
+  'lilac',
+  'pink',
+  'magenta',
+  'plum',
+  'beige',
+  'mink',
+  'platinum',
+  'anchor',
+] as const;
+export type AvatarSize = typeof AvatarSizes[number];
+export type AvatarNamedColor = typeof AvatarColors[number];
+
+export type AvatarShape = 'circular' | 'square';
+export type AvatarActive = 'active' | 'inactive' | 'unset';
+export type AvatarActiveAppearance = 'ring' | 'shadow' | 'glow' | 'ring-shadow' | 'ring-glow';
+export type AvatarColor = 'neutral' | 'brand' | 'colorful' | AvatarNamedColor;
+export type IconAlignment = 'start' | 'center' | 'end';
+
 export interface RingConfig {
   accent?: boolean;
   transparent?: boolean;
@@ -59,9 +74,18 @@ export interface RingConfig {
 }
 
 export interface AvatarConfigurableProps {
+  /**
+   * The color when displaying either an icon or initials.
+   * * neutral (default): gray
+   * * brand: color from the brand palette
+   * * colorful: picks a color from a set of pre-defined colors, based on a hash of the name (or idForColor if provided)
+   * * [AvatarNamedColor]: a specific color from the theme
+   *
+   * @defaultvalue neutral
+   */
+  avatarColor?: AvatarColor;
   size?: AvatarSize;
   ring?: RingConfig;
-  coinColorFluent?: AvatarColor;
 }
 
 export interface JSAvatarProps extends IViewProps, AvatarConfigurableProps {
@@ -69,6 +93,13 @@ export interface JSAvatarProps extends IViewProps, AvatarConfigurableProps {
   activeAppearance?: AvatarActiveAppearance;
   badge?: PresenceBadgeProps;
   icon?: IconSourcesType;
+
+  /**
+   * Specify a string to be used instead of the name, to determine which color to use when color="colorful".
+   * Use this when a name is not available, but there is another unique identifier that can be used instead.
+   */
+  idForColor?: string | undefined;
+
   image?: ImageProps;
   initials?: string;
   name?: string;
@@ -76,22 +107,8 @@ export interface JSAvatarProps extends IViewProps, AvatarConfigurableProps {
   src?: string;
 }
 
-export interface AvatarSlotProps {
-  root: ViewProps;
-  image: ImageProps;
-  initials: TextProps;
-  initialsBackground: ViewProps;
-  icon: IconProps;
-  ring: ViewProps;
-  badge: BadgeProps;
-}
-
-export type IconAlignment = 'start' | 'center' | 'end';
-
 export interface JSAvatarTokens extends IBackgroundColorTokens, IForegroundColorTokens, AvatarConfigurableProps, IBorderTokens {
   iconSize?: number;
-  iconStrokeWidth?: number;
-  iconStrokeColor?: string;
   initialsSize?: number;
   height?: number;
   horizontalIconAlignment?: IconAlignment;
@@ -115,6 +132,48 @@ export interface JSAvatarTokens extends IBackgroundColorTokens, IForegroundColor
   size120?: JSAvatarTokens;
   width?: number;
   badgeSize?: BadgeSize;
+  neutral?: JSAvatarTokens;
+  brand?: JSAvatarTokens;
+  darkRed?: JSAvatarTokens;
+  cranberry?: JSAvatarTokens;
+  red?: JSAvatarTokens;
+  pumpkin?: JSAvatarTokens;
+  peach?: JSAvatarTokens;
+  marigold?: JSAvatarTokens;
+  gold?: JSAvatarTokens;
+  brass?: JSAvatarTokens;
+  brown?: JSAvatarTokens;
+  forest?: JSAvatarTokens;
+  seafoam?: JSAvatarTokens;
+  darkGreen?: JSAvatarTokens;
+  lightTeal?: JSAvatarTokens;
+  teal?: JSAvatarTokens;
+  steel?: JSAvatarTokens;
+  blue?: JSAvatarTokens;
+  royalBlue?: JSAvatarTokens;
+  cornflower?: JSAvatarTokens;
+  navy?: JSAvatarTokens;
+  lavender?: JSAvatarTokens;
+  purple?: JSAvatarTokens;
+  grape?: JSAvatarTokens;
+  lilac?: JSAvatarTokens;
+  pink?: JSAvatarTokens;
+  magenta?: JSAvatarTokens;
+  plum?: JSAvatarTokens;
+  beige?: JSAvatarTokens;
+  mink?: JSAvatarTokens;
+  platinum?: JSAvatarTokens;
+  anchor?: JSAvatarTokens;
+}
+
+export interface AvatarSlotProps {
+  root: ViewProps;
+  image: ImageProps;
+  initials: TextProps;
+  initialsBackground: ViewProps;
+  icon: IconProps;
+  ring: ViewProps;
+  badge: BadgeProps;
 }
 
 export interface JSAvatarState {

--- a/packages/experimental/Avatar/src/JSAvatarTokens.ts
+++ b/packages/experimental/Avatar/src/JSAvatarTokens.ts
@@ -1,16 +1,14 @@
 import { Theme } from '@fluentui-react-native/framework';
 import { TokenSettings } from '@fluentui-react-native/use-styling';
 import { JSAvatarTokens } from '.';
-import { convertCoinColorFluent } from './JSAvatar.helpers';
 import { globalTokens } from '@fluentui-react-native/theme-tokens';
 
-export const defaultJSAvatarTokens: TokenSettings<JSAvatarTokens, Theme> = () =>
+export const defaultJSAvatarTokens: TokenSettings<JSAvatarTokens, Theme> = (t: Theme) =>
   ({
     horizontalIconAlignment: 'end',
     verticalIconAlignment: 'end',
-    color: 'white', // initials is always 'white', unless overriden by token
-    iconStrokeColor: 'white', // icon stroke color is always 'white', unless overriden by token
-    backgroundColor: convertCoinColorFluent('cornflower'),
+    color: globalTokens.color.white,
+    backgroundColor: globalTokens.color.cornflower.primary,
     avatarOpacity: 1,
     circular: {
       borderRadius: globalTokens.corner.radius.circle,
@@ -104,5 +102,105 @@ export const defaultJSAvatarTokens: TokenSettings<JSAvatarTokens, Theme> = () =>
       badgeSize: 'largest',
       iconSize: 40,
       initialsSize: 48,
+    },
+    neutral: {
+      backgroundColor: t.colors.neutralBackground6,
+      color: t.colors.neutralForeground3,
+      ringColor: t.colors.defaultBorder,
+    },
+    brand: {
+      backgroundColor: t.colors.brandBackgroundStatic,
+      color: t.colors.neutralForegroundOnBrand,
+      ringColor: t.colors.brandedBorder,
+    },
+    darkRed: {
+      backgroundColor: globalTokens.color.darkRed.primary,
+    },
+    cranberry: {
+      backgroundColor: globalTokens.color.cranberry.primary,
+    },
+    red: {
+      backgroundColor: globalTokens.color.red.primary,
+    },
+    pumpkin: {
+      backgroundColor: globalTokens.color.pumpkin.primary,
+    },
+    peach: {
+      backgroundColor: globalTokens.color.peach.primary,
+    },
+    marigold: {
+      backgroundColor: globalTokens.color.marigold.primary,
+    },
+    gold: {
+      backgroundColor: globalTokens.color.gold.primary,
+    },
+    brass: {
+      backgroundColor: globalTokens.color.brass.primary,
+    },
+    brown: {
+      backgroundColor: globalTokens.color.brown.primary,
+    },
+    forest: {
+      backgroundColor: globalTokens.color.forest.primary,
+    },
+    seafoam: {
+      backgroundColor: globalTokens.color.seafoam.primary,
+    },
+    darkGreen: {
+      backgroundColor: globalTokens.color.darkGreen.primary,
+    },
+    lightTeal: {
+      backgroundColor: globalTokens.color.lightTeal.primary,
+    },
+    teal: {
+      backgroundColor: globalTokens.color.teal.primary,
+    },
+    steel: {
+      backgroundColor: globalTokens.color.steel.primary,
+    },
+    blue: {
+      backgroundColor: globalTokens.color.blue.primary,
+    },
+    royalBlue: {
+      backgroundColor: globalTokens.color.royalBlue.primary,
+    },
+    cornflower: {
+      backgroundColor: globalTokens.color.cornflower.primary,
+    },
+    navy: {
+      backgroundColor: globalTokens.color.navy.primary,
+    },
+    lavender: {
+      backgroundColor: globalTokens.color.lavender.primary,
+    },
+    purple: {
+      backgroundColor: globalTokens.color.purple.primary,
+    },
+    grape: {
+      backgroundColor: globalTokens.color.grape.primary,
+    },
+    lilac: {
+      backgroundColor: globalTokens.color.lilac.primary,
+    },
+    pink: {
+      backgroundColor: globalTokens.color.pink.primary,
+    },
+    magenta: {
+      backgroundColor: globalTokens.color.magenta.primary,
+    },
+    plum: {
+      backgroundColor: globalTokens.color.plum.primary,
+    },
+    beige: {
+      backgroundColor: globalTokens.color.beige.primary,
+    },
+    mink: {
+      backgroundColor: globalTokens.color.mink.primary,
+    },
+    platinum: {
+      backgroundColor: globalTokens.color.platinum.primary,
+    },
+    anchor: {
+      backgroundColor: globalTokens.color.anchor.primary,
     },
   } as JSAvatarTokens);


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
Added colors to the tokens. I got colors from Web spec. Waiting for the RN Avatar design. We'll need to update colors according to RN design.

### Verification
![image](https://user-images.githubusercontent.com/11574680/166453937-0a9de495-50df-4dc9-bfa8-79abb852ef21.png)
![image](https://user-images.githubusercontent.com/11574680/166453975-eb39aa08-4dda-4fd5-b60c-fdd72df1ae45.png)
![image](https://user-images.githubusercontent.com/11574680/166454048-513b7fa2-4e0d-4fe5-b643-dd304e217c48.png)


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
