### PR TITLE
Update deprecation messages for Checkbox

### DIFF
--- a/change/@fluentui-react-native-checkbox-ae8278ab-24e4-405c-95ee-d9bd8b108391.json
+++ b/change/@fluentui-react-native-checkbox-ae8278ab-24e4-405c-95ee-d9bd8b108391.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add deprecation message",
+  "packageName": "@fluentui-react-native/checkbox",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-checkbox-e9986486-1ad8-44ad-a787-b65e16501972.json
+++ b/change/@fluentui-react-native-experimental-checkbox-e9986486-1ad8-44ad-a787-b65e16501972.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add deprecation message",
+  "packageName": "@fluentui-react-native/experimental-checkbox",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Checkbox/src/deprecated/Checkbox.tsx
+++ b/packages/components/Checkbox/src/deprecated/Checkbox.tsx
@@ -1,6 +1,6 @@
 /** @jsx withSlots */
 import * as React from 'react';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 import { Text } from '@fluentui-react-native/text';
 import { ICheckboxState, ICheckboxProps, ICheckboxSlotProps, ICheckboxRenderData, ICheckboxType, checkboxName } from './Checkbox.types';
 import { compose, IUseComposeStyling } from '@uifabricshared/foundation-compose';
@@ -19,10 +19,10 @@ import {
 import { backgroundColorTokens } from '@fluentui-react-native/tokens';
 import { IPressableProps } from '@fluentui-react-native/pressable';
 
-/**
- * @deprecated This will be removed when the package moves to 1.0.0.
- * Please see MIGRATION.md for details on how to move to the new Checkbox.
- */
+if (__DEV__ && Platform.OS === ('win32' as any)) {
+  console.warn('This version of the component is deprecated for win32. Please use CheckboxV1 from @fluentui-react-native/checkbox.');
+}
+
 export const Checkbox = compose<ICheckboxType>({
   displayName: checkboxName,
 

--- a/packages/components/Checkbox/src/deprecated/Checkbox.types.ts
+++ b/packages/components/Checkbox/src/deprecated/Checkbox.types.ts
@@ -7,16 +7,8 @@ import { FontTokens, IForegroundColorTokens, IBackgroundColorTokens, IBorderToke
 import type { IViewProps } from '@fluentui-react-native/adapters';
 import { ColorValue } from 'react-native';
 
-/**
- * @deprecated This will be removed when the package moves to 1.0.0.
- * Please see MIGRATION.md for details on how to move to the new Checkbox.
- */
 export const checkboxName = 'Checkbox';
 
-/**
- * @deprecated This will be removed when the package moves to 1.0.0.
- * Please see MIGRATION.md for details on how to move to the new Checkbox.
- */
 export interface ICheckboxState extends IPressableState {
   /**
    * Whether the Checkbox is checked or not
@@ -34,10 +26,6 @@ export interface ICheckboxState extends IPressableState {
   boxAtEnd?: boolean;
 }
 
-/**
- * @deprecated This will be removed when the package moves to 1.0.0.
- * Please see MIGRATION.md for details on how to move to the new Checkbox.
- */
 export interface ICheckboxProps extends Omit<IViewProps, 'onPress'> {
   /**
    * An string for screen readers to read. If not provided, this will be set to the Checkbox label
@@ -90,10 +78,6 @@ export interface ICheckboxProps extends Omit<IViewProps, 'onPress'> {
   tooltip?: string;
 }
 
-/**
- * @deprecated This will be removed when the package moves to 1.0.0.
- * Please see MIGRATION.md for details on how to move to the new Checkbox.
- */
 export interface ICheckboxTokens extends FontTokens, IForegroundColorTokens, IBackgroundColorTokens, IBorderTokens {
   checkboxBackgroundColor?: ColorValue;
   checkboxBorderColor?: ColorValue;
@@ -102,10 +86,6 @@ export interface ICheckboxTokens extends FontTokens, IForegroundColorTokens, IBa
   textBorderColor?: ColorValue;
 }
 
-/**
- * @deprecated This will be removed when the package moves to 1.0.0.
- * Please see MIGRATION.md for details on how to move to the new Checkbox.
- */
 export interface ICheckboxSlotProps {
   root: React.PropsWithRef<IViewProps>;
   checkbox: IViewProps;
@@ -113,16 +93,8 @@ export interface ICheckboxSlotProps {
   content: ITextProps;
 }
 
-/**
- * @deprecated This will be removed when the package moves to 1.0.0.
- * Please see MIGRATION.md for details on how to move to the new Checkbox.
- */
 export type ICheckboxRenderData = IRenderData<ICheckboxSlotProps, ICheckboxState>;
 
-/**
- * @deprecated This will be removed when the package moves to 1.0.0.
- * Please see MIGRATION.md for details on how to move to the new Checkbox.
- */
 export interface ICheckboxType {
   props: ICheckboxProps;
   tokens: ICheckboxTokens;

--- a/packages/experimental/Checkbox/src/Checkbox.tsx
+++ b/packages/experimental/Checkbox/src/Checkbox.tsx
@@ -3,7 +3,7 @@ import { CheckboxV1 } from '@fluentui-react-native/checkbox';
 
 if (__DEV__) {
   console.warn(
-    'The @fluentui-react-native/exprimental-checkbox package is deprecated for win32. The contents of this package have been moved to @fluentui-react-native/checkbox. If you need to use the Button component from this package, please use CheckboxV1 from @fluentui-react-native/checkbox.',
+    'The @fluentui-react-native/exprimental-checkbox package is deprecated. The contents of this package have been moved to @fluentui-react-native/checkbox. If you need to use the Checkbox component from this package, please use CheckboxV1 from @fluentui-react-native/checkbox.',
   );
 }
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Since the old checkbox is still viable on other platforms like macOS I decided to change from the deprecation comment header to firing a warning if the Platform is win32.

### Verification

Warning shows in console.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
