### PR TITLE
Implement persistOnClick on Menu

### DIFF
--- a/change/@fluentui-react-native-menu-944c6782-aa8f-4d30-b87b-165798b7b7ee.json
+++ b/change/@fluentui-react-native-menu-944c6782-aa8f-4d30-b87b-165798b7b7ee.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Implement persisting behavior",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/MIGRATION.md
+++ b/packages/components/Menu/MIGRATION.md
@@ -301,7 +301,6 @@ The FURN menu cannot be used in place of a FluentUI menu - these componentss are
 #### Not implemented on MenuItem
 
 - `hasSubmenu` - currently automatically handled
-- `persistOnClick`
 
 ### MenuItemCheckbox and MenuItemRadio
 

--- a/packages/components/Menu/SPEC.md
+++ b/packages/components/Menu/SPEC.md
@@ -139,6 +139,11 @@ export interface MenuProps extends MenuListProps {
    * Opens the menu on hovering over the trigger
    */
   openOnHover?: boolean;
+
+  /**
+   * Do not dismiss the menu when a menu item is clicked
+   */
+  persistOnItemClick?: boolean;
 }
 ```
 
@@ -221,6 +226,11 @@ export interface MenuItemProps extends Omit<IWithPressableOptions<ViewProps>, 'o
    * A callback to call on button click event
    */
   onClick?: (e: InteractionEvent) => void;
+
+  /**
+   * Do not dismiss the menu when a menu item is clicked
+   */
+  persistOnClick?: boolean;
 }
 ```
 
@@ -282,6 +292,11 @@ export interface MenuItemCheckboxProps extends Omit<IWithPressableOptions<ViewPr
    * Identifier for the control
    */
   name: string;
