### PR TITLE
Remove menu popover from being tab stop

### DIFF
--- a/change/@fluentui-react-native-menu-45467e83-9f22-4a47-b3e4-cc6a8796c768.json
+++ b/change/@fluentui-react-native-menu-45467e83-9f22-4a47-b3e4-cc6a8796c768.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix container being tab stop",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Menu/src/MenuPopover/useMenuPopover.ts
+++ b/packages/experimental/Menu/src/MenuPopover/useMenuPopover.ts
@@ -48,6 +48,11 @@ export const useMenuPopover = (_props: MenuPopoverProps): MenuPopoverState => {
     setPopoverHoverOutTimer(timer);
   }, [openOnHover, setOpen, setPopoverHoverOutTimer]);
 
+  const [canFocusOnContainer, setCanFocusOnContainer] = React.useState<boolean>(shouldFocusOnContainer);
+  const onBlur = React.useCallback(() => {
+    setCanFocusOnContainer(false);
+  }, [setCanFocusOnContainer]);
+
   return {
     props: {
       accessibilityRole,
@@ -62,7 +67,8 @@ export const useMenuPopover = (_props: MenuPopoverProps): MenuPopoverState => {
       onMouseEnter,
       onMouseLeave: isCloseOnHoverOutEnabled && onMouseLeave,
       accessible: shouldFocusOnContainer,
-      focusable: shouldFocusOnContainer,
+      focusable: canFocusOnContainer,
+      onBlur,
     },
   };
 };

--- a/packages/experimental/Menu/src/MenuPopover/useMenuPopover.ts
+++ b/packages/experimental/Menu/src/MenuPopover/useMenuPopover.ts
@@ -48,10 +48,10 @@ export const useMenuPopover = (_props: MenuPopoverProps): MenuPopoverState => {
     setPopoverHoverOutTimer(timer);
   }, [openOnHover, setOpen, setPopoverHoverOutTimer]);
 
-  const [canFocusOnContainer, setCanFocusOnContainer] = React.useState<boolean>(shouldFocusOnContainer);
+  const [canFocusOnPopover, setCanFocusOnPopover] = React.useState<boolean>(shouldFocusOnContainer);
   const onBlur = React.useCallback(() => {
-    setCanFocusOnContainer(false);
-  }, [setCanFocusOnContainer]);
+    setCanFocusOnPopover(false);
+  }, [setCanFocusOnPopover]);
 
   return {
     props: {
@@ -67,7 +67,7 @@ export const useMenuPopover = (_props: MenuPopoverProps): MenuPopoverState => {
       onMouseEnter,
       onMouseLeave: isCloseOnHoverOutEnabled && onMouseLeave,
       accessible: shouldFocusOnContainer,
-      focusable: canFocusOnContainer,
+      focusable: canFocusOnPopover,
       onBlur,
     },
   };

--- a/packages/experimental/Menu/src/__tests__/__snapshots__/Menu.test.tsx.snap
+++ b/packages/experimental/Menu/src/__tests__/__snapshots__/Menu.test.tsx.snap
@@ -155,6 +155,7 @@ Array [
     <View
       accessible={false}
       focusable={false}
+      onBlur={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={false}
     >
@@ -375,6 +376,7 @@ Array [
     <View
       accessible={false}
       focusable={false}
+      onBlur={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={false}
     >
@@ -540,6 +542,7 @@ Array [
     <View
       accessible={false}
       focusable={false}
+      onBlur={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={false}
     >
@@ -892,6 +895,7 @@ Array [
     <View
       accessible={false}
       focusable={false}
+      onBlur={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={false}
     >
@@ -1243,6 +1247,7 @@ Array [
     <View
       accessible={false}
       focusable={false}
+      onBlur={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={false}
     >
@@ -1594,6 +1599,7 @@ Array [
     <View
       accessible={false}
       focusable={false}
+      onBlur={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={false}
     >
@@ -1933,6 +1939,7 @@ Array [
     <View
       accessible={false}
       focusable={false}
+      onBlur={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={false}
     >


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Bug was that the menu popover was a tab stop when tabbing when the menu was opened via mouse. This was because it was listed as tabble when the Menu is invoked via mouse.

Copied this fix from ContextualMenu. Focusable is set to false on the container as soon as focus is shifted away from it, removing it from the tab loop.

### Verification

Tested via tester.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [x] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
