### PR TITLE
Avatar migration

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/Avatar/BasicAvatar.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Avatar/BasicAvatar.tsx
@@ -97,6 +97,7 @@ export const StandardUsage: FunctionComponent = () => {
         <StyledPicker prompt="Presence status" selected={presence} onChange={onPresenceChange} collection={allPresences} />
       </View>
       <JSAvatar />
+      <JSAvatar image={{ accessibilityLabel: 'test', source: { uri: satyaPhotoUrl } }} />
       <JSAvatar icon={{ fontSource: { ...fontBuiltInProps, fontSize: 32 }, color: 'red' }} size={56} />
       <JSAvatar icon={{ fontSource: { ...fontBuiltInProps }, color: 'white' }} size={120} />
       <JSAvatar

--- a/change/@fluentui-react-native-experimental-avatar-8c9dca7a-c585-4bcd-a6bd-e3b357dbf8aa.json
+++ b/change/@fluentui-react-native-experimental-avatar-8c9dca7a-c585-4bcd-a6bd-e3b357dbf8aa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added Avatar migration and added image prop",
+  "packageName": "@fluentui-react-native/experimental-avatar",
+  "email": "v.kozova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-a4703585-827e-4155-b6b7-0270dc8284fd.json
+++ b/change/@fluentui-react-native-tester-a4703585-827e-4155-b6b7-0270dc8284fd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added Avatar migration and added image prop",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "v.kozova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Avatar/MIGRATION.md
+++ b/packages/experimental/Avatar/MIGRATION.md
@@ -1,0 +1,158 @@
+# Avatar Migration
+
+## Migration from PersonaCoin component
+
+### Component renames
+
+| `PersonaCoin`                                    | `Avatar`                                                     |
+| ------------------------------------------------ | ------------------------------------------------------------ |
+| `<Avatar size={24} initials="SN" />`             | `<PersonaCoin size='size24' initials="SN" />`                |
+| `<Avatar size={24} initials="SN" />`             | `<PersonaCoin presence='available' coinColorFluent="red" />` |
+| `<Avatar image={{source: './path/name.png'}} />` | `<PersonaCoin imageUrl="./path/name.png" />`                 |
+| `<Avatar accessibilityLabel="Photo" />`          | `<PersonaCoin imageDescription="Photo" />`                   |
+
+### Props that remain as is
+
+- `icon`
+- `idForColor`
+- `initials`
+- `size`
+
+### Props no longer supported with an equivalent functionality in Avatar
+
+- `coinColorFluent` => Use `avatarColor` instead.
+- `imageUrl` => Images passes using `image` slot: `image={{ src: './image.jpg' }} />`.
+- `imageDescription` => Use `accessibilityLabel` instead.
+- `isOutOfOffice` => `outOfOffice` is part of `badge` slot. Use `badge={{ outOfOffice: true }} />`.
+- `presence` => It's part of `badge` slot. Use `badge={{ presence: 'available' }} />`.
+- `ring` => `ring` became part of `activeAppearance` prop. It's used together with `active='active'` prop.
+
+### New props
+
+- `active`
+- `activeAppearance` - According to Web spec there should be `ring`, `shadow`, `glow`, `ring-shadow`, `ring-glow`.
+  Currently we support only `ring`. `activeAppearance` can be used when `active` prop set to `active`
+- `name` - is used for generation initials with `getInitials` method.
+- `shape` - can be `circular` and `square`.
+
+### Tokens that remain as is
+
+- Any props that are part of `IBackgroundColorTokens`, `IForegroundColorTokens`
+
+- `iconSize`
+- `iconWeight`
+- `horizontalIconAlignment`
+- `verticalIconAlignment`
+- `size`
+
+### Tokens no longer supported with an equivalent functionality in Avatar
+
+- `initialsSize` => Use `fontSize` token instead
+- `coinColorFluent` => Use `avatarColor` token instead
+- `coinSize` => Use size tokens instead.
+- `ring` => Use `ringBackgroundColor`, `ringColor`, `ringThickness` and `ringInnerGap`
+
+### Tokens no longer supported without an equivalent functionality in Avatar
+
+- `iconStrokeWidth` and `iconStrokeColor` => This was for activity ring around the Avatar.
+  We support ring in `activeAppearance` prop. `borderColor` will be changed using `ringColor` token and `borderWidth` using ringThickness token.
+
+### New tokens
+
+- Any props that are part of `FontTokens` and `IBorderTokens`.
+- `avatarOpacity`
+- `badgeSize`
+- `circular`
+- `iconColor`
+- `inactive`
+- `square`
+
+Size tokens:
+
+- `size20`
+- `size24`
+- `size28`
+- `size32`
+- `size36`
+- `size40`
+- `size48`
+- `size56`
+- `size64`
+- `size72`
+- `size96`
+- `size120`
+
+Color tokens:
+
+- `neutral`
+- `brand`
+- `darkRed`
+- `cranberry`
+- `red`
+- `pumpkin`
+- `peach`
+- `marigold`
+- `gold`
+- `brass`
+- `brown`
+- `forest`
+- `seafoam`
+- `darkGreen`
+- `lightTeal`
+- `teal`
+- `steel`
+- `blue`
+- `royalBlue`
+- `cornflower`
+- `navy`
+- `lavender`
+- `purple`
+- `grape`
+- `lilac`
+- `pink`
+- `magenta`
+- `plum`
+- `beige`
+- `mink`
+- `platinum`
+- `anchor`
+
+### Slots no longer supported with an equivalent functionality in v1 Avatar
+
+- `photo` => Use `image` slot instead
+
+### Slots no longer supported without an equivalent functionality in v1 Avatar
+
+- `glow` => is not suported in this version of Avatar
+
+### New slots
+
+- `badge`
+
+### Prop differences due to technical differences and limitations
+
+- Web uses `image` slot which is part of `react-image` component. They use syntax `image={{ src: './MonaKane.jpg' }}`. If we use similar syntax, our users will need to write `image={{ source: { uri: './MonaKane.jpg' } }} />`. In majority of cases users pass image URL that's why we still have opportunity to pass this parameter using `src` prop. But there's also a way to pass `image` object similar to Web.
+
+### Other Prop differences
+
+- `avatarColor` => Web uses `color` prop and omits it from `ComponentProps<AvatarSlots>`. Their users can style font color using CSS but our users can style the component via tokens. If we use the same prop name (color), we'll need to omit it from foregroundTokens and come up with a new name for the font color prop. That's why we use `avatarColor` prop instead of `color`.
+
+## Property mapping
+
+| `PersonaCoin`      | `Avatar`             |
+| ------------------ | -------------------- |
+|                    | `active`             |
+|                    | `activeAppearance`   |
+|                    | `badge`              |
+| `coinColorFluent`  | `avatarColor`        |
+| `icon`             | `icon`               |
+| `idForColor`       | `idForColor`         |
+| `imageUrl`         | `iamge`              |
+| `imageDescription` | `accessibilityLabel` |
+| `isOutOfOffice`    |                      |
+| `initials`         | `initials`           |
+|                    | `name`               |
+| `presence`         |                      |
+| `ring`             |                      |
+|                    | `shape`              |
+| `size`             | `size`               |

--- a/packages/experimental/Avatar/src/JSAvatar.types.ts
+++ b/packages/experimental/Avatar/src/JSAvatar.types.ts
@@ -67,7 +67,6 @@ export type AvatarColor = 'neutral' | 'brand' | 'colorful' | AvatarNamedColor;
 export type IconAlignment = 'start' | 'center' | 'end';
 
 export interface RingConfig {
-  accent?: boolean;
   transparent?: boolean;
   ringThickness?: number;
   innerGap?: number;

--- a/packages/experimental/Avatar/src/useAvatar.ts
+++ b/packages/experimental/Avatar/src/useAvatar.ts
@@ -10,7 +10,7 @@ import { titles } from './titles';
  * @returns configured props and state for FURN Avatar
  */
 export const useAvatar = (props: JSAvatarProps): AvatarInfo => {
-  const { active, accessibilityLabel, activeAppearance, badge, initials, name, src, ring, shape, ...rest } = props;
+  const { active, accessibilityLabel, activeAppearance, badge, image, initials, name, src, ring, shape, ...rest } = props;
 
   const showRing = active === 'active' && activeAppearance === 'ring';
   const transparentRing = !!ring?.transparent;
@@ -40,7 +40,7 @@ export const useAvatar = (props: JSAvatarProps): AvatarInfo => {
       ...rest,
       active,
       activeAppearance,
-      image: imageProps,
+      image: image || imageProps,
       badge: badgeProps,
       initials: _initials,
     },


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
- Added MIGRATION.md file.
- Added image prop so users will be able to pass image this way: `image={{ source: { uri: './name.jpg' } }} />`.

**There are still a couple of opened questions:**
1. Is it ok to stay with `avatarColor` prop? I added explanation why we didn't aligned with web this one:
Web uses `color` prop and omits it from `ComponentProps<AvatarSlots>`. Their users can style font color using inline CSS but our users can style the component via tokens. If we use the same prop name (color), we'll need to omit it from foregroundTokens and come up with a new name for the font color prop.

2. I suggested to use `src` prop as shorthand because in majority of cases users will use image URL and they won't need to write this long syntax: `image={{ source: { uri: './name.jpg' } }} />`. But there is also an opportunity to use similar syntax with Web.
3. If we stay with `src` prop, maybe it would be good to return `imageURL` prop?


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [X] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
