### PR TITLE
Menu popover tokens

### DIFF
--- a/change/@fluentui-react-native-menu-6bf928f6-c9ee-4e80-9ed1-7326e34d682d.json
+++ b/change/@fluentui-react-native-menu-6bf928f6-c9ee-4e80-9ed1-7326e34d682d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add tokens to MenuPopover",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Menu/src/MenuPopover/MenuPopover.tsx
+++ b/packages/experimental/Menu/src/MenuPopover/MenuPopover.tsx
@@ -1,24 +1,37 @@
 import React from 'react';
-import { mergeProps, stagedComponent, useFluentTheme } from '@fluentui-react-native/framework';
+import { compressible, mergeProps, patchTokens, useFluentTheme, UseTokens } from '@fluentui-react-native/framework';
 import { Callout } from '@fluentui-react-native/callout';
-import { menuPopoverName, MenuPopoverProps } from './MenuPopover.types';
+import { menuPopoverName, MenuPopoverProps, MenuPopoverTokens } from './MenuPopover.types';
 import { useMenuPopover } from './useMenuPopover';
+import { useMenuPopoverTokens } from './MenuPopoverTokens';
 import { View } from 'react-native';
 
-export const MenuPopover = stagedComponent((props: MenuPopoverProps) => {
-  const state = useMenuPopover(props);
-  const theme = useFluentTheme();
+export const MenuPopover = compressible<MenuPopoverProps, MenuPopoverTokens>(
+  (props: MenuPopoverProps, useTokens: UseTokens<MenuPopoverTokens>) => {
+    const { directionalHint, gapSpace, maxHeight, maxWidth, minPadding, borderWidth, borderColor, backgroundColor } = props;
+    const state = useMenuPopover(props);
+    const theme = useFluentTheme();
+    let [tokens, cache] = useTokens(theme);
 
-  return (final: MenuPopoverProps, children: React.ReactNode) => {
-    const mergedProps = mergeProps(state.props, final);
-    const content = React.createElement(View, state.innerView, children);
-    return (
-      <Callout borderWidth={1} borderColor={theme.colors.neutralStrokeAccessible} {...mergedProps}>
-        {content}
-      </Callout>
-    );
-  };
-});
+    [tokens, cache] = patchTokens(tokens, cache, {
+      directionalHint,
+      gapSpace,
+      maxHeight,
+      maxWidth,
+      minPadding,
+      borderWidth,
+      borderColor,
+      backgroundColor,
+    });
+
+    return (final: MenuPopoverProps, children: React.ReactNode) => {
+      const mergedProps = mergeProps(tokens, state.props, final);
+      const content = React.createElement(View, state.innerView, children);
+      return <Callout {...mergedProps}>{content}</Callout>;
+    };
+  },
+  useMenuPopoverTokens,
+);
 MenuPopover.displayName = menuPopoverName;
 
 export default MenuPopover;

--- a/packages/experimental/Menu/src/MenuPopover/MenuPopover.types.ts
+++ b/packages/experimental/Menu/src/MenuPopover/MenuPopover.types.ts
@@ -1,7 +1,11 @@
 import { IViewProps } from '@fluentui-react-native/adapters';
-import { ICalloutProps } from '@fluentui-react-native/callout';
+import { ICalloutProps, ICalloutTokens } from '@fluentui-react-native/callout';
 
 export const menuPopoverName = 'MenuPopover';
+
+// Support for anchorRect and beakWidth will come at a later time.
+// Omitting dismissBehaviors as it doesn't seem to make sense as a token
+export type MenuPopoverTokens = Omit<ICalloutTokens, 'anchorRect' | 'beakWidth' | 'dismissBehaviors'>;
 
 export type MenuPopoverProps = ICalloutProps;
 

--- a/packages/experimental/Menu/src/MenuPopover/MenuPopoverTokens.ts
+++ b/packages/experimental/Menu/src/MenuPopover/MenuPopoverTokens.ts
@@ -1,0 +1,7 @@
+import { buildUseTokens, Theme } from '@fluentui-react-native/framework';
+import { menuPopoverName, MenuPopoverTokens } from './MenuPopover.types';
+
+export const useMenuPopoverTokens = buildUseTokens<MenuPopoverTokens>(
+  (t: Theme) => ({ borderWidth: 1, borderColor: t.colors.neutralStrokeAccessible }),
+  menuPopoverName,
+);


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Add tokens to MenuPopover and the ability to change them.
All MenuPopover tokens are exposed through props, so compose seems a bit overkill. Using compressible and patchTokens instead for "tokensThatAreAlsoProps" functionality.

### Verification

Will test UI through tester

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
