### PR TITLE
[Avatar] Fixed icon size and color

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/Avatar/BasicAvatar.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Avatar/BasicAvatar.tsx
@@ -98,7 +98,7 @@ export const StandardUsage: FunctionComponent = () => {
       </View>
       <JSAvatar name="Richard" avatarColor="colorful" />
       <JSAvatar icon={{ fontSource: { ...fontBuiltInProps, fontSize: 32 }, color: 'red' }} size={56} />
-      <JSAvatar icon={{ fontSource: { ...fontBuiltInProps }, color: 'white' }} size={120} />
+      <JSAvatar icon={{ fontSource: { ...fontBuiltInProps } }} size={120} />
       <JSAvatar
         active={active}
         activeAppearance={activeAppearance}
@@ -117,7 +117,6 @@ export const StandardUsage: FunctionComponent = () => {
         shape={isSquare ? 'square' : 'circular'}
         accessibilityLabel="Icon"
         name="* Richard Faynman *"
-        icon={{ fontSource: { ...fontBuiltInProps }, color: 'white' }}
         avatarColor={avatarColor}
       />
       {svgIconsEnabled && (
@@ -137,7 +136,7 @@ export const StandardUsage: FunctionComponent = () => {
             size={imageSize === undefinedText ? undefined : imageSize}
             shape={isSquare ? 'square' : 'circular'}
             accessibilityLabel="SVG Icon"
-            icon={{ svgSource: svgProps, width: 20, height: 20 }}
+            icon={{ svgSource: svgProps }}
             avatarColor={avatarColor}
             idForColor="15"
           />

--- a/change/@fluentui-react-native-experimental-avatar-736dbbd6-14a3-400a-95e9-8cb9991d07d5.json
+++ b/change/@fluentui-react-native-experimental-avatar-736dbbd6-14a3-400a-95e9-8cb9991d07d5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed SVG icon size and color for the Avatar",
+  "packageName": "@fluentui-react-native/experimental-avatar",
+  "email": "v.kozova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-dd17b451-9a3c-4266-8706-2b59456057a4.json
+++ b/change/@fluentui-react-native-tester-dd17b451-9a3c-4266-8706-2b59456057a4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed SVG icon size and color for the Avatar",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "v.kozova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Avatar/src/JSAvatar.styling.ts
+++ b/packages/experimental/Avatar/src/JSAvatar.styling.ts
@@ -22,6 +22,7 @@ export const avatarStates: (keyof JSAvatarTokens)[] = [
   'ringColor',
   'ringBackgroundColor',
   'iconColor',
+  'iconSize',
   'size',
 ];
 
@@ -100,10 +101,11 @@ export const stylingSettings: UseStylingOptions<JSAvatarProps, AvatarSlotProps, 
         return {
           style: {
             position: 'absolute',
-            color: tokens.iconColor,
-            width: tokens.iconSize,
-            height: tokens.iconSize,
+            fontSize: tokens.iconSize,
           },
+          color: tokens.color,
+          width: tokens.iconSize,
+          height: tokens.iconSize,
         };
       },
       ['iconSize', 'iconColor'],


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
Fixed colors for all types of icons. Size is fixed only for SVG icons. In case of font icons `fontSize` is part of `fontSource` so for now size for icon font is not working.

### Verification
![image](https://user-images.githubusercontent.com/11574680/171878417-33939ec8-1151-49de-b284-dc37d34dba76.png)
<img width="165" alt="image" src="https://user-images.githubusercontent.com/11574680/171878527-e2b9a9a0-4497-4574-b2b1-077fe992449f.png">
<img width="178" alt="image" src="https://user-images.githubusercontent.com/11574680/171878565-9df1e1b6-0d02-457b-a4d3-9aa9aeab809f.png">


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
