### PR TITLE
[Avatar] Exposed colors as props

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/Avatar/BasicAvatar.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Avatar/BasicAvatar.tsx
@@ -96,7 +96,7 @@ export const StandardUsage: FunctionComponent = () => {
         <StyledPicker prompt="Avatar Color" selected={avatarColor} onChange={onAvatarColorChange} collection={avatarColors} />
         <StyledPicker prompt="Presence status" selected={presence} onChange={onPresenceChange} collection={allPresences} />
       </View>
-      <JSAvatar name="Richard" avatarColor="colorful" />
+      <JSAvatar name="Richard" avatarColor="#ff0099" initialsColor="yellow" />
       <JSAvatar icon={{ fontSource: { ...fontBuiltInProps, fontSize: 32 }, color: 'red' }} size={56} />
       <JSAvatar accessibilityLabel="Fall-back Icon" accessibilityHint="A picture representing a user" size={120} />
       <JSAvatar

--- a/change/@fluentui-react-native-experimental-avatar-892403db-148b-4509-9617-066a58f670a1.json
+++ b/change/@fluentui-react-native-experimental-avatar-892403db-148b-4509-9617-066a58f670a1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added missing colors from PersonaCoin, exposed colors as props",
+  "packageName": "@fluentui-react-native/experimental-avatar",
+  "email": "v.kozova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-11af2d56-d066-4a2e-bd4d-7277972e1489.json
+++ b/change/@fluentui-react-native-tester-11af2d56-d066-4a2e-bd4d-7277972e1489.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added missing colors from PersonaCoin, exposed colors as props",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "v.kozova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Avatar/src/JSAvatar.styling.ts
+++ b/packages/experimental/Avatar/src/JSAvatar.styling.ts
@@ -1,4 +1,15 @@
-import { JSAvatarName, JSAvatarTokens, AvatarSlotProps, JSAvatarProps, AvatarColors, AvatarSizesForTokens } from './JSAvatar.types';
+import {
+  JSAvatarName,
+  JSAvatarTokens,
+  AvatarConfigurableProps,
+  AvatarSlotProps,
+  JSAvatarProps,
+  AvatarColors,
+  AvatarSizesForTokens,
+  AvatarNamedColor,
+  ColorSchemes,
+  AvatarColorSchemes,
+} from './JSAvatar.types';
 import { Theme, UseStylingOptions, buildProps } from '@fluentui-react-native/framework';
 import { defaultJSAvatarTokens } from './JSAvatarTokens';
 import { ViewStyle } from 'react-native';
@@ -20,14 +31,16 @@ export const avatarStates: (keyof JSAvatarTokens)[] = [
   'square',
   'inactive',
   'ringColor',
-  'ringBackgroundColor',
   'iconColor',
   'iconSize',
   'size',
 ];
 
+const tokensThatAreAlsoProps: (keyof AvatarConfigurableProps)[] = ['avatarColor', 'initialsColor', 'ring'];
+
 export const stylingSettings: UseStylingOptions<JSAvatarProps, AvatarSlotProps, JSAvatarTokens> = {
   tokens: [defaultJSAvatarTokens, JSAvatarName],
+  tokensThatAreAlsoProps,
   states: avatarStates,
   slotProps: {
     root: buildProps(
@@ -53,7 +66,7 @@ export const stylingSettings: UseStylingOptions<JSAvatarProps, AvatarSlotProps, 
         return {
           style: {
             ...fontStyles.from(tokens, theme),
-            color: tokens.color,
+            color: tokens.initialsColor || tokens.color,
             textAlign: 'center',
           },
         };
@@ -62,7 +75,11 @@ export const stylingSettings: UseStylingOptions<JSAvatarProps, AvatarSlotProps, 
     ),
     initialsBackground: buildProps(
       (tokens: JSAvatarTokens, theme: Theme) => {
-        const { backgroundColor, size } = tokens;
+        const { backgroundColor, size, avatarColor } = tokens;
+        const _avatarColor =
+          !avatarColor || AvatarColors.includes(avatarColor as AvatarNamedColor) || ColorSchemes.includes(avatarColor as AvatarColorSchemes)
+            ? backgroundColor
+            : avatarColor;
 
         return {
           style: {
@@ -73,7 +90,7 @@ export const stylingSettings: UseStylingOptions<JSAvatarProps, AvatarSlotProps, 
             alignSelf: 'stretch',
             justifyContent: 'center',
             alignItems: 'center',
-            backgroundColor: backgroundColor,
+            backgroundColor: _avatarColor,
             borderWidth: tokens.borderWidth,
             borderColor: tokens.borderColor,
           },

--- a/packages/experimental/Avatar/src/JSAvatar.styling.ts
+++ b/packages/experimental/Avatar/src/JSAvatar.styling.ts
@@ -71,7 +71,7 @@ export const stylingSettings: UseStylingOptions<JSAvatarProps, AvatarSlotProps, 
           },
         };
       },
-      ['color', ...fontStyles.keys],
+      ['color', 'initialsColor', ...fontStyles.keys],
     ),
     initialsBackground: buildProps(
       (tokens: JSAvatarTokens, theme: Theme) => {
@@ -96,7 +96,7 @@ export const stylingSettings: UseStylingOptions<JSAvatarProps, AvatarSlotProps, 
           },
         };
       },
-      ['backgroundColor', 'size', 'borderColor', 'borderWidth', ...borderStyles.keys],
+      ['avatarColor', 'backgroundColor', 'size', 'borderColor', 'borderWidth', ...borderStyles.keys],
     ),
     image: buildProps(
       (tokens: JSAvatarTokens) => {

--- a/packages/experimental/Avatar/src/JSAvatar.tsx
+++ b/packages/experimental/Avatar/src/JSAvatar.tsx
@@ -26,7 +26,6 @@ export const avatarLookup = (layer: string, state: JSAvatarState, userProps: JSA
     layer === userProps['shape'] ||
     (!userProps['shape'] && layer === 'circular') ||
     layer === userProps['avatarColor'] ||
-    (!userProps['avatarColor'] && layer === 'neutral') ||
     layer === avatarSize ||
     (userProps.active === 'inactive' && layer === 'inactive')
   );

--- a/packages/experimental/Avatar/src/JSAvatar.types.ts
+++ b/packages/experimental/Avatar/src/JSAvatar.types.ts
@@ -56,14 +56,19 @@ export const AvatarColors = [
   'mink',
   'platinum',
   'anchor',
+  'burgundy',
+  'hotPink',
+  'orchid',
 ] as const;
+export const ColorSchemes = ['neutral', 'brand', 'colorful'] as const;
 export type AvatarSize = typeof AvatarSizes[number];
 export type AvatarNamedColor = typeof AvatarColors[number];
+export type AvatarColorSchemes = typeof ColorSchemes[number];
 
 export type AvatarShape = 'circular' | 'square';
 export type AvatarActive = 'active' | 'inactive' | 'unset';
 export type AvatarActiveAppearance = 'ring';
-export type AvatarColor = 'neutral' | 'brand' | 'colorful' | AvatarNamedColor;
+export type AvatarColor = AvatarColorSchemes | AvatarNamedColor | ColorValue;
 export type IconAlignment = 'start' | 'center' | 'end';
 
 export interface RingConfig {
@@ -83,6 +88,7 @@ export interface AvatarConfigurableProps {
    * @defaultvalue neutral
    */
   avatarColor?: AvatarColor;
+  initialsColor?: ColorValue;
   ring?: RingConfig;
 
   /**
@@ -219,6 +225,9 @@ export interface JSAvatarTokens extends IBackgroundColorTokens, IForegroundColor
   mink?: JSAvatarTokens;
   platinum?: JSAvatarTokens;
   anchor?: JSAvatarTokens;
+  burgundy?: JSAvatarTokens;
+  hotPink?: JSAvatarTokens;
+  orchid?: JSAvatarTokens;
 }
 
 export interface AvatarSlotProps {

--- a/packages/experimental/Avatar/src/JSAvatarTokens.ts
+++ b/packages/experimental/Avatar/src/JSAvatarTokens.ts
@@ -7,15 +7,15 @@ export const defaultJSAvatarTokens: TokenSettings<JSAvatarTokens, Theme> = (t: T
   ({
     horizontalIconAlignment: 'end',
     verticalIconAlignment: 'end',
-    color: globalTokens.color.white,
-    backgroundColor: globalTokens.color.cornflower.primary,
+    color: t.colors.neutralForeground3,
+    backgroundColor: t.colors.neutralBackground6,
     avatarOpacity: 1,
     fontFamily: t.typography.families.primary,
     fontWeight: globalTokens.font.weight.semibold,
     fontSize: globalTokens.font.size[200],
     size: 24,
     iconSize: 16,
-    iconColor: globalTokens.color.white,
+    iconColor: t.colors.neutralForeground3,
     ringColor: t.colors.transparentStroke,
     borderColor: globalTokens.color.white,
     borderWidth: t.host.appearance === 'highContrast' ? 1 : 0,
@@ -163,6 +163,9 @@ export const defaultJSAvatarTokens: TokenSettings<JSAvatarTokens, Theme> = (t: T
     mink: getColorProps('mink', t),
     platinum: getColorProps('platinum', t),
     anchor: getColorProps('anchor', t),
+    burgundy: getColorProps('burgundy', t),
+    hotPink: getColorProps('hotPink', t),
+    orchid: getColorProps('orchid', t),
   } as JSAvatarTokens);
 
 /**

--- a/packages/experimental/Avatar/src/JSAvatarTokens.win32.ts
+++ b/packages/experimental/Avatar/src/JSAvatarTokens.win32.ts
@@ -163,6 +163,9 @@ export const defaultJSAvatarTokens: TokenSettings<JSAvatarTokens, Theme> = (t: T
     mink: getColorProps('mink', t),
     platinum: getColorProps('platinum', t),
     anchor: getColorProps('anchor', t),
+    burgundy: getColorProps('burgundy', t),
+    hotPink: getColorProps('hotPink', t),
+    orchid: getColorProps('orchid', t),
   } as JSAvatarTokens);
 
 /**


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [X] windows
- [ ] android

### Description of changes
- Added missing colors from PersonaCOin
- Exposed colors as props (Ruriko, thanks for reminding about tokensThatAreAsoProps :))

### Verification
`<JSAvatar name="Richard" avatarColor="#ff0099" initialsColor="yellow" />`
<img width="403" alt="image" src="https://user-images.githubusercontent.com/11574680/172392306-9d0cf2cb-f12e-4893-8b9d-81e40ef7c34c.png">

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
