### PR TITLE
Fixed presenceBadge icon size

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/Avatar/BasicAvatar.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Avatar/BasicAvatar.tsx
@@ -96,6 +96,7 @@ export const StandardUsage: FunctionComponent = () => {
         <StyledPicker prompt="Avatar Color" selected={avatarColor} onChange={onAvatarColorChange} collection={avatarColors} />
         <StyledPicker prompt="Presence status" selected={presence} onChange={onPresenceChange} collection={allPresences} />
       </View>
+      <JSAvatar badge={{ status: 'available' }} />
       <JSAvatar name="Richard" avatarColor="#ff0099" initialsColor="yellow" />
       <JSAvatar icon={{ fontSource: { ...fontBuiltInProps, fontSize: 32 }, color: 'red' }} size={56} />
       <JSAvatar accessibilityLabel="Fall-back Icon" accessibilityHint="A picture representing a user" size={120} />

--- a/change/@fluentui-react-native-badge-4ca407d8-45bf-4e64-85d3-e8b287d6c4ab.json
+++ b/change/@fluentui-react-native-badge-4ca407d8-45bf-4e64-85d3-e8b287d6c4ab.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed presenceBadge icon size",
+  "packageName": "@fluentui-react-native/badge",
+  "email": "v.kozova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-avatar-70be1f34-739e-4842-874e-335df55c1d88.json
+++ b/change/@fluentui-react-native-experimental-avatar-70be1f34-739e-4842-874e-335df55c1d88.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added a new example to Tester",
+  "packageName": "@fluentui-react-native/experimental-avatar",
+  "email": "v.kozova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-d6ced9aa-614c-4baf-8757-d3d761e8729b.json
+++ b/change/@fluentui-react-native-tester-d6ced9aa-614c-4baf-8757-d3d761e8729b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added a new example to Tester",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "v.kozova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Avatar/src/JSAvatarTokens.win32.ts
+++ b/packages/experimental/Avatar/src/JSAvatarTokens.win32.ts
@@ -5,6 +5,7 @@ import { globalTokens } from '@fluentui-react-native/theme-tokens';
 
 export const defaultJSAvatarTokens: TokenSettings<JSAvatarTokens, Theme> = (t: Theme) =>
   ({
+    badgeSize: 'smallest',
     horizontalIconAlignment: 'end',
     verticalIconAlignment: 'end',
     color: t.colors.neutralForeground3,

--- a/packages/experimental/Badge/src/Badge.types.ts
+++ b/packages/experimental/Badge/src/Badge.types.ts
@@ -1,4 +1,4 @@
-import { ViewStyle, ColorValue, FlexStyle } from 'react-native';
+import { ColorValue, FlexStyle } from 'react-native';
 import { TextProps } from '@fluentui-react-native/experimental-text';
 import { FontTokens, IBorderTokens, IColorTokens, IShadowTokens, LayoutTokens } from '@fluentui-react-native/tokens';
 import { IViewProps } from '@fluentui-react-native/adapters';
@@ -21,7 +21,7 @@ export interface BadgeCoreTokens extends LayoutTokens, FontTokens, IBorderTokens
   /**
    * The height of the Badge.
    */
-  height?: ViewStyle['height'];
+  height?: number;
   /**
    * Set the left edge of the Badge
    */
@@ -40,7 +40,7 @@ export interface BadgeCoreTokens extends LayoutTokens, FontTokens, IBorderTokens
   /**
    * The width of the Badge.
    */
-  width?: ViewStyle['width'];
+  width?: number;
 
   /**
    * Sizes of the Badge

--- a/packages/experimental/Badge/src/PresenceBadge/PresenceBadge.styling.ts
+++ b/packages/experimental/Badge/src/PresenceBadge/PresenceBadge.styling.ts
@@ -10,22 +10,26 @@ export const stylingSettings: UseStylingOptions<PresenceBadgeProps, PresenceBadg
   states: coreBadgeStates,
   slotProps: {
     root: buildProps(
-      (tokens: PresenceBadgeTokens, theme: Theme) => ({
-        style: {
-          ...getBadgePosition(tokens),
-          width: tokens.width,
-          height: tokens.height,
-          display: 'flex',
-          alignItems: 'center',
-          flexDirection: 'row',
-          alignSelf: 'flex-start',
-          justifyContent: 'center',
-          position: 'absolute',
-          backgroundColor: tokens.backgroundColor,
-          ...borderStyles.from(tokens, theme),
-          ...layoutStyles.from(tokens, theme),
-        },
-      }),
+      (tokens: PresenceBadgeTokens, theme: Theme) => {
+        const { width, height, borderWidth } = tokens;
+        const borderGap = borderWidth * 2;
+        return {
+          style: {
+            ...getBadgePosition(tokens),
+            width: (width as number) + borderGap,
+            height: (height as number) + borderGap,
+            display: 'flex',
+            alignItems: 'center',
+            flexDirection: 'row',
+            alignSelf: 'flex-start',
+            justifyContent: 'center',
+            position: 'absolute',
+            backgroundColor: tokens.backgroundColor,
+            ...borderStyles.from(tokens, theme),
+            ...layoutStyles.from(tokens, theme),
+          },
+        };
+      },
       ['backgroundColor', 'width', 'height', 'bottom', 'right', 'top', 'left', ...borderStyles.keys, ...layoutStyles.keys],
     ),
     svgXml: buildProps(

--- a/packages/experimental/Badge/src/PresenceBadge/PresenceBadge.styling.ts
+++ b/packages/experimental/Badge/src/PresenceBadge/PresenceBadge.styling.ts
@@ -16,8 +16,8 @@ export const stylingSettings: UseStylingOptions<PresenceBadgeProps, PresenceBadg
         return {
           style: {
             ...getBadgePosition(tokens),
-            width: (width as number) + borderGap,
-            height: (height as number) + borderGap,
+            width: width + borderGap,
+            height: height + borderGap,
             display: 'flex',
             alignItems: 'center',
             flexDirection: 'row',


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [X] windows
- [ ] android

### Description of changes
Fixed size of the icon. But the are still 2 icons which have smaller size - 'unknown' status and 'blocked'. There are no such icons in Figma in large size
### Verification
**Before:**
<img width="104" alt="image" src="https://user-images.githubusercontent.com/11574680/173066394-ad6494da-0461-4e4e-b06b-b91cdb97e9a5.png">

**After:**
<img width="394" alt="image" src="https://user-images.githubusercontent.com/11574680/173066274-b48de25d-d9bf-46ee-9c4d-b8f8967d87ba.png">
Updated screenshot:
![image](https://user-images.githubusercontent.com/11574680/173668677-78578a0b-6cff-47f9-a1ad-11ae5315fdf3.png)


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
