### PR TITLE
Datepicker - add ability to update the reference start/end dates

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/NativeDatePicker/NativeDatePickerTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/NativeDatePicker/NativeDatePickerTest.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@fluentui-react-native/button';
+import { Checkbox } from '@fluentui/react-native';
 import { NativeDatePicker } from '@fluentui-react-native/experimental-native-date-picker';
 import { NATIVEDATEPICKER_TESTPAGE } from './consts';
 import { PlatformStatus, Test, TestSection } from '../Test';
@@ -22,6 +23,10 @@ const NativeDatePickerMainTest: React.FunctionComponent = () => {
     endDate: NativeDatePicker.parseISOString('2020-03-07T11:55:00.000Z'),
     referenceStartDate: NativeDatePicker.parseISOString('1999-01-01T00:00:00.000Z'),
     referenceEndDate: NativeDatePicker.parseISOString('2000-01-01T00:00:00.000Z'),
+    firstWeekday: 2,
+    defaultReferenceStartDate: new Date(new Date().getFullYear() - 3, 1, 1),
+    defaultReferenceEndDate: new Date(new Date().getFullYear() + 7, 1, 1),
+    defaultFirstWeekday: 1,
   };
   const titles = {
     startTitle: 'Start Title',
@@ -104,16 +109,20 @@ const NativeDatePickerMainTest: React.FunctionComponent = () => {
         onClick={() => NativeDatePicker.present({ mode: 'dateTimeRange', ...fixedDates, ...titles, callback: didPickDates })}
       />
 
-      <Text variant="headerStandard">Change default calendar reference start and end dates to 1999 - 2000</Text>
-      <Button
-        content="Update to 1999 - 2000"
-        onClick={() =>
+      <Text variant="headerStandard">Calendar configuration</Text>
+      <Checkbox
+        label="Override default calendar configuration"
+        onChange={(isChecked: boolean) =>
           NativeDatePicker.setDefaultCalendarConfiguration({
-            referenceStartDate: fixedDates.referenceStartDate,
-            referenceEndDate: fixedDates.referenceEndDate,
+            referenceStartDate: isChecked ? fixedDates.referenceStartDate : fixedDates.defaultReferenceStartDate,
+            referenceEndDate: isChecked ? fixedDates.referenceEndDate : fixedDates.defaultReferenceEndDate,
+            firstWeekday: isChecked ? fixedDates.firstWeekday : fixedDates.defaultFirstWeekday,
           })
         }
       />
+      <Text variant="subheaderStandard">Override reference start date: {fixedDates.referenceStartDate.getUTCFullYear().toString()}</Text>
+      <Text variant="subheaderStandard">Override reference end date: {fixedDates.referenceEndDate.getUTCFullYear().toString()}</Text>
+      <Text variant="subheaderStandard">Override first weekday: {fixedDates.firstWeekday.toString()}</Text>
     </Stack>
   );
 };

--- a/apps/fluent-tester/src/FluentTester/TestComponents/NativeDatePicker/NativeDatePickerTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/NativeDatePicker/NativeDatePickerTest.tsx
@@ -22,9 +22,9 @@ const NativeDatePickerMainTest: React.FunctionComponent = () => {
   const fixedDates = {
     startDate: NativeDatePicker.parseISOString('2020-02-29T12:25:00.000Z'),
     endDate: NativeDatePicker.parseISOString('2020-03-07T11:55:00.000Z'),
-    referenceStartDate: NativeDatePicker.parseISOString('1999-01-01T00:00:00.000Z'),
-    referenceEndDate: NativeDatePicker.parseISOString('2000-01-01T00:00:00.000Z'),
-    firstWeekday: 2,
+    overrideReferenceStartDate: NativeDatePicker.parseISOString('1999-01-01T00:00:00.000Z'),
+    overrideReferenceEndDate: NativeDatePicker.parseISOString('2000-01-01T00:00:00.000Z'),
+    overrideFirstWeekday: 2,
     defaultReferenceStartDate: new Date(new Date().getFullYear() - 3, 1, 1),
     defaultReferenceEndDate: new Date(new Date().getFullYear() + 7, 1, 1),
     defaultFirstWeekday: 1,
@@ -118,16 +118,20 @@ const NativeDatePickerMainTest: React.FunctionComponent = () => {
           onValueChange={(value) => {
             setOverrideDefaultCalendarConfiguration(value);
             NativeDatePicker.setDefaultCalendarConfiguration({
-              referenceStartDate: value ? fixedDates.referenceStartDate : fixedDates.defaultReferenceStartDate,
-              referenceEndDate: value ? fixedDates.referenceEndDate : fixedDates.defaultReferenceEndDate,
-              firstWeekday: value ? fixedDates.firstWeekday : fixedDates.defaultFirstWeekday,
+              referenceStartDate: value ? fixedDates.overrideReferenceStartDate : fixedDates.defaultReferenceStartDate,
+              referenceEndDate: value ? fixedDates.overrideReferenceEndDate : fixedDates.defaultReferenceEndDate,
+              firstWeekday: value ? fixedDates.overrideFirstWeekday : fixedDates.defaultFirstWeekday,
             });
           }}
         />
       </View>
-      <Text variant="subheaderStandard">Override reference start date: {fixedDates.referenceStartDate.getUTCFullYear().toString()}</Text>
-      <Text variant="subheaderStandard">Override reference end date: {fixedDates.referenceEndDate.getUTCFullYear().toString()}</Text>
-      <Text variant="subheaderStandard">Override first weekday: {fixedDates.firstWeekday.toString()}</Text>
+      <Text variant="subheaderStandard">
+        Override reference start date: {fixedDates.overrideReferenceStartDate.getUTCFullYear().toString()}
+      </Text>
+      <Text variant="subheaderStandard">
+        Override reference end date: {fixedDates.overrideReferenceEndDate.getUTCFullYear().toString()}
+      </Text>
+      <Text variant="subheaderStandard">Override first weekday: {fixedDates.overrideFirstWeekday.toString()}</Text>
     </Stack>
   );
 };

--- a/apps/fluent-tester/src/FluentTester/TestComponents/NativeDatePicker/NativeDatePickerTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/NativeDatePicker/NativeDatePickerTest.tsx
@@ -120,7 +120,7 @@ const NativeDatePickerMainTest: React.FunctionComponent = () => {
             NativeDatePicker.setDefaultCalendarConfiguration({
               referenceStartDate: value ? fixedDates.overrideReferenceStartDate : fixedDates.defaultReferenceStartDate,
               referenceEndDate: value ? fixedDates.overrideReferenceEndDate : fixedDates.defaultReferenceEndDate,
-              firstWeekday: value ? fixedDates.overrideFirstWeekday : fixedDates.defaultFirstWeekday,
+              //firstWeekday: value ? fixedDates.overrideFirstWeekday : fixedDates.defaultFirstWeekday,
             });
           }}
         />

--- a/apps/fluent-tester/src/FluentTester/TestComponents/NativeDatePicker/NativeDatePickerTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/NativeDatePicker/NativeDatePickerTest.tsx
@@ -1,16 +1,17 @@
 import { Button } from '@fluentui-react-native/button';
-import { Checkbox } from '@fluentui/react-native';
 import { NativeDatePicker } from '@fluentui-react-native/experimental-native-date-picker';
 import { NATIVEDATEPICKER_TESTPAGE } from './consts';
 import { PlatformStatus, Test, TestSection } from '../Test';
 import * as React from 'react';
 import { Stack } from '@fluentui-react-native/stack';
-import { stackStyle } from '../Common/styles';
+import { stackStyle, commonTestStyles as commonStyles } from '../Common/styles';
+import { Switch, View } from 'react-native';
 import { Text } from '@fluentui/react-native';
 
 const NativeDatePickerMainTest: React.FunctionComponent = () => {
   const [startDate, setStartDate] = React.useState<Date>(new Date());
   const [endDate, setEndDate] = React.useState<Date>(null);
+  const [overrideDefaultCalendarConfiguration, setOverrideDefaultCalendarConfiguration] = React.useState(false);
 
   function didPickDates(pickedStartDate: string, pickedEndDate: string) {
     setStartDate(NativeDatePicker.parseISOString(pickedStartDate));
@@ -110,16 +111,20 @@ const NativeDatePickerMainTest: React.FunctionComponent = () => {
       />
 
       <Text variant="headerStandard">Calendar configuration</Text>
-      <Checkbox
-        label="Override default calendar configuration"
-        onChange={(isChecked: boolean) =>
-          NativeDatePicker.setDefaultCalendarConfiguration({
-            referenceStartDate: isChecked ? fixedDates.referenceStartDate : fixedDates.defaultReferenceStartDate,
-            referenceEndDate: isChecked ? fixedDates.referenceEndDate : fixedDates.defaultReferenceEndDate,
-            firstWeekday: isChecked ? fixedDates.firstWeekday : fixedDates.defaultFirstWeekday,
-          })
-        }
-      />
+      <View style={commonStyles.switch}>
+        <Text>Override default calendar configuration</Text>
+        <Switch
+          value={overrideDefaultCalendarConfiguration}
+          onValueChange={(value) => {
+            setOverrideDefaultCalendarConfiguration(value);
+            NativeDatePicker.setDefaultCalendarConfiguration({
+              referenceStartDate: value ? fixedDates.referenceStartDate : fixedDates.defaultReferenceStartDate,
+              referenceEndDate: value ? fixedDates.referenceEndDate : fixedDates.defaultReferenceEndDate,
+              firstWeekday: value ? fixedDates.firstWeekday : fixedDates.defaultFirstWeekday,
+            });
+          }}
+        />
+      </View>
       <Text variant="subheaderStandard">Override reference start date: {fixedDates.referenceStartDate.getUTCFullYear().toString()}</Text>
       <Text variant="subheaderStandard">Override reference end date: {fixedDates.referenceEndDate.getUTCFullYear().toString()}</Text>
       <Text variant="subheaderStandard">Override first weekday: {fixedDates.firstWeekday.toString()}</Text>

--- a/apps/fluent-tester/src/FluentTester/TestComponents/NativeDatePicker/NativeDatePickerTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/NativeDatePicker/NativeDatePickerTest.tsx
@@ -24,10 +24,8 @@ const NativeDatePickerMainTest: React.FunctionComponent = () => {
     endDate: NativeDatePicker.parseISOString('2020-03-07T11:55:00.000Z'),
     overrideReferenceStartDate: NativeDatePicker.parseISOString('1999-01-01T00:00:00.000Z'),
     overrideReferenceEndDate: NativeDatePicker.parseISOString('2000-01-01T00:00:00.000Z'),
-    overrideFirstWeekday: 2,
     defaultReferenceStartDate: new Date(new Date().getFullYear() - 3, 1, 1),
     defaultReferenceEndDate: new Date(new Date().getFullYear() + 7, 1, 1),
-    defaultFirstWeekday: 1,
   };
   const titles = {
     startTitle: 'Start Title',
@@ -120,7 +118,6 @@ const NativeDatePickerMainTest: React.FunctionComponent = () => {
             NativeDatePicker.setDefaultCalendarConfiguration({
               referenceStartDate: value ? fixedDates.overrideReferenceStartDate : fixedDates.defaultReferenceStartDate,
               referenceEndDate: value ? fixedDates.overrideReferenceEndDate : fixedDates.defaultReferenceEndDate,
-              //firstWeekday: value ? fixedDates.overrideFirstWeekday : fixedDates.defaultFirstWeekday,
             });
           }}
         />
@@ -131,7 +128,6 @@ const NativeDatePickerMainTest: React.FunctionComponent = () => {
       <Text variant="subheaderStandard">
         Override reference end date: {fixedDates.overrideReferenceEndDate.getUTCFullYear().toString()}
       </Text>
-      <Text variant="subheaderStandard">Override first weekday: {fixedDates.overrideFirstWeekday.toString()}</Text>
     </Stack>
   );
 };

--- a/apps/fluent-tester/src/FluentTester/TestComponents/NativeDatePicker/NativeDatePickerTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/NativeDatePicker/NativeDatePickerTest.tsx
@@ -20,6 +20,8 @@ const NativeDatePickerMainTest: React.FunctionComponent = () => {
   const fixedDates = {
     startDate: NativeDatePicker.parseISOString('2020-02-29T12:25:00.000Z'),
     endDate: NativeDatePicker.parseISOString('2020-03-07T11:55:00.000Z'),
+    referenceStartDate: NativeDatePicker.parseISOString('1990-01-01T00:00:00.000Z'),
+    referenceEndDate: NativeDatePicker.parseISOString('1999-01-01T00:00:00.000Z'),
   };
   const titles = {
     startTitle: 'Start Title',
@@ -36,14 +38,14 @@ const NativeDatePickerMainTest: React.FunctionComponent = () => {
 
   return (
     <Stack style={stackStyle}>
-      <Text variant="headerStandard">Start Date/Time</Text>
+      <Text variant="headerStandard">Selected Start Date/Time</Text>
       <Text variant="subheaderStandard">
         {startDate?.toString()} {'\n'}
       </Text>
 
-      <Text variant="headerStandard">End Date/Time</Text>
+      <Text variant="headerStandard">Selected End Date/Time</Text>
       <Text variant="subheaderStandard">
-        {endDate?.toString()} {'\n'}
+        {endDate?.toString() ?? 'N/A'} {'\n'}
       </Text>
 
       <Button content="Date picker" onClick={() => NativeDatePicker.present({ callback: didPickDates })} />
@@ -100,6 +102,17 @@ const NativeDatePickerMainTest: React.FunctionComponent = () => {
       <Button
         content="Date time range with custom titles (tabbed)"
         onClick={() => NativeDatePicker.present({ mode: 'dateTimeRange', ...fixedDates, ...titles, callback: didPickDates })}
+      />
+
+      <Text variant="headerStandard">Change default calendar reference start and end dates to 1900 - 1999</Text>
+      <Button
+        content="Update to 1900 - 1999"
+        onClick={() =>
+          NativeDatePicker.setDefaultCalendarConfiguration({
+            referenceStartDate: fixedDates.referenceStartDate,
+            referenceEndDate: fixedDates.referenceEndDate,
+          })
+        }
       />
     </Stack>
   );

--- a/apps/fluent-tester/src/FluentTester/TestComponents/NativeDatePicker/NativeDatePickerTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/NativeDatePicker/NativeDatePickerTest.tsx
@@ -20,8 +20,8 @@ const NativeDatePickerMainTest: React.FunctionComponent = () => {
   const fixedDates = {
     startDate: NativeDatePicker.parseISOString('2020-02-29T12:25:00.000Z'),
     endDate: NativeDatePicker.parseISOString('2020-03-07T11:55:00.000Z'),
-    referenceStartDate: NativeDatePicker.parseISOString('1990-01-01T00:00:00.000Z'),
-    referenceEndDate: NativeDatePicker.parseISOString('1999-01-01T00:00:00.000Z'),
+    referenceStartDate: NativeDatePicker.parseISOString('1999-01-01T00:00:00.000Z'),
+    referenceEndDate: NativeDatePicker.parseISOString('2000-01-01T00:00:00.000Z'),
   };
   const titles = {
     startTitle: 'Start Title',
@@ -104,9 +104,9 @@ const NativeDatePickerMainTest: React.FunctionComponent = () => {
         onClick={() => NativeDatePicker.present({ mode: 'dateTimeRange', ...fixedDates, ...titles, callback: didPickDates })}
       />
 
-      <Text variant="headerStandard">Change default calendar reference start and end dates to 1900 - 1999</Text>
+      <Text variant="headerStandard">Change default calendar reference start and end dates to 1999 - 2000</Text>
       <Button
-        content="Update to 1900 - 1999"
+        content="Update to 1999 - 2000"
         onClick={() =>
           NativeDatePicker.setDefaultCalendarConfiguration({
             referenceStartDate: fixedDates.referenceStartDate,

--- a/apps/ios/src/Podfile.lock
+++ b/apps/ios/src/Podfile.lock
@@ -9,11 +9,11 @@ PODS:
     - React-Core (= 0.64.3)
     - React-jsi (= 0.64.3)
     - ReactCommon/turbomodule/core (= 0.64.3)
-  - FRNAvatar (0.14.18):
+  - FRNAvatar (0.14.31):
     - MicrosoftFluentUI (= 0.5.0)
     - MicrosoftFluentUI/Avatar_ios (= 0.5.0)
     - React
-  - FRNDatePicker (0.4.1):
+  - FRNDatePicker (0.4.2):
     - MicrosoftFluentUI (= 0.5.0)
     - React
   - glog (0.3.5)
@@ -568,9 +568,9 @@ SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: c71c5917ec0ad2de41d5d06a5855f6d5eda06971
-  FBReactNativeSpec: 7189a9ff15d719a773adfd8fa4b819ad238d15c3
-  FRNAvatar: 1430d4e7359483316f5b2b322a6924dbed892dce
-  FRNDatePicker: ed80987a29e17c2e26f5b825e726d4a1195aae70
+  FBReactNativeSpec: e46380c3ebf05dc813f8b8e5ca403e47822318f6
+  FRNAvatar: cdd0c28b495bdeb236e292b2f10cc5003d83a9ba
+  FRNDatePicker: cc3390f45f874ecd01e2675563e6bc9c059450db
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   MicrosoftFluentUI: 4c12374f2eab4c8f37b9d0c9a1e96210e96db78e
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c

--- a/apps/ios/src/Podfile.lock
+++ b/apps/ios/src/Podfile.lock
@@ -437,7 +437,7 @@ PODS:
     - React-cxxreact (= 0.64.3)
     - React-jsi (= 0.64.3)
     - React-perflogger (= 0.64.3)
-  - ReactTestApp-DevSupport (1.3.7):
+  - ReactTestApp-DevSupport (1.3.8):
     - React-Core
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
@@ -598,7 +598,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: c7f845861e79eae13dc1e8217a3cf47a3945b504
   React-runtimeexecutor: 493d9abb8b23c3f84e19ae221eeba92cadcb70dc
   ReactCommon: 8fea6422328e2fc093e25c9fac67adbcf0f04fb4
-  ReactTestApp-DevSupport: 184027604fa0bff24e3467092ba799c2fc6be16f
+  ReactTestApp-DevSupport: 1075d13c9f78457e4e7365dffb30f131e5b16a5b
   ReactTestApp-Resources: 51437f32bf317329a7c9ca3f68e3a4cc952567ba
   RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519

--- a/change/@fluentui-react-native-experimental-native-date-picker-682bb52d-a31b-4075-93b1-226229192a2c.json
+++ b/change/@fluentui-react-native-experimental-native-date-picker-682bb52d-a31b-4075-93b1-226229192a2c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add method to set default calendar configuration",
+  "packageName": "@fluentui-react-native/experimental-native-date-picker",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-118003fa-8f24-46fb-8168-67189ad442c1.json
+++ b/change/@fluentui-react-native-tester-118003fa-8f24-46fb-8168-67189ad442c1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add method to set default calendar configuration",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/NativeDatePicker/ios/DatePickerManager.swift
+++ b/packages/experimental/NativeDatePicker/ios/DatePickerManager.swift
@@ -1,4 +1,5 @@
 import FluentUI
+import Foundation
 
 @objc(FRNDatePickerManager)
 public class DatePickerManager: NSObject {
@@ -62,7 +63,8 @@ public class DatePickerManager: NSObject {
     
     @objc public func setDefaultCalendarConfiguration(
         referenceStartDate: Date?,
-        referenceEndDate: Date?
+        referenceEndDate: Date?,
+        firstWeekday: NSNumber?
     ) {
         if let referenceStartDate = referenceStartDate {
             CalendarConfiguration.default.referenceStartDate = referenceStartDate
@@ -70,6 +72,10 @@ public class DatePickerManager: NSObject {
         
         if let referenceEndDate = referenceEndDate {
             CalendarConfiguration.default.referenceEndDate = referenceEndDate
+        }
+        
+        if let firstWeekday = firstWeekday {
+            CalendarConfiguration.default.firstWeekday = firstWeekday.intValue
         }
     }
 

--- a/packages/experimental/NativeDatePicker/ios/DatePickerManager.swift
+++ b/packages/experimental/NativeDatePicker/ios/DatePickerManager.swift
@@ -59,6 +59,19 @@ public class DatePickerManager: NSObject {
                 titles: titles)
         }
     }
+    
+    @objc public func setDefaultCalendarConfiguration(
+        referenceStartDate: Date?,
+        referenceEndDate: Date?
+    ) {
+        if let referenceStartDate = referenceStartDate {
+            CalendarConfiguration.default.referenceStartDate = referenceStartDate
+        }
+        
+        if let referenceEndDate = referenceEndDate {
+            CalendarConfiguration.default.referenceEndDate = referenceEndDate
+        }
+    }
 
     func releaseLastDelegate(_ delegate: DatePickerDelegate) {
         precondition(delegate === lastDelegate, "DatePickerDelegate requested to be released should match the last one initialized.")

--- a/packages/experimental/NativeDatePicker/ios/DatePickerManager.swift
+++ b/packages/experimental/NativeDatePicker/ios/DatePickerManager.swift
@@ -63,19 +63,14 @@ public class DatePickerManager: NSObject {
     
     @objc public func setDefaultCalendarConfiguration(
         referenceStartDate: Date?,
-        referenceEndDate: Date?,
-        firstWeekday: NSNumber?
+        referenceEndDate: Date?
     ) {
         if let referenceStartDate = referenceStartDate {
             CalendarConfiguration.default.referenceStartDate = referenceStartDate
         }
-        
+
         if let referenceEndDate = referenceEndDate {
             CalendarConfiguration.default.referenceEndDate = referenceEndDate
-        }
-        
-        if let firstWeekday = firstWeekday {
-            CalendarConfiguration.default.firstWeekday = firstWeekday.intValue
         }
     }
 

--- a/packages/experimental/NativeDatePicker/ios/FRNDatePickerManager.m
+++ b/packages/experimental/NativeDatePicker/ios/FRNDatePickerManager.m
@@ -65,4 +65,7 @@ RCT_EXTERN_METHOD(presentWithMode:(MSFDateTimePickerMode)mode
                   timeSubtitle:(nullable NSString *)timeSubtitle
                   callback:(RCTResponseSenderBlock)callback)
 
+RCT_EXTERN_METHOD(setDefaultCalendarConfigurationWithReferenceStartDate:(nullable NSDate *)referenceStartDate
+                  referenceEndDate:(nullable NSDate *)referenceEndDate)
+
 @end

--- a/packages/experimental/NativeDatePicker/ios/FRNDatePickerManager.m
+++ b/packages/experimental/NativeDatePicker/ios/FRNDatePickerManager.m
@@ -66,6 +66,7 @@ RCT_EXTERN_METHOD(presentWithMode:(MSFDateTimePickerMode)mode
                   callback:(RCTResponseSenderBlock)callback)
 
 RCT_EXTERN_METHOD(setDefaultCalendarConfigurationWithReferenceStartDate:(nullable NSDate *)referenceStartDate
-                  referenceEndDate:(nullable NSDate *)referenceEndDate)
+                  referenceEndDate:(nullable NSDate *)referenceEndDate
+                  firstWeekday:(nullable NSNumber *)firstWeekday)
 
 @end

--- a/packages/experimental/NativeDatePicker/ios/FRNDatePickerManager.m
+++ b/packages/experimental/NativeDatePicker/ios/FRNDatePickerManager.m
@@ -67,6 +67,6 @@ RCT_EXTERN_METHOD(presentWithMode:(MSFDateTimePickerMode)mode
 
 RCT_EXTERN_METHOD(setDefaultCalendarConfigurationWithReferenceStartDate:(nullable NSDate *)referenceStartDate
                   referenceEndDate:(nullable NSDate *)referenceEndDate
-                  firstWeekday:(nullable NSNumber *)firstWeekday)
+                  firstWeekday:(nonnull NSNumber *)firstWeekday)
 
 @end

--- a/packages/experimental/NativeDatePicker/ios/FRNDatePickerManager.m
+++ b/packages/experimental/NativeDatePicker/ios/FRNDatePickerManager.m
@@ -66,7 +66,6 @@ RCT_EXTERN_METHOD(presentWithMode:(MSFDateTimePickerMode)mode
                   callback:(RCTResponseSenderBlock)callback)
 
 RCT_EXTERN_METHOD(setDefaultCalendarConfigurationWithReferenceStartDate:(nullable NSDate *)referenceStartDate
-                  referenceEndDate:(nullable NSDate *)referenceEndDate
-                  firstWeekday:(nonnull NSNumber *)firstWeekday)
+                  referenceEndDate:(nullable NSDate *)referenceEndDate)
 
 @end

--- a/packages/experimental/NativeDatePicker/src/NativeDatePicker.tsx
+++ b/packages/experimental/NativeDatePicker/src/NativeDatePicker.tsx
@@ -74,7 +74,7 @@ interface CalendarConfigurationObject {
 NativeDatePicker.setDefaultCalendarConfiguration = ({
   referenceStartDate = null,
   referenceEndDate = null,
-  firstWeekday = null,
+  firstWeekday = 1,
 }: CalendarConfigurationObject) => {
   NativeDatePicker.setDefaultCalendarConfigurationWithReferenceStartDate(
     referenceStartDate?.toISOString(),

--- a/packages/experimental/NativeDatePicker/src/NativeDatePicker.tsx
+++ b/packages/experimental/NativeDatePicker/src/NativeDatePicker.tsx
@@ -68,18 +68,15 @@ NativeDatePicker.present = ({
 interface CalendarConfigurationObject {
   referenceStartDate?: Date;
   referenceEndDate?: Date;
-  firstWeekday?: number;
 }
 
 NativeDatePicker.setDefaultCalendarConfiguration = ({
   referenceStartDate = null,
   referenceEndDate = null,
-  firstWeekday = 1,
 }: CalendarConfigurationObject) => {
   NativeDatePicker.setDefaultCalendarConfigurationWithReferenceStartDate(
     referenceStartDate?.toISOString(),
     referenceEndDate?.toISOString(),
-    firstWeekday,
   );
 };
 

--- a/packages/experimental/NativeDatePicker/src/NativeDatePicker.tsx
+++ b/packages/experimental/NativeDatePicker/src/NativeDatePicker.tsx
@@ -65,6 +65,21 @@ NativeDatePicker.present = ({
   );
 };
 
+interface CalendarConfigurationObject {
+  referenceStartDate?: Date;
+  referenceEndDate?: Date;
+}
+
+NativeDatePicker.setDefaultCalendarConfiguration = ({
+  referenceStartDate = null,
+  referenceEndDate = null,
+}: CalendarConfigurationObject) => {
+  NativeDatePicker.setDefaultCalendarConfigurationWithReferenceStartDate(
+    referenceStartDate?.toISOString(),
+    referenceEndDate?.toISOString(),
+  );
+};
+
 // We get date values back from the native side as strings in ISO 8601 format and UTC.
 // We want to immediately put them back into `Date` objects in local time.
 NativeDatePicker.parseISOString = (dateISOString: string): Date => {
@@ -79,6 +94,7 @@ NativeDatePicker.parseISOString = (dateISOString: string): Date => {
 
 interface NativeDatePickerInterface {
   present(object: DatePickerParameterObject): void;
+  setDefaultCalendarConfiguration(object: CalendarConfigurationObject): void;
   parseISOString(dateISOString: string): Date;
 }
 

--- a/packages/experimental/NativeDatePicker/src/NativeDatePicker.tsx
+++ b/packages/experimental/NativeDatePicker/src/NativeDatePicker.tsx
@@ -68,15 +68,18 @@ NativeDatePicker.present = ({
 interface CalendarConfigurationObject {
   referenceStartDate?: Date;
   referenceEndDate?: Date;
+  firstWeekday?: number;
 }
 
 NativeDatePicker.setDefaultCalendarConfiguration = ({
   referenceStartDate = null,
   referenceEndDate = null,
+  firstWeekday = null,
 }: CalendarConfigurationObject) => {
   NativeDatePicker.setDefaultCalendarConfigurationWithReferenceStartDate(
     referenceStartDate?.toISOString(),
     referenceEndDate?.toISOString(),
+    firstWeekday,
   );
 };
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Ask from a client team to be able to set the reference start/end dates (range of possible dates the calendar allows, not to be confused with "date range" which refers to the dates a user can select). 

The default reference start date is Jan 1, 3 years before the current year. The default reference end date is 10 years after the default reference start date. Ex. For May 23, 2022, the default range is Jan 1, 2019 - Dec 21, 2029.

This change allows the default Calendar Configuration to be overridden - which includes the reference start and end dates, as well as firstWeekday (usually begins on Sunday or Monday). Note that overriding the default calendar configuration affects **all** FURN datepickers. Additional work will be required if we want to support different calendar configurations for different datepickers.

### Verification

Added a button at the bottom of the FluentTester DatePicker test page that updates the default reference start/end dates to be from 1999 to 2000.

| Before | After |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/78454019/169923134-4bc8469e-2b98-48dc-9595-42ce730fd8d3.png) | ![image](https://user-images.githubusercontent.com/78454019/169923462-d6d96d36-0931-4186-8230-0a07d1e901e2.png) | ![image](https://user-images.githubusercontent.com/78454019/169923134-4bc8469e-2b98-48dc-9595-42ce730fd8d3.png)
 

| Before (earliest possible start date you could scroll to) | After (earliest possible start date you could scroll to) |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/78454019/169923204-43860ae9-bf22-46ed-82aa-4dd75d33a5b1.png) | ![image](https://user-images.githubusercontent.com/78454019/169923219-51e41698-0804-4d80-9602-6134cc630aaa.png) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts


Notes:
- Not sure if using a button in the FluentTester datepicker page to change the default reference start end dates is best. Maybe a toggle would be better?
- This allows users to set the default "CalendarConfiguration", but this PR only exposes referenceStartDate and referenceEndDate. Do we also want to expose firstWeekday?
- With this change it is easier to get into a state where the selected date is outside the reference start/end dates, ex if the default start date is already out of the range, and you try to select the default date. There is an assert in datetimepickerviewdatasource (line 308, assert(dateIndex >= 0 && dateIndex < numberOfDates, "index out of bound")) that gets hit when this happens. Do we want to do anything about this? 