### PR TITLE
Add delay to hover behavior

### DIFF
--- a/change/@fluentui-react-native-menu-926fceae-999c-443b-92c2-b7df6b67dff8.json
+++ b/change/@fluentui-react-native-menu-926fceae-999c-443b-92c2-b7df6b67dff8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Implement a slight delay on the hover behavior",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Menu/src/MenuPopover/MenuPopover.tsx
+++ b/packages/experimental/Menu/src/MenuPopover/MenuPopover.tsx
@@ -17,6 +17,7 @@ export const MenuPopover = stagedComponent((props: MenuPopoverProps) => {
         onDismiss={state.onDismiss}
         dismissBehaviors={state.dismissBehaviors}
         setInitialFocus={state.setInitialFocus}
+        doNotTakePointerCapture={state.doNotTakePointerCapture}
       >
         {children}
       </Callout>

--- a/packages/experimental/Menu/src/MenuPopover/MenuPopover.types.ts
+++ b/packages/experimental/Menu/src/MenuPopover/MenuPopover.types.ts
@@ -7,6 +7,7 @@ export interface MenuPopoverProps extends Omit<IViewProps, 'onPress'> {}
 
 export interface MenuPopoverState {
   dismissBehaviors: DismissBehaviors[];
+  doNotTakePointerCapture: boolean;
   onDismiss: () => void;
   setInitialFocus: boolean;
   triggerRef: React.RefObject<React.Component>;

--- a/packages/experimental/Menu/src/MenuPopover/useMenuPopover.ts
+++ b/packages/experimental/Menu/src/MenuPopover/useMenuPopover.ts
@@ -17,6 +17,7 @@ export const useMenuPopover = (_props: MenuPopoverProps): MenuPopoverState => {
   // Initial focus behavior differs per platform, Windows platforms move focus
   // automatically onto first element of Callout
   const setInitialFocus = Platform.OS === ('win32' as any) || Platform.OS === 'windows';
+  const doNotTakePointerCapture = context.openOnHover;
 
-  return { triggerRef, onDismiss, dismissBehaviors, setInitialFocus };
+  return { triggerRef, onDismiss, dismissBehaviors, doNotTakePointerCapture, setInitialFocus };
 };

--- a/packages/experimental/Menu/src/MenuTrigger/useMenuTrigger.ts
+++ b/packages/experimental/Menu/src/MenuTrigger/useMenuTrigger.ts
@@ -1,6 +1,7 @@
 import { useMenuContext } from '../context/menuContext';
 import { InteractionEvent } from '@fluentui-react-native/interactive-hooks';
 import { MenuTriggerProps } from './MenuTrigger.types';
+import { Platform } from 'react-native';
 
 export const useMenuTrigger = (_props: MenuTriggerProps) => {
   const context = useMenuContext();
@@ -10,9 +11,20 @@ export const useMenuTrigger = (_props: MenuTriggerProps) => {
   const openOnHover = context.openOnHover;
   const triggerRef = context.triggerRef;
 
+  const delayHover = Platform.select({
+    macos: 100,
+    default: 500, // win32
+  });
+
   const onHoverIn = (e: InteractionEvent) => {
     if (openOnHover) {
       setOpen(e, true /* isOpen */);
+    }
+  };
+
+  const onHoverOut = (e: InteractionEvent) => {
+    if (openOnHover) {
+      setOpen(e, false /* isOpen */);
     }
   };
 
@@ -20,5 +32,5 @@ export const useMenuTrigger = (_props: MenuTriggerProps) => {
     setOpen(e, !open);
   };
 
-  return { onClick, onHoverIn, componentRef: triggerRef };
+  return { onClick, onHoverIn, onHoverOut, componentRef: triggerRef, delayHoverIn: delayHover, delayHoverOut: delayHover };
 };


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This change adds a default delay value for the onHoverIn/onHoverOut behaviors. It also adds the onHoverOut behavior which uses the newer doNotTakePointerCapture prop on the Callout (Note that the behavior is not visible yet and is buggy with the built-in version of rex-win32, we have to update it to get the correct behavior, which is currently gated behind 0.66 update).

Delay values were taken from the ContextMenu.

### Verification

![hover](https://user-images.githubusercontent.com/4602628/169919369-8ddb8cab-295f-492d-878b-9199a6dcf9cb.gif)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
