### PR TITLE
Fix various arrowing behaviors for closing menus

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/Menu/MenuTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Menu/MenuTest.tsx
@@ -119,8 +119,8 @@ const Submenu: React.FunctionComponent = () => {
       </MenuTrigger>
       <MenuPopover>
         <MenuList>
+          <MenuItemCheckbox name={'a'}>A nested MenuItemCheckbox</MenuItemCheckbox>
           <MenuItem>A nested MenuItem</MenuItem>
-          <MenuItem>A second nested MenuItem</MenuItem>
           <Submenu />
         </MenuList>
       </MenuPopover>

--- a/change/@fluentui-react-native-menu-1ecf27ef-0190-4927-b0a9-5e6de8ec7806.json
+++ b/change/@fluentui-react-native-menu-1ecf27ef-0190-4927-b0a9-5e6de8ec7806.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix arrow close not working",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-96e03ad1-b18d-4da5-a9cf-7c53d38490dc.json
+++ b/change/@fluentui-react-native-tester-96e03ad1-b18d-4da5-a9cf-7c53d38490dc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Modify a test",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Menu/src/MenuItem/useMenuItem.ts
+++ b/packages/experimental/Menu/src/MenuItem/useMenuItem.ts
@@ -13,8 +13,8 @@ import { useMenuContext } from '../context/menuContext';
 import { useMenuListContext } from '../context/menuListContext';
 import { useMenuTriggerContext } from '../context/menuTriggerContext';
 
-const triggerKeys = [' ', 'Enter'];
-const submenuTriggerKeys = [...triggerKeys, 'ArrowLeft', 'ArrowRight'];
+export const triggerKeys = [' ', 'Enter'];
+export const submenuTriggerKeys = [...triggerKeys, 'ArrowLeft', 'ArrowRight'];
 
 export const useMenuItem = (props: MenuItemProps): MenuItemState => {
   // attach the pressable state handlers
@@ -29,10 +29,6 @@ export const useMenuItem = (props: MenuItemProps): MenuItemState => {
 
   const onInvoke = React.useCallback(
     (e: InteractionEvent) => {
-      if (disabled) {
-        return;
-      }
-
       const isRtl = I18nManager.isRTL;
       if (
         isKeyPressEvent(e) &&
@@ -49,13 +45,16 @@ export const useMenuItem = (props: MenuItemProps): MenuItemState => {
         return;
       }
 
-      onClick?.(e);
-      if (!hasSubmenu) {
-        const isArrowClose =
-          isKeyPressEvent(e) &&
-          isInSubmenu &&
-          ((isRtl && e.nativeEvent.key === 'ArrowRight') || (!isRtl && e.nativeEvent.key === 'ArrowLeft'));
+      const isArrowClose =
+        isKeyPressEvent(e) &&
+        isInSubmenu &&
+        ((isRtl && e.nativeEvent.key === 'ArrowRight') || (!isRtl && e.nativeEvent.key === 'ArrowLeft'));
 
+      if (!disabled && !isArrowClose) {
+        onClick?.(e);
+      }
+
+      if (!hasSubmenu) {
         setOpen(e, false /*isOpen*/, !isArrowClose /*bubble*/);
       }
     },

--- a/packages/experimental/Menu/src/MenuItem/useMenuItem.ts
+++ b/packages/experimental/Menu/src/MenuItem/useMenuItem.ts
@@ -30,31 +30,22 @@ export const useMenuItem = (props: MenuItemProps): MenuItemState => {
   const onInvoke = React.useCallback(
     (e: InteractionEvent) => {
       const isRtl = I18nManager.isRTL;
-      if (
-        isKeyPressEvent(e) &&
-        hasSubmenu &&
-        ((isRtl && e.nativeEvent.key === 'ArrowRight') || (!isRtl && e.nativeEvent.key === 'ArrowLeft'))
-      ) {
-        return;
-      }
-      if (
-        isKeyPressEvent(e) &&
-        isInSubmenu &&
-        ((isRtl && e.nativeEvent.key === 'ArrowLeft') || (!isRtl && e.nativeEvent.key === 'ArrowRight'))
-      ) {
-        return;
-      }
 
-      const isArrowClose =
+      const isArrowKey = isKeyPressEvent(e) && (e.nativeEvent.key === 'ArrowLeft' || e.nativeEvent.key === 'ArrowRight');
+      const isArrowOpen =
+        hasSubmenu &&
         isKeyPressEvent(e) &&
+        ((isRtl && e.nativeEvent.key === 'ArrowLeft') || (!isRtl && e.nativeEvent.key === 'ArrowRight'));
+      const isArrowClose =
         isInSubmenu &&
+        isKeyPressEvent(e) &&
         ((isRtl && e.nativeEvent.key === 'ArrowRight') || (!isRtl && e.nativeEvent.key === 'ArrowLeft'));
 
-      if (!disabled && !isArrowClose) {
+      if (!disabled && (!isArrowKey || isArrowOpen)) {
         onClick?.(e);
       }
 
-      if (!hasSubmenu) {
+      if (!isArrowKey || isArrowClose) {
         setOpen(e, false /*isOpen*/, !isArrowClose /*bubble*/);
       }
     },

--- a/packages/experimental/Menu/src/MenuItemCheckbox/useMenuItemCheckbox.ts
+++ b/packages/experimental/Menu/src/MenuItemCheckbox/useMenuItemCheckbox.ts
@@ -65,12 +65,11 @@ export const useMenuCheckboxInteraction = (
     onAccessibilityAction,
     ...rest
   } = props;
-  const context = useMenuContext();
-  const isSubmenu = context.isSubmenu;
-  const setOpen = context.setOpen;
 
-  const listContext = useMenuListContext();
-  const checked = listContext.checked?.[name];
+  const isSubmenu = useMenuContext().isSubmenu;
+
+  const { checked, onArrowClose } = useMenuListContext();
+  const isChecked = checked?.[name];
 
   // Ensure focus is placed on checkbox after click
   const toggleCheckedWithFocus = useOnPressWithFocus(componentRef, toggleCallback);
@@ -88,14 +87,14 @@ export const useMenuCheckboxInteraction = (
 
       const isRtl = I18nManager.isRTL;
       const isArrowClose = isSubmenu && ((isRtl && e.nativeEvent.key === 'ArrowRight') || (!isRtl && e.nativeEvent.key === 'ArrowLeft'));
-      console.log(e.nativeEvent.key);
 
       if (isArrowClose) {
-        setOpen(e, false /*isOpen*/, false /*bubble*/);
+        onArrowClose?.(e);
       }
     },
-    [disabled, isSubmenu, toggleCallback, setOpen],
+    [disabled, isSubmenu, onArrowClose, toggleCallback],
   );
+
   const keys = isSubmenu ? submenuTriggerKeys : triggerKeys;
   const onKeyProps = useKeyDownProps(onKeysPressed, ...keys);
 
@@ -119,7 +118,7 @@ export const useMenuCheckboxInteraction = (
   const state = {
     ...pressable.state,
     disabled: !!props.disabled,
-    checked: checked,
+    checked: isChecked,
   };
 
   return {

--- a/packages/experimental/Menu/src/MenuList/MenuList.types.ts
+++ b/packages/experimental/Menu/src/MenuList/MenuList.types.ts
@@ -40,6 +40,7 @@ export interface MenuListState extends Omit<MenuListProps, 'checked' | 'onChecke
   props: MenuListProps;
   checked?: Record<string, boolean>;
   isCheckedControlled: boolean;
+  onArrowClose?: (e: InteractionEvent) => void;
   onCheckedChange?: (e: InteractionEvent, name: string, isChecked: boolean) => void;
   selectRadio?: (e: InteractionEvent, name: string) => void;
   addRadioItem: (name: string) => void;

--- a/packages/experimental/Menu/src/MenuList/useMenuList.ts
+++ b/packages/experimental/Menu/src/MenuList/useMenuList.ts
@@ -20,7 +20,7 @@ export const useMenuList = (_props: MenuListProps): MenuListState => {
 
   // MenuList v2 needs to be able to be standalone, but this is not in scope for v1
   // Assuming that checked information will come from parent Menu
-  const { defaultChecked, onCheckedChange: onCheckedChangeOriginal, checked: checkedOriginal } = context;
+  const { defaultChecked, onCheckedChange: onCheckedChangeOriginal, checked: checkedOriginal, isSubmenu, setOpen } = context;
 
   // Convert passed in array to map so that i's easier to look up checked state
   const checkedMap = React.useMemo(() => {
@@ -93,12 +93,29 @@ export const useMenuList = (_props: MenuListProps): MenuListState => {
     [isCheckedControlled, onCheckedChangeOriginal, setCheckedInternal, checked],
   );
 
+  // The close arrow key must be handled at this level so that close arrow is responsive when arrowing
+  // on a submenu trigger inside a submenu. Otherwise the arrowing event gets "swallowed up" by the trigger,
+  // because it is considered to be inside the submenu due to the Menu component wrapping both the
+  // trigger and popover. Listening to key events directly here to handle this case doesn't work
+  // since left and right arrow key events are already handled and swallowed by native behavior
+  const onArrowClose = React.useCallback(
+    (e: InteractionEvent) => {
+      if (!isSubmenu) {
+        return;
+      }
+
+      setOpen(e, false /* isOpen */, false /* bubble */);
+    },
+    [isSubmenu, setOpen],
+  );
+
   return {
     props: {
       ...context,
     },
     isCheckedControlled,
     checked,
+    onArrowClose,
     onCheckedChange,
     selectRadio,
     addRadioItem,

--- a/packages/experimental/Menu/src/MenuTrigger/MenuTrigger.tsx
+++ b/packages/experimental/Menu/src/MenuTrigger/MenuTrigger.tsx
@@ -13,7 +13,7 @@ export const MenuTrigger = stagedComponent((_props: React.PropsWithChildren<Reco
 
     if (__DEV__) {
       if (childrenArray.length !== 1) {
-        console.log('Only expecting one child for MenuTrigger');
+        console.warn('Only expecting one child for MenuTrigger');
       }
     }
 

--- a/packages/experimental/Menu/src/context/menuListContext.ts
+++ b/packages/experimental/Menu/src/context/menuListContext.ts
@@ -13,6 +13,7 @@ export const MenuListContext = React.createContext<MenuListContextValue>({
   checked: {},
   hasCheckmarks: false,
   onCheckedChange: () => false,
+  onArrowClose: () => false,
   addRadioItem: () => false,
   removeRadioItem: () => false,
 });


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This change fixes three bugs around arrowing left (or right in RTL) to close a submenu:

1. Fixes bug where arrowing on disabled items wouldn't close the submenu (move disable check to just checking executing onClick)
2. Fixes bug where arrowing on checkbox/radio items wouldn't close the submenu (add arrowing behavior to checkbox/radio items
3. Fixes bug where arrowing on submenu triggers in submenus wouldn't close the submenu (handle closing the submenu at one level higher so that the event is outside of the submenu the trigger is responsible for. Comment added to explain case).

Web's solution (which is to handle arrow open on the MenuTrigger and arrow close on the MenuPopover) is more elegant here but 1. takes advantage of being able to query the HTML attribute of the source element of the event to look for disabled state of children (which we don't have access to on native) and 2. relies on arrowing events going up the UI tree, which we don't get because arrow events get handled natively if not handled first by shifting focus in a list. So we get this instead :)

### Verification

Tested with tester.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
