### PR TITLE
Fire warning that ContextualMenu is deprecated on win32

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/ContextualMenu/ContextualMenuTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ContextualMenu/ContextualMenuTest.tsx
@@ -508,7 +508,7 @@ const contextualMenuSections: TestSection[] = [
 
 export const ContextualMenuTest: React.FunctionComponent = () => {
   const status: PlatformStatus = {
-    win32Status: 'Experimental',
+    win32Status: 'Deprecated',
     uwpStatus: 'Backlog',
     iosStatus: 'Backlog',
     macosStatus: 'Backlog',

--- a/apps/fluent-tester/src/FluentTester/TestComponents/Test.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Test.tsx
@@ -10,7 +10,7 @@ export type TestSection = {
   component: React.FunctionComponent;
 };
 
-export type Status = 'Production' | 'Beta' | 'Experimental' | 'Backlog' | 'N/A';
+export type Status = 'Production' | 'Beta' | 'Experimental' | 'Backlog' | 'Deprecated' | 'N/A';
 export type PlatformStatus = {
   win32Status: Status;
   uwpStatus: Status;

--- a/change/@fluentui-react-native-contextual-menu-232e2759-6593-4188-8119-9fc179166b55.json
+++ b/change/@fluentui-react-native-contextual-menu-232e2759-6593-4188-8119-9fc179166b55.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add warning that ContextualMenu is deprecated if loaded on win32.",
+  "packageName": "@fluentui-react-native/contextual-menu",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-32381617-7aed-471e-a226-908456645765.json
+++ b/change/@fluentui-react-native-tester-32381617-7aed-471e-a226-908456645765.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add warning that ContextualMenu is deprecated if loaded on win32.",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/ContextualMenu/src/ContextualMenu.tsx
+++ b/packages/components/ContextualMenu/src/ContextualMenu.tsx
@@ -19,6 +19,10 @@ import { Callout } from '@fluentui-react-native/callout';
 import { ISlots, withSlots } from '@uifabricshared/foundation-composable';
 import { FocusZone } from '@fluentui-react-native/focus-zone';
 
+if (__DEV__ && Platform.OS === ('win32' as any)) {
+  console.warn('The ContextualMenu is deprecated on win32. Please use Menu from @fluentui-react-native/menu instead.');
+}
+
 export const CMContext = React.createContext<ContextualMenuContext>({
   selectedKey: null,
   onItemClick: (/* key: string */) => {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Added a warning that will fire if the ContextualMenu file is loaded in win32. Decided on this approach over adding deprecate function headers since the component is still used on macOS.

### Verification

Warning shows up in console logs.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
