### PR TITLE
Menu V1: Add infinite submenu test

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/Menu/MenuTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Menu/MenuTest.tsx
@@ -107,6 +107,7 @@ const Submenu: React.FunctionComponent = () => {
         <MenuList>
           <MenuItem content="A nested MenuItem" />
           <MenuItem content="A second nested MenuItem" />
+          <Submenu />
         </MenuList>
       </MenuPopover>
     </Menu>

--- a/change/@fluentui-react-native-tester-c68659bb-fb6d-488d-ad53-2d482ab2201e.json
+++ b/change/@fluentui-react-native-tester-c68659bb-fb6d-488d-ad53-2d482ab2201e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add a test for infinite submenus",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Besides the fun of it, I _do_ think this test is useful for testing dismissal / submenu behavior. And shows how much simpler the new Menu V1 API is (I couldn't even get 2 levels of submenus easily with ContextualMenu because the code was too verbose).

### Verification

![Screen Shot 2022-06-02 at 2 02 06 PM](https://user-images.githubusercontent.com/6722175/171923443-af1aa427-2c4d-455d-b5ad-627eef37085c.png)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
