### PR TITLE
Implement checkbox behavior for MenuItemCheckbox

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/Menu/MenuTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Menu/MenuTest.tsx
@@ -27,7 +27,7 @@ const MenuDefault: React.FunctionComponent = () => {
 const MenuCheckmarks: React.FunctionComponent = () => {
   return (
     <Stack style={stackStyle}>
-      <Menu>
+      <Menu defaultChecked={{ itemOne: true }}>
         <MenuTrigger>
           <Button>All checkmark items</Button>
         </MenuTrigger>
@@ -38,9 +38,9 @@ const MenuCheckmarks: React.FunctionComponent = () => {
           </MenuList>
         </MenuPopover>
       </Menu>
-      <Menu hasCheckmarks>
+      <Menu hasCheckmarks checked={{ itemTwo: true }}>
         <MenuTrigger>
-          <Button>Some checkmark items with alignment</Button>
+          <Button>Some controlled checkmark items with alignment</Button>
         </MenuTrigger>
         <MenuPopover>
           <MenuList>

--- a/apps/fluent-tester/src/FluentTester/TestComponents/Menu/MenuTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Menu/MenuTest.tsx
@@ -33,8 +33,8 @@ const MenuCheckmarks: React.FunctionComponent = () => {
         </MenuTrigger>
         <MenuPopover>
           <MenuList>
-            <MenuItemCheckbox name="itemOne" content="A MenuItem" />
-            <MenuItemCheckbox name="itemTwo" content="A MenuItem" />
+            <MenuItemCheckbox name="itemOne" content="A MenuItem with checkmark" />
+            <MenuItemCheckbox name="itemTwo" content="Another MenuItem with checkmark" />
           </MenuList>
         </MenuPopover>
       </Menu>
@@ -44,8 +44,9 @@ const MenuCheckmarks: React.FunctionComponent = () => {
         </MenuTrigger>
         <MenuPopover>
           <MenuList>
-            <MenuItem content="A MenuItem" />
-            <MenuItemCheckbox name="itemTwo" content="A MenuItem" />
+            <MenuItem content="A plain MenuItem" />
+            <MenuItemCheckbox name="itemTwo" content="A MenuItem with checkmark" />
+            <MenuItemCheckbox name="itemThree" content="A MenuItem with checkmark" />
           </MenuList>
         </MenuPopover>
       </Menu>
@@ -55,8 +56,9 @@ const MenuCheckmarks: React.FunctionComponent = () => {
         </MenuTrigger>
         <MenuPopover>
           <MenuList>
-            <MenuItem content="A MenuItem" />
-            <MenuItemCheckbox name="itemTwo" content="A MenuItem" />
+            <MenuItem content="A plain MenuItem" />
+            <MenuItemCheckbox name="itemTwo" content="A MenuItem with checkmark" />
+            <MenuItemCheckbox name="itemThree" content="A MenuItem with checkmark" />
           </MenuList>
         </MenuPopover>
       </Menu>

--- a/apps/fluent-tester/src/FluentTester/TestComponents/Menu/MenuTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Menu/MenuTest.tsx
@@ -33,8 +33,8 @@ const MenuCheckmarks: React.FunctionComponent = () => {
         </MenuTrigger>
         <MenuPopover>
           <MenuList>
-            <MenuItemCheckbox content="A MenuItem" />
-            <MenuItemCheckbox content="A MenuItem" />
+            <MenuItemCheckbox name="itemOne" content="A MenuItem" />
+            <MenuItemCheckbox name="itemTwo" content="A MenuItem" />
           </MenuList>
         </MenuPopover>
       </Menu>
@@ -45,7 +45,7 @@ const MenuCheckmarks: React.FunctionComponent = () => {
         <MenuPopover>
           <MenuList>
             <MenuItem content="A MenuItem" />
-            <MenuItemCheckbox content="A MenuItem" />
+            <MenuItemCheckbox name="itemTwo" content="A MenuItem" />
           </MenuList>
         </MenuPopover>
       </Menu>
@@ -56,7 +56,7 @@ const MenuCheckmarks: React.FunctionComponent = () => {
         <MenuPopover>
           <MenuList>
             <MenuItem content="A MenuItem" />
-            <MenuItemCheckbox content="A MenuItem" />
+            <MenuItemCheckbox name="itemTwo" content="A MenuItem" />
           </MenuList>
         </MenuPopover>
       </Menu>

--- a/change/@fluentui-react-native-menu-0cae64ae-938c-4dfc-a183-93dc66686cea.json
+++ b/change/@fluentui-react-native-menu-0cae64ae-938c-4dfc-a183-93dc66686cea.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Implement toggle behavior on MenuItemCheckbox",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-47f67a6b-d3f8-4846-90b7-dfff2a825d75.json
+++ b/change/@fluentui-react-native-tester-47f67a6b-d3f8-4846-90b7-dfff2a825d75.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix bug, add test",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Menu/src/MenuItem/useMenuItem.ts
+++ b/packages/experimental/Menu/src/MenuItem/useMenuItem.ts
@@ -4,6 +4,7 @@ import { MenuItemProps, MenuItemState } from './MenuItem.types';
 import { memoize } from '@fluentui-react-native/framework';
 import { useAsPressable, useKeyProps } from '@fluentui-react-native/interactive-hooks';
 import { useMenuContext } from '../context/menuContext';
+import { useMenuListContext } from '../context/menuListContext';
 
 export const useMenuItem = (props: MenuItemProps): MenuItemState => {
   // attach the pressable state handlers
@@ -12,7 +13,7 @@ export const useMenuItem = (props: MenuItemProps): MenuItemState => {
   const pressable = useAsPressable({ ...rest, disabled, onPress: onClick });
   const onKeyProps = useKeyProps(onClick, ' ', 'Enter');
   const hasSubmenu = useMenuContext().isSubmenu;
-  const hasCheckmarks = useMenuContext().hasCheckmarks;
+  const hasCheckmarks = useMenuListContext().hasCheckmarks;
 
   return {
     props: {

--- a/packages/experimental/Menu/src/MenuItem/useMenuItem.ts
+++ b/packages/experimental/Menu/src/MenuItem/useMenuItem.ts
@@ -18,7 +18,7 @@ export const useMenuItem = (props: MenuItemProps): MenuItemState => {
     props: {
       ...pressable.props,
       accessible: true,
-      accessibilityRole: 'button',
+      accessibilityRole: 'menuitem',
       onAccessibilityTap: props.onAccessibilityTap || props.onClick,
       accessibilityLabel: props.accessibilityLabel,
       accessibilityState: getAccessibilityState(disabled, accessibilityState),

--- a/packages/experimental/Menu/src/MenuItemCheckbox/MenuItemCheckbox.styling.ts
+++ b/packages/experimental/Menu/src/MenuItemCheckbox/MenuItemCheckbox.styling.ts
@@ -23,6 +23,7 @@ export const stylingSettings: UseStylingOptions<MenuItemCheckboxProps, MenuItemC
     ),
     checkmark: buildProps(
       (tokens: MenuItemCheckboxTokens) => ({
+        opacity: tokens.checkmarkVisibility,
         color: tokens.color,
         height: tokens.checkmarkSize,
         width: tokens.checkmarkSize,

--- a/packages/experimental/Menu/src/MenuItemCheckbox/MenuItemCheckbox.types.ts
+++ b/packages/experimental/Menu/src/MenuItemCheckbox/MenuItemCheckbox.types.ts
@@ -34,16 +34,9 @@ export interface MenuItemCheckboxProps extends Omit<IWithPressableOptions<ViewPr
    * A RefObject to access the IButton interface. Use this to access the public methods and properties of the component.
    */
   componentRef?: React.RefObject<IFocusable>;
-
-  /**
-   * A callback to call on button click event
-   */
-  onClick?: (e: InteractionEvent) => void;
 }
 
-export interface MenuItemCheckboxState extends IPressableHooks<MenuItemCheckboxProps & React.ComponentPropsWithRef<any>> {
-  hasCheckmarks?: boolean;
-}
+export interface MenuItemCheckboxState extends IPressableHooks<MenuItemCheckboxProps & React.ComponentPropsWithRef<any>> {}
 
 export interface MenuItemCheckboxSlotProps {
   root: React.PropsWithRef<IViewProps>;

--- a/packages/experimental/Menu/src/MenuItemCheckbox/MenuItemCheckbox.types.ts
+++ b/packages/experimental/Menu/src/MenuItemCheckbox/MenuItemCheckbox.types.ts
@@ -3,7 +3,7 @@ import { ColorValue, ViewProps } from 'react-native';
 import { XmlProps } from 'react-native-svg';
 import type { IViewProps } from '@fluentui-react-native/adapters';
 import { TextProps } from '@fluentui-react-native/experimental-text';
-import { IFocusable, InteractionEvent, IPressableHooks, IWithPressableOptions } from '@fluentui-react-native/interactive-hooks';
+import { IFocusable, IPressableHooks, IWithPressableOptions } from '@fluentui-react-native/interactive-hooks';
 import { FontTokens, IBorderTokens, IColorTokens, LayoutTokens } from '@fluentui-react-native/tokens';
 
 export const menuItemCheckboxName = 'MenuItemCheckbox';
@@ -34,6 +34,11 @@ export interface MenuItemCheckboxProps extends Omit<IWithPressableOptions<ViewPr
    * A RefObject to access the IButton interface. Use this to access the public methods and properties of the component.
    */
   componentRef?: React.RefObject<IFocusable>;
+
+  /**
+   * Identifier for the control
+   */
+  name: string;
 }
 
 export interface MenuItemCheckboxState extends IPressableHooks<MenuItemCheckboxProps & React.ComponentPropsWithRef<any>> {}

--- a/packages/experimental/Menu/src/MenuItemCheckbox/useMenuItemCheckbox.ts
+++ b/packages/experimental/Menu/src/MenuItemCheckbox/useMenuItemCheckbox.ts
@@ -10,7 +10,7 @@ import {
   useOnPressWithFocus,
   useViewCommandFocus,
 } from '@fluentui-react-native/interactive-hooks';
-import { useMenuContext } from '../context/menuContext';
+import { useMenuListContext } from '../context/menuListContext';
 
 const defaultAccessibilityActions = [{ name: 'Toggle' }];
 
@@ -26,19 +26,17 @@ export const useMenuItemCheckbox = (props: MenuItemCheckboxProps): MenuItemCheck
     onAccessibilityAction,
     ...rest
   } = props;
-  const context = useMenuContext();
-  const defaultChecked = context.defaultChecked[name];
-  const checked = context.checked[name];
+  const context = useMenuListContext();
+  const checked = context.checked?.name;
   const onCheckedChange = context.onCheckedChange;
 
   const onChange = React.useCallback(
     (e: InteractionEvent, isChecked: boolean) => {
-      // TODO: figure this out???
-      onCheckedChange(e, name, !isChecked);
+      onCheckedChange(e, name, isChecked);
     },
     [name, onCheckedChange],
   );
-  const [isChecked, toggleChecked] = useAsToggleWithEvent(defaultChecked, checked, onChange);
+  const [isChecked, toggleChecked] = useAsToggleWithEvent(undefined /*defaultChecked*/, checked, onChange);
 
   // Ensure focus is placed on checkbox after click
   const toggleCheckedWithFocus = useOnPressWithFocus(componentRef, toggleChecked);

--- a/packages/experimental/Menu/src/MenuItemCheckbox/useMenuItemCheckbox.ts
+++ b/packages/experimental/Menu/src/MenuItemCheckbox/useMenuItemCheckbox.ts
@@ -1,40 +1,95 @@
 import * as React from 'react';
-import { AccessibilityState } from 'react-native';
+import { AccessibilityActionEvent, AccessibilityState } from 'react-native';
 import { MenuItemCheckboxProps, MenuItemCheckboxState } from './MenuItemCheckbox.types';
 import { memoize } from '@fluentui-react-native/framework';
-import { useAsPressable, useKeyProps } from '@fluentui-react-native/interactive-hooks';
+import {
+  InteractionEvent,
+  useAsPressable,
+  useAsToggleWithEvent,
+  useKeyProps,
+  useOnPressWithFocus,
+  useViewCommandFocus,
+} from '@fluentui-react-native/interactive-hooks';
 import { useMenuContext } from '../context/menuContext';
+
+const defaultAccessibilityActions = [{ name: 'Toggle' }];
 
 export const useMenuItemCheckbox = (props: MenuItemCheckboxProps): MenuItemCheckboxState => {
   // attach the pressable state handlers
   const defaultComponentRef = React.useRef(null);
-  const { onClick, accessibilityState, componentRef = defaultComponentRef, disabled, ...rest } = props;
-  const pressable = useAsPressable({ ...rest, disabled, onPress: onClick });
-  const onKeyProps = useKeyProps(onClick, ' ', 'Enter');
-  const hasCheckmarks = useMenuContext().hasCheckmarks;
+  const {
+    accessibilityActions,
+    accessibilityState,
+    componentRef = defaultComponentRef,
+    disabled,
+    name,
+    onAccessibilityAction,
+    ...rest
+  } = props;
+  const context = useMenuContext();
+  const defaultChecked = context.defaultChecked[name];
+  const checked = context.checked[name];
+  const onCheckedChange = context.onCheckedChange;
+
+  const onChange = React.useCallback(
+    (e: InteractionEvent, isChecked: boolean) => {
+      // TODO: figure this out???
+      onCheckedChange(e, name, !isChecked);
+    },
+    [name, onCheckedChange],
+  );
+  const [isChecked, toggleChecked] = useAsToggleWithEvent(defaultChecked, checked, onChange);
+
+  // Ensure focus is placed on checkbox after click
+  const toggleCheckedWithFocus = useOnPressWithFocus(componentRef, toggleChecked);
+
+  const pressable = useAsPressable({ onPress: toggleCheckedWithFocus, ...rest });
+  const buttonRef = useViewCommandFocus(componentRef);
+
+  const onKeyProps = useKeyProps(toggleChecked, ' ');
+  const accessibilityActionsProp = accessibilityActions
+    ? [...defaultAccessibilityActions, ...accessibilityActions]
+    : defaultAccessibilityActions;
+  const onAccessibilityActionProp = React.useCallback(
+    (event: AccessibilityActionEvent) => {
+      switch (event.nativeEvent.actionName) {
+        case 'Toggle':
+          toggleChecked(event);
+          break;
+      }
+      onAccessibilityAction && onAccessibilityAction(event);
+    },
+    [toggleChecked, onAccessibilityAction],
+  );
+
+  const state = {
+    ...pressable.state,
+    disabled: !!props.disabled,
+    checked: isChecked,
+  };
 
   return {
     props: {
       ...pressable.props,
       accessible: true,
-      accessibilityRole: 'button',
-      onAccessibilityTap: props.onAccessibilityTap || props.onClick,
+      accessibilityActions: accessibilityActionsProp,
       accessibilityLabel: props.accessibilityLabel,
-      accessibilityState: getAccessibilityState(disabled, accessibilityState),
+      accessibilityRole: 'menuitem',
+      accessibilityState: getAccessibilityState(disabled, state.checked, accessibilityState),
       enableFocusRing: true,
       focusable: !disabled,
-      ref: componentRef,
+      onAccessibilityAction: onAccessibilityActionProp,
+      ref: buttonRef,
       ...onKeyProps,
     },
-    state: pressable.state,
-    hasCheckmarks,
+    state: state,
   };
 };
 
 const getAccessibilityState = memoize(getAccessibilityStateWorker);
-function getAccessibilityStateWorker(disabled: boolean, accessibilityState?: AccessibilityState) {
+function getAccessibilityStateWorker(disabled: boolean, checked: boolean, accessibilityState?: AccessibilityState) {
   if (accessibilityState) {
-    return { disabled, ...accessibilityState };
+    return { disabled, checked, ...accessibilityState };
   }
-  return { disabled };
+  return { disabled, checked };
 }

--- a/packages/experimental/Menu/src/MenuItemCheckbox/useMenuItemCheckbox.ts
+++ b/packages/experimental/Menu/src/MenuItemCheckbox/useMenuItemCheckbox.ts
@@ -30,14 +30,12 @@ export const useMenuItemCheckbox = (props: MenuItemCheckboxProps): MenuItemCheck
   const checked = context.checked?.[name];
   const onCheckedChange = context.onCheckedChange;
 
-  const onChange = React.useCallback(
-    (e: InteractionEvent, isChecked: boolean) => {
-      onCheckedChange(e, name, isChecked);
+  const toggleChecked = React.useCallback(
+    (e: InteractionEvent) => {
+      onCheckedChange(e, name, !checked);
     },
-    [name, onCheckedChange],
+    [checked, name, onCheckedChange],
   );
-  const [isChecked, toggleChecked] = useAsToggleWithEvent(undefined /*defaultChecked*/, checked, onChange);
-
   // Ensure focus is placed on checkbox after click
   const toggleCheckedWithFocus = useOnPressWithFocus(componentRef, toggleChecked);
 
@@ -63,7 +61,7 @@ export const useMenuItemCheckbox = (props: MenuItemCheckboxProps): MenuItemCheck
   const state = {
     ...pressable.state,
     disabled: !!props.disabled,
-    checked: isChecked,
+    checked: checked,
   };
 
   return {

--- a/packages/experimental/Menu/src/MenuItemCheckbox/useMenuItemCheckbox.ts
+++ b/packages/experimental/Menu/src/MenuItemCheckbox/useMenuItemCheckbox.ts
@@ -27,7 +27,7 @@ export const useMenuItemCheckbox = (props: MenuItemCheckboxProps): MenuItemCheck
     ...rest
   } = props;
   const context = useMenuListContext();
-  const checked = context.checked?.name;
+  const checked = context.checked?.[name];
   const onCheckedChange = context.onCheckedChange;
 
   const onChange = React.useCallback(

--- a/packages/experimental/Menu/src/MenuItemCheckbox/useMenuItemCheckbox.ts
+++ b/packages/experimental/Menu/src/MenuItemCheckbox/useMenuItemCheckbox.ts
@@ -47,10 +47,8 @@ export const useMenuItemCheckbox = (props: MenuItemCheckboxProps): MenuItemCheck
     : defaultAccessibilityActions;
   const onAccessibilityActionProp = React.useCallback(
     (event: AccessibilityActionEvent) => {
-      switch (event.nativeEvent.actionName) {
-        case 'Toggle':
-          toggleChecked(event);
-          break;
+      if (event.nativeEvent.actionName === 'Toggle') {
+        toggleChecked(event);
       }
       onAccessibilityAction && onAccessibilityAction(event);
     },

--- a/packages/experimental/Menu/src/MenuItemCheckbox/useMenuItemCheckbox.ts
+++ b/packages/experimental/Menu/src/MenuItemCheckbox/useMenuItemCheckbox.ts
@@ -5,7 +5,6 @@ import { memoize } from '@fluentui-react-native/framework';
 import {
   InteractionEvent,
   useAsPressable,
-  useAsToggleWithEvent,
   useKeyProps,
   useOnPressWithFocus,
   useViewCommandFocus,

--- a/packages/experimental/Menu/src/MenuList/MenuList.tsx
+++ b/packages/experimental/Menu/src/MenuList/MenuList.tsx
@@ -4,6 +4,9 @@ import { View } from 'react-native';
 import { compose, UseSlots, withSlots } from '@fluentui-react-native/framework';
 import { menuListName, MenuListProps, MenuListType } from './MenuList.types';
 import { stylingSettings } from './MenuList.styling';
+import { MenuListProvider } from '../context/menuListContext';
+import { useMenuList } from './useMenuList';
+import { useMenuListContextValue } from './useMenuContextValue';
 
 export const MenuList = compose<MenuListType>({
   displayName: menuListName,
@@ -12,10 +15,16 @@ export const MenuList = compose<MenuListType>({
     root: View,
   },
   useRender: (userProps: MenuListProps, useSlots: UseSlots<MenuListType>) => {
-    const Slots = useSlots(userProps);
+    const menuList = useMenuList(userProps);
+    const contextValue = useMenuListContextValue(menuList);
+    const Slots = useSlots(menuList);
 
     return (_final: MenuListProps, children: React.ReactNode) => {
-      return <Slots.root>{children}</Slots.root>;
+      return (
+        <MenuListProvider value={contextValue}>
+          <Slots.root>{children}</Slots.root>
+        </MenuListProvider>
+      );
     };
   },
 });

--- a/packages/experimental/Menu/src/MenuList/MenuList.types.ts
+++ b/packages/experimental/Menu/src/MenuList/MenuList.types.ts
@@ -1,4 +1,5 @@
 import type { IViewProps } from '@fluentui-react-native/adapters';
+import { InteractionEvent } from '@fluentui-react-native/interactive-hooks';
 import { IBackgroundColorTokens, LayoutTokens } from '@fluentui-react-native/tokens';
 
 export const menuListName = 'MenuList';
@@ -6,7 +7,10 @@ export const menuListName = 'MenuList';
 export interface MenuListTokens extends LayoutTokens, IBackgroundColorTokens {}
 
 export interface MenuListProps extends Omit<IViewProps, 'onPress'> {
+  checked?: Record<string, boolean>;
+  defaultChecked?: Record<string, boolean>;
   hasCheckmarks?: boolean;
+  onCheckedChange?: (e: InteractionEvent, name: string, isChecked: boolean) => void;
 }
 
 export interface MenuListSlotProps {

--- a/packages/experimental/Menu/src/MenuList/MenuList.types.ts
+++ b/packages/experimental/Menu/src/MenuList/MenuList.types.ts
@@ -13,6 +13,10 @@ export interface MenuListProps extends Omit<IViewProps, 'onPress'> {
   onCheckedChange?: (e: InteractionEvent, name: string, isChecked: boolean) => void;
 }
 
+export interface MenuListState extends MenuListProps {
+  isCheckedControlled: boolean;
+}
+
 export interface MenuListSlotProps {
   root: React.PropsWithRef<IViewProps>;
 }

--- a/packages/experimental/Menu/src/MenuList/useMenuContextValue.ts
+++ b/packages/experimental/Menu/src/MenuList/useMenuContextValue.ts
@@ -1,0 +1,6 @@
+import { MenuListContextValue } from '../context/menuListContext';
+import { MenuListState } from './MenuList.types';
+
+export const useMenuListContextValue = (state: MenuListState): MenuListContextValue => {
+  return { ...state };
+};

--- a/packages/experimental/Menu/src/MenuList/useMenuList.ts
+++ b/packages/experimental/Menu/src/MenuList/useMenuList.ts
@@ -3,7 +3,7 @@ import React from 'react';
 import { useMenuContext } from '../context/menuContext';
 import { MenuListProps, MenuListState } from './MenuList.types';
 
-export const useMenuList = (props: MenuListProps): MenuListState => {
+export const useMenuList = (_props: MenuListProps): MenuListState => {
   const context = useMenuContext();
 
   // MenuList v2 needs to be able to be standalone, but this is not in scope for v1
@@ -12,7 +12,7 @@ export const useMenuList = (props: MenuListProps): MenuListState => {
   const [checked, onCheckedChange] = useMenuCheckedState(isCheckedControlled, context);
 
   return {
-    ...props,
+    ...context,
     isCheckedControlled,
     checked,
     onCheckedChange,

--- a/packages/experimental/Menu/src/MenuList/useMenuList.ts
+++ b/packages/experimental/Menu/src/MenuList/useMenuList.ts
@@ -1,0 +1,49 @@
+import { InteractionEvent } from '@fluentui-react-native/interactive-hooks';
+import React from 'react';
+import { useMenuContext } from '../context/menuContext';
+import { MenuListProps, MenuListState } from './MenuList.types';
+
+export const useMenuList = (props: MenuListProps): MenuListState => {
+  const context = useMenuContext();
+
+  // MenuList v2 needs to be able to be standalone, but this is not in scope for v1
+  // Assuming that checked information will come from parent Menu
+  const isCheckedControlled = typeof context.checked !== 'undefined';
+  const [checked, onCheckedChange] = useMenuCheckedState(isCheckedControlled, context);
+
+  return {
+    ...props,
+    isCheckedControlled,
+    checked,
+    onCheckedChange,
+  };
+};
+
+const useMenuCheckedState = (
+  isControlled: boolean,
+  props: MenuListProps,
+): [Record<string, boolean>, (e: InteractionEvent, name: string, isChecked: boolean) => void] => {
+  const { defaultChecked, onCheckedChange, checked } = props;
+  const initialState = defaultChecked ?? checked ?? {};
+  const [checkedInternal, setCheckedInternal] = React.useState<Record<string, boolean>>(initialState);
+
+  const state = isControlled ? checked : checkedInternal;
+
+  const setChecked = React.useCallback(
+    (e: InteractionEvent, name: string, isChecked: boolean) => {
+      if (!isControlled) {
+        const curChecked = state;
+        curChecked[name] = isChecked;
+        const updatedChecked = { ...curChecked };
+        setCheckedInternal(updatedChecked);
+      }
+
+      if (onCheckedChange) {
+        onCheckedChange(e, name, isChecked);
+      }
+    },
+    [isControlled, state, onCheckedChange, setCheckedInternal],
+  );
+
+  return [state, setChecked];
+};

--- a/packages/experimental/Menu/src/context/menuContext.ts
+++ b/packages/experimental/Menu/src/context/menuContext.ts
@@ -8,8 +8,12 @@ export type MenuContextValue = MenuState;
 
 export const MenuContext = React.createContext<MenuContextValue>({
   isControlled: false,
+  checked: {},
+  defaultChecked: {},
+  hasCheckmarks: false,
   isSubmenu: false,
   open: false,
+  onCheckedChange: () => false,
   setOpen: () => false,
   triggerRef: null,
 });

--- a/packages/experimental/Menu/src/context/menuListContext.ts
+++ b/packages/experimental/Menu/src/context/menuListContext.ts
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import type { MenuListState } from '../MenuList/MenuList.types';
+
+/**
+ * Context shared between Menu and its child components
+ */
+export type MenuListContextValue = MenuListState;
+
+export const MenuListContext = React.createContext<MenuListContextValue>({
+  isCheckedControlled: false,
+  checked: {},
+  defaultChecked: {},
+  hasCheckmarks: false,
+  onCheckedChange: () => false,
+});
+
+export const MenuListProvider = MenuListContext.Provider;
+export const useMenuListContext = () => React.useContext(MenuListContext);


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This PR implements the checkbox behavior for MenuItemCheckbox.

Props implemented:
- checked (if provided, the checkmarks are considered controlled)
- defaultChecked (whether an item should start checked
- onCheckedChange (fired whenever the checked state of a component changes)

This change also adds toggle pattern on menu item checkbox and focus-on-click behavior for the checkbox menu item. Accessibility role has been fixed on both menu item and menu item checkbox.

checked/defaultChecked state is supplied as mapping of names to a boolean. The boolean could be considered redundant, but makes the lookup for checked state easier/faster. Alternative shape for API could be to take an array of names of controls instead.

Tracking the checked state is in MenuList instead of Menu to make it easier in the future for MenuList to be standalone.

Still waiting on PM for final API shape, but this covers the basic implementation and the API shape itself would be a minor change later.

### Verification

![checkmark_behavior](https://user-images.githubusercontent.com/4602628/169160488-de29799a-002d-4a8c-baf9-d074acefbecc.gif)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
