### PR TITLE
Focus should move on hovering over Menu Items

### DIFF
--- a/change/@fluentui-react-native-menu-e1449a6c-0102-4aa8-9a1e-bc2fb3e66328.json
+++ b/change/@fluentui-react-native-menu-e1449a6c-0102-4aa8-9a1e-bc2fb3e66328.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "A fix for hover focus?",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This PR attempts to address issues with focus moving while hovering through items.

Unfortunately, React doesn't differentiate between mouse and keyboard hovering, so we have to resort to tricks to get the visuals we want on win32, which is that the focus ring should not show when mousing over items but should show when keyboarding through them.

The way I attempted to address this is by setting enableFocusRing to match isHovered, and then use a useEffect call to focus on a component when the hover state changes. Calling for focus changes in onHoverIn/onHoverOut calls focus too soon and so it doesn't quite work the way we'd like.

It does lead to some weird behaviors though so I'm passing this through PM before committing.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
