### PR TITLE
Bump rex-win32 in FURN to latest* possible

### DIFF
--- a/apps/win32/package.json
+++ b/apps/win32/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@office-iss/react-native-win32": "^0.64.8",
-    "@office-iss/rex-win32": "0.64.26-devmain.14807.10000",
+    "@office-iss/rex-win32": "0.64.30-devmain.15128.10000",
     "@rnx-kit/cli": "^0.9.57",
     "@rnx-kit/metro-config": "^1.2.26",
     "@types/jasmine": "3.5.10",

--- a/change/@fluentui-react-native-tester-win32-444bbe2c-1b58-48da-81c9-b1d35ffc3945.json
+++ b/change/@fluentui-react-native-tester-win32-444bbe2c-1b58-48da-81c9-b1d35ffc3945.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update rexwin32",
+  "packageName": "@fluentui-react-native/tester-win32",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2095,10 +2095,10 @@
     whatwg-fetch "^3.0.0"
     ws "^6.1.4"
 
-"@office-iss/rex-win32@0.64.26-devmain.14807.10000":
-  version "0.64.26-devmain.14807.10000"
-  resolved "https://registry.yarnpkg.com/@office-iss/rex-win32/-/rex-win32-0.64.26-devmain.14807.10000.tgz#b862c79db5105cb9077e752e2e36f4b3931d5bae"
-  integrity sha512-oO7g4BrNWW0LnvBjRz903QC5HviLFIbExlIicWuY5jXy/lS3nqj9XEdrrE/obxVHiYDlFA+v2YLSNKNNTvf5lA==
+"@office-iss/rex-win32@0.64.30-devmain.15128.10000":
+  version "0.64.30-devmain.15128.10000"
+  resolved "https://registry.yarnpkg.com/@office-iss/rex-win32/-/rex-win32-0.64.30-devmain.15128.10000.tgz#119ab9fba825ddcf0550a9a7dcf7fbdea8ccc5fe"
+  integrity sha512-R3VPVy/q7XhULMWA4mCkKoQjVQB0HotXbDxgIQxJbkNc9gU9cSwedVGAtEIsg8M0KK6w9vlWvPzCt13d11oVxg==
   dependencies:
     command-line-args "^5.0.2"
     command-line-usage "^5.0.5"


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Although we can't bump past a certain build since FURN still needs to get to 0.66 to support latest builds, we can bump to latest* possible. This catches us up on about 3 months of changes up til end of March.
*the latest fork build to ensure symbols are available for a while when native debugging

### Verification

Booted locally. CI should test general functionality.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
