### PR TITLE
Fix focus button visual

### DIFF
--- a/change/@fluentui-react-native-button-8eac7382-8953-4773-90db-340c6febb260.json
+++ b/change/@fluentui-react-native-button-8eac7382-8953-4773-90db-340c6febb260.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix focus button size",
+  "packageName": "@fluentui-react-native/button",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Button/src/Button.styling.ts
+++ b/packages/components/Button/src/Button.styling.ts
@@ -14,9 +14,6 @@ export const buttonStates: (keyof ButtonTokens)[] = [
   'primary',
   'subtle',
   'hovered',
-  'focused',
-  'pressed',
-  'disabled',
   'small',
   'medium',
   'large',
@@ -26,6 +23,9 @@ export const buttonStates: (keyof ButtonTokens)[] = [
   'rounded',
   'circular',
   'square',
+  'focused',
+  'pressed',
+  'disabled',
 ];
 
 export const stylingSettings: UseStylingOptions<ButtonProps, ButtonSlotProps, ButtonTokens> = {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Noticed a bug where if a button is focused, it is 2 pixels shorter and narrower.

The bug is that the styling order made it so that the borderWidth and padding changes for the 'focused' state weren't applied properly as 'focused' was processed before the size/hasContent states.
Fix is to move the focused state after all the other states. I moved pressed/disabled too since those have similar priority to focused

### Verification

Before:
![image](https://user-images.githubusercontent.com/4602628/169627109-16276fa1-bdce-4dd8-8c58-810392fd2ba6.png)

After:
![image](https://user-images.githubusercontent.com/4602628/169627034-fbbb1238-469f-467c-95cd-575b9b095931.png)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
