### PR TITLE
Focus first element on popover open

### DIFF
--- a/change/@fluentui-react-native-menu-f53969f8-621e-4877-b705-4830ea208547.json
+++ b/change/@fluentui-react-native-menu-f53969f8-621e-4877-b705-4830ea208547.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Focus first element when popover opens",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Menu/src/MenuPopover/MenuPopover.tsx
+++ b/packages/experimental/Menu/src/MenuPopover/MenuPopover.tsx
@@ -16,6 +16,7 @@ export const MenuPopover = stagedComponent((props: MenuPopoverProps) => {
         target={state.triggerRef}
         onDismiss={state.onDismiss}
         dismissBehaviors={state.dismissBehaviors}
+        setInitialFocus={true}
       >
         {children}
       </Callout>

--- a/packages/experimental/Menu/src/MenuPopover/MenuPopover.tsx
+++ b/packages/experimental/Menu/src/MenuPopover/MenuPopover.tsx
@@ -3,16 +3,12 @@ import { stagedComponent, useFluentTheme } from '@fluentui-react-native/framewor
 import { Callout } from '@fluentui-react-native/callout';
 import { menuPopoverName, MenuPopoverProps } from './MenuPopover.types';
 import { useMenuPopover } from './useMenuPopover';
-import { Platform } from 'react-native';
 
 export const MenuPopover = stagedComponent((props: MenuPopoverProps) => {
   const state = useMenuPopover(props);
   const theme = useFluentTheme();
 
   return (_rest: MenuPopoverProps, children: React.ReactNode) => {
-    // Initial focus behavior differs per platform, Windows platforms move focus
-    // automatically onto first element of Callout
-    const setInitialFocus = Platform.OS === ('win32' as any) || Platform.OS === 'windows';
     return (
       <Callout
         borderWidth={1}
@@ -20,7 +16,7 @@ export const MenuPopover = stagedComponent((props: MenuPopoverProps) => {
         target={state.triggerRef}
         onDismiss={state.onDismiss}
         dismissBehaviors={state.dismissBehaviors}
-        setInitialFocus={setInitialFocus}
+        setInitialFocus={state.setInitialFocus}
       >
         {children}
       </Callout>

--- a/packages/experimental/Menu/src/MenuPopover/MenuPopover.tsx
+++ b/packages/experimental/Menu/src/MenuPopover/MenuPopover.tsx
@@ -3,12 +3,16 @@ import { stagedComponent, useFluentTheme } from '@fluentui-react-native/framewor
 import { Callout } from '@fluentui-react-native/callout';
 import { menuPopoverName, MenuPopoverProps } from './MenuPopover.types';
 import { useMenuPopover } from './useMenuPopover';
+import { Platform } from 'react-native';
 
 export const MenuPopover = stagedComponent((props: MenuPopoverProps) => {
   const state = useMenuPopover(props);
   const theme = useFluentTheme();
 
   return (_rest: MenuPopoverProps, children: React.ReactNode) => {
+    // Initial focus behavior differs per platform, Windows platforms move focus
+    // automatically onto first element of Callout
+    const setInitialFocus = Platform.OS === ('win32' as any) || Platform.OS === 'windows';
     return (
       <Callout
         borderWidth={1}
@@ -16,7 +20,7 @@ export const MenuPopover = stagedComponent((props: MenuPopoverProps) => {
         target={state.triggerRef}
         onDismiss={state.onDismiss}
         dismissBehaviors={state.dismissBehaviors}
-        setInitialFocus={true}
+        setInitialFocus={setInitialFocus}
       >
         {children}
       </Callout>

--- a/packages/experimental/Menu/src/MenuPopover/MenuPopover.types.ts
+++ b/packages/experimental/Menu/src/MenuPopover/MenuPopover.types.ts
@@ -8,5 +8,6 @@ export interface MenuPopoverProps extends Omit<IViewProps, 'onPress'> {}
 export interface MenuPopoverState {
   dismissBehaviors: DismissBehaviors[];
   onDismiss: () => void;
+  setInitialFocus: boolean;
   triggerRef: React.RefObject<React.Component>;
 }

--- a/packages/experimental/Menu/src/MenuPopover/useMenuPopover.ts
+++ b/packages/experimental/Menu/src/MenuPopover/useMenuPopover.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Platform } from 'react-native';
 import { DismissBehaviors } from '@fluentui-react-native/callout';
 import { useMenuContext } from '../context/menuContext';
 import { MenuPopoverProps, MenuPopoverState } from './MenuPopover.types';
@@ -13,5 +14,9 @@ export const useMenuPopover = (_props: MenuPopoverProps): MenuPopoverState => {
     ? (['preventDismissOnKeyDown', 'preventDismissOnClickOutside'] as DismissBehaviors[])
     : undefined;
 
-  return { triggerRef, onDismiss, dismissBehaviors };
+  // Initial focus behavior differs per platform, Windows platforms move focus
+  // automatically onto first element of Callout
+  const setInitialFocus = Platform.OS === ('win32' as any) || Platform.OS === 'windows';
+
+  return { triggerRef, onDismiss, dismissBehaviors, setInitialFocus };
 };


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Focus should move to the first element when the popover appears.
Easy fix, need to add "setInitialFocus" to the wrapped Callout

### Verification

![focus](https://user-images.githubusercontent.com/4602628/169629374-0069e1b3-faf0-4c31-8866-304559d9414c.gif)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
