### PR TITLE
Add optional title

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/Notification/NotificationTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Notification/NotificationTest.tsx
@@ -16,6 +16,21 @@ const PrimaryTest: React.FunctionComponent = () => {
   );
 };
 
+const PrimaryTestWithTitle: React.FunctionComponent = () => {
+  return (
+    <Notification
+      variant={'primary'}
+      title="Kat's iPhone X"
+      action="X"
+      onPress={() => {
+        console.log('Notification tapped');
+      }}
+    >
+      Listen to Emails • 7 mins
+    </Notification>
+  );
+};
+
 const NeutralTest: React.FunctionComponent = () => {
   return (
     <Notification
@@ -62,6 +77,10 @@ const notificationSections: TestSection[] = [
   {
     name: 'Primary',
     component: PrimaryTest,
+  },
+  {
+    name: 'Primary With Title',
+    component: PrimaryTestWithTitle,
   },
   {
     name: 'Neutral',

--- a/change/@fluentui-react-native-notification-752c47a1-3fef-4e15-af65-805675a665c7.json
+++ b/change/@fluentui-react-native-notification-752c47a1-3fef-4e15-af65-805675a665c7.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "added optional title",
+  "packageName": "@fluentui-react-native/notification",
+  "email": "joannaquu@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-c165e6c2-eea1-45ac-add6-14c71e5f8ba8.json
+++ b/change/@fluentui-react-native-tester-c165e6c2-eea1-45ac-add6-14c71e5f8ba8.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "added letter spacing",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "joannaquu@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tokens-a691fdc9-d637-46cc-ba99-52d72fd43c31.json
+++ b/change/@fluentui-react-native-tokens-a691fdc9-d637-46cc-ba99-52d72fd43c31.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "added letter spacing",
+  "packageName": "@fluentui-react-native/tokens",
+  "email": "joannaquu@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Notification/package.json
+++ b/packages/components/Notification/package.json
@@ -26,6 +26,7 @@
     "directory": "packages/components/Notification"
   },
   "dependencies": {
+    "@fluentui-react-native/adapters": "^0.8.5",
     "@fluentui-react-native/button": ">=0.22.29 <1.0.0",
     "@fluentui-react-native/experimental-text": ">=0.9.0 <1.0.0",
     "@fluentui-react-native/framework": "0.7.30",

--- a/packages/components/Notification/src/Notification.styling.ts
+++ b/packages/components/Notification/src/Notification.styling.ts
@@ -2,6 +2,7 @@ import { notification, NotificationTokens, NotificationSlotProps, NotificationPr
 import { Theme, UseStylingOptions, buildProps } from '@fluentui-react-native/framework';
 import { borderStyles, layoutStyles } from '@fluentui-react-native/tokens';
 import { defaultNotificationTokens } from './NotificationTokens';
+import { TextStyle } from 'react-native';
 
 export const notificationStates: (keyof NotificationTokens)[] = [
   'primary',
@@ -72,7 +73,7 @@ export const stylingSettings: UseStylingOptions<NotificationProps, NotificationS
         };
       },
       ['color'],
-    ),
+    ) as TextStyle,
     action: buildProps(
       (tokens: NotificationTokens) => {
         return {

--- a/packages/components/Notification/src/Notification.styling.ts
+++ b/packages/components/Notification/src/Notification.styling.ts
@@ -65,7 +65,7 @@ export const stylingSettings: UseStylingOptions<NotificationProps, NotificationS
             fontSize: tokens.fontSize,
             fontWeight: tokens.fontWeight,
             lineHeight: tokens.fontLineHeight,
-            // letterSpacing: -0.08,
+            letterSpacing: tokens.fontLetterSpacing,
             flex: 1,
             flexGrow: 1,
           },

--- a/packages/components/Notification/src/Notification.styling.ts
+++ b/packages/components/Notification/src/Notification.styling.ts
@@ -34,7 +34,7 @@ export const stylingSettings: UseStylingOptions<NotificationProps, NotificationS
       }),
       ['backgroundColor', ...borderStyles.keys, ...layoutStyles.keys],
     ),
-    inner: buildProps(() => {
+    contentContainer: buildProps(() => {
       return {
         style: {
           flex: 1,
@@ -72,7 +72,7 @@ export const stylingSettings: UseStylingOptions<NotificationProps, NotificationS
           },
         };
       },
-      ['color'],
+      ['color', 'fontSize', 'fontWeight', 'fontLineHeight', 'fontLetterSpacing'],
     ) as TextStyle,
     action: buildProps(
       (tokens: NotificationTokens) => {

--- a/packages/components/Notification/src/Notification.styling.ts
+++ b/packages/components/Notification/src/Notification.styling.ts
@@ -27,7 +27,6 @@ export const stylingSettings: UseStylingOptions<NotificationProps, NotificationS
           flex: 1,
           flexDirection: 'row',
           justifyContent: 'space-between',
-          alignItems: 'center',
           ...borderStyles.from(tokens, theme),
           ...layoutStyles.from(tokens, theme),
         },
@@ -63,10 +62,10 @@ export const stylingSettings: UseStylingOptions<NotificationProps, NotificationS
         return {
           style: {
             color: tokens.color,
-            fontSize: 13,
-            fontWeight: '400',
-            lineHeight: 18,
-            letterSpacing: -0.08,
+            fontSize: tokens.fontSize,
+            fontWeight: tokens.fontWeight,
+            lineHeight: tokens.fontLineHeight,
+            // letterSpacing: -0.08,
             flex: 1,
             flexGrow: 1,
           },

--- a/packages/components/Notification/src/Notification.styling.ts
+++ b/packages/components/Notification/src/Notification.styling.ts
@@ -11,6 +11,7 @@ export const notificationStates: (keyof NotificationTokens)[] = [
   'neutralBar',
   'danger',
   'warning',
+  'hasTitle',
 ];
 
 export const stylingSettings: UseStylingOptions<NotificationProps, NotificationSlotProps, NotificationTokens> = {
@@ -33,7 +34,15 @@ export const stylingSettings: UseStylingOptions<NotificationProps, NotificationS
       }),
       ['backgroundColor', ...borderStyles.keys, ...layoutStyles.keys],
     ),
-    message: buildProps(
+    inner: buildProps(() => {
+      return {
+        style: {
+          flex: 1,
+          flexDirection: 'column',
+        },
+      };
+    }),
+    title: buildProps(
       (tokens: NotificationTokens) => {
         return {
           style: {
@@ -42,6 +51,22 @@ export const stylingSettings: UseStylingOptions<NotificationProps, NotificationS
             fontWeight: '600',
             lineHeight: 20,
             letterSpacing: -0.24,
+            flex: 1,
+            flexGrow: 1,
+          },
+        };
+      },
+      ['color'],
+    ),
+    message: buildProps(
+      (tokens: NotificationTokens) => {
+        return {
+          style: {
+            color: tokens.color,
+            fontSize: 13,
+            fontWeight: '400',
+            lineHeight: 18,
+            letterSpacing: -0.08,
             flex: 1,
             flexGrow: 1,
           },

--- a/packages/components/Notification/src/Notification.styling.ts
+++ b/packages/components/Notification/src/Notification.styling.ts
@@ -1,8 +1,7 @@
 import { notification, NotificationTokens, NotificationSlotProps, NotificationProps } from './Notification.types';
 import { Theme, UseStylingOptions, buildProps } from '@fluentui-react-native/framework';
-import { borderStyles, layoutStyles } from '@fluentui-react-native/tokens';
+import { borderStyles, fontStyles, layoutStyles } from '@fluentui-react-native/tokens';
 import { defaultNotificationTokens } from './NotificationTokens';
-import { TextStyle } from 'react-native';
 
 export const notificationStates: (keyof NotificationTokens)[] = [
   'primary',
@@ -59,21 +58,18 @@ export const stylingSettings: UseStylingOptions<NotificationProps, NotificationS
       ['color'],
     ),
     message: buildProps(
-      (tokens: NotificationTokens) => {
+      (tokens: NotificationTokens, theme: Theme) => {
         return {
           style: {
             color: tokens.color,
-            fontSize: tokens.fontSize,
-            fontWeight: tokens.fontWeight,
-            lineHeight: tokens.fontLineHeight,
-            letterSpacing: tokens.fontLetterSpacing,
             flex: 1,
             flexGrow: 1,
+            ...fontStyles.from(tokens, theme),
           },
         };
       },
-      ['color', 'fontSize', 'fontWeight', 'fontLineHeight', 'fontLetterSpacing'],
-    ) as TextStyle,
+      ['color', ...fontStyles.keys],
+    ),
     action: buildProps(
       (tokens: NotificationTokens) => {
         return {

--- a/packages/components/Notification/src/Notification.tsx
+++ b/packages/components/Notification/src/Notification.tsx
@@ -1,6 +1,7 @@
 /** @jsx withSlots */
 import { notification, NotificationType, NotificationProps } from './Notification.types';
 import { Pressable } from '@fluentui-react-native/pressable';
+import { View } from 'react-native';
 import { Text } from '@fluentui-react-native/experimental-text';
 import { ButtonV1 as Button } from '@fluentui-react-native/button';
 import { stylingSettings } from './Notification.styling';
@@ -14,7 +15,7 @@ import { compose, mergeProps, withSlots, UseSlots } from '@fluentui-react-native
  * @returns Whether the styles that are assigned to the layer should be applied to the Notification
  */
 export const notificationLookup = (layer: string, userProps: NotificationProps): boolean => {
-  return userProps['variant'] === layer;
+  return userProps['variant'] === layer || (layer === 'hasTitle' && userProps.title != undefined);
 };
 
 export const Notification = compose<NotificationType>({
@@ -22,6 +23,8 @@ export const Notification = compose<NotificationType>({
   ...stylingSettings,
   slots: {
     root: Pressable,
+    inner: View,
+    title: Text,
     message: Text,
     action: Button,
   },
@@ -29,11 +32,14 @@ export const Notification = compose<NotificationType>({
     const Slots = useSlots(userProps, (layer) => notificationLookup(layer, userProps));
 
     return (final: NotificationProps, ...children: React.ReactNode[]) => {
-      const { variant, action, ...mergedProps } = mergeProps(userProps, final);
+      const { variant, title, action, ...mergedProps } = mergeProps(userProps, final);
 
       return (
         <Slots.root {...mergedProps}>
-          <Slots.message>{children}</Slots.message>
+          <Slots.inner>
+            {title && <Slots.title>{title}</Slots.title>}
+            <Slots.message>{children}</Slots.message>
+          </Slots.inner>
           {action && <Slots.action>{action}</Slots.action>}
         </Slots.root>
       );

--- a/packages/components/Notification/src/Notification.tsx
+++ b/packages/components/Notification/src/Notification.tsx
@@ -15,7 +15,7 @@ import { compose, mergeProps, withSlots, UseSlots } from '@fluentui-react-native
  * @returns Whether the styles that are assigned to the layer should be applied to the Notification
  */
 export const notificationLookup = (layer: string, userProps: NotificationProps): boolean => {
-  return userProps['variant'] === layer || (layer === 'hasTitle' && userProps.title != undefined);
+  return userProps.variant === layer || (layer === 'hasTitle' && userProps.title != undefined);
 };
 
 export const Notification = compose<NotificationType>({

--- a/packages/components/Notification/src/Notification.tsx
+++ b/packages/components/Notification/src/Notification.tsx
@@ -15,7 +15,7 @@ import { compose, mergeProps, withSlots, UseSlots } from '@fluentui-react-native
  * @returns Whether the styles that are assigned to the layer should be applied to the Notification
  */
 export const notificationLookup = (layer: string, userProps: NotificationProps): boolean => {
-  return userProps.variant === layer || (layer === 'hasTitle' && userProps.title != undefined);
+  return layer === userProps.variant || (layer === 'hasTitle' && userProps.title != undefined);
 };
 
 export const Notification = compose<NotificationType>({

--- a/packages/components/Notification/src/Notification.tsx
+++ b/packages/components/Notification/src/Notification.tsx
@@ -23,7 +23,7 @@ export const Notification = compose<NotificationType>({
   ...stylingSettings,
   slots: {
     root: Pressable,
-    inner: View,
+    contentContainer: View,
     title: Text,
     message: Text,
     action: Button,
@@ -36,10 +36,10 @@ export const Notification = compose<NotificationType>({
 
       return (
         <Slots.root {...mergedProps}>
-          <Slots.inner>
+          <Slots.contentContainer>
             {title && <Slots.title>{title}</Slots.title>}
             <Slots.message>{children}</Slots.message>
-          </Slots.inner>
+          </Slots.contentContainer>
           {action && <Slots.action>{action}</Slots.action>}
         </Slots.root>
       );

--- a/packages/components/Notification/src/Notification.types.ts
+++ b/packages/components/Notification/src/Notification.types.ts
@@ -1,5 +1,5 @@
-import { PressableProps, ViewProps } from 'react-native';
-import { TextProps } from '@fluentui-react-native/experimental-text';
+import { PressableProps } from 'react-native';
+import { IViewProps, ITextProps } from '@fluentui-react-native/adapters';
 import { ButtonProps } from '@fluentui-react-native/button';
 import { FontTokens, IBorderTokens, IColorTokens, LayoutTokens } from '@fluentui-react-native/tokens';
 import { InteractionEvent } from '@fluentui-react-native/interactive-hooks';
@@ -31,9 +31,9 @@ export interface NotificationProps {
 
 export interface NotificationSlotProps {
   root: PressableProps;
-  inner: ViewProps;
-  title: TextProps;
-  message: TextProps;
+  contentContainer: IViewProps;
+  title: ITextProps;
+  message: ITextProps;
   action?: ButtonProps;
 }
 

--- a/packages/components/Notification/src/Notification.types.ts
+++ b/packages/components/Notification/src/Notification.types.ts
@@ -1,4 +1,4 @@
-import { PressableProps } from 'react-native';
+import { PressableProps, ViewProps } from 'react-native';
 import { TextProps } from '@fluentui-react-native/experimental-text';
 import { ButtonProps } from '@fluentui-react-native/button';
 import { IBorderTokens, IColorTokens, LayoutTokens } from '@fluentui-react-native/tokens';
@@ -16,6 +16,7 @@ export interface NotificationTokens extends LayoutTokens, IBorderTokens, IColorT
   neutralBar: NotificationTokens;
   danger: NotificationTokens;
   warning: NotificationTokens;
+  hasTitle: NotificationTokens;
 }
 
 export interface NotificationProps {
@@ -23,12 +24,15 @@ export interface NotificationProps {
    * Notification variants: 'primary' | 'neutral' | 'primaryBar' | 'primaryOutlineBar' | 'neutralBar' | 'danger' | 'warning'
    */
   variant: NotificationVariant;
+  title?: string;
   action?: string;
   onPress?: (e: InteractionEvent) => void;
 }
 
 export interface NotificationSlotProps {
   root: PressableProps;
+  inner: ViewProps;
+  title: TextProps;
   message: TextProps;
   action?: ButtonProps;
 }

--- a/packages/components/Notification/src/Notification.types.ts
+++ b/packages/components/Notification/src/Notification.types.ts
@@ -1,14 +1,14 @@
 import { PressableProps, ViewProps } from 'react-native';
 import { TextProps } from '@fluentui-react-native/experimental-text';
 import { ButtonProps } from '@fluentui-react-native/button';
-import { IBorderTokens, IColorTokens, LayoutTokens } from '@fluentui-react-native/tokens';
+import { FontTokens, IBorderTokens, IColorTokens, LayoutTokens } from '@fluentui-react-native/tokens';
 import { InteractionEvent } from '@fluentui-react-native/interactive-hooks';
 
 export const notification = 'Notification';
 export const NotificationVariants = ['primary', 'neutral', 'primaryBar', 'primaryOutlineBar', 'neutralBar', 'danger', 'warning'] as const;
 export type NotificationVariant = typeof NotificationVariants[number];
 
-export interface NotificationTokens extends LayoutTokens, IBorderTokens, IColorTokens {
+export interface NotificationTokens extends LayoutTokens, IBorderTokens, IColorTokens, FontTokens {
   primary: NotificationTokens;
   neutral: NotificationTokens;
   primaryBar: NotificationTokens;

--- a/packages/components/Notification/src/NotificationTokens.ts
+++ b/packages/components/Notification/src/NotificationTokens.ts
@@ -9,7 +9,7 @@ export const defaultNotificationTokens: TokenSettings<NotificationTokens, Theme>
     fontSize: 15,
     fontWeight: '600',
     fontLineHeight: 20,
-    // letterSpacing: -0.24,
+    fontLetterSpacing: -0.24,
     borderColor: 'transparent',
     borderWidth: 1,
     padding: 16,
@@ -18,7 +18,7 @@ export const defaultNotificationTokens: TokenSettings<NotificationTokens, Theme>
       fontSize: 13,
       fontWeight: '400',
       fontLineHeight: 18,
-      // fontLetterSpacing: -0.08,
+      fontLetterSpacing: -0.08,
     },
     primary: {
       backgroundColor: '#EBF3FC',

--- a/packages/components/Notification/src/NotificationTokens.ts
+++ b/packages/components/Notification/src/NotificationTokens.ts
@@ -9,6 +9,9 @@ export const defaultNotificationTokens: TokenSettings<NotificationTokens, Theme>
     borderColor: 'transparent',
     borderWidth: 1,
     padding: 16,
+    hasTitle: {
+      paddingVertical: 12,
+    },
     primary: {
       backgroundColor: '#EBF3FC',
       color: '#0F6CBD',

--- a/packages/components/Notification/src/NotificationTokens.ts
+++ b/packages/components/Notification/src/NotificationTokens.ts
@@ -6,6 +6,7 @@ export const defaultNotificationTokens: TokenSettings<NotificationTokens, Theme>
   ({
     backgroundColor: t.colors.background,
     color: t.colors.brandForeground1,
+    fontFamily: 'primary',
     fontSize: 15,
     fontWeight: '600',
     fontLineHeight: 20,

--- a/packages/components/Notification/src/NotificationTokens.ts
+++ b/packages/components/Notification/src/NotificationTokens.ts
@@ -6,11 +6,19 @@ export const defaultNotificationTokens: TokenSettings<NotificationTokens, Theme>
   ({
     backgroundColor: t.colors.background,
     color: t.colors.brandForeground1,
+    fontSize: 15,
+    fontWeight: '600',
+    fontLineHeight: 20,
+    // letterSpacing: -0.24,
     borderColor: 'transparent',
     borderWidth: 1,
     padding: 16,
     hasTitle: {
       paddingVertical: 12,
+      fontSize: 13,
+      fontWeight: '400',
+      fontLineHeight: 18,
+      // fontLetterSpacing: -0.08,
     },
     primary: {
       backgroundColor: '#EBF3FC',

--- a/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
+++ b/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
@@ -14,7 +14,6 @@ exports[`Notification component tests Notification default 1`] = `
   onStartShouldSetResponder={[Function]}
   style={
     Object {
-      "alignItems": "center",
       "backgroundColor": "#EBF3FC",
       "borderColor": "transparent",
       "borderRadius": 12,
@@ -44,10 +43,9 @@ exports[`Notification component tests Notification default 1`] = `
           "flex": 1,
           "flexGrow": 1,
           "fontFamily": "Segoe UI",
-          "fontSize": 13,
-          "fontWeight": "400",
-          "letterSpacing": -0.08,
-          "lineHeight": 18,
+          "fontSize": 15,
+          "fontWeight": "600",
+          "lineHeight": 20,
           "margin": 0,
         }
       }

--- a/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
+++ b/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
@@ -45,8 +45,6 @@ exports[`Notification component tests Notification default 1`] = `
           "fontFamily": "Segoe UI",
           "fontSize": 15,
           "fontWeight": "600",
-          "letterSpacing": -0.24,
-          "lineHeight": 20,
           "margin": 0,
         }
       }

--- a/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
+++ b/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
@@ -45,6 +45,7 @@ exports[`Notification component tests Notification default 1`] = `
           "fontFamily": "Segoe UI",
           "fontSize": 15,
           "fontWeight": "600",
+          "letterSpacing": -0.24,
           "lineHeight": 20,
           "margin": 0,
         }

--- a/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
+++ b/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
@@ -27,25 +27,34 @@ exports[`Notification component tests Notification default 1`] = `
     }
   }
 >
-  <Text
-    ellipsizeMode="tail"
-    numberOfLines={0}
+  <View
     style={
       Object {
-        "color": "#0F6CBD",
         "flex": 1,
-        "flexGrow": 1,
-        "fontFamily": "Segoe UI",
-        "fontSize": 15,
-        "fontWeight": "600",
-        "letterSpacing": -0.24,
-        "lineHeight": 20,
-        "margin": 0,
+        "flexDirection": "column",
       }
     }
   >
-    Mail Archived
-  </Text>
+    <Text
+      ellipsizeMode="tail"
+      numberOfLines={0}
+      style={
+        Object {
+          "color": "#0F6CBD",
+          "flex": 1,
+          "flexGrow": 1,
+          "fontFamily": "Segoe UI",
+          "fontSize": 13,
+          "fontWeight": "400",
+          "letterSpacing": -0.08,
+          "lineHeight": 18,
+          "margin": 0,
+        }
+      }
+    >
+      Mail Archived
+    </Text>
+  </View>
   <View
     accessibilityLabel="Undo"
     accessibilityRole="button"

--- a/packages/utils/tokens/src/text-tokens.ts
+++ b/packages/utils/tokens/src/text-tokens.ts
@@ -13,6 +13,7 @@ export interface FontStyleTokens {
   fontSize?: keyof Typography['sizes'] | TextStyle['fontSize'];
   fontWeight?: keyof Typography['weights'] | TextStyle['fontWeight'];
   fontLineHeight?: TextStyle['lineHeight'];
+  fontLetterSpacing?: TextStyle['letterSpacing'];
 }
 
 export type FontTokens = FontStyleTokens & FontVariantTokens;


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Added support for an optional title. If no title is provided, the message body uses the title's style.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![6 - Button:Pressable](https://user-images.githubusercontent.com/55368679/177614192-85408387-59fe-4d68-96f0-c108674d83e2.png) | ![7 - Title](https://user-images.githubusercontent.com/55368679/177614221-33b278a0-e440-4653-bf81-c7b7944671b1.png) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
