### PR TITLE
Menu V1 - Should focus on container for win32

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/Menu/MenuTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Menu/MenuTest.tsx
@@ -139,7 +139,6 @@ const MenuOpenOnHover: React.FunctionComponent = () => {
         <MenuPopover>
           <MenuList>
             <MenuItem content="A MenuItem" />
-            <Submenu />
           </MenuList>
         </MenuPopover>
       </Menu>
@@ -159,7 +158,25 @@ const MenuControlledOpen: React.FunctionComponent = () => {
         <MenuPopover>
           <MenuList>
             <MenuItem content="A MenuItem" />
-            <Submenu />
+          </MenuList>
+        </MenuPopover>
+      </Menu>
+    </Stack>
+  );
+};
+
+const MenuContainer: React.FunctionComponent = () => {
+  return (
+    <Stack style={[stackStyle, { flexDirection: 'row' }]}>
+      <Menu shouldFocusOnContainer>
+        <MenuTrigger>
+          <Button>Test</Button>
+        </MenuTrigger>
+        <MenuPopover>
+          <MenuList>
+            <MenuItem content="A MenuItem" />
+            <MenuItem content="A MenuItem" />
+            <MenuItem content="A MenuItem" />
           </MenuList>
         </MenuPopover>
       </Menu>
@@ -192,6 +209,10 @@ const menuSections: TestSection[] = [
   {
     name: 'Menu Submenu',
     component: MenuSubMenu,
+  },
+  {
+    name: 'Menu focus on container',
+    component: MenuContainer,
   },
 ];
 

--- a/change/@fluentui-react-native-menu-3faaff32-3730-4ac2-b028-a9983775e1f0.json
+++ b/change/@fluentui-react-native-menu-3faaff32-3730-4ac2-b028-a9983775e1f0.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Implement shouldFocusOnContainer",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-4a85c9f3-3eac-4797-890c-1d3fa23ae96d.json
+++ b/change/@fluentui-react-native-tester-4a85c9f3-3eac-4797-890c-1d3fa23ae96d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Implement shouldFocusOnContainer",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Menu/src/Menu/Menu.types.ts
+++ b/packages/experimental/Menu/src/Menu/Menu.types.ts
@@ -9,6 +9,13 @@ export interface MenuProps extends MenuListProps {
   open?: boolean;
   onOpenChange?: (e: InteractionEvent, isOpen: boolean) => void;
   openOnHover?: boolean;
+
+  /**
+   * Whether to set initial focus on the contextual menu container.
+   * @default false
+   * @platform win32
+   */
+  shouldFocusOnContainer?: boolean;
 }
 
 export interface MenuState extends MenuProps {

--- a/packages/experimental/Menu/src/Menu/useMenu.ts
+++ b/packages/experimental/Menu/src/Menu/useMenu.ts
@@ -1,5 +1,6 @@
 import { InteractionEvent } from '@fluentui-react-native/interactive-hooks';
 import React from 'react';
+import { Platform } from 'react-native';
 import { useMenuContext } from '../context/menuContext';
 import { MenuProps, MenuState } from './Menu.types';
 
@@ -9,6 +10,7 @@ export const useMenu = (props: MenuProps): MenuState => {
   const isSubmenu = context.triggerRef !== null;
   const isControlled = typeof props.open !== 'undefined';
   const [open, setOpen] = useMenuOpenState(isControlled, props);
+  const shouldFocusOnContainer = Platform.OS !== ('win32' as any) ? false : props.shouldFocusOnContainer;
 
   // Default behavior for submenu is to open on hover
   // the ...props line below will override this behavior for a submenu
@@ -20,6 +22,7 @@ export const useMenu = (props: MenuProps): MenuState => {
     ...props,
     open,
     setOpen,
+    shouldFocusOnContainer,
     triggerRef,
     isSubmenu,
     isControlled,

--- a/packages/experimental/Menu/src/Menu/useMenu.ts
+++ b/packages/experimental/Menu/src/Menu/useMenu.ts
@@ -10,7 +10,7 @@ export const useMenu = (props: MenuProps): MenuState => {
   const isControlled = typeof props.open !== 'undefined';
   const [open, setOpen] = useMenuOpenState(isControlled, props);
 
-  // Default behaviot for submenu is to open on hover
+  // Default behavior for submenu is to open on hover
   // the ...props line below will override this behavior for a submenu
   // or apply openOnHover if passed into a root Menu.
   const openOnHover = isSubmenu;

--- a/packages/experimental/Menu/src/MenuList/MenuList.tsx
+++ b/packages/experimental/Menu/src/MenuList/MenuList.tsx
@@ -39,10 +39,11 @@ export const MenuList = compose<MenuListType>({
     const contextValue = useMenuListContextValue(menuList);
     const Slots = useSlots(menuList);
 
-    return (_final: MenuListProps, children: React.ReactNode) => {
+    return (final: MenuListProps, children: React.ReactNode) => {
+      const mergedProps = mergeProps(menuList, final);
       return (
         <MenuListProvider value={contextValue}>
-          <Slots.root>{children}</Slots.root>
+          <Slots.root {...mergedProps}>{children}</Slots.root>
         </MenuListProvider>
       );
     };

--- a/packages/experimental/Menu/src/MenuList/useMenuList.ts
+++ b/packages/experimental/Menu/src/MenuList/useMenuList.ts
@@ -13,6 +13,8 @@ export const useMenuList = (_props: MenuListProps): MenuListState => {
 
   return {
     ...context,
+    accessible: context.shouldFocusOnContainer,
+    focusable: context.shouldFocusOnContainer,
     isCheckedControlled,
     checked,
     onCheckedChange,

--- a/packages/experimental/Menu/src/context/menuContext.ts
+++ b/packages/experimental/Menu/src/context/menuContext.ts
@@ -15,6 +15,7 @@ export const MenuContext = React.createContext<MenuContextValue>({
   open: false,
   onCheckedChange: () => false,
   setOpen: () => false,
+  shouldFocusOnContainer: false,
   triggerRef: null,
 });
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Add behavior to allow for focusing on the container on open. This is done by passing shouldFocusOnContainer to the Menu component.

This is accomplished by setting accessible and focused to true when shouldFocusOnContainer is true.
This prop is overriden to false on non-win32 platforms.

### Verification

![focus_on_container](https://user-images.githubusercontent.com/4602628/170597294-6f790bde-e625-402d-9162-b6c33c76a34d.gif)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [x] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
