### PR TITLE
Fix some Shadow token stuff

### DIFF
--- a/change/@fluentui-react-native-apple-theme-4dabbf45-a24f-4eb7-88f6-21d2c6647342.json
+++ b/change/@fluentui-react-native-apple-theme-4dabbf45-a24f-4eb7-88f6-21d2c6647342.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix shadow tokens not getting mapped properly",
+  "packageName": "@fluentui-react-native/apple-theme",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tokens-b1cd9a29-3ac8-4d39-9801-542e1c5d8ebc.json
+++ b/change/@fluentui-react-native-tokens-b1cd9a29-3ac8-4d39-9801-542e1c5d8ebc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add back elevation as a token",
+  "packageName": "@fluentui-react-native/tokens",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/theming/apple-theme/src/createMacOSAliasTokens.ts
+++ b/packages/theming/apple-theme/src/createMacOSAliasTokens.ts
@@ -6,7 +6,6 @@ import { ThemeShadowDefinition } from '@fluentui-react-native/theme-types/lib/Sh
 
 function createMacOSColorAliasTokensWorker(mode: AppearanceOptions, isHighContrast: boolean): AliasColorTokens {
   const aliasTokens = getMacOSAliasTokens(mode, isHighContrast);
-  console.log(aliasTokens);
   return mapPipelineToTheme(aliasTokens);
 }
 

--- a/packages/theming/apple-theme/src/createMacOSAliasTokens.ts
+++ b/packages/theming/apple-theme/src/createMacOSAliasTokens.ts
@@ -1,4 +1,4 @@
-import { getMacOSAliasTokens } from './getMacOSTokens';
+import { getMacOSAliasTokens, getMacOSShadowTokens } from './getMacOSTokens';
 import { AliasColorTokens, AppearanceOptions } from '@fluentui-react-native/theme-types';
 import { mapPipelineToTheme, mapPipelineToShadow } from '@fluentui-react-native/theming-utils';
 import { memoize } from '@fluentui-react-native/memo-cache';
@@ -6,13 +6,14 @@ import { ThemeShadowDefinition } from '@fluentui-react-native/theme-types/lib/Sh
 
 function createMacOSColorAliasTokensWorker(mode: AppearanceOptions, isHighContrast: boolean): AliasColorTokens {
   const aliasTokens = getMacOSAliasTokens(mode, isHighContrast);
+  console.log(aliasTokens);
   return mapPipelineToTheme(aliasTokens);
 }
 
 export const createMacOSColorAliasTokens = memoize(createMacOSColorAliasTokensWorker);
 
 function createMacOSShadowAliasTokensWorker(mode: AppearanceOptions, isHighContrast: boolean): ThemeShadowDefinition {
-  const aliasTokens = getMacOSAliasTokens(mode, isHighContrast);
+  const aliasTokens = getMacOSShadowTokens(mode, isHighContrast);
   return mapPipelineToShadow(aliasTokens);
 }
 

--- a/packages/utils/tokens/src/shadow-tokens.ts
+++ b/packages/utils/tokens/src/shadow-tokens.ts
@@ -11,7 +11,6 @@ export interface IShadowTokens {
   };
   shadowOpacity?: number;
   shadowRadius?: number;
-  elevation?: number;
 }
 
 export const shadowTokens: IOperationSet<IShadowTokens, ITheme> = [
@@ -19,6 +18,7 @@ export const shadowTokens: IOperationSet<IShadowTokens, ITheme> = [
   { source: 'shadowOffset' },
   { source: 'shadowOpacity' },
   { source: 'shadowRadius' },
+  { source: 'elevation' },
 ];
 
 export const shadowStyles = tokenBuilder<IShadowTokens>('shadowColor', 'shadowOffset', 'shadowOpacity', 'shadowRadius');

--- a/packages/utils/tokens/src/shadow-tokens.ts
+++ b/packages/utils/tokens/src/shadow-tokens.ts
@@ -11,6 +11,7 @@ export interface IShadowTokens {
   };
   shadowOpacity?: number;
   shadowRadius?: number;
+  elevation?: number;
 }
 
 export const shadowTokens: IOperationSet<IShadowTokens, ITheme> = [


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

A previous commit had some changes that made the macOS test app fail to run. And I also made a change accidentally removing `elevation` from IShadowTokens. This fixes both.


### Verification

macOS test app runs

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
