### PR TITLE
Final Testpath for the Avatar component

### DIFF
--- a/apps/fluent-tester/src/FluentTester/theme/applyTheme.ts
+++ b/apps/fluent-tester/src/FluentTester/theme/applyTheme.ts
@@ -55,7 +55,7 @@ const themingModule = getThemingModule()[0];
 export function applyTheme(parent: Theme, name: ThemeNames, appearance: ThemeOptions['appearance']): PartialTheme {
   switch (name) {
     case 'Office':
-      return themingModule ? createOfficeTheme({ appearance, paletteName: 'WhiteColors' }).theme : {};
+      return themingModule ? createOfficeTheme({ appearance, paletteName: 'LowerRibbon_FluentSV' }).theme : {};
     case 'Caterpillar':
       return applyCaterpillarTheme(parent);
     default:


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [X] macOS
- [X] win32 (Office)
- [X] windows
- [ ] android

### Description of changes
This is final test path for the Avatar component. The only thing was changed here is paletteName from "WhiteColors" to "LowerRibbon_FluentSV".
