### PR TITLE
Add hoverDelay prop to Menu

### DIFF
--- a/change/@fluentui-react-native-menu-5cd5c152-8855-44d7-b7eb-287419a7f95c.json
+++ b/change/@fluentui-react-native-menu-5cd5c152-8855-44d7-b7eb-287419a7f95c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add hoverDelay prop",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/MIGRATION.md
+++ b/packages/components/Menu/MIGRATION.md
@@ -245,6 +245,7 @@ The FURN menu cannot be used in place of a FluentUI menu - these componentss are
 
 - `children`
 - `defaultOpen`
+- `hoverDelay`
 - `open`
 - `openOnHover`
 
@@ -254,7 +255,6 @@ The FURN menu cannot be used in place of a FluentUI menu - these componentss are
 
 #### Not implemented on Menu
 
-- `hoverDelay`
 - `inline`
 - `openOnContext`
 - `positioning` (`directionalHint` can be passed into `MenuPopover` instead)

--- a/packages/components/Menu/SPEC.md
+++ b/packages/components/Menu/SPEC.md
@@ -121,6 +121,11 @@ export interface MenuProps extends MenuListProps {
   defaultOpen?: boolean;
 
   /**
+   * How much delay to have between hover in and showing the menu, in ms.
+   */
+  hoverDelay?: number;
+
+  /**
    * Whether the popup is open
    */
   open?: boolean;

--- a/packages/experimental/Menu/src/Menu/Menu.types.ts
+++ b/packages/experimental/Menu/src/Menu/Menu.types.ts
@@ -11,6 +11,11 @@ export interface MenuProps extends MenuListProps {
   defaultOpen?: boolean;
 
   /**
+   * How much delay to have between hover in and showing the menu, in ms.
+   */
+  hoverDelay?: number;
+
+  /**
    * Whether the popup is open
    */
   open?: boolean;

--- a/packages/experimental/Menu/src/MenuTrigger/useMenuTrigger.ts
+++ b/packages/experimental/Menu/src/MenuTrigger/useMenuTrigger.ts
@@ -3,7 +3,7 @@ import { InteractionEvent } from '@fluentui-react-native/interactive-hooks';
 import { MenuTriggerState } from './MenuTrigger.types';
 import { AccessibilityActionEvent, AccessibilityActionName, Platform } from 'react-native';
 import React from 'react';
-import { delayHover, isCloseOnHoverOutEnabled } from '../consts';
+import { hoverDelayDefault, isCloseOnHoverOutEnabled } from '../consts';
 
 const accessibilityActions =
   Platform.OS === ('win32' as any) ? [{ name: 'Expand' as AccessibilityActionName }, { name: 'Collapse' as AccessibilityActionName }] : [];
@@ -12,7 +12,16 @@ const collapsedState = { expanded: false };
 
 export const useMenuTrigger = (): MenuTriggerState => {
   const context = useMenuContext();
-  const { open, openOnHover, popoverHoverOutTimer, setOpen, setTriggerHoverOutTimer, triggerHoverOutTimer, triggerRef } = context;
+  const {
+    hoverDelay = hoverDelayDefault,
+    open,
+    openOnHover,
+    popoverHoverOutTimer,
+    setOpen,
+    setTriggerHoverOutTimer,
+    triggerHoverOutTimer,
+    triggerRef,
+  } = context;
 
   const accessibilityState = open ? expandedState : collapsedState;
 
@@ -41,10 +50,10 @@ export const useMenuTrigger = (): MenuTriggerState => {
         e.persist();
         setTimeout(() => {
           setOpen(e, true /* isOpen */);
-        }, delayHover);
+        }, hoverDelay);
       }
     },
-    [openOnHover, setOpen, triggerHoverOutTimer, popoverHoverOutTimer],
+    [hoverDelay, openOnHover, setOpen, triggerHoverOutTimer, popoverHoverOutTimer],
   );
 
   const onHoverOut = React.useCallback(
@@ -53,11 +62,11 @@ export const useMenuTrigger = (): MenuTriggerState => {
         e.persist();
         const timer = setTimeout(() => {
           setOpen(e, false /* isOpen */);
-        }, delayHover);
+        }, hoverDelay);
         setTriggerHoverOutTimer(timer);
       }
     },
-    [openOnHover, setOpen, setTriggerHoverOutTimer],
+    [hoverDelay, openOnHover, setOpen, setTriggerHoverOutTimer],
   );
 
   const onClick = React.useCallback(

--- a/packages/experimental/Menu/src/consts.ts
+++ b/packages/experimental/Menu/src/consts.ts
@@ -1,6 +1,6 @@
 import { Platform } from 'react-native';
 
-export const delayHover = Platform.select({
+export const hoverDelayDefault = Platform.select({
   macos: 100,
   default: 500, // win32
 });


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Add hoverDelay prop which overrides the default hoverDelay amount if one is passed in.

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
