### PR TITLE
Apple Nuget Pipeline fix

### DIFF
--- a/.ado/azure-pipelines.yml
+++ b/.ado/azure-pipelines.yml
@@ -170,12 +170,12 @@ jobs:
         displayName: 'testing links'
   # Uncomment this job to test changes to the NuGet package
   # We keep it commented out by default because this job is much longer than the other PR jobs
-  # - job: NuGetPublish
-  #   displayName: NuGet Publish
-  #   pool:
-  #     vmImage: 'internal-macos12'
-  #     demands: ['xcode', 'sh', 'npm']
-  #   timeoutInMinutes: 90 # how long to run the job before automatically cancelling
-  #   cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
-  #   steps:
-  #     - template: templates/apple-nuget-publish.yml
+  - job: NuGetPublish
+    displayName: NuGet Publish
+    pool:
+      vmImage: 'internal-macos12'
+      demands: ['xcode', 'sh', 'npm']
+    timeoutInMinutes: 90 # how long to run the job before automatically cancelling
+    cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
+    steps:
+      - template: templates/apple-nuget-publish.yml

--- a/.ado/templates/apple-nuget-publish.yml
+++ b/.ado/templates/apple-nuget-publish.yml
@@ -42,7 +42,7 @@ steps:
       xcode_sdk: 'macosx'
       xcode_workspacePath: 'apps/macos/src/FluentTester.xcworkspace'
       xcode_actions: 'build'
-      xcode_scheme: 'FluentTester'
+      xcode_scheme: 'FluentTester-macos'
       xcode_configuration: 'Release'
       xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/publish_overrides.xcconfig'
 
@@ -52,7 +52,7 @@ steps:
       xcode_sdk: 'iphonesimulator'
       xcode_workspacePath: 'apps/ios/src/FluentTester.xcworkspace'
       xcode_actions: 'build'
-      xcode_scheme: 'FluentTester'
+      xcode_scheme: 'FluentTester-ios'
       xcode_configuration: 'Release'
       xcode_extraArgs: ''
 
@@ -62,7 +62,7 @@ steps:
       xcode_sdk: 'iphoneos'
       xcode_workspacePath: 'apps/ios/src/FluentTester.xcworkspace'
       xcode_actions: 'build'
-      xcode_scheme: 'FluentTester'
+      xcode_scheme: 'FluentTester-ios'
       xcode_configuration: 'Release'
       xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/publish_overrides_ios_device.xcconfig'
 
@@ -99,4 +99,3 @@ steps:
       command: push
       packagesToPush: '$(Build.ArtifactStagingDirectory)/Microsoft.FluentUI.ReactNative.*.nupkg'
       publishVstsFeed: Office
-


### PR DESCRIPTION
Testing CI, don't merge yet

#1786 broke the nuget publish pipeline. This should fix it. I'm first running a test of the CI job in PR to make sure things do build.