### PR TITLE
Implement checkmark styling for MenuItem and MenuItemCheckbox

### DIFF
--- a/apps/fluent-tester/src/E2E/README.md
+++ b/apps/fluent-tester/src/E2E/README.md
@@ -147,7 +147,7 @@ For example, a common task we want to perform is selecting a UI element and gett
 
 - In order for a Page Object to access a component from the test page, you must use [selectors](https://webdriver.io/docs/selectors.html). The WebDriver Protocol provides several selector strategies to query an element.
 
-- If [testID](https://reactnative.dev/docs/picker-item#testid) is specified in React Native app for Windows, the locator strategy should choose accessibility id.
+- If [testID](https://reactnative.dev/docs/next/view#testid) is specified in React Native app for Windows, the locator strategy should choose accessibility id.
   A unique accessiblity id/testID per Window is recommended for React Native Windows E2E testing when authoring the test app and test cases.
 
 - To use this, we must add a prop to our component or UI element in question called “testID”. In our test page, set the “testID” for the component, and we can then select it in our Page Object using the imported **_By_** method above from a base class.

--- a/apps/fluent-tester/src/FluentTester/TestComponents/Menu/MenuTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Menu/MenuTest.tsx
@@ -24,6 +24,23 @@ const MenuDefault: React.FunctionComponent = () => {
   );
 };
 
+const MenuCheckmarks: React.FunctionComponent = () => {
+  return (
+    <Stack style={stackStyle}>
+      <Menu hasCheckmarks>
+        <MenuTrigger>
+          <Button>Test</Button>
+        </MenuTrigger>
+        <MenuPopover>
+          <MenuList>
+            <MenuItem content="A MenuItem" />
+          </MenuList>
+        </MenuPopover>
+      </Menu>
+    </Stack>
+  );
+};
+
 const Submenu: React.FunctionComponent = () => {
   return (
     <Menu>
@@ -62,6 +79,10 @@ const menuSections: TestSection[] = [
     name: 'Menu Default',
     testID: MENU_TESTPAGE,
     component: MenuDefault,
+  },
+  {
+    name: 'Menu Checkmarks',
+    component: MenuCheckmarks,
   },
   {
     name: 'Menu Submenu',

--- a/apps/fluent-tester/src/FluentTester/TestComponents/Menu/MenuTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Menu/MenuTest.tsx
@@ -27,9 +27,31 @@ const MenuDefault: React.FunctionComponent = () => {
 const MenuCheckmarks: React.FunctionComponent = () => {
   return (
     <Stack style={stackStyle}>
+      <Menu>
+        <MenuTrigger>
+          <Button>All checkmark items</Button>
+        </MenuTrigger>
+        <MenuPopover>
+          <MenuList>
+            <MenuItemCheckbox content="A MenuItem" />
+            <MenuItemCheckbox content="A MenuItem" />
+          </MenuList>
+        </MenuPopover>
+      </Menu>
       <Menu hasCheckmarks>
         <MenuTrigger>
-          <Button>Test</Button>
+          <Button>Some checkmark items with alignment</Button>
+        </MenuTrigger>
+        <MenuPopover>
+          <MenuList>
+            <MenuItem content="A MenuItem" />
+            <MenuItemCheckbox content="A MenuItem" />
+          </MenuList>
+        </MenuPopover>
+      </Menu>
+      <Menu>
+        <MenuTrigger>
+          <Button>Some checkmark items without alignment</Button>
         </MenuTrigger>
         <MenuPopover>
           <MenuList>

--- a/apps/fluent-tester/src/FluentTester/TestComponents/Menu/MenuTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Menu/MenuTest.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ButtonV1 as Button } from '@fluentui/react-native';
-import { Menu, MenuItem, MenuTrigger, MenuPopover, MenuList } from '@fluentui-react-native/menu';
+import { Menu, MenuItem, MenuItemCheckbox, MenuTrigger, MenuPopover, MenuList } from '@fluentui-react-native/menu';
 import { Stack } from '@fluentui-react-native/stack';
 import { Text } from '@fluentui-react-native/experimental-text';
 import { stackStyle } from '../Common/styles';
@@ -34,6 +34,7 @@ const MenuCheckmarks: React.FunctionComponent = () => {
         <MenuPopover>
           <MenuList>
             <MenuItem content="A MenuItem" />
+            <MenuItemCheckbox content="A MenuItem" />
           </MenuList>
         </MenuPopover>
       </Menu>

--- a/change/@fluentui-react-native-menu-122f9dac-c1b6-4cd1-9cac-02688a2eb80a.json
+++ b/change/@fluentui-react-native-menu-122f9dac-c1b6-4cd1-9cac-02688a2eb80a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add standup code for hasCheckmarks",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-de5f46bf-3b4a-47fd-b955-e17ce841441c.json
+++ b/change/@fluentui-react-native-tester-de5f46bf-3b4a-47fd-b955-e17ce841441c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add standup code for hasCheckmarks",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Menu/src/Menu/Menu.types.ts
+++ b/packages/experimental/Menu/src/Menu/Menu.types.ts
@@ -1,9 +1,9 @@
-import type { IViewProps } from '@fluentui-react-native/adapters';
+import type { MenuListProps } from '../MenuList/MenuList.types';
 import React from 'react';
 
 export const menuName = 'Menu';
 
-export interface MenuProps extends Omit<IViewProps, 'onPress'> {
+export interface MenuProps extends MenuListProps {
   open?: boolean;
 }
 

--- a/packages/experimental/Menu/src/Menu/useMenu.ts
+++ b/packages/experimental/Menu/src/Menu/useMenu.ts
@@ -9,6 +9,7 @@ export const useMenu = (props: MenuProps): MenuState => {
   const isSubmenu = context.triggerRef !== null;
 
   return {
+    ...props,
     open,
     setOpen,
     triggerRef,

--- a/packages/experimental/Menu/src/Menu/useMenuContextValue.ts
+++ b/packages/experimental/Menu/src/Menu/useMenuContextValue.ts
@@ -2,5 +2,5 @@ import { MenuContextValue } from '../context/menuContext';
 import { MenuState } from './Menu.types';
 
 export const useMenuContextValue = (state: MenuState): MenuContextValue => {
-  return { open: state.open, setOpen: state.setOpen, triggerRef: state.triggerRef, isSubmenu: state.isSubmenu };
+  return { ...state };
 };

--- a/packages/experimental/Menu/src/MenuItem/MenuItem.styling.ts
+++ b/packages/experimental/Menu/src/MenuItem/MenuItem.styling.ts
@@ -21,6 +21,16 @@ export const stylingSettings: UseStylingOptions<MenuItemProps, MenuItemSlotProps
       }),
       ['backgroundColor', ...layoutStyles.keys],
     ),
+    checkmark: buildProps(
+      (tokens: MenuItemTokens) => ({
+        style: {
+          height: tokens.checkmarkSize,
+          width: tokens.checkmarkSize,
+          marginEnd: tokens.gap,
+        },
+      }),
+      ['checkmarkSize', 'gap'],
+    ),
     content: buildProps(
       (tokens: MenuItemTokens, theme: Theme) => {
         return {

--- a/packages/experimental/Menu/src/MenuItem/MenuItem.tsx
+++ b/packages/experimental/Menu/src/MenuItem/MenuItem.tsx
@@ -31,7 +31,7 @@ export const MenuItem = compose<MenuItemType>({
         <Slots.root {...mergedProps}>
           {menuItem.hasCheckmarks && <Slots.checkmark />}
           {mergedProps.content && <Slots.content>{mergedProps.content}</Slots.content>}
-          {mergedProps.hasSubmenu && <Slots.submenuIndicator xml={chevronXml} />}
+          {menuItem.hasSubmenu && <Slots.submenuIndicator xml={chevronXml} />}
         </Slots.root>
       );
     };

--- a/packages/experimental/Menu/src/MenuItem/MenuItem.tsx
+++ b/packages/experimental/Menu/src/MenuItem/MenuItem.tsx
@@ -12,6 +12,7 @@ export const MenuItem = compose<MenuItemType>({
   ...stylingSettings,
   slots: {
     root: View,
+    checkmark: View,
     content: Text,
     submenuIndicator: SvgXml,
   },
@@ -28,6 +29,7 @@ export const MenuItem = compose<MenuItemType>({
 
       return (
         <Slots.root {...mergedProps}>
+          {menuItem.hasCheckmarks && <Slots.checkmark />}
           {mergedProps.content && <Slots.content>{mergedProps.content}</Slots.content>}
           {mergedProps.hasSubmenu && <Slots.submenuIndicator xml={chevronXml} />}
         </Slots.root>

--- a/packages/experimental/Menu/src/MenuItem/MenuItem.types.ts
+++ b/packages/experimental/Menu/src/MenuItem/MenuItem.types.ts
@@ -32,11 +32,6 @@ export interface MenuItemProps extends Omit<IWithPressableOptions<ViewProps>, 'o
   componentRef?: React.RefObject<IFocusable>;
 
   /**
-   * If the menu item is a trigger for a submenu
-   */
-  hasSubmenu?: boolean;
-
-  /**
    * A callback to call on button click event
    */
   onClick?: (e: InteractionEvent) => void;
@@ -44,6 +39,11 @@ export interface MenuItemProps extends Omit<IWithPressableOptions<ViewProps>, 'o
 
 export interface MenuItemState extends IPressableHooks<MenuItemProps & React.ComponentPropsWithRef<any>> {
   hasCheckmarks?: boolean;
+
+  /**
+   * If the menu item is a trigger for a submenu
+   */
+  hasSubmenu?: boolean;
 }
 
 export interface MenuItemSlotProps {

--- a/packages/experimental/Menu/src/MenuItem/MenuItem.types.ts
+++ b/packages/experimental/Menu/src/MenuItem/MenuItem.types.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ViewProps } from 'react-native';
-import { SvgProps, XmlProps } from 'react-native-svg';
+import { XmlProps } from 'react-native-svg';
 import type { IViewProps } from '@fluentui-react-native/adapters';
 import { TextProps } from '@fluentui-react-native/experimental-text';
 import { IFocusable, InteractionEvent, IPressableHooks, IWithPressableOptions } from '@fluentui-react-native/interactive-hooks';
@@ -50,7 +50,7 @@ export interface MenuItemSlotProps {
   root: React.PropsWithRef<IViewProps>;
   content?: TextProps;
   checkmark?: React.PropsWithRef<IViewProps>;
-  submenuIndicator?: SvgProps | XmlProps;
+  submenuIndicator?: XmlProps;
 }
 
 export interface MenuItemType {

--- a/packages/experimental/Menu/src/MenuItem/MenuItem.types.ts
+++ b/packages/experimental/Menu/src/MenuItem/MenuItem.types.ts
@@ -9,6 +9,9 @@ import { FontTokens, IBorderTokens, IColorTokens, LayoutTokens } from '@fluentui
 export const menuItemName = 'MenuItem';
 
 export interface MenuItemTokens extends LayoutTokens, FontTokens, IBorderTokens, IColorTokens {
+  checkmarkSize?: number;
+  gap?: number;
+
   disabled?: MenuItemTokens;
   focused?: MenuItemTokens;
   hovered?: MenuItemTokens;
@@ -39,11 +42,14 @@ export interface MenuItemProps extends Omit<IWithPressableOptions<ViewProps>, 'o
   onClick?: (e: InteractionEvent) => void;
 }
 
-export type MenuItemState = IPressableHooks<MenuItemProps & React.ComponentPropsWithRef<any>>;
+export interface MenuItemState extends IPressableHooks<MenuItemProps & React.ComponentPropsWithRef<any>> {
+  hasCheckmarks?: boolean;
+}
 
 export interface MenuItemSlotProps {
   root: React.PropsWithRef<IViewProps>;
   content?: TextProps;
+  checkmark?: React.PropsWithRef<IViewProps>;
   submenuIndicator?: SvgProps | XmlProps;
 }
 

--- a/packages/experimental/Menu/src/MenuItem/MenuItemTokens.ts
+++ b/packages/experimental/Menu/src/MenuItem/MenuItemTokens.ts
@@ -6,10 +6,12 @@ import { MenuItemTokens } from './MenuItem.types';
 export const defaultMenuItemTokens: TokenSettings<MenuItemTokens, Theme> = (t: Theme): MenuItemTokens => ({
   backgroundColor: t.colors.neutralBackground1,
   borderRadius: globalTokens.corner.radius.medium,
+  checkmarkSize: 16,
   color: t.colors.neutralForeground2,
   fontFamily: t.typography.families.primary,
   fontSize: globalTokens.font.size[300],
   fontWeight: globalTokens.font.weight.regular as FontWeightValue,
+  gap: globalTokens.spacing.xs,
   minHeight: 32,
   minWidth: 160,
   maxWidth: 300,

--- a/packages/experimental/Menu/src/MenuItem/MenuItemTokens.win32.ts
+++ b/packages/experimental/Menu/src/MenuItem/MenuItemTokens.win32.ts
@@ -6,10 +6,12 @@ import { MenuItemTokens } from './MenuItem.types';
 export const defaultMenuItemTokens: TokenSettings<MenuItemTokens, Theme> = (t: Theme): MenuItemTokens => ({
   backgroundColor: t.colors.neutralBackground1,
   borderRadius: globalTokens.corner.radius.none,
+  checkmarkSize: 16,
   color: t.colors.neutralForeground1,
   fontFamily: t.typography.families.primary,
   fontSize: globalTokens.font.size[200],
   fontWeight: globalTokens.font.weight.regular as FontWeightValue,
+  gap: globalTokens.spacing.xs,
   minHeight: 24,
   minWidth: 160,
   maxWidth: 300,

--- a/packages/experimental/Menu/src/MenuItem/useMenuItem.ts
+++ b/packages/experimental/Menu/src/MenuItem/useMenuItem.ts
@@ -12,6 +12,7 @@ export const useMenuItem = (props: MenuItemProps): MenuItemState => {
   const pressable = useAsPressable({ ...rest, disabled, onPress: onClick });
   const onKeyProps = useKeyProps(onClick, ' ', 'Enter');
   const hasSubmenu = useMenuContext().isSubmenu;
+  const hasCheckmarks = useMenuContext().hasCheckmarks;
 
   return {
     props: {
@@ -28,6 +29,7 @@ export const useMenuItem = (props: MenuItemProps): MenuItemState => {
       ...onKeyProps,
     },
     state: pressable.state,
+    hasCheckmarks,
   };
 };
 

--- a/packages/experimental/Menu/src/MenuItem/useMenuItem.ts
+++ b/packages/experimental/Menu/src/MenuItem/useMenuItem.ts
@@ -24,11 +24,11 @@ export const useMenuItem = (props: MenuItemProps): MenuItemState => {
       accessibilityState: getAccessibilityState(disabled, accessibilityState),
       enableFocusRing: true,
       focusable: !disabled,
-      hasSubmenu,
       ref: componentRef,
       ...onKeyProps,
     },
     state: pressable.state,
+    hasSubmenu,
     hasCheckmarks,
   };
 };

--- a/packages/experimental/Menu/src/MenuItemCheckbox/MenuItemCheckbox.styling.ts
+++ b/packages/experimental/Menu/src/MenuItemCheckbox/MenuItemCheckbox.styling.ts
@@ -22,28 +22,23 @@ export const stylingSettings: UseStylingOptions<MenuItemCheckboxProps, MenuItemC
       ['backgroundColor', ...layoutStyles.keys],
     ),
     checkmark: buildProps(
-      (tokens: MenuItemCheckboxTokens) => {
-        return {
-          color: tokens.color,
-          height: tokens.checkmarkSize,
-          width: tokens.checkmarkSize,
-          viewBox:
-            '0 0 ' + (tokens.checkmarkSize - tokens.checkmarkPadding * 2) + ' ' + (tokens.checkmarkSize - tokens.checkmarkPadding * 2),
-          style: { marginEnd: tokens.gap },
-        };
-      },
+      (tokens: MenuItemCheckboxTokens) => ({
+        color: tokens.color,
+        height: tokens.checkmarkSize,
+        width: tokens.checkmarkSize,
+        viewBox: '0 0 ' + (tokens.checkmarkSize - tokens.checkmarkPadding * 2) + ' ' + (tokens.checkmarkSize - tokens.checkmarkPadding * 2),
+        style: { marginEnd: tokens.gap },
+      }),
       ['checkmarkSize', 'gap', 'color'],
     ),
     content: buildProps(
-      (tokens: MenuItemCheckboxTokens, theme: Theme) => {
-        return {
-          style: {
-            flexGrow: 1,
-            color: tokens.color,
-            ...fontStyles.from(tokens, theme),
-          },
-        };
-      },
+      (tokens: MenuItemCheckboxTokens, theme: Theme) => ({
+        style: {
+          flexGrow: 1,
+          color: tokens.color,
+          ...fontStyles.from(tokens, theme),
+        },
+      }),
       ['color', ...fontStyles.keys],
     ),
   },

--- a/packages/experimental/Menu/src/MenuItemCheckbox/MenuItemCheckbox.styling.ts
+++ b/packages/experimental/Menu/src/MenuItemCheckbox/MenuItemCheckbox.styling.ts
@@ -3,7 +3,7 @@ import { fontStyles, layoutStyles } from '@fluentui-react-native/tokens';
 import { defaultMenuItemCheckboxTokens } from './MenuItemCheckboxTokens';
 import { menuItemCheckboxName, MenuItemCheckboxProps, MenuItemCheckboxTokens, MenuItemCheckboxSlotProps } from './MenuItemCheckbox.types';
 
-export const menuItemCheckboxStates: (keyof MenuItemCheckboxTokens)[] = ['hovered', 'focused', 'pressed', 'disabled'];
+export const menuItemCheckboxStates: (keyof MenuItemCheckboxTokens)[] = ['hovered', 'focused', 'pressed', 'disabled', 'checked'];
 
 export const stylingSettings: UseStylingOptions<MenuItemCheckboxProps, MenuItemCheckboxSlotProps, MenuItemCheckboxTokens> = {
   tokens: [defaultMenuItemCheckboxTokens, menuItemCheckboxName],
@@ -20,6 +20,19 @@ export const stylingSettings: UseStylingOptions<MenuItemCheckboxProps, MenuItemC
         },
       }),
       ['backgroundColor', ...layoutStyles.keys],
+    ),
+    checkmark: buildProps(
+      (tokens: MenuItemCheckboxTokens) => {
+        return {
+          color: tokens.color,
+          height: tokens.checkmarkSize,
+          width: tokens.checkmarkSize,
+          viewBox:
+            '0 0 ' + (tokens.checkmarkSize - tokens.checkmarkPadding * 2) + ' ' + (tokens.checkmarkSize - tokens.checkmarkPadding * 2),
+          style: { marginEnd: tokens.gap },
+        };
+      },
+      ['checkmarkSize', 'gap', 'color'],
     ),
     content: buildProps(
       (tokens: MenuItemCheckboxTokens, theme: Theme) => {

--- a/packages/experimental/Menu/src/MenuItemCheckbox/MenuItemCheckbox.tsx
+++ b/packages/experimental/Menu/src/MenuItemCheckbox/MenuItemCheckbox.tsx
@@ -1,5 +1,6 @@
 /** @jsx withSlots */
 import { View } from 'react-native';
+import { SvgXml } from 'react-native-svg';
 import { compose, mergeProps, UseSlots, withSlots } from '@fluentui-react-native/framework';
 import { Text } from '@fluentui-react-native/experimental-text';
 import { menuItemCheckboxName, MenuItemCheckboxProps, MenuItemCheckboxType } from './MenuItemCheckbox.types';
@@ -11,6 +12,7 @@ export const MenuItemCheckbox = compose<MenuItemCheckboxType>({
   ...stylingSettings,
   slots: {
     root: View,
+    checkmark: SvgXml,
     content: Text,
   },
   useRender: (userProps: MenuItemCheckboxProps, useSlots: UseSlots<MenuItemCheckboxType>) => {
@@ -19,8 +21,17 @@ export const MenuItemCheckbox = compose<MenuItemCheckboxType>({
 
     return (final: MenuItemCheckboxProps) => {
       const mergedProps = mergeProps(menuItem.props, final);
+      const chevronXml = `
+      <svg>
+        <path fill='currentColor' d='M9.85355 3.14645C10.0488 3.34171 10.0488 3.65829 9.85355 3.85355L5.35355 8.35355C5.15829 8.54882 4.84171 8.54882 4.64645 8.35355L2.64645 6.35355C2.45118 6.15829 2.45118 5.84171 2.64645 5.64645C2.84171 5.45118 3.15829 5.45118 3.35355 5.64645L5 7.29289L9.14645 3.14645C9.34171 2.95118 9.65829 2.95118 9.85355 3.14645Z' />
+      </svg>`;
 
-      return <Slots.root {...mergedProps}>{mergedProps.content && <Slots.content>{mergedProps.content}</Slots.content>}</Slots.root>;
+      return (
+        <Slots.root {...mergedProps}>
+          {menuItem.hasCheckmarks && <Slots.checkmark xml={chevronXml} />}
+          {mergedProps.content && <Slots.content>{mergedProps.content}</Slots.content>}
+        </Slots.root>
+      );
     };
   },
 });

--- a/packages/experimental/Menu/src/MenuItemCheckbox/MenuItemCheckbox.tsx
+++ b/packages/experimental/Menu/src/MenuItemCheckbox/MenuItemCheckbox.tsx
@@ -28,7 +28,7 @@ export const MenuItemCheckbox = compose<MenuItemCheckboxType>({
 
       return (
         <Slots.root {...mergedProps}>
-          {menuItem.hasCheckmarks && <Slots.checkmark xml={chevronXml} />}
+          <Slots.checkmark xml={chevronXml} />
           {mergedProps.content && <Slots.content>{mergedProps.content}</Slots.content>}
         </Slots.root>
       );

--- a/packages/experimental/Menu/src/MenuItemCheckbox/MenuItemCheckbox.types.ts
+++ b/packages/experimental/Menu/src/MenuItemCheckbox/MenuItemCheckbox.types.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { ViewProps } from 'react-native';
+import { ColorValue, ViewProps } from 'react-native';
+import { SvgProps, XmlProps } from 'react-native-svg';
 import type { IViewProps } from '@fluentui-react-native/adapters';
 import { TextProps } from '@fluentui-react-native/experimental-text';
 import { IFocusable, InteractionEvent, IPressableHooks, IWithPressableOptions } from '@fluentui-react-native/interactive-hooks';
@@ -8,6 +9,13 @@ import { FontTokens, IBorderTokens, IColorTokens, LayoutTokens } from '@fluentui
 export const menuItemCheckboxName = 'MenuItemCheckbox';
 
 export interface MenuItemCheckboxTokens extends LayoutTokens, FontTokens, IBorderTokens, IColorTokens {
+  checkmarkColor?: ColorValue;
+  checkmarkPadding?: number;
+  checkmarkSize?: number;
+  checkmarkVisibility?: number;
+  gap?: number;
+
+  checked?: MenuItemCheckboxTokens;
   disabled?: MenuItemCheckboxTokens;
   focused?: MenuItemCheckboxTokens;
   hovered?: MenuItemCheckboxTokens;
@@ -28,20 +36,18 @@ export interface MenuItemCheckboxProps extends Omit<IWithPressableOptions<ViewPr
   componentRef?: React.RefObject<IFocusable>;
 
   /**
-   * If the menu item is a trigger for a submenu
-   */
-  hasSubmenu?: boolean;
-
-  /**
    * A callback to call on button click event
    */
   onClick?: (e: InteractionEvent) => void;
 }
 
-export type MenuItemCheckboxState = IPressableHooks<MenuItemCheckboxProps & React.ComponentPropsWithRef<any>>;
+export interface MenuItemCheckboxState extends IPressableHooks<MenuItemCheckboxProps & React.ComponentPropsWithRef<any>> {
+  hasCheckmarks?: boolean;
+}
 
 export interface MenuItemCheckboxSlotProps {
   root: React.PropsWithRef<IViewProps>;
+  checkmark?: SvgProps | XmlProps;
   content?: TextProps;
 }
 

--- a/packages/experimental/Menu/src/MenuItemCheckbox/MenuItemCheckbox.types.ts
+++ b/packages/experimental/Menu/src/MenuItemCheckbox/MenuItemCheckbox.types.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ColorValue, ViewProps } from 'react-native';
-import { SvgProps, XmlProps } from 'react-native-svg';
+import { XmlProps } from 'react-native-svg';
 import type { IViewProps } from '@fluentui-react-native/adapters';
 import { TextProps } from '@fluentui-react-native/experimental-text';
 import { IFocusable, InteractionEvent, IPressableHooks, IWithPressableOptions } from '@fluentui-react-native/interactive-hooks';
@@ -47,7 +47,7 @@ export interface MenuItemCheckboxState extends IPressableHooks<MenuItemCheckboxP
 
 export interface MenuItemCheckboxSlotProps {
   root: React.PropsWithRef<IViewProps>;
-  checkmark?: SvgProps | XmlProps;
+  checkmark?: XmlProps;
   content?: TextProps;
 }
 

--- a/packages/experimental/Menu/src/MenuItemCheckbox/MenuItemCheckboxTokens.ts
+++ b/packages/experimental/Menu/src/MenuItemCheckbox/MenuItemCheckboxTokens.ts
@@ -6,10 +6,14 @@ import { MenuItemCheckboxTokens } from './MenuItemCheckbox.types';
 export const defaultMenuItemCheckboxTokens: TokenSettings<MenuItemCheckboxTokens, Theme> = (t: Theme): MenuItemCheckboxTokens => ({
   backgroundColor: t.colors.neutralBackground1,
   borderRadius: globalTokens.corner.radius.medium,
+  checkmarkPadding: globalTokens.spacing.none,
+  checkmarkSize: 16,
+  checkmarkVisibility: 0,
   color: t.colors.neutralForeground2,
   fontFamily: t.typography.families.primary,
   fontSize: globalTokens.font.size[300],
   fontWeight: globalTokens.font.weight.regular as FontWeightValue,
+  gap: globalTokens.spacing.xs,
   minHeight: 32,
   minWidth: 160,
   maxWidth: 300,
@@ -17,13 +21,29 @@ export const defaultMenuItemCheckboxTokens: TokenSettings<MenuItemCheckboxTokens
   hovered: {
     backgroundColor: t.colors.neutralBackground1Hover,
     color: t.colors.neutralForeground2Hover,
+    checked: {
+      checkmarkColor: t.colors.neutralForeground2Hover,
+      checkmarkVisibility: 1,
+    },
   },
   pressed: {
     backgroundColor: t.colors.neutralBackground1Pressed,
     color: t.colors.neutralForeground2Pressed,
+    checked: {
+      checkmarkColor: t.colors.neutralForeground2Pressed,
+      checkmarkVisibility: 1,
+    },
   },
   disabled: {
     backgroundColor: t.colors.neutralBackground1,
     color: t.colors.neutralForegroundDisabled,
+    checked: {
+      checkmarkColor: t.colors.neutralForegroundDisabled,
+      checkmarkVisibility: 1,
+    },
+  },
+  checked: {
+    checkmarkColor: t.colors.neutralForeground2,
+    checkmarkVisibility: 1,
   },
 });

--- a/packages/experimental/Menu/src/MenuItemCheckbox/MenuItemCheckboxTokens.win32.ts
+++ b/packages/experimental/Menu/src/MenuItemCheckbox/MenuItemCheckboxTokens.win32.ts
@@ -6,7 +6,7 @@ import { MenuItemCheckboxTokens } from './MenuItemCheckbox.types';
 export const defaultMenuItemCheckboxTokens: TokenSettings<MenuItemCheckboxTokens, Theme> = (t: Theme): MenuItemCheckboxTokens => ({
   backgroundColor: t.colors.neutralBackground1,
   borderRadius: globalTokens.corner.radius.none,
-  checkmarkPadding: globalTokens.spacing.xs,
+  checkmarkPadding: globalTokens.spacing.xxs,
   checkmarkSize: 16,
   checkmarkVisibility: 0,
   color: t.colors.neutralForeground1,

--- a/packages/experimental/Menu/src/MenuItemCheckbox/MenuItemCheckboxTokens.win32.ts
+++ b/packages/experimental/Menu/src/MenuItemCheckbox/MenuItemCheckboxTokens.win32.ts
@@ -6,10 +6,14 @@ import { MenuItemCheckboxTokens } from './MenuItemCheckbox.types';
 export const defaultMenuItemCheckboxTokens: TokenSettings<MenuItemCheckboxTokens, Theme> = (t: Theme): MenuItemCheckboxTokens => ({
   backgroundColor: t.colors.neutralBackground1,
   borderRadius: globalTokens.corner.radius.none,
+  checkmarkPadding: globalTokens.spacing.xs,
+  checkmarkSize: 16,
+  checkmarkVisibility: 0,
   color: t.colors.neutralForeground1,
   fontFamily: t.typography.families.primary,
   fontSize: globalTokens.font.size[200],
   fontWeight: globalTokens.font.weight.regular as FontWeightValue,
+  gap: globalTokens.spacing.xs,
   minHeight: 24,
   minWidth: 160,
   maxWidth: 300,
@@ -18,13 +22,29 @@ export const defaultMenuItemCheckboxTokens: TokenSettings<MenuItemCheckboxTokens
   hovered: {
     backgroundColor: t.colors.neutralBackground1Hover,
     color: t.colors.neutralForeground1Hover,
+    checked: {
+      checkmarkColor: t.colors.neutralForeground1Hover,
+      checkmarkVisibility: 1,
+    },
   },
   pressed: {
     backgroundColor: t.colors.neutralBackground1Pressed,
     color: t.colors.neutralForeground1Pressed,
+    checked: {
+      checkmarkColor: t.colors.neutralForeground1Pressed,
+      checkmarkVisibility: 1,
+    },
   },
   disabled: {
     backgroundColor: t.colors.neutralBackground1,
     color: t.colors.neutralForegroundDisabled,
+    checked: {
+      checkmarkColor: t.colors.neutralForegroundDisabled,
+      checkmarkVisibility: 1,
+    },
+  },
+  checked: {
+    checkmarkColor: t.colors.neutralForeground1,
+    checkmarkVisibility: 1,
   },
 });

--- a/packages/experimental/Menu/src/MenuItemCheckbox/useMenuItemCheckbox.ts
+++ b/packages/experimental/Menu/src/MenuItemCheckbox/useMenuItemCheckbox.ts
@@ -11,7 +11,7 @@ export const useMenuItemCheckbox = (props: MenuItemCheckboxProps): MenuItemCheck
   const { onClick, accessibilityState, componentRef = defaultComponentRef, disabled, ...rest } = props;
   const pressable = useAsPressable({ ...rest, disabled, onPress: onClick });
   const onKeyProps = useKeyProps(onClick, ' ', 'Enter');
-  const hasSubmenu = useMenuContext().isSubmenu;
+  const hasCheckmarks = useMenuContext().hasCheckmarks;
 
   return {
     props: {
@@ -23,11 +23,11 @@ export const useMenuItemCheckbox = (props: MenuItemCheckboxProps): MenuItemCheck
       accessibilityState: getAccessibilityState(disabled, accessibilityState),
       enableFocusRing: true,
       focusable: !disabled,
-      hasSubmenu,
       ref: componentRef,
       ...onKeyProps,
     },
     state: pressable.state,
+    hasCheckmarks,
   };
 };
 

--- a/packages/experimental/Menu/src/MenuList/MenuList.types.ts
+++ b/packages/experimental/Menu/src/MenuList/MenuList.types.ts
@@ -5,7 +5,9 @@ export const menuListName = 'MenuList';
 
 export interface MenuListTokens extends LayoutTokens, IBackgroundColorTokens {}
 
-export interface MenuListProps extends Omit<IViewProps, 'onPress'> {}
+export interface MenuListProps extends Omit<IViewProps, 'onPress'> {
+  hasCheckmarks?: boolean;
+}
 
 export interface MenuListSlotProps {
   root: React.PropsWithRef<IViewProps>;

--- a/packages/experimental/Menu/src/index.ts
+++ b/packages/experimental/Menu/src/index.ts
@@ -2,4 +2,5 @@ export { Menu } from './Menu/Menu';
 export { MenuTrigger } from './MenuTrigger/MenuTrigger';
 export { MenuPopover } from './MenuPopover/MenuPopover';
 export { MenuItem } from './MenuItem/MenuItem';
+export { MenuItemCheckbox } from './MenuItemCheckbox/MenuItemCheckbox';
 export { MenuList } from './MenuList/MenuList';


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This change just adds styling for MenuItem and MenuItemCheckbox to have a checkmark. The actual toggling & keeping track of checked vs. unchecked behavior is not part of this PR and will be a separate change.

`hasCheckmarks` is added as a prop to `Menu` and `MenuList`. This value gets added to the menu context which MenuItemX then uses to determine if it should apply styling for checkmarks, namely giving space for alignment & showing the checkmark.

MenuItem adds some space & padding.
MenuItemCheckmark shows a checkmark. The checkmark was copied from https://github.com/microsoft/fluentui-system-icons/blob/master/assets/Checkmark/SVG/ic_fluent_checkmark_12_regular.svg

### Verification

![checkmarks](https://user-images.githubusercontent.com/4602628/168402631-5530c3ab-a853-4fdd-a8a5-9c5bbdc4fb7a.gif)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
