### PR TITLE
Menu V1 keyboarding

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/Menu/MenuTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Menu/MenuTest.tsx
@@ -11,7 +11,6 @@ import {
   MenuDivider,
 } from '@fluentui-react-native/menu';
 import { Stack } from '@fluentui-react-native/stack';
-import { Text } from '@fluentui-react-native/experimental-text';
 import { stackStyle } from '../Common/styles';
 import { MENU_TESTPAGE } from './consts';
 import { Test, TestSection, PlatformStatus } from '../Test';
@@ -25,7 +24,9 @@ const MenuDefault: React.FunctionComponent = () => {
         </MenuTrigger>
         <MenuPopover>
           <MenuList>
-            <Text>Hello world!!!</Text>
+            <MenuItem content="A plain MenuItem" />
+            <MenuItem disabled content="A plain MenuItem" />
+            <MenuItem content="A plain MenuItem" />
           </MenuList>
         </MenuPopover>
       </Menu>

--- a/apps/fluent-tester/src/FluentTester/TestComponents/Menu/MenuTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Menu/MenuTest.tsx
@@ -57,7 +57,8 @@ const MenuCheckmarks: React.FunctionComponent = () => {
           <MenuList>
             <MenuItem content="A plain MenuItem" />
             <MenuItemCheckbox name="itemTwo" content="A MenuItem with checkmark" />
-            <MenuItemCheckbox name="itemThree" content="A MenuItem with checkmark" />
+            <MenuItemCheckbox disabled name="itemThree" content="A disabled MenuItem with checkmark" />
+            <MenuItemCheckbox name="itemFour" content="A MenuItem with checkmark" />
           </MenuList>
         </MenuPopover>
       </Menu>

--- a/change/@fluentui-react-native-menu-c7694c16-d525-498d-853c-8b0cec2e74f1.json
+++ b/change/@fluentui-react-native-menu-c7694c16-d525-498d-853c-8b0cec2e74f1.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Fix keyboarding",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-c463fcc6-c84a-4a17-8b77-436acdd36c0c.json
+++ b/change/@fluentui-react-native-tester-c463fcc6-c84a-4a17-8b77-436acdd36c0c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Create a normal example of a menu",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Menu/src/MenuItem/MenuItem.tsx
+++ b/packages/experimental/Menu/src/MenuItem/MenuItem.tsx
@@ -18,7 +18,7 @@ export const MenuItem = compose<MenuItemType>({
   },
   useRender: (userProps: MenuItemProps, useSlots: UseSlots<MenuItemType>) => {
     const menuItem = useMenuItem(userProps);
-    const Slots = useSlots(userProps, (layer): boolean => menuItem.state[layer]);
+    const Slots = useSlots(userProps, (layer): boolean => menuItem.state[layer] || userProps[layer]);
 
     return (final: MenuItemProps) => {
       const mergedProps = mergeProps(menuItem.props, final);

--- a/packages/experimental/Menu/src/MenuItem/useMenuItem.ts
+++ b/packages/experimental/Menu/src/MenuItem/useMenuItem.ts
@@ -15,10 +15,12 @@ export const useMenuItem = (props: MenuItemProps): MenuItemState => {
   const setOpen = useMenuContext().setOpen;
   const onInvoke = React.useCallback(
     (e: InteractionEvent) => {
-      onClick && onClick(e);
-      setOpen(e, false /*isOpen*/);
+      if (!disabled) {
+        onClick && onClick(e);
+        setOpen(e, false /*isOpen*/);
+      }
     },
-    [onClick, setOpen],
+    [disabled, onClick, setOpen],
   );
   const pressable = useAsPressable({ ...rest, disabled, onPress: onInvoke });
   const onKeyProps = useKeyProps(onInvoke, ' ', 'Enter');
@@ -35,7 +37,7 @@ export const useMenuItem = (props: MenuItemProps): MenuItemState => {
       accessibilityLabel: props.accessibilityLabel,
       accessibilityState: getAccessibilityState(disabled, accessibilityState),
       enableFocusRing: true,
-      focusable: !disabled,
+      focusable: true,
       ref: componentRef,
       ...onKeyProps,
     },

--- a/packages/experimental/Menu/src/MenuItemCheckbox/MenuItemCheckbox.tsx
+++ b/packages/experimental/Menu/src/MenuItemCheckbox/MenuItemCheckbox.tsx
@@ -23,7 +23,7 @@ export const MenuItemCheckbox = compose<MenuItemCheckboxType>({
   },
   useRender: (userProps: MenuItemCheckboxProps, useSlots: UseSlots<MenuItemCheckboxType>) => {
     const menuItem = useMenuItemCheckbox(userProps);
-    const Slots = useSlots(userProps, (layer): boolean => menuItem.state[layer]);
+    const Slots = useSlots(userProps, (layer): boolean => menuItem.state[layer] || userProps[layer]);
 
     return menuItemFinalRender(menuItem, Slots);
   },

--- a/packages/experimental/Menu/src/MenuItemCheckbox/useMenuItemCheckbox.ts
+++ b/packages/experimental/Menu/src/MenuItemCheckbox/useMenuItemCheckbox.ts
@@ -14,16 +14,18 @@ import { useMenuListContext } from '../context/menuListContext';
 const defaultAccessibilityActions = [{ name: 'Toggle' }];
 
 export const useMenuItemCheckbox = (props: MenuItemCheckboxProps): MenuItemCheckboxState => {
-  const { name } = props;
+  const { disabled, name } = props;
   const context = useMenuListContext();
   const checked = context.checked?.[name];
   const onCheckedChange = context.onCheckedChange;
 
   const toggleChecked = React.useCallback(
     (e: InteractionEvent) => {
-      onCheckedChange(e, name, !checked);
+      if (!disabled) {
+        onCheckedChange(e, name, !checked);
+      }
     },
-    [checked, name, onCheckedChange],
+    [checked, disabled, name, onCheckedChange],
   );
 
   return useMenuCheckboxInteraction(props, toggleChecked);
@@ -74,12 +76,14 @@ export const useMenuCheckboxInteraction = (
     : defaultAccessibilityActions;
   const onAccessibilityActionProp = React.useCallback(
     (event: AccessibilityActionEvent) => {
-      if (event.nativeEvent.actionName === 'Toggle') {
-        toggleCallback(event);
+      if (!disabled) {
+        if (event.nativeEvent.actionName === 'Toggle') {
+          toggleCallback(event);
+        }
+        onAccessibilityAction && onAccessibilityAction(event);
       }
-      onAccessibilityAction && onAccessibilityAction(event);
     },
-    [toggleCallback, onAccessibilityAction],
+    [disabled, toggleCallback, onAccessibilityAction],
   );
 
   const state = {
@@ -97,7 +101,7 @@ export const useMenuCheckboxInteraction = (
       accessibilityRole: 'menuitem',
       accessibilityState: getAccessibilityState(disabled, state.checked, accessibilityState),
       enableFocusRing: true,
-      focusable: !disabled,
+      focusable: true,
       onAccessibilityAction: onAccessibilityActionProp,
       ref: buttonRef,
       ...onKeyProps,

--- a/packages/experimental/Menu/src/MenuItemRadio/useMenuItemRadio.ts
+++ b/packages/experimental/Menu/src/MenuItemRadio/useMenuItemRadio.ts
@@ -5,16 +5,18 @@ import { MenuItemCheckboxProps, MenuItemCheckboxState } from '../MenuItemCheckbo
 import { useMenuCheckboxInteraction } from '../MenuItemCheckbox/useMenuItemCheckbox';
 
 export const useMenuItemRadio = (props: MenuItemCheckboxProps): MenuItemCheckboxState => {
-  const { name } = props;
+  const { disabled, name } = props;
   const context = useMenuListContext();
   const checked = context.checked?.[name];
   const selectRadio = context.selectRadio;
 
   const toggleChecked = React.useCallback(
     (e: InteractionEvent) => {
-      selectRadio(e, name, !checked);
+      if (!disabled) {
+        selectRadio(e, name, !checked);
+      }
     },
-    [checked, name, selectRadio],
+    [checked, disabled, name, selectRadio],
   );
 
   return useMenuCheckboxInteraction(props, toggleChecked);


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This change shores up some keyboarding behavior on the Menu. Spec that has been implemented is:

- Up and down inside of the menu that has focus should navigate vertically between keyboard focusable elements (note: focus should never land on the "split" part of a split button this way)
- Up and down should circularly navigate through a list of menu items by default, e.g. if I hit down at the bottom of a menu, it should navigate to the first item.
- Right key on a menu item that has an available submenu or split button should invoke the submenu, and move focus into it onto the first focusable item (flipped for RTL)
- Left key when in a submenu should close the submenu and place focus back on the parent menu's item that opened the submenu. (flipped for RTL)
- ESC on a menu should close the currently focused menu. If you are in a submenu and hit ESC, you should only close the current submenu and return focus to the parent's element where focus was previously.
- Space and Enter key execute the action that is currently focused in the menu.

Additional fixes:
- Disabled visuals are now applied when disabled is passed in as a prop
- Close the Menu on MenuItem invoke

### Verification

Used tester to validate keyboard behavior

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [x] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
