### PR TITLE
Close all menus when submenu item clicked

### DIFF
--- a/change/@fluentui-react-native-menu-d54cd76c-909a-49ca-ab41-d9935edc9072.json
+++ b/change/@fluentui-react-native-menu-d54cd76c-909a-49ca-ab41-d9935edc9072.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Close all menus when submenu item clicked",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Menu/src/Menu/Menu.types.ts
+++ b/packages/experimental/Menu/src/Menu/Menu.types.ts
@@ -15,6 +15,6 @@ export interface MenuState extends MenuProps {
   isControlled: boolean;
   isSubmenu: boolean;
   parentPopoverHoverOutTimer?: NodeJS.Timeout;
-  setOpen: (e: InteractionEvent, isOpen: boolean) => void;
+  setOpen: (e: InteractionEvent, isOpen: boolean, bubble?: boolean) => void;
   triggerRef: React.RefObject<React.Component>;
 }

--- a/packages/experimental/Menu/src/Menu/useMenu.ts
+++ b/packages/experimental/Menu/src/Menu/useMenu.ts
@@ -3,6 +3,13 @@ import React from 'react';
 import { useMenuContext } from '../context/menuContext';
 import { MenuProps, MenuState } from './Menu.types';
 
+// Due to how events get fired we get double notifications
+// for the same event causing us to immediately reopen
+// a menu when we close it. Adding in a delay to prevent
+// this behavior.
+const delayOpen = 150;
+let lastCloseTimestamp = -1;
+
 export const useMenu = (props: MenuProps): MenuState => {
   const triggerRef = React.useRef();
   const context = useMenuContext();
@@ -48,7 +55,13 @@ const useMenuOpenState = (
     (e: InteractionEvent, isOpen: boolean, bubble?: boolean) => {
       const openPrev = state;
       if (!isControlled) {
-        setOpenInternal(isOpen);
+        if (!isOpen || lastCloseTimestamp + delayOpen <= Date.now()) {
+          setOpenInternal(isOpen);
+        }
+
+        if (!isOpen) {
+          lastCloseTimestamp = Date.now();
+        }
       }
       if (onOpenChange && openPrev !== isOpen) {
         onOpenChange(e, isOpen);

--- a/packages/experimental/Menu/src/MenuItem/useMenuItem.ts
+++ b/packages/experimental/Menu/src/MenuItem/useMenuItem.ts
@@ -44,7 +44,7 @@ export const useMenuItem = (props: MenuItemProps): MenuItemState => {
 
       onClick?.(e);
       if (!hasSubmenu) {
-        setOpen(e, false /*isOpen*/);
+        setOpen(e, false /*isOpen*/, true /*bubble*/);
       }
     },
     [disabled, hasSubmenu, isInSubmenu, onClick, setOpen],

--- a/packages/experimental/Menu/src/MenuItem/useMenuItem.ts
+++ b/packages/experimental/Menu/src/MenuItem/useMenuItem.ts
@@ -44,7 +44,12 @@ export const useMenuItem = (props: MenuItemProps): MenuItemState => {
 
       onClick?.(e);
       if (!hasSubmenu) {
-        setOpen(e, false /*isOpen*/, true /*bubble*/);
+        const isArrowClose =
+          isKeyPressEvent(e) &&
+          isInSubmenu &&
+          ((isRtl && e.nativeEvent.key === 'ArrowRight') || (!isRtl && e.nativeEvent.key === 'ArrowLeft'));
+
+        setOpen(e, false /*isOpen*/, !isArrowClose /*bubble*/);
       }
     },
     [disabled, hasSubmenu, isInSubmenu, onClick, setOpen],


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Adding an optional "bubble" option which will call setOpen on parent menus with the same args until you hit the root menu. In this case, bubble is set to true on the setOpen call in the MenuItem, which will close all parent menus when a submenu item is invoked.

This then led to flickering behavior for the keyboard as the keyboard event would get sent to the trigger as well, causing it to reopen the menu. To prevent this, I added a delay or cooldown buffer of 150ms, during which the menu doesn't reopen if it was closed within the last 150ms. This also fixes the issue where the menu reopens if you click on the trigger button to dismiss it.

### Verification


| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![submenu_close_bug](https://user-images.githubusercontent.com/4602628/172915545-09cf9a7e-bb83-46a1-aaa6-817981cc8e9c.gif) | ![close_submenu_all](https://user-images.githubusercontent.com/4602628/172915781-0bad5f1e-6a19-4b4c-b2e4-d868c8c03d32.gif) |
|----------------------------------------------|--------------------------------------------|
| ![click_close_bug](https://user-images.githubusercontent.com/4602628/172915821-a5032c86-0e37-46ee-b3fd-b8bb03cab1ae.gif) | ![close_menu_trigger_frix](https://user-images.githubusercontent.com/4602628/172915613-40f23aeb-4d60-4ab8-b7e9-e73d44ca64b6.gif) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
