### PR TITLE
Fix Menu focus visual bug

### DIFF
--- a/change/@fluentui-react-native-menu-cf662fa1-3ebc-4261-a35a-7a7cc3bc3a98.json
+++ b/change/@fluentui-react-native-menu-cf662fa1-3ebc-4261-a35a-7a7cc3bc3a98.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Focus visuals should show as soon as component is hovered",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Menu/src/MenuItem/useMenuItem.ts
+++ b/packages/experimental/Menu/src/MenuItem/useMenuItem.ts
@@ -105,7 +105,7 @@ function getAccessibilityStateWorker(disabled: boolean, accessibilityState?: Acc
 }
 
 export const useHoverFocusEffect = (hovered: boolean, componentRef: React.MutableRefObject<any>) => {
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     if (hovered) {
       componentRef?.current?.focus();
     } else {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This bug didn't show until I added hover visuals for focused components. Although components are focused when hovered state is changed because of useEffect, the component doesn't show the UI until the next rerender because the focus state is triggered using useEffect. This means that the UI shows up when a component is, for example, hovered out of.

To fix this, change running focus() to useLayoutEffect so that it runs sooner in the render cycle. The visual now updates as part of hovering the component.

### Verification

Tested via tester.

Before:
![focus_visual_bug](https://user-images.githubusercontent.com/4602628/175698332-d0795a28-f595-419a-8933-738002f7e98d.gif)

After:
![focus_visual_fix](https://user-images.githubusercontent.com/4602628/175699081-5a0c2fc0-ba1b-4d7a-89ad-70237870c2db.gif)


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
