### PR TITLE
Menu item refactor

### DIFF
--- a/change/@fluentui-react-native-menu-8a29fb90-8c32-455a-8d1a-ba9696960890.json
+++ b/change/@fluentui-react-native-menu-8a29fb90-8c32-455a-8d1a-ba9696960890.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Some refactoring",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Menu/src/MenuItemCheckbox/MenuItemCheckbox.types.ts
+++ b/packages/experimental/Menu/src/MenuItemCheckbox/MenuItemCheckbox.types.ts
@@ -1,14 +1,15 @@
 import * as React from 'react';
-import { ColorValue, ViewProps } from 'react-native';
+import { ColorValue } from 'react-native';
 import { XmlProps } from 'react-native-svg';
 import type { IViewProps } from '@fluentui-react-native/adapters';
 import { TextProps } from '@fluentui-react-native/experimental-text';
-import { IFocusable, IPressableHooks, IWithPressableOptions } from '@fluentui-react-native/interactive-hooks';
-import { FontTokens, IBorderTokens, IColorTokens, LayoutTokens } from '@fluentui-react-native/tokens';
+import { IPressableHooks } from '@fluentui-react-native/interactive-hooks';
+import { MenuItemProps, MenuItemTokens } from '../MenuItem/MenuItem.types';
 
 export const menuItemCheckboxName = 'MenuItemCheckbox';
 
-export interface MenuItemCheckboxTokens extends LayoutTokens, FontTokens, IBorderTokens, IColorTokens {
+export interface MenuItemCheckboxTokens
+  extends Omit<MenuItemTokens, 'submenuIndicatorPadding' | 'submenuIndicatorSize' | 'disabled' | 'focused' | 'hovered' | 'pressed'> {
   /**
    * Color of the checkmark icon
    */
@@ -20,19 +21,9 @@ export interface MenuItemCheckboxTokens extends LayoutTokens, FontTokens, IBorde
   checkmarkPadding?: number;
 
   /**
-   * Height and width in pixels of the checkmark icon
-   */
-  checkmarkSize?: number;
-
-  /**
    * Visibility of the checkmark icon from 0 to 1
    */
   checkmarkVisibility?: number;
-
-  /**
-   * Space between parts of the item control in pixels
-   */
-  gap?: number;
 
   /**
    * States of the item control
@@ -44,12 +35,7 @@ export interface MenuItemCheckboxTokens extends LayoutTokens, FontTokens, IBorde
   pressed?: MenuItemCheckboxTokens;
 }
 
-export interface MenuItemCheckboxProps extends Omit<IWithPressableOptions<ViewProps>, 'onPress'> {
-  /**
-   * A RefObject to access the IButton interface. Use this to access the public methods and properties of the component.
-   */
-  componentRef?: React.RefObject<IFocusable>;
-
+export interface MenuItemCheckboxProps extends MenuItemProps {
   /**
    * Identifier for the control
    */


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Some slight refactoring of types on the MenuItem*s. Having Tokens and Props of MenuItemCheckbox extend MenuItem so that they share more implementation.

Not sure if it's better to edit the documentation to change the types to match or to have all the props written out explicitly. Thoughts?

### Verification

Things build

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
