### PR TITLE
MenuItem text as child instead of `content`

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/Menu/E2EMenuTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Menu/E2EMenuTest.tsx
@@ -33,9 +33,11 @@ export const E2EMenuTest: React.FunctionComponent = () => {
         </MenuTrigger>
         <MenuPopover testID={MENUPOPOVER_TEST_COMPONENT}>
           <MenuList>
-            <MenuItem testID={MENUITEM_TEST_COMPONENT} accessibilityLabel={MENUITEM_ACCESSIBILITY_LABEL} content="A plain MenuItem" />
-            <MenuItem disabled content="A second disabled plain MenuItem" />
-            <MenuItem testID={MENUITEM_NO_A11Y_LABEL_COMPONENT} content={MENUITEM_TEST_LABEL} />
+            <MenuItem testID={MENUITEM_TEST_COMPONENT} accessibilityLabel={MENUITEM_ACCESSIBILITY_LABEL}>
+              A plain MenuItem
+            </MenuItem>
+            <MenuItem disabled>A second disabled plain MenuItem</MenuItem>
+            <MenuItem testID={MENUITEM_NO_A11Y_LABEL_COMPONENT}>{MENUITEM_TEST_LABEL}</MenuItem>
           </MenuList>
         </MenuPopover>
       </Menu>

--- a/apps/fluent-tester/src/FluentTester/TestComponents/Menu/MenuTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Menu/MenuTest.tsx
@@ -45,9 +45,9 @@ const MenuCheckmarks: React.FunctionComponent = () => {
         </MenuTrigger>
         <MenuPopover>
           <MenuList>
-            <MenuItemCheckbox name="itemOne" content="A MenuItem with checkmark" />
+            <MenuItemCheckbox name="itemOne">A MenuItem with checkmark</MenuItemCheckbox>
             <MenuDivider />
-            <MenuItemCheckbox name="itemTwo" content="Another MenuItem with checkmark" />
+            <MenuItemCheckbox name="itemTwo">Another MenuItem with checkmark</MenuItemCheckbox>
           </MenuList>
         </MenuPopover>
       </Menu>
@@ -58,9 +58,11 @@ const MenuCheckmarks: React.FunctionComponent = () => {
         <MenuPopover>
           <MenuList>
             <MenuItem>A plain MenuItem</MenuItem>
-            <MenuItemCheckbox name="itemTwo" content="A MenuItem with checkmark" />
-            <MenuItemCheckbox disabled name="itemThree" content="A disabled MenuItem with checkmark" />
-            <MenuItemCheckbox name="itemFour" content="A MenuItem with checkmark" />
+            <MenuItemCheckbox name="itemTwo">A MenuItem with checkmark</MenuItemCheckbox>
+            <MenuItemCheckbox disabled name="itemThree">
+              A disabled MenuItem with checkmark
+            </MenuItemCheckbox>
+            <MenuItemCheckbox name="itemFour">A MenuItem with checkmark</MenuItemCheckbox>
           </MenuList>
         </MenuPopover>
       </Menu>
@@ -71,8 +73,8 @@ const MenuCheckmarks: React.FunctionComponent = () => {
         <MenuPopover>
           <MenuList>
             <MenuItem>A plain MenuItem</MenuItem>
-            <MenuItemCheckbox name="itemTwo" content="A MenuItem with checkmark" />
-            <MenuItemCheckbox name="itemThree" content="A MenuItem with checkmark" />
+            <MenuItemCheckbox name="itemTwo">A MenuItem with checkmark</MenuItemCheckbox>
+            <MenuItemCheckbox name="itemThree">A MenuItem with checkmark</MenuItemCheckbox>
           </MenuList>
         </MenuPopover>
       </Menu>
@@ -98,10 +100,10 @@ const MenuRadioItem: React.FunctionComponent = () => {
         </MenuTrigger>
         <MenuPopover>
           <MenuList>
-            <MenuItemRadio name="itemOne" content="A MenuItem with checkmark and radio selection" />
-            <MenuItemRadio name="itemTwo" content="Another MenuItem with checkmark and radio selection" />
-            <MenuItemRadio name="itemThree" content="A third MenuItem with checkmark and radio selection" />
-            <MenuItemCheckbox name="itemFour" content="A MenuItem with checkmark and toggle selection" />
+            <MenuItemRadio name="itemOne">A MenuItem with checkmark and radio selection</MenuItemRadio>
+            <MenuItemRadio name="itemTwo">Another MenuItem with checkmark and radio selection</MenuItemRadio>
+            <MenuItemRadio name="itemThree">A third MenuItem with checkmark and radio selection</MenuItemRadio>
+            <MenuItemCheckbox name="itemFour">A MenuItem with checkmark and toggle selection</MenuItemCheckbox>
           </MenuList>
         </MenuPopover>
       </Menu>

--- a/apps/fluent-tester/src/FluentTester/TestComponents/Menu/MenuTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Menu/MenuTest.tsx
@@ -26,9 +26,9 @@ const MenuDefault: React.FunctionComponent = () => {
         </MenuTrigger>
         <MenuPopover>
           <MenuList>
-            <MenuItem content="A plain MenuItem" />
-            <MenuItem disabled content="A second disabled plain MenuItem" />
-            <MenuItem content="A third plain MenuItem" />
+            <MenuItem>A plain MenuItem</MenuItem>
+            <MenuItem disabled>A second disabled plain MenuItem</MenuItem>
+            <MenuItem>A third plain MenuItem</MenuItem>
           </MenuList>
         </MenuPopover>
       </Menu>
@@ -57,7 +57,7 @@ const MenuCheckmarks: React.FunctionComponent = () => {
         </MenuTrigger>
         <MenuPopover>
           <MenuList>
-            <MenuItem content="A plain MenuItem" />
+            <MenuItem>A plain MenuItem</MenuItem>
             <MenuItemCheckbox name="itemTwo" content="A MenuItem with checkmark" />
             <MenuItemCheckbox disabled name="itemThree" content="A disabled MenuItem with checkmark" />
             <MenuItemCheckbox name="itemFour" content="A MenuItem with checkmark" />
@@ -70,7 +70,7 @@ const MenuCheckmarks: React.FunctionComponent = () => {
         </MenuTrigger>
         <MenuPopover>
           <MenuList>
-            <MenuItem content="A plain MenuItem" />
+            <MenuItem>A plain MenuItem</MenuItem>
             <MenuItemCheckbox name="itemTwo" content="A MenuItem with checkmark" />
             <MenuItemCheckbox name="itemThree" content="A MenuItem with checkmark" />
           </MenuList>
@@ -113,12 +113,12 @@ const Submenu: React.FunctionComponent = () => {
   return (
     <Menu>
       <MenuTrigger>
-        <MenuItem content="A second MenuItem" />
+        <MenuItem>A second MenuItem</MenuItem>
       </MenuTrigger>
       <MenuPopover>
         <MenuList>
-          <MenuItem content="A nested MenuItem" />
-          <MenuItem content="A second nested MenuItem" />
+          <MenuItem>A nested MenuItem</MenuItem>
+          <MenuItem>A second nested MenuItem</MenuItem>
           <Submenu />
         </MenuList>
       </MenuPopover>
@@ -135,7 +135,7 @@ const MenuSubMenu: React.FunctionComponent = () => {
         </MenuTrigger>
         <MenuPopover>
           <MenuList>
-            <MenuItem content="A MenuItem" />
+            <MenuItem>A MenuItem</MenuItem>
             <Submenu />
           </MenuList>
         </MenuPopover>
@@ -153,7 +153,7 @@ const MenuOpenOnHover: React.FunctionComponent = () => {
         </MenuTrigger>
         <MenuPopover>
           <MenuList>
-            <MenuItem content="A MenuItem" />
+            <MenuItem>A MenuItem</MenuItem>
             <Submenu />
           </MenuList>
         </MenuPopover>
@@ -173,7 +173,7 @@ const MenuControlledOpen: React.FunctionComponent = () => {
         </MenuTrigger>
         <MenuPopover>
           <MenuList>
-            <MenuItem content="A MenuItem" />
+            <MenuItem>A MenuItem</MenuItem>
             <Submenu />
           </MenuList>
         </MenuPopover>

--- a/change/@fluentui-react-native-menu-c281bf78-55c3-4219-8d17-166e70ddf311.json
+++ b/change/@fluentui-react-native-menu-c281bf78-55c3-4219-8d17-166e70ddf311.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Fix MenuItemCheckbox/Radio",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-cf3da1b0-a619-4fe8-b5bc-b57c90ef7d62.json
+++ b/change/@fluentui-react-native-tester-cf3da1b0-a619-4fe8-b5bc-b57c90ef7d62.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix MenuItemCheckbox/Radio",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Menu/src/MenuItem/MenuItem.tsx
+++ b/packages/experimental/Menu/src/MenuItem/MenuItem.tsx
@@ -6,6 +6,7 @@ import { Text } from '@fluentui-react-native/experimental-text';
 import { menuItemName, MenuItemProps, MenuItemType } from './MenuItem.types';
 import { useMenuItem } from './useMenuItem';
 import { stylingSettings } from './MenuItem.styling';
+import React from 'react';
 
 export const MenuItem = compose<MenuItemType>({
   displayName: menuItemName,
@@ -20,8 +21,8 @@ export const MenuItem = compose<MenuItemType>({
     const menuItem = useMenuItem(userProps);
     const Slots = useSlots(userProps, (layer): boolean => menuItem.state[layer] || userProps[layer]);
 
-    return (final: MenuItemProps) => {
-      const mergedProps = mergeProps(menuItem.props, final);
+    return (final: MenuItemProps, children: React.ReactNode) => {
+      const { accessibilityLabel, ...mergedProps } = mergeProps(menuItem.props, final);
       const chevronXml = I18nManager.isRTL
         ? `
           <svg>
@@ -32,10 +33,20 @@ export const MenuItem = compose<MenuItemType>({
             <path fill='currentColor' d='M4.64645 2.14645C4.45118 2.34171 4.45118 2.65829 4.64645 2.85355L7.79289 6L4.64645 9.14645C4.45118 9.34171 4.45118 9.65829 4.64645 9.85355C4.84171 10.0488 5.15829 10.0488 5.35355 9.85355L8.85355 6.35355C9.04882 6.15829 9.04882 5.84171 8.85355 5.64645L5.35355 2.14645C5.15829 1.95118 4.84171 1.95118 4.64645 2.14645Z' />
           </svg>`;
 
+      let childText = '';
+      if (accessibilityLabel === undefined) {
+        React.Children.forEach(children, (child) => {
+          if (typeof child === 'string') {
+            childText = child; // We only automatically support the one child string.
+          }
+        });
+      }
+      const label = accessibilityLabel ?? childText;
+
       return (
-        <Slots.root {...mergedProps}>
+        <Slots.root {...mergedProps} accessibilityLabel={label}>
           {menuItem.hasCheckmarks && <Slots.checkmark />}
-          {mergedProps.content && <Slots.content>{mergedProps.content}</Slots.content>}
+          {children && <Slots.content>{children}</Slots.content>}
           {menuItem.hasSubmenu && <Slots.submenuIndicator xml={chevronXml} />}
         </Slots.root>
       );

--- a/packages/experimental/Menu/src/MenuItem/MenuItem.types.ts
+++ b/packages/experimental/Menu/src/MenuItem/MenuItem.types.ts
@@ -21,8 +21,6 @@ export interface MenuItemTokens extends LayoutTokens, FontTokens, IBorderTokens,
 }
 
 export interface MenuItemProps extends Omit<IWithPressableOptions<ViewProps>, 'onPress'> {
-  content: string;
-
   /**
    * Applies disabled styles to menu item but remains focusable
    */

--- a/packages/experimental/Menu/src/MenuItem/useMenuItem.ts
+++ b/packages/experimental/Menu/src/MenuItem/useMenuItem.ts
@@ -68,7 +68,6 @@ export const useMenuItem = (props: MenuItemProps): MenuItemState => {
       accessible: true,
       accessibilityRole: 'menuitem',
       onAccessibilityTap: props.onAccessibilityTap || onInvoke,
-      accessibilityLabel: props.accessibilityLabel || props.content,
       accessibilityState: getAccessibilityState(disabled, accessibilityState),
       enableFocusRing: true,
       focusable: true,

--- a/packages/experimental/Menu/src/MenuItemCheckbox/MenuItemCheckbox.tsx
+++ b/packages/experimental/Menu/src/MenuItemCheckbox/MenuItemCheckbox.tsx
@@ -12,6 +12,7 @@ import {
 } from './MenuItemCheckbox.types';
 import { useMenuItemCheckbox } from './useMenuItemCheckbox';
 import { stylingSettings } from './MenuItemCheckbox.styling';
+import React from 'react';
 
 export const MenuItemCheckbox = compose<MenuItemCheckboxType>({
   displayName: menuItemCheckboxName,
@@ -33,17 +34,27 @@ export const menuItemFinalRender = (
   menuItem: MenuItemCheckboxState,
   Slots: Slots<MenuItemCheckboxSlotProps>,
 ): React.FunctionComponent<MenuItemCheckboxProps> => {
-  return (final: MenuItemCheckboxProps) => {
-    const mergedProps = mergeProps(menuItem.props, final);
+  return (final: MenuItemCheckboxProps, children: React.ReactNode) => {
+    const { accessibilityLabel, ...mergedProps } = mergeProps(menuItem.props, final);
     const checkmarkXml = `
     <svg>
       <path fill='currentColor' d='M9.85355 3.14645C10.0488 3.34171 10.0488 3.65829 9.85355 3.85355L5.35355 8.35355C5.15829 8.54882 4.84171 8.54882 4.64645 8.35355L2.64645 6.35355C2.45118 6.15829 2.45118 5.84171 2.64645 5.64645C2.84171 5.45118 3.15829 5.45118 3.35355 5.64645L5 7.29289L9.14645 3.14645C9.34171 2.95118 9.65829 2.95118 9.85355 3.14645Z' />
     </svg>`;
 
+    let childText = '';
+    if (accessibilityLabel === undefined) {
+      React.Children.forEach(children, (child) => {
+        if (typeof child === 'string') {
+          childText = child; // We only automatically support the one child string.
+        }
+      });
+    }
+    const label = accessibilityLabel ?? childText;
+
     return (
-      <Slots.root {...mergedProps}>
+      <Slots.root {...mergedProps} accessibilityLabel={label}>
         <Slots.checkmark xml={checkmarkXml} />
-        {mergedProps.content && <Slots.content>{mergedProps.content}</Slots.content>}
+        {children && <Slots.content>{children}</Slots.content>}
       </Slots.root>
     );
   };

--- a/packages/experimental/Menu/src/MenuItemCheckbox/MenuItemCheckbox.types.ts
+++ b/packages/experimental/Menu/src/MenuItemCheckbox/MenuItemCheckbox.types.ts
@@ -23,8 +23,6 @@ export interface MenuItemCheckboxTokens extends LayoutTokens, FontTokens, IBorde
 }
 
 export interface MenuItemCheckboxProps extends Omit<IWithPressableOptions<ViewProps>, 'onPress'> {
-  content: string;
-
   /**
    * Applies disabled styles to menu item but remains focusable
    */

--- a/packages/experimental/Menu/src/MenuItemCheckbox/useMenuItemCheckbox.ts
+++ b/packages/experimental/Menu/src/MenuItemCheckbox/useMenuItemCheckbox.ts
@@ -54,6 +54,7 @@ export const useMenuCheckboxInteraction = (
   const defaultComponentRef = React.useRef(null);
   const {
     accessibilityActions,
+    accessibilityLabel,
     accessibilityState,
     componentRef = defaultComponentRef,
     disabled,
@@ -97,7 +98,7 @@ export const useMenuCheckboxInteraction = (
       ...pressable.props,
       accessible: true,
       accessibilityActions: accessibilityActionsProp,
-      accessibilityLabel: props.accessibilityLabel || props.content,
+      accessibilityLabel,
       accessibilityRole: 'menuitem',
       accessibilityState: getAccessibilityState(disabled, state.checked, accessibilityState),
       enableFocusRing: true,

--- a/packages/experimental/Menu/src/__tests__/Menu.test.tsx
+++ b/packages/experimental/Menu/src/__tests__/Menu.test.tsx
@@ -77,9 +77,11 @@ describe('Checkbox component tests', () => {
           </MenuTrigger>
           <MenuPopover>
             <MenuList>
-              <MenuItemCheckbox content="Option 1" name="Option 1" />
+              <MenuItemCheckbox name="Option 1">Option 1</MenuItemCheckbox>
               <MenuDivider />
-              <MenuItemCheckbox disabled content="Option 2" name="Option 2" />
+              <MenuItemCheckbox disabled name="Option 2">
+                Option 2
+              </MenuItemCheckbox>
             </MenuList>
           </MenuPopover>
         </Menu>,
@@ -97,8 +99,8 @@ describe('Checkbox component tests', () => {
           </MenuTrigger>
           <MenuPopover>
             <MenuList>
-              <MenuItemRadio content="Option 1" name="Option 1" />
-              <MenuItemRadio content="Option 2" name="Option 2" />
+              <MenuItemRadio name="Option 1">Option 1</MenuItemRadio>
+              <MenuItemRadio name="Option 2">Option 2</MenuItemRadio>
             </MenuList>
           </MenuPopover>
         </Menu>,
@@ -116,9 +118,9 @@ describe('Checkbox component tests', () => {
           </MenuTrigger>
           <MenuPopover>
             <MenuList>
-              <MenuItemCheckbox content="Option 1" name="Option 1" />
+              <MenuItemCheckbox name="Option 1">Option 1</MenuItemCheckbox>
               <MenuDivider />
-              <MenuItemCheckbox content="Option 2" name="Option 2" />
+              <MenuItemCheckbox name="Option 2">Option 2</MenuItemCheckbox>
             </MenuList>
           </MenuPopover>
         </Menu>,
@@ -136,9 +138,9 @@ describe('Checkbox component tests', () => {
           </MenuTrigger>
           <MenuPopover>
             <MenuList>
-              <MenuItemCheckbox content="Option 1" name="Option 1" />
+              <MenuItemCheckbox name="Option 1">Option 1</MenuItemCheckbox>
               <MenuDivider />
-              <MenuItemCheckbox content="Option 2" name="Option 2" />
+              <MenuItemCheckbox name="Option 2">Option 2</MenuItemCheckbox>
             </MenuList>
           </MenuPopover>
         </Menu>,

--- a/packages/experimental/Menu/src/__tests__/Menu.test.tsx
+++ b/packages/experimental/Menu/src/__tests__/Menu.test.tsx
@@ -22,7 +22,7 @@ describe('Checkbox component tests', () => {
           </MenuTrigger>
           <MenuPopover>
             <MenuList>
-              <MenuItem content="Option 1" />
+              <MenuItem>Option 1</MenuItem>
             </MenuList>
           </MenuPopover>
         </Menu>,
@@ -40,7 +40,7 @@ describe('Checkbox component tests', () => {
           </MenuTrigger>
           <MenuPopover>
             <MenuList>
-              <MenuItem content="Option 1" />
+              <MenuItem>Option 1</MenuItem>
             </MenuList>
           </MenuPopover>
         </Menu>,
@@ -58,8 +58,8 @@ describe('Checkbox component tests', () => {
           </MenuTrigger>
           <MenuPopover>
             <MenuList>
-              <MenuItem content="Option 1" />
-              <MenuItem disabled content="Option 2" />
+              <MenuItem>Option 1</MenuItem>
+              <MenuItem disabled>Option 2</MenuItem>
             </MenuList>
           </MenuPopover>
         </Menu>,
@@ -156,14 +156,14 @@ describe('Checkbox component tests', () => {
           </MenuTrigger>
           <MenuPopover>
             <MenuList>
-              <MenuItem content="Option 1" />
+              <MenuItem>Option 1</MenuItem>
               <Menu>
                 <MenuTrigger>
-                  <MenuItem content="Option 2" />
+                  <MenuItem>Option 2</MenuItem>
                 </MenuTrigger>
                 <MenuPopover>
                   <MenuList>
-                    <MenuItem content="Option 1" />
+                    <MenuItem>Option 1</MenuItem>
                   </MenuList>
                 </MenuPopover>
               </Menu>
@@ -186,7 +186,7 @@ describe('Menu rerender tests', () => {
           </MenuTrigger>
           <MenuPopover>
             <MenuList>
-              <MenuItem content="Option 1" />
+              <MenuItem>Option 1</MenuItem>
             </MenuList>
           </MenuPopover>
         </Menu>
@@ -205,7 +205,7 @@ describe('Menu rerender tests', () => {
           </MenuTrigger>
           <MenuPopover>
             <MenuList>
-              <MenuItem content="Option 1" />
+              <MenuItem>Option 1</MenuItem>
             </MenuList>
           </MenuPopover>
         </Menu>
@@ -224,7 +224,7 @@ describe('Menu rerender tests', () => {
           </MenuTrigger>
           <MenuPopover>
             <MenuList>
-              <MenuItem accessibilityActions={action} content="Option 1" />
+              <MenuItem accessibilityActions={action}>Option 1</MenuItem>
             </MenuList>
           </MenuPopover>
         </Menu>

--- a/packages/experimental/Menu/src/__tests__/__snapshots__/Menu.test.tsx.snap
+++ b/packages/experimental/Menu/src/__tests__/__snapshots__/Menu.test.tsx.snap
@@ -178,7 +178,6 @@ Array [
             }
           }
           accessible={true}
-          content="Option 1"
           enableFocusRing={true}
           focusable={true}
           onAccessibilityTap={[Function]}
@@ -231,7 +230,6 @@ Array [
             }
           }
           accessible={true}
-          content="Option 2"
           disabled={true}
           enableFocusRing={true}
           focusable={true}
@@ -398,7 +396,6 @@ Array [
             }
           }
           accessible={true}
-          content="Option 1"
           enableFocusRing={true}
           focusable={true}
           onAccessibilityTap={[Function]}
@@ -571,7 +568,6 @@ Array [
             }
           }
           accessible={true}
-          content="Option 1"
           enableFocusRing={true}
           focusable={true}
           onAccessibilityAction={[Function]}
@@ -696,7 +692,6 @@ Array [
             }
           }
           accessible={true}
-          content="Option 2"
           enableFocusRing={true}
           focusable={true}
           onAccessibilityAction={[Function]}
@@ -922,7 +917,6 @@ Array [
             }
           }
           accessible={true}
-          content="Option 1"
           enableFocusRing={true}
           focusable={true}
           onAccessibilityAction={[Function]}
@@ -1047,7 +1041,6 @@ Array [
             }
           }
           accessible={true}
-          content="Option 2"
           enableFocusRing={true}
           focusable={true}
           onAccessibilityAction={[Function]}
@@ -1273,7 +1266,6 @@ Array [
             }
           }
           accessible={true}
-          content="Option 1"
           enableFocusRing={true}
           focusable={true}
           onAccessibilityAction={[Function]}
@@ -1398,7 +1390,6 @@ Array [
             }
           }
           accessible={true}
-          content="Option 2"
           enableFocusRing={true}
           focusable={true}
           onAccessibilityAction={[Function]}
@@ -1624,7 +1615,6 @@ Array [
             }
           }
           accessible={true}
-          content="Option 1"
           enableFocusRing={true}
           focusable={true}
           onAccessibilityAction={[Function]}
@@ -1737,7 +1727,6 @@ Array [
             }
           }
           accessible={true}
-          content="Option 2"
           enableFocusRing={true}
           focusable={true}
           onAccessibilityAction={[Function]}
@@ -1955,7 +1944,6 @@ Array [
             }
           }
           accessible={true}
-          content="Option 1"
           enableFocusRing={true}
           focusable={true}
           onAccessibilityTap={[Function]}
@@ -2010,7 +1998,6 @@ Array [
             }
           }
           accessible={true}
-          content="Option 2"
           enableFocusRing={true}
           focusable={true}
           onAccessibilityAction={[Function]}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

To align with FluentUI and Button, passing text of a MenuItem* as a child of the component instead of through the `content` prop

### Verification

Snapshot tests show that outside of removing the extra prop that used to be passed in, the structure of the components is the same, which should mean that text shows up the same as it did before, and accessibility labels are generated as they were before. CI will verify custom accessibility labels.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
