### PR TITLE
Fix hover-related issues with Menu

### DIFF
--- a/change/@fluentui-react-native-menu-023b2fb1-2310-4c4b-b9c6-21756183da21.json
+++ b/change/@fluentui-react-native-menu-023b2fb1-2310-4c4b-b9c6-21756183da21.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix some hover shenanigans",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Menu/src/Menu/Menu.types.ts
+++ b/packages/experimental/Menu/src/Menu/Menu.types.ts
@@ -14,6 +14,7 @@ export interface MenuProps extends MenuListProps {
 export interface MenuState extends MenuProps {
   isControlled: boolean;
   isSubmenu: boolean;
+  parentPopoverHoverOutTimer?: NodeJS.Timeout;
   setOpen: (e: InteractionEvent, isOpen: boolean) => void;
   triggerRef: React.RefObject<React.Component>;
 }

--- a/packages/experimental/Menu/src/Menu/useMenu.ts
+++ b/packages/experimental/Menu/src/Menu/useMenu.ts
@@ -7,6 +7,7 @@ export const useMenu = (props: MenuProps): MenuState => {
   const triggerRef = React.useRef(null);
   const context = useMenuContext();
   const isSubmenu = context.triggerRef !== null;
+  const parentPopoverHoverOutTimer = isSubmenu ? context.popoverHoverOutTimer : undefined;
   const isControlled = typeof props.open !== 'undefined';
   const [open, setOpen] = useMenuOpenState(isControlled, props);
 
@@ -23,6 +24,7 @@ export const useMenu = (props: MenuProps): MenuState => {
     triggerRef,
     isSubmenu,
     isControlled,
+    parentPopoverHoverOutTimer,
   };
 };
 

--- a/packages/experimental/Menu/src/Menu/useMenu.ts
+++ b/packages/experimental/Menu/src/Menu/useMenu.ts
@@ -7,7 +7,6 @@ export const useMenu = (props: MenuProps): MenuState => {
   const triggerRef = React.useRef(null);
   const context = useMenuContext();
   const isSubmenu = context.triggerRef !== null;
-  const parentPopoverHoverOutTimer = isSubmenu ? context.popoverHoverOutTimer : undefined;
   const isControlled = typeof props.open !== 'undefined';
   const [open, setOpen] = useMenuOpenState(isControlled, props);
 
@@ -15,6 +14,12 @@ export const useMenu = (props: MenuProps): MenuState => {
   // the ...props line below will override this behavior for a submenu
   // or apply openOnHover if passed into a root Menu.
   const openOnHover = isSubmenu;
+
+  // We need to be able to cancel the timer that gets set on
+  // hover out of the parent popover if the parent popover
+  // is also set to open/close on hover out. Otherwise
+  // the parent menu will close when the timeout passes.
+  const parentPopoverHoverOutTimer = isSubmenu ? context.popoverHoverOutTimer : undefined;
 
   return {
     openOnHover,

--- a/packages/experimental/Menu/src/Menu/useMenu.ts
+++ b/packages/experimental/Menu/src/Menu/useMenu.ts
@@ -10,7 +10,7 @@ export const useMenu = (props: MenuProps): MenuState => {
   const isControlled = typeof props.open !== 'undefined';
   const [open, setOpen] = useMenuOpenState(isControlled, props);
 
-  // Default behaviot for submenu is to open on hover
+  // Default behavior for submenu is to open on hover
   // the ...props line below will override this behavior for a submenu
   // or apply openOnHover if passed into a root Menu.
   const openOnHover = isSubmenu;

--- a/packages/experimental/Menu/src/Menu/useMenuContextValue.ts
+++ b/packages/experimental/Menu/src/Menu/useMenuContextValue.ts
@@ -1,6 +1,8 @@
+import React from 'react';
 import { MenuContextValue } from '../context/menuContext';
 import { MenuState } from './Menu.types';
 
 export const useMenuContextValue = (state: MenuState): MenuContextValue => {
-  return { ...state };
+  const [triggerHoverOutTimer, setTriggerHoverOutTimer] = React.useState<NodeJS.Timeout | undefined>();
+  return { ...state, triggerHoverOutTimer, setTriggerHoverOutTimer };
 };

--- a/packages/experimental/Menu/src/Menu/useMenuContextValue.ts
+++ b/packages/experimental/Menu/src/Menu/useMenuContextValue.ts
@@ -4,5 +4,6 @@ import { MenuState } from './Menu.types';
 
 export const useMenuContextValue = (state: MenuState): MenuContextValue => {
   const [triggerHoverOutTimer, setTriggerHoverOutTimer] = React.useState<NodeJS.Timeout | undefined>();
-  return { ...state, triggerHoverOutTimer, setTriggerHoverOutTimer };
+  const [popoverHoverOutTimer, setPopoverHoverOutTimer] = React.useState<NodeJS.Timeout>();
+  return { ...state, popoverHoverOutTimer, triggerHoverOutTimer, setPopoverHoverOutTimer, setTriggerHoverOutTimer };
 };

--- a/packages/experimental/Menu/src/MenuPopover/MenuPopover.tsx
+++ b/packages/experimental/Menu/src/MenuPopover/MenuPopover.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { stagedComponent, useFluentTheme } from '@fluentui-react-native/framework';
+import { mergeProps, stagedComponent, useFluentTheme } from '@fluentui-react-native/framework';
 import { Callout } from '@fluentui-react-native/callout';
 import { menuPopoverName, MenuPopoverProps } from './MenuPopover.types';
 import { useMenuPopover } from './useMenuPopover';
@@ -9,22 +9,12 @@ export const MenuPopover = stagedComponent((props: MenuPopoverProps) => {
   const state = useMenuPopover(props);
   const theme = useFluentTheme();
 
-  return (_rest: MenuPopoverProps, children: React.ReactNode) => {
+  return (final: MenuPopoverProps, children: React.ReactNode) => {
+    const mergedProps = mergeProps(state.props, final);
+    const content = React.createElement(View, state.innerView, children);
     return (
-      <Callout
-        accessibilityRole={state.accessibilityRole}
-        borderWidth={1}
-        borderColor={theme.colors.neutralStrokeAccessible}
-        target={state.triggerRef}
-        onDismiss={state.onDismiss}
-        dismissBehaviors={state.dismissBehaviors}
-        setInitialFocus={state.setInitialFocus}
-        directionalHint={state.directionalHint}
-        doNotTakePointerCapture={state.doNotTakePointerCapture}
-      >
-        <View onMouseEnter={state.onMouseEnter} onMouseLeave={state.onMouseLeave}>
-          {children}
-        </View>
+      <Callout borderWidth={1} borderColor={theme.colors.neutralStrokeAccessible} {...mergedProps}>
+        {content}
       </Callout>
     );
   };

--- a/packages/experimental/Menu/src/MenuPopover/MenuPopover.tsx
+++ b/packages/experimental/Menu/src/MenuPopover/MenuPopover.tsx
@@ -3,6 +3,7 @@ import { stagedComponent, useFluentTheme } from '@fluentui-react-native/framewor
 import { Callout } from '@fluentui-react-native/callout';
 import { menuPopoverName, MenuPopoverProps } from './MenuPopover.types';
 import { useMenuPopover } from './useMenuPopover';
+import { View } from 'react-native';
 
 export const MenuPopover = stagedComponent((props: MenuPopoverProps) => {
   const state = useMenuPopover(props);
@@ -21,7 +22,9 @@ export const MenuPopover = stagedComponent((props: MenuPopoverProps) => {
         directionalHint={state.directionalHint}
         doNotTakePointerCapture={state.doNotTakePointerCapture}
       >
-        {children}
+        <View onMouseEnter={state.onMouseEnter} onMouseLeave={state.onMouseLeave}>
+          {children}
+        </View>
       </Callout>
     );
   };

--- a/packages/experimental/Menu/src/MenuPopover/MenuPopover.types.ts
+++ b/packages/experimental/Menu/src/MenuPopover/MenuPopover.types.ts
@@ -1,19 +1,11 @@
-import { DirectionalHint, DismissBehaviors, ICalloutProps } from '@fluentui-react-native/callout';
-import { InteractionEvent } from '@fluentui-react-native/interactive-hooks';
-import { AccessibilityRole } from 'react-native';
+import { IViewProps } from '@fluentui-react-native/adapters';
+import { ICalloutProps } from '@fluentui-react-native/callout';
 
 export const menuPopoverName = 'MenuPopover';
 
 export type MenuPopoverProps = ICalloutProps;
 
 export interface MenuPopoverState {
-  accessibilityRole: AccessibilityRole;
-  directionalHint?: DirectionalHint;
-  dismissBehaviors: DismissBehaviors[];
-  doNotTakePointerCapture: boolean;
-  onDismiss: () => void;
-  onMouseEnter: () => void;
-  onMouseLeave?: (e: InteractionEvent) => void;
-  setInitialFocus: boolean;
-  triggerRef: React.RefObject<React.Component>;
+  props: ICalloutProps;
+  innerView: IViewProps;
 }

--- a/packages/experimental/Menu/src/MenuPopover/MenuPopover.types.ts
+++ b/packages/experimental/Menu/src/MenuPopover/MenuPopover.types.ts
@@ -1,4 +1,5 @@
 import { DirectionalHint, DismissBehaviors, ICalloutProps } from '@fluentui-react-native/callout';
+import { InteractionEvent } from '@fluentui-react-native/interactive-hooks';
 import { AccessibilityRole } from 'react-native';
 
 export const menuPopoverName = 'MenuPopover';
@@ -11,6 +12,8 @@ export interface MenuPopoverState {
   dismissBehaviors: DismissBehaviors[];
   doNotTakePointerCapture: boolean;
   onDismiss: () => void;
+  onMouseEnter: () => void;
+  onMouseLeave?: (e: InteractionEvent) => void;
   setInitialFocus: boolean;
   triggerRef: React.RefObject<React.Component>;
 }

--- a/packages/experimental/Menu/src/MenuPopover/useMenuPopover.ts
+++ b/packages/experimental/Menu/src/MenuPopover/useMenuPopover.ts
@@ -27,12 +27,16 @@ export const useMenuPopover = (_props: MenuPopoverProps): MenuPopoverState => {
   }, [popoverHoverOutTimer, triggerHoverOutTimer]);
   const onMouseLeave = React.useCallback(
     (e: InteractionEvent) => {
+      if (!openOnHover) {
+        return;
+      }
+
       const timer = setTimeout(() => {
         setOpen(e, false /* isOpen */);
       }, 500);
       setPopoverHoverOutTimer(timer);
     },
-    [setOpen, setPopoverHoverOutTimer],
+    [openOnHover, setOpen, setPopoverHoverOutTimer],
   );
 
   return {

--- a/packages/experimental/Menu/src/MenuPopover/useMenuPopover.ts
+++ b/packages/experimental/Menu/src/MenuPopover/useMenuPopover.ts
@@ -8,8 +8,17 @@ import { isCloseOnHoverOutEnabled } from '../consts';
 
 export const useMenuPopover = (_props: MenuPopoverProps): MenuPopoverState => {
   const context = useMenuContext();
-  const { setOpen, triggerRef, isControlled, isSubmenu, openOnHover, popoverHoverOutTimer, setPopoverHoverOutTimer, triggerHoverOutTimer } =
-    context;
+  const {
+    setOpen,
+    triggerRef,
+    isControlled,
+    isSubmenu,
+    openOnHover,
+    parentPopoverHoverOutTimer,
+    popoverHoverOutTimer,
+    setPopoverHoverOutTimer,
+    triggerHoverOutTimer,
+  } = context;
 
   const onDismiss = React.useCallback(() => setOpen(undefined, false /* isOpen */), [setOpen]);
   const dismissBehaviors = isControlled ? (['preventDismissOnKeyDown', 'preventDismissOnClickOutside'] as DismissBehaviors[]) : undefined;
@@ -24,7 +33,8 @@ export const useMenuPopover = (_props: MenuPopoverProps): MenuPopoverState => {
   const onMouseEnter = React.useCallback(() => {
     clearTimeout(triggerHoverOutTimer);
     clearTimeout(popoverHoverOutTimer);
-  }, [popoverHoverOutTimer, triggerHoverOutTimer]);
+    clearTimeout(parentPopoverHoverOutTimer);
+  }, [parentPopoverHoverOutTimer, popoverHoverOutTimer, triggerHoverOutTimer]);
   const onMouseLeave = React.useCallback(
     (e: InteractionEvent) => {
       if (!openOnHover) {
@@ -34,6 +44,7 @@ export const useMenuPopover = (_props: MenuPopoverProps): MenuPopoverState => {
       const timer = setTimeout(() => {
         setOpen(e, false /* isOpen */);
       }, 500);
+      console.log('popoverout');
       setPopoverHoverOutTimer(timer);
     },
     [openOnHover, setOpen, setPopoverHoverOutTimer],

--- a/packages/experimental/Menu/src/MenuPopover/useMenuPopover.ts
+++ b/packages/experimental/Menu/src/MenuPopover/useMenuPopover.ts
@@ -7,7 +7,8 @@ import { InteractionEvent } from '@fluentui-react-native/interactive-hooks';
 
 export const useMenuPopover = (_props: MenuPopoverProps): MenuPopoverState => {
   const context = useMenuContext();
-  const { setOpen, triggerRef, isControlled, isSubmenu, openOnHover, triggerHoverOutTimer } = context;
+  const { setOpen, triggerRef, isControlled, isSubmenu, openOnHover, popoverHoverOutTimer, setPopoverHoverOutTimer, triggerHoverOutTimer } =
+    context;
 
   const onDismiss = React.useCallback(() => setOpen(undefined, false /* isOpen */), [setOpen]);
   const dismissBehaviors = isControlled ? (['preventDismissOnKeyDown', 'preventDismissOnClickOutside'] as DismissBehaviors[]) : undefined;
@@ -19,20 +20,18 @@ export const useMenuPopover = (_props: MenuPopoverProps): MenuPopoverState => {
   const doNotTakePointerCapture = openOnHover;
   const accessibilityRole = 'menu';
 
-  const [timer, setTimer] = React.useState<NodeJS.Timeout>();
   const onMouseEnter = React.useCallback(() => {
     clearTimeout(triggerHoverOutTimer);
-    clearTimeout(timer);
-  }, [timer, triggerHoverOutTimer]);
+    clearTimeout(popoverHoverOutTimer);
+  }, [popoverHoverOutTimer, triggerHoverOutTimer]);
   const onMouseLeave = React.useCallback(
     (e: InteractionEvent) => {
-      setTimer(
-        setTimeout(() => {
-          setOpen(e, false /* isOpen */);
-        }, 500),
-      );
+      const timer = setTimeout(() => {
+        setOpen(e, false /* isOpen */);
+      }, 500);
+      setPopoverHoverOutTimer(timer);
     },
-    [setOpen, setTimer],
+    [setOpen, setPopoverHoverOutTimer],
   );
 
   return {

--- a/packages/experimental/Menu/src/MenuPopover/useMenuPopover.ts
+++ b/packages/experimental/Menu/src/MenuPopover/useMenuPopover.ts
@@ -3,25 +3,49 @@ import { I18nManager, Platform } from 'react-native';
 import { DirectionalHint, DismissBehaviors } from '@fluentui-react-native/callout';
 import { useMenuContext } from '../context/menuContext';
 import { MenuPopoverProps, MenuPopoverState } from './MenuPopover.types';
+import { InteractionEvent } from '@fluentui-react-native/interactive-hooks';
 
 export const useMenuPopover = (_props: MenuPopoverProps): MenuPopoverState => {
   const context = useMenuContext();
-  const setOpen = context.setOpen;
+  const { setOpen, triggerRef, isControlled, isSubmenu, openOnHover, triggerHoverOutTimer } = context;
 
-  const triggerRef = context.triggerRef;
   const onDismiss = React.useCallback(() => setOpen(undefined, false /* isOpen */), [setOpen]);
-  const dismissBehaviors = context.isControlled
-    ? (['preventDismissOnKeyDown', 'preventDismissOnClickOutside'] as DismissBehaviors[])
-    : undefined;
-  const directionalHint = getDirectionalHint(context.isSubmenu, I18nManager.isRTL);
+  const dismissBehaviors = isControlled ? (['preventDismissOnKeyDown', 'preventDismissOnClickOutside'] as DismissBehaviors[]) : undefined;
+  const directionalHint = getDirectionalHint(isSubmenu, I18nManager.isRTL);
 
   // Initial focus behavior differs per platform, Windows platforms move focus
   // automatically onto first element of Callout
   const setInitialFocus = Platform.OS === ('win32' as any) || Platform.OS === 'windows';
-  const doNotTakePointerCapture = context.openOnHover;
+  const doNotTakePointerCapture = openOnHover;
   const accessibilityRole = 'menu';
 
-  return { accessibilityRole, triggerRef, onDismiss, directionalHint, dismissBehaviors, doNotTakePointerCapture, setInitialFocus };
+  const [timer, setTimer] = React.useState<NodeJS.Timeout>();
+  const onMouseEnter = React.useCallback(() => {
+    clearTimeout(triggerHoverOutTimer);
+    clearTimeout(timer);
+  }, [timer, triggerHoverOutTimer]);
+  const onMouseLeave = React.useCallback(
+    (e: InteractionEvent) => {
+      setTimer(
+        setTimeout(() => {
+          setOpen(e, false /* isOpen */);
+        }, 500),
+      );
+    },
+    [setOpen, setTimer],
+  );
+
+  return {
+    accessibilityRole,
+    triggerRef,
+    onDismiss,
+    onMouseEnter,
+    onMouseLeave: Platform.OS === ('win32' as any) && onMouseLeave,
+    directionalHint,
+    dismissBehaviors,
+    doNotTakePointerCapture,
+    setInitialFocus,
+  };
 };
 
 const getDirectionalHint = (isSubmenu: boolean, isRtl: boolean): DirectionalHint | undefined => {

--- a/packages/experimental/Menu/src/MenuPopover/useMenuPopover.ts
+++ b/packages/experimental/Menu/src/MenuPopover/useMenuPopover.ts
@@ -3,7 +3,6 @@ import { I18nManager, Platform } from 'react-native';
 import { DirectionalHint, DismissBehaviors } from '@fluentui-react-native/callout';
 import { useMenuContext } from '../context/menuContext';
 import { MenuPopoverProps, MenuPopoverState } from './MenuPopover.types';
-import { InteractionEvent } from '@fluentui-react-native/interactive-hooks';
 import { isCloseOnHoverOutEnabled } from '../consts';
 
 export const useMenuPopover = (_props: MenuPopoverProps): MenuPopoverState => {
@@ -35,31 +34,32 @@ export const useMenuPopover = (_props: MenuPopoverProps): MenuPopoverState => {
     clearTimeout(popoverHoverOutTimer);
     clearTimeout(parentPopoverHoverOutTimer);
   }, [parentPopoverHoverOutTimer, popoverHoverOutTimer, triggerHoverOutTimer]);
-  const onMouseLeave = React.useCallback(
-    (e: InteractionEvent) => {
-      if (!openOnHover) {
-        return;
-      }
+  const onMouseLeave = React.useCallback(() => {
+    if (!openOnHover) {
+      return;
+    }
 
-      const timer = setTimeout(() => {
-        setOpen(e, false /* isOpen */);
-      }, 500);
-      console.log('popoverout');
-      setPopoverHoverOutTimer(timer);
-    },
-    [openOnHover, setOpen, setPopoverHoverOutTimer],
-  );
+    const timer = setTimeout(() => {
+      setOpen(undefined, false /* isOpen */);
+    }, 500);
+    console.log('popoverout');
+    setPopoverHoverOutTimer(timer);
+  }, [openOnHover, setOpen, setPopoverHoverOutTimer]);
 
   return {
-    accessibilityRole,
-    triggerRef,
-    onDismiss,
-    onMouseEnter,
-    onMouseLeave: isCloseOnHoverOutEnabled && onMouseLeave,
-    directionalHint,
-    dismissBehaviors,
-    doNotTakePointerCapture,
-    setInitialFocus,
+    props: {
+      accessibilityRole,
+      target: triggerRef,
+      onDismiss,
+      directionalHint,
+      dismissBehaviors,
+      doNotTakePointerCapture,
+      setInitialFocus,
+    },
+    innerView: {
+      onMouseEnter,
+      onMouseLeave: isCloseOnHoverOutEnabled && onMouseLeave,
+    },
   };
 };
 

--- a/packages/experimental/Menu/src/MenuPopover/useMenuPopover.ts
+++ b/packages/experimental/Menu/src/MenuPopover/useMenuPopover.ts
@@ -4,6 +4,7 @@ import { DirectionalHint, DismissBehaviors } from '@fluentui-react-native/callou
 import { useMenuContext } from '../context/menuContext';
 import { MenuPopoverProps, MenuPopoverState } from './MenuPopover.types';
 import { InteractionEvent } from '@fluentui-react-native/interactive-hooks';
+import { isCloseOnHoverOutEnabled } from '../consts';
 
 export const useMenuPopover = (_props: MenuPopoverProps): MenuPopoverState => {
   const context = useMenuContext();
@@ -39,7 +40,7 @@ export const useMenuPopover = (_props: MenuPopoverProps): MenuPopoverState => {
     triggerRef,
     onDismiss,
     onMouseEnter,
-    onMouseLeave: Platform.OS === ('win32' as any) && onMouseLeave,
+    onMouseLeave: isCloseOnHoverOutEnabled && onMouseLeave,
     directionalHint,
     dismissBehaviors,
     doNotTakePointerCapture,

--- a/packages/experimental/Menu/src/MenuPopover/useMenuPopover.ts
+++ b/packages/experimental/Menu/src/MenuPopover/useMenuPopover.ts
@@ -42,7 +42,6 @@ export const useMenuPopover = (_props: MenuPopoverProps): MenuPopoverState => {
     const timer = setTimeout(() => {
       setOpen(undefined, false /* isOpen */);
     }, 500);
-    console.log('popoverout');
     setPopoverHoverOutTimer(timer);
   }, [openOnHover, setOpen, setPopoverHoverOutTimer]);
 

--- a/packages/experimental/Menu/src/MenuTrigger/MenuTrigger.tsx
+++ b/packages/experimental/Menu/src/MenuTrigger/MenuTrigger.tsx
@@ -21,8 +21,8 @@ export const MenuTrigger = stagedComponent((props: MenuTriggerProps) => {
     // child component which may affect accessibility, we need to modify the
     // state in the inner render so we can access the child component and its props.
     const child = childrenArray[0];
-    const revisedState = getRevisedState(menuTrigger, child.props);
-    const revised = React.cloneElement(child, revisedState);
+    const revisedProps = getRevisedState(menuTrigger, child.props);
+    const revised = React.cloneElement(child, revisedProps);
 
     return <MenuTriggerProvider value={menuTrigger.hasSubmenu}>{revised}</MenuTriggerProvider>;
   };
@@ -30,24 +30,24 @@ export const MenuTrigger = stagedComponent((props: MenuTriggerProps) => {
 MenuTrigger.displayName = menuTriggerName;
 
 const getRevisedState = memoize(getRevisedStateWorker);
-function getRevisedStateWorker(state: MenuTriggerState, props: any): MenuTriggerState {
-  const revisedState = { ...state };
+function getRevisedStateWorker(state: MenuTriggerState, props: any): MenuTriggerProps {
+  const revisedProps = { ...state.props };
   if (props.accessibilityState) {
-    revisedState.props.accessibilityState = { ...state.props.accessibilityState, ...props.accessibilityState };
+    revisedProps.accessibilityState = { ...state.props.accessibilityState, ...props.accessibilityState };
   }
 
   if (props.accessibilityActions) {
-    revisedState.props.accessibilityActions = { ...state.props.accessibilityActions, ...props.accessibilityActions };
+    revisedProps.accessibilityActions = { ...state.props.accessibilityActions, ...props.accessibilityActions };
   }
 
   if (props.onAccessibilityAction) {
-    revisedState.props.onAccessibilityAction = (e: AccessibilityActionEvent) => {
+    revisedProps.onAccessibilityAction = (e: AccessibilityActionEvent) => {
       state.props.onAccessibilityAction(e);
       props.onAccessibilityAction(e);
     };
   }
 
-  return revisedState;
+  return revisedProps;
 }
 
 export default MenuTrigger;

--- a/packages/experimental/Menu/src/MenuTrigger/useMenuTrigger.ts
+++ b/packages/experimental/Menu/src/MenuTrigger/useMenuTrigger.ts
@@ -3,6 +3,7 @@ import { InteractionEvent } from '@fluentui-react-native/interactive-hooks';
 import { MenuTriggerProps, MenuTriggerState } from './MenuTrigger.types';
 import { AccessibilityActionEvent, AccessibilityActionName, Platform } from 'react-native';
 import React from 'react';
+import { delayHover, isCloseOnHoverOutEnabled } from '../consts';
 
 const accessibilityActions =
   Platform.OS === ('win32' as any) ? [{ name: 'Expand' as AccessibilityActionName }, { name: 'Collapse' as AccessibilityActionName }] : [];
@@ -30,11 +31,6 @@ export const useMenuTrigger = (_props: MenuTriggerProps): MenuTriggerState => {
     [setOpen],
   );
 
-  const delayHover = Platform.select({
-    macos: 100,
-    default: 500, // win32
-  });
-
   const onHoverIn = React.useCallback(
     (e: InteractionEvent) => {
       if (openOnHover) {
@@ -45,7 +41,7 @@ export const useMenuTrigger = (_props: MenuTriggerProps): MenuTriggerState => {
         }, delayHover);
       }
     },
-    [openOnHover, setOpen, delayHover, triggerHoverOutTimer, popoverHoverOutTimer],
+    [openOnHover, setOpen, triggerHoverOutTimer, popoverHoverOutTimer],
   );
 
   const onHoverOut = React.useCallback(
@@ -57,7 +53,7 @@ export const useMenuTrigger = (_props: MenuTriggerProps): MenuTriggerState => {
         setTriggerHoverOutTimer(timer);
       }
     },
-    [openOnHover, setOpen, delayHover, setTriggerHoverOutTimer],
+    [openOnHover, setOpen, setTriggerHoverOutTimer],
   );
 
   const onClick = React.useCallback(
@@ -71,7 +67,7 @@ export const useMenuTrigger = (_props: MenuTriggerProps): MenuTriggerState => {
     props: {
       onClick,
       onHoverIn,
-      onHoverOut: Platform.OS === ('win32' as any) && onHoverOut,
+      onHoverOut: isCloseOnHoverOutEnabled && onHoverOut,
       componentRef: triggerRef,
       accessibilityState,
       accessibilityActions,

--- a/packages/experimental/Menu/src/MenuTrigger/useMenuTrigger.ts
+++ b/packages/experimental/Menu/src/MenuTrigger/useMenuTrigger.ts
@@ -9,13 +9,9 @@ const accessibilityActions =
 
 export const useMenuTrigger = (_props: MenuTriggerProps): MenuTriggerState => {
   const context = useMenuContext();
+  const { open, openOnHover, popoverHoverOutTimer, setOpen, setTriggerHoverOutTimer, triggerHoverOutTimer, triggerRef } = context;
 
-  const setOpen = context.setOpen;
-  const open = context.open;
-  const openOnHover = context.openOnHover;
-  const triggerRef = context.triggerRef;
-  const accessibilityState = context.open ? { expanded: true } : { expanded: false };
-  const setTriggerHoverOutTimer = context.setTriggerHoverOutTimer;
+  const accessibilityState = open ? { expanded: true } : { expanded: false };
 
   const onAccessibilityAction = React.useCallback(
     (e: AccessibilityActionEvent) => {
@@ -42,12 +38,14 @@ export const useMenuTrigger = (_props: MenuTriggerProps): MenuTriggerState => {
   const onHoverIn = React.useCallback(
     (e: InteractionEvent) => {
       if (openOnHover) {
+        clearTimeout(popoverHoverOutTimer);
+        clearTimeout(triggerHoverOutTimer);
         setTimeout(() => {
           setOpen(e, true /* isOpen */);
         }, delayHover);
       }
     },
-    [openOnHover, setOpen, delayHover],
+    [openOnHover, setOpen, delayHover, triggerHoverOutTimer, popoverHoverOutTimer],
   );
 
   const onHoverOut = React.useCallback(

--- a/packages/experimental/Menu/src/MenuTrigger/useMenuTrigger.ts
+++ b/packages/experimental/Menu/src/MenuTrigger/useMenuTrigger.ts
@@ -15,6 +15,8 @@ export const useMenuTrigger = (_props: MenuTriggerProps): MenuTriggerState => {
   const openOnHover = context.openOnHover;
   const triggerRef = context.triggerRef;
   const accessibilityState = context.open ? { expanded: true } : { expanded: false };
+  const setTriggerHoverOutTimer = context.setTriggerHoverOutTimer;
+
   const onAccessibilityAction = React.useCallback(
     (e: AccessibilityActionEvent) => {
       if (Platform.OS === ('win32' as any)) {
@@ -51,12 +53,13 @@ export const useMenuTrigger = (_props: MenuTriggerProps): MenuTriggerState => {
   const onHoverOut = React.useCallback(
     (e: InteractionEvent) => {
       if (openOnHover) {
-        setTimeout(() => {
+        const timer = setTimeout(() => {
           setOpen(e, false /* isOpen */);
         }, delayHover);
+        setTriggerHoverOutTimer(timer);
       }
     },
-    [openOnHover, setOpen, delayHover],
+    [openOnHover, setOpen, delayHover, setTriggerHoverOutTimer],
   );
 
   const onClick = React.useCallback(

--- a/packages/experimental/Menu/src/MenuTrigger/useMenuTrigger.ts
+++ b/packages/experimental/Menu/src/MenuTrigger/useMenuTrigger.ts
@@ -37,25 +37,34 @@ export const useMenuTrigger = (_props: MenuTriggerProps): MenuTriggerState => {
     default: 500, // win32
   });
 
-  const onHoverIn = (e: InteractionEvent) => {
-    if (openOnHover) {
-      setTimeout(() => {
-        setOpen(e, true /* isOpen */);
-      }, delayHover);
-    }
-  };
+  const onHoverIn = React.useCallback(
+    (e: InteractionEvent) => {
+      if (openOnHover) {
+        setTimeout(() => {
+          setOpen(e, true /* isOpen */);
+        }, delayHover);
+      }
+    },
+    [openOnHover, setOpen, delayHover],
+  );
 
-  const onHoverOut = (e: InteractionEvent) => {
-    if (openOnHover) {
-      setTimeout(() => {
-        setOpen(e, false /* isOpen */);
-      }, delayHover);
-    }
-  };
+  const onHoverOut = React.useCallback(
+    (e: InteractionEvent) => {
+      if (openOnHover) {
+        setTimeout(() => {
+          setOpen(e, false /* isOpen */);
+        }, delayHover);
+      }
+    },
+    [openOnHover, setOpen, delayHover],
+  );
 
-  const onClick = (e: InteractionEvent) => {
-    setOpen(e, !open);
-  };
+  const onClick = React.useCallback(
+    (e: InteractionEvent) => {
+      setOpen(e, !open);
+    },
+    [open, setOpen],
+  );
 
   return {
     props: {

--- a/packages/experimental/Menu/src/MenuTrigger/useMenuTrigger.ts
+++ b/packages/experimental/Menu/src/MenuTrigger/useMenuTrigger.ts
@@ -39,13 +39,17 @@ export const useMenuTrigger = (_props: MenuTriggerProps): MenuTriggerState => {
 
   const onHoverIn = (e: InteractionEvent) => {
     if (openOnHover) {
-      setOpen(e, true /* isOpen */);
+      setTimeout(() => {
+        setOpen(e, true /* isOpen */);
+      }, delayHover);
     }
   };
 
   const onHoverOut = (e: InteractionEvent) => {
     if (openOnHover) {
-      setOpen(e, false /* isOpen */);
+      setTimeout(() => {
+        setOpen(e, false /* isOpen */);
+      }, delayHover);
     }
   };
 
@@ -59,8 +63,6 @@ export const useMenuTrigger = (_props: MenuTriggerProps): MenuTriggerState => {
       onHoverIn,
       onHoverOut: Platform.OS === ('win32' as any) && onHoverOut,
       componentRef: triggerRef,
-      delayHoverIn: delayHover,
-      delayHoverOut: Platform.OS === ('win32' as any) && delayHover,
       accessibilityState,
       accessibilityActions,
       onAccessibilityAction,

--- a/packages/experimental/Menu/src/consts.ts
+++ b/packages/experimental/Menu/src/consts.ts
@@ -1,0 +1,8 @@
+import { Platform } from 'react-native';
+
+export const delayHover = Platform.select({
+  macos: 100,
+  default: 500, // win32
+});
+
+export const isCloseOnHoverOutEnabled = Platform.OS === ('win32' as any);

--- a/packages/experimental/Menu/src/context/menuContext.ts
+++ b/packages/experimental/Menu/src/context/menuContext.ts
@@ -4,7 +4,10 @@ import type { MenuState } from '../Menu/Menu.types';
 /**
  * Context shared between Menu and its child components
  */
-export type MenuContextValue = MenuState;
+export interface MenuContextValue extends MenuState {
+  triggerHoverOutTimer?: NodeJS.Timeout;
+  setTriggerHoverOutTimer?: (timer: NodeJS.Timeout) => void;
+}
 
 export const MenuContext = React.createContext<MenuContextValue>({
   isControlled: false,

--- a/packages/experimental/Menu/src/context/menuContext.ts
+++ b/packages/experimental/Menu/src/context/menuContext.ts
@@ -5,7 +5,9 @@ import type { MenuState } from '../Menu/Menu.types';
  * Context shared between Menu and its child components
  */
 export interface MenuContextValue extends MenuState {
+  popoverHoverOutTimer?: NodeJS.Timeout;
   triggerHoverOutTimer?: NodeJS.Timeout;
+  setPopoverHoverOutTimer?: (timer: NodeJS.Timeout) => void;
   setTriggerHoverOutTimer?: (timer: NodeJS.Timeout) => void;
 }
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This change:
1. Fixes behavior where hover color doesn't apply until after the delay passes. This is because pressable's hover state doesn't get set until after the timeout passes in Pressable.ts, and that state drives the coloring of the button/menuItem. The fix to this is to handle the delay in the component's hoverIn/hoverOut instead of passing the delay to useAsPressable.
2. Fixes behavior where the menu will close prematurely if the menu is set to open on hover and you move the mouse into the menu (where you would expect it to stay open). This is because the timeout to close the menu is set once the trigger is hovered out of, and there isn't anything stopping it from executing when the mouse enters the popover. The fix to this (thanks @PPatBoyd) is to cancel the timeout on the trigger once you hover into the popover. This can be done by storing the timer on the menu context - then both the trigger and the popover have access to the timer.
3. The Popover now needed to handle mouse events in order to clear timers on hover in and close the menu on hover out. This necessitated an additional View in the MenuPopover under the Callout since the Callout doesn't handle mouse events. The same clearing of the timeout needs to be done in the opposite direction (moving mouse from popover to trigger shouldn't cause the menu to close), so the popover's timer is also on the context.
4. Submenus add an additional layer of timeout complexity since there's two timeouts that get triggered when you go from a popover to a submenu's popover - the close submenu timeout that gets set on hovering out of the submenu's trigger (which is handled by 2), and the close menu timeout that gets set on hovering out of the menu's popover. To fix this, we store the parent's popover timer when we create the submenu on the context, and cancel it on hovering into a menu's popover so that the menu doesn't close prematurely.

Like I said, shenanigans.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
