### PR TITLE
Fix hc checkmark menuitem

### DIFF
--- a/change/@fluentui-react-native-win32-theme-8f043bf1-fa5b-4ea7-a677-b3249100f542.json
+++ b/change/@fluentui-react-native-win32-theme-8f043bf1-fa5b-4ea7-a677-b3249100f542.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Override colors for checkmark in MenuItem",
+  "packageName": "@fluentui-react-native/win32-theme",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/theming/win32-theme/src/createAliasesFromPalette.ts
+++ b/packages/theming/win32-theme/src/createAliasesFromPalette.ts
@@ -6,6 +6,9 @@ export function createAliasesFromPalette(palette: OfficePalette, isHighContrast:
   if (isHighContrast) {
     return {
       neutralForeground1: palette.Text,
+      neutralForeground1Hover: palette.TextHover,
+      neutralForeground1Pressed: palette.TextPressed,
+      neutralForeground1Selected: palette.TextSelected,
       neutralForeground2: palette.TextSecondary,
       neutralForeground4: palette.TextCtlSubtlePlaceholder,
       neutralForegroundDisabled: palette.TextDisabled,
@@ -17,6 +20,9 @@ export function createAliasesFromPalette(palette: OfficePalette, isHighContrast:
 
   return {
     neutralForeground1: palette.Text,
+    neutralForeground1Hover: palette.TextHover,
+    neutralForeground1Pressed: palette.TextPressed,
+    neutralForeground1Selected: palette.TextSelected,
     neutralForeground2: palette.TextSecondary,
     neutralForeground2Hover: palette.TextSecondaryHover,
     neutralForeground2Pressed: palette.TextSecondaryPressed,


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

MenuItemCheckbox has an HC bug with the current FURN tester version where the checkmark doesn't show the proper color. This is because the native code hasn't updated to allow for PlatformColor on SVGs yet.

Applying the workaround of pulling palette color for the icon color on HC so that the color shows properly, as palette colors are passed as Hex color strings and not PlatformColors even on HC.

FWIW the MenuItemCheckbox looks fine on latest native so we can remove the workaround once we bump to 0.66

### Verification

Booted tester and tested Button, Checkbox, and Menu in HC to make sure there weren't regressions.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
