### PR TITLE
Fix minor menu

### DIFF
--- a/change/@fluentui-react-native-menu-aac75818-27ee-45f4-941f-258259e19773.json
+++ b/change/@fluentui-react-native-menu-aac75818-27ee-45f4-941f-258259e19773.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Minor Menu bug fixes",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Menu/src/MenuItem/MenuItemTokens.win32.ts
+++ b/packages/experimental/Menu/src/MenuItem/MenuItemTokens.win32.ts
@@ -31,4 +31,8 @@ export const defaultMenuItemTokens: TokenSettings<MenuItemTokens, Theme> = (t: T
     backgroundColor: t.colors.neutralBackground1,
     color: t.colors.neutralForegroundDisabled,
   },
+  focused: {
+    backgroundColor: t.colors.neutralBackground1Hover,
+    color: t.colors.neutralForeground1Hover,
+  },
 });

--- a/packages/experimental/Menu/src/MenuItemCheckbox/MenuItemCheckboxTokens.win32.ts
+++ b/packages/experimental/Menu/src/MenuItemCheckbox/MenuItemCheckboxTokens.win32.ts
@@ -43,6 +43,14 @@ export const defaultMenuItemCheckboxTokens: TokenSettings<MenuItemCheckboxTokens
       checkmarkVisibility: 1,
     },
   },
+  focused: {
+    backgroundColor: t.colors.neutralBackground1Hover,
+    color: t.colors.neutralForeground1Hover,
+    checked: {
+      checkmarkColor: t.colors.neutralForeground1Hover,
+      checkmarkVisibility: 1,
+    },
+  },
   checked: {
     checkmarkColor: t.colors.neutralForeground1,
     checkmarkVisibility: 1,

--- a/packages/experimental/Menu/src/MenuItemCheckbox/useMenuItemCheckbox.ts
+++ b/packages/experimental/Menu/src/MenuItemCheckbox/useMenuItemCheckbox.ts
@@ -72,7 +72,7 @@ export const useMenuCheckboxInteraction = (
   const pressable = useAsPressable({ ...rest, disabled, onPress: toggleCheckedWithFocus });
   const buttonRef = useViewCommandFocus(componentRef);
 
-  const onKeyProps = useKeyProps(toggleCallback, ' ');
+  const onKeyProps = useKeyProps(toggleCallback, ' ', 'Enter');
   const accessibilityActionsProp = accessibilityActions
     ? [...defaultAccessibilityActions, ...accessibilityActions]
     : defaultAccessibilityActions;

--- a/packages/experimental/Menu/src/MenuItemRadio/useMenuItemRadio.ts
+++ b/packages/experimental/Menu/src/MenuItemRadio/useMenuItemRadio.ts
@@ -3,27 +3,31 @@ import { InteractionEvent } from '@fluentui-react-native/interactive-hooks';
 import { useMenuListContext } from '../context/menuListContext';
 import { MenuItemCheckboxProps, MenuItemCheckboxState } from '../MenuItemCheckbox/MenuItemCheckbox.types';
 import { useMenuCheckboxInteraction } from '../MenuItemCheckbox/useMenuItemCheckbox';
+import { useMenuContext } from '../context/menuContext';
 
 export const useMenuItemRadio = (props: MenuItemCheckboxProps): MenuItemCheckboxState => {
   const { disabled, name } = props;
-  const context = useMenuListContext();
-  const selectRadio = context.selectRadio;
+  const context = useMenuContext();
+  const listContext = useMenuListContext();
+  const selectRadio = listContext.selectRadio;
+  const setOpen = context.setOpen;
 
   const toggleChecked = React.useCallback(
     (e: InteractionEvent) => {
       if (!disabled) {
         selectRadio(e, name);
+        setOpen(e, false /*isOpen*/, true /*bubble*/);
       }
     },
-    [disabled, name, selectRadio],
+    [disabled, name, selectRadio, setOpen],
   );
 
   // Explicitly only run on mount and unmount
   React.useEffect(() => {
-    context.addRadioItem(name);
+    listContext.addRadioItem(name);
 
     return () => {
-      context.removeRadioItem(name);
+      listContext.removeRadioItem(name);
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/packages/experimental/Menu/src/MenuItemRadio/useMenuItemRadio.ts
+++ b/packages/experimental/Menu/src/MenuItemRadio/useMenuItemRadio.ts
@@ -3,31 +3,27 @@ import { InteractionEvent } from '@fluentui-react-native/interactive-hooks';
 import { useMenuListContext } from '../context/menuListContext';
 import { MenuItemCheckboxProps, MenuItemCheckboxState } from '../MenuItemCheckbox/MenuItemCheckbox.types';
 import { useMenuCheckboxInteraction } from '../MenuItemCheckbox/useMenuItemCheckbox';
-import { useMenuContext } from '../context/menuContext';
 
 export const useMenuItemRadio = (props: MenuItemCheckboxProps): MenuItemCheckboxState => {
   const { disabled, name } = props;
-  const context = useMenuContext();
-  const listContext = useMenuListContext();
-  const selectRadio = listContext.selectRadio;
-  const setOpen = context.setOpen;
+  const context = useMenuListContext();
+  const selectRadio = context.selectRadio;
 
   const toggleChecked = React.useCallback(
     (e: InteractionEvent) => {
       if (!disabled) {
         selectRadio(e, name);
-        setOpen(e, false /*isOpen*/, true /*bubble*/);
       }
     },
-    [disabled, name, selectRadio, setOpen],
+    [disabled, name, selectRadio],
   );
 
   // Explicitly only run on mount and unmount
   React.useEffect(() => {
-    listContext.addRadioItem(name);
+    context.addRadioItem(name);
 
     return () => {
-      listContext.removeRadioItem(name);
+      context.removeRadioItem(name);
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Fixes for some minor bugs:

- In win32, Focused items should have hover visuals
- Enter should toggle a checked item
- If you select a radio item, it should dismiss the Menu.

### Verification

Verified behavior with PM

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