+
+  /**
+   * Do not dismiss the menu when a menu item is clicked
+   */
+  persistOnClick?: boolean;
 }
 ```
 

--- a/packages/experimental/Menu/src/Menu/Menu.types.ts
+++ b/packages/experimental/Menu/src/Menu/Menu.types.ts
@@ -29,6 +29,11 @@ export interface MenuProps extends MenuListProps {
    * Opens the menu on hovering over the trigger
    */
   openOnHover?: boolean;
+
+  /**
+   * Do not dismiss the menu when a menu item is clicked
+   */
+  persistOnItemClick?: boolean;
 }
 
 export interface MenuState extends MenuProps {

--- a/packages/experimental/Menu/src/MenuItem/MenuItem.types.ts
+++ b/packages/experimental/Menu/src/MenuItem/MenuItem.types.ts
@@ -48,6 +48,11 @@ export interface MenuItemProps extends Omit<IWithPressableOptions<ViewProps>, 'o
    * A callback to call on button click event
    */
   onClick?: (e: InteractionEvent) => void;
+
+  /**
+   * Do not dismiss the menu when a menu item is clicked
+   */
+  persistOnClick?: boolean;
 }
 
 export interface MenuItemState extends IPressableHooks<MenuItemProps & React.ComponentPropsWithRef<any>> {

--- a/packages/experimental/Menu/src/MenuItem/useMenuItem.ts
+++ b/packages/experimental/Menu/src/MenuItem/useMenuItem.ts
@@ -19,11 +19,13 @@ const submenuTriggerKeys = [...triggerKeys, 'ArrowLeft', 'ArrowRight'];
 export const useMenuItem = (props: MenuItemProps): MenuItemState => {
   // attach the pressable state handlers
   const defaultComponentRef = React.useRef(null);
-  const { onClick, accessibilityState, componentRef = defaultComponentRef, disabled, ...rest } = props;
+  const { onClick, accessibilityState, componentRef = defaultComponentRef, disabled, persistOnClick, ...rest } = props;
   const isTrigger = useMenuTriggerContext();
   const isSubmenu = useMenuContext().isSubmenu;
   const hasSubmenu = isSubmenu && isTrigger;
   const isInSubmenu = isSubmenu && !isTrigger;
+  let shouldPersist = useMenuContext().persistOnItemClick;
+  shouldPersist = persistOnClick ?? shouldPersist;
 
   const setOpen = useMenuContext().setOpen;
 
@@ -56,10 +58,12 @@ export const useMenuItem = (props: MenuItemProps): MenuItemState => {
           isInSubmenu &&
           ((isRtl && e.nativeEvent.key === 'ArrowRight') || (!isRtl && e.nativeEvent.key === 'ArrowLeft'));
 
-        setOpen(e, false /*isOpen*/, !isArrowClose /*bubble*/);
+        if (isArrowClose || !shouldPersist) {
+          setOpen(e, false /*isOpen*/, !isArrowClose /*bubble*/);
+        }
       }
     },
-    [disabled, hasSubmenu, isInSubmenu, onClick, setOpen],
+    [disabled, hasSubmenu, isInSubmenu, onClick, setOpen, shouldPersist],
   );
 
   const pressable = useAsPressable({ ...rest, disabled, onPress: onInvoke });

--- a/packages/experimental/Menu/src/MenuItemRadio/useMenuItemRadio.ts
+++ b/packages/experimental/Menu/src/MenuItemRadio/useMenuItemRadio.ts
@@ -3,27 +3,31 @@ import { InteractionEvent } from '@fluentui-react-native/interactive-hooks';
 import { useMenuListContext } from '../context/menuListContext';
 import { MenuItemCheckboxProps, MenuItemCheckboxState } from '../MenuItemCheckbox/MenuItemCheckbox.types';
 import { useMenuCheckboxInteraction } from '../MenuItemCheckbox/useMenuItemCheckbox';
+import { useMenuContext } from '../context/menuContext';
 
 export const useMenuItemRadio = (props: MenuItemCheckboxProps): MenuItemCheckboxState => {
   const { disabled, name } = props;
-  const context = useMenuListContext();
-  const selectRadio = context.selectRadio;
+  const context = useMenuContext();
+  const listContext = useMenuListContext();
+  const selectRadio = listContext.selectRadio;
+  const setOpen = context.setOpen;
 
   const toggleChecked = React.useCallback(
     (e: InteractionEvent) => {
       if (!disabled) {
         selectRadio(e, name);
+        setOpen(e, false /*isOpen*/, true /*bubble*/);
       }
     },
-    [disabled, name, selectRadio],
+    [disabled, name, selectRadio, setOpen],
   );
 
   // Explicitly only run on mount and unmount
   React.useEffect(() => {
-    context.addRadioItem(name);
+    listContext.addRadioItem(name);
 
     return () => {
-      context.removeRadioItem(name);
+      listContext.removeRadioItem(name);
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/packages/experimental/Menu/src/MenuItemRadio/useMenuItemRadio.ts
+++ b/packages/experimental/Menu/src/MenuItemRadio/useMenuItemRadio.ts
@@ -6,20 +6,24 @@ import { useMenuCheckboxInteraction } from '../MenuItemCheckbox/useMenuItemCheck
 import { useMenuContext } from '../context/menuContext';
 
 export const useMenuItemRadio = (props: MenuItemCheckboxProps): MenuItemCheckboxState => {
-  const { disabled, name } = props;
+  const { disabled, name, persistOnClick } = props;
   const context = useMenuContext();
   const listContext = useMenuListContext();
   const selectRadio = listContext.selectRadio;
   const setOpen = context.setOpen;
+  let shouldPersist = context.persistOnItemClick;
+  shouldPersist = persistOnClick ?? shouldPersist;
 
   const toggleChecked = React.useCallback(
     (e: InteractionEvent) => {
       if (!disabled) {
         selectRadio(e, name);
-        setOpen(e, false /*isOpen*/, true /*bubble*/);
+        if (!shouldPersist) {
+          setOpen(e, false /*isOpen*/, true /*bubble*/);
+        }
       }
     },
-    [disabled, name, selectRadio, setOpen],
+    [disabled, name, selectRadio, setOpen, shouldPersist],
   );
 
   // Explicitly only run on mount and unmount


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This brings the Menu API in better alignment with v9 FLuentUI
This also adds dismiss behavior for radio selection, which I removed from a different PR since a partner is looking for persist behavior for radio selection, and that wouldn't work without this prop.

### Verification

Tested via tester.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
