### PR TITLE
Update workspace name for macos/ios

### DIFF
--- a/apps/ios/src/Podfile
+++ b/apps/ios/src/Podfile
@@ -1,6 +1,6 @@
 require_relative '../../../node_modules/react-native-test-app/test_app.rb'
 
-workspace 'FluentTester.xcworkspace'
+workspace 'FluentTester-ios.xcworkspace'
 
 react_native_path = "#{__dir__}/../../../node_modules/react-native"
 

--- a/apps/ios/src/Podfile.lock
+++ b/apps/ios/src/Podfile.lock
@@ -9,11 +9,11 @@ PODS:
     - React-Core (= 0.64.3)
     - React-jsi (= 0.64.3)
     - ReactCommon/turbomodule/core (= 0.64.3)
-  - FRNAvatar (0.15.0):
+  - FRNAvatar (0.15.1):
     - MicrosoftFluentUI (= 0.5.2)
     - MicrosoftFluentUI/Avatar_ios (= 0.5.2)
     - React
-  - FRNDatePicker (0.4.4):
+  - FRNDatePicker (0.5.0):
     - MicrosoftFluentUI (= 0.5.2)
     - React
   - glog (0.3.5)
@@ -568,12 +568,12 @@ SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: c71c5917ec0ad2de41d5d06a5855f6d5eda06971
-  FBReactNativeSpec: e46380c3ebf05dc813f8b8e5ca403e47822318f6
-  FRNAvatar: e176ece0a413636c7ea6b82ec603dfb772c92090
-  FRNDatePicker: a2be59f115ff637d41837ca7a7b809ffd4905ee7
-  glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
+  FBReactNativeSpec: 2e23f365db4551ce59b5411a90f7ad9bc0aabffe
+  FRNAvatar: a532bbf467cf1c49c9762b1838808b1482a11835
+  FRNDatePicker: 961e96f437d1dcd25fe6d7a80790dade00ef714b
+  glog: 7a8788d88d2a384c05df45e95c5e763e4d81f3ad
   MicrosoftFluentUI: 2f4c624fd4606aa2392c09be69a45e297a41f593
-  RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
+  RCT-Folly: 91521e05ace43e89980cabd1fb54685f7827ddb9
   RCTRequired: d34bf57e17cb6e3b2681f4809b13843c021feb6c
   RCTTypeSafety: 8dab4933124ed39bb0c1d88d74d61b1eb950f28f
   React: ef700aeb19afabff83a9cc5799ac955a9c6b5e0f
@@ -604,6 +604,6 @@ SPEC CHECKSUMS:
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
   Yoga: e6ecf3fa25af9d4c87e94ad7d5d292eedef49749
 
-PODFILE CHECKSUM: 2cc422f3c850b8ad8daa73a1a0fb1cb8171cc171
+PODFILE CHECKSUM: f64a57f6649f1cccdf4afd873f858c19e442f2e6
 
 COCOAPODS: 1.11.3

--- a/apps/macos/src/Podfile
+++ b/apps/macos/src/Podfile
@@ -1,6 +1,6 @@
 require_relative '../../../node_modules/react-native-test-app/macos/test_app.rb'
 
-workspace 'FluentTester.xcworkspace'
+workspace 'FluentTester-macos.xcworkspace'
 
 react_native_path = "#{__dir__}/../../../node_modules/react-native-macos"
 

--- a/apps/macos/src/Podfile.lock
+++ b/apps/macos/src/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
     - React-Core (= 0.64.30)
     - React-jsi (= 0.64.30)
     - ReactCommon/turbomodule/core (= 0.64.30)
-  - FRNAvatar (0.15.0):
+  - FRNAvatar (0.15.1):
     - MicrosoftFluentUI (= 0.5.2)
     - MicrosoftFluentUI/Avatar_ios (= 0.5.2)
     - React
@@ -353,7 +353,7 @@ PODS:
     - React-Core
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
-  - RNCPicker (2.4.1):
+  - RNCPicker (2.4.2):
     - React-Core
   - RNSVG (12.3.0):
     - React-Core
@@ -493,15 +493,15 @@ SPEC CHECKSUMS:
   boost-for-react-native: d5ad1140010aa8cb622323a781ecbeab4425d19a
   DoubleConversion: 0ea4559a49682230337df966e735d6cc7760108e
   FBLazyVector: 8a96f324df8c1bc4e2f7e2163d704ec364f0bc6c
-  FBReactNativeSpec: 625af937353349e558cc2651adf11201e2660f1c
-  FRNAvatar: e176ece0a413636c7ea6b82ec603dfb772c92090
+  FBReactNativeSpec: 565b9e3e0d677e88cebf57f4d847e30dfaaf6a32
+  FRNAvatar: a532bbf467cf1c49c9762b1838808b1482a11835
   FRNCallout: a91af06afd4ac99fe854d722bbd3dc5ed12b52c4
   FRNCheckbox: 8e81d152fe7a0447b5eeb70595c96ac3c491b95f
   FRNMenuButton: 4f8646e57af2781043844d391f90bf11c8e9dcbc
   FRNRadioButton: e98049db228b2ea3cdf7eb8f02dd085408629f06
-  glog: 0dc7efada961c0793012970b60faebbd58b0decb
+  glog: 05f0ec9bc4f27fdfeffe017aef0c06d454a18b31
   MicrosoftFluentUI: 2f4c624fd4606aa2392c09be69a45e297a41f593
-  RCT-Folly: b3998425a8ee9f695f57a204dc494534246f0fe9
+  RCT-Folly: 02d00279d7b23f9c1966297e57a66a8ff9d5d2f6
   RCTFocusZone: e13db0cc2e4d324259579e3c29afe771423a0e87
   RCTRequired: 8903667b081ec6b4b870c6b25ff1038eef62db0d
   RCTTypeSafety: 061b065a52bcd68ca38755bc56784a4889659625
@@ -527,11 +527,11 @@ SPEC CHECKSUMS:
   ReactCommon: 0665778a9e30416d3bff636251a34d1e93ee59af
   ReactTestApp-DevSupport: 6275cb3b001d9d971f8328580f757409a1c1cf64
   ReactTestApp-Resources: 320923a3635f7bf90caa1a28fd29765b577888d9
-  RNCPicker: abc646b53a3d28ccfa3232c927a0ca52e0cf024d
+  RNCPicker: 0250e95ad170569a96f5b0555cdd5e65b9084dca
   RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
   Yoga: 1ea22d438a06b78c080c477ecadd4eae4c4907f4
 
-PODFILE CHECKSUM: 568704fb95966cf7ad6daa54a1d36eb2d5c3bba6
+PODFILE CHECKSUM: 75b2b8a2e78c08bffa7e05387a19800c139d5c86
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Update workspace names for MacOS and iOS Fluent Tester apps for clarity

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="233" alt="Screen Shot 2022-06-24 at 4 03 16 PM" src="https://user-images.githubusercontent.com/55368679/175728309-e85ead3d-c464-42e4-92cf-846baf69fc89.png">  | <img width="230" alt="Screen Shot 2022-06-24 at 4 23 44 PM" src="https://user-images.githubusercontent.com/55368679/175737267-1fad4d67-7823-445e-bf18-5f6088b7db71.png"> <img width="289" alt="Screen Shot 2022-06-24 at 4 09 40 PM" src="https://user-images.githubusercontent.com/55368679/175728555-87cf5552-4d4a-47d1-a488-5e687f975a84.png">  |
