### PR TITLE
Revert "Fire warning that ContextualMenu is deprecated on win32"

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/ContextualMenu/ContextualMenuTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/ContextualMenu/ContextualMenuTest.tsx
@@ -508,7 +508,7 @@ const contextualMenuSections: TestSection[] = [
 
 export const ContextualMenuTest: React.FunctionComponent = () => {
   const status: PlatformStatus = {
-    win32Status: 'Deprecated',
+    win32Status: 'Experimental',
     uwpStatus: 'Backlog',
     iosStatus: 'Backlog',
     macosStatus: 'Backlog',

--- a/apps/fluent-tester/src/FluentTester/TestComponents/Test.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Test.tsx
@@ -10,7 +10,7 @@ export type TestSection = {
   component: React.FunctionComponent;
 };
 
-export type Status = 'Production' | 'Beta' | 'Experimental' | 'Backlog' | 'Deprecated' | 'N/A';
+export type Status = 'Production' | 'Beta' | 'Experimental' | 'Backlog' | 'N/A';
 export type PlatformStatus = {
   win32Status: Status;
   uwpStatus: Status;

--- a/change/@fluentui-react-native-contextual-menu-05de9819-c982-4731-943f-eb2e6710fb06.json
+++ b/change/@fluentui-react-native-contextual-menu-05de9819-c982-4731-943f-eb2e6710fb06.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Revert \"Fire warning that ContextualMenu is deprecated on win32 (#1804)\"",
+  "packageName": "@fluentui-react-native/contextual-menu",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-14c1def2-083b-4e6f-b0c5-6fd33a6ee99d.json
+++ b/change/@fluentui-react-native-tester-14c1def2-083b-4e6f-b0c5-6fd33a6ee99d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Revert \"Fire warning that ContextualMenu is deprecated on win32 (#1804)\"",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/ContextualMenu/src/ContextualMenu.tsx
+++ b/packages/components/ContextualMenu/src/ContextualMenu.tsx
@@ -19,10 +19,6 @@ import { Callout } from '@fluentui-react-native/callout';
 import { ISlots, withSlots } from '@uifabricshared/foundation-composable';
 import { FocusZone } from '@fluentui-react-native/focus-zone';
 
-if (__DEV__ && Platform.OS === ('win32' as any)) {
-  console.warn('The ContextualMenu is deprecated on win32. Please use Menu from @fluentui-react-native/menu instead.');
-}
-
 export const CMContext = React.createContext<ContextualMenuContext>({
   selectedKey: null,
   onItemClick: (/* key: string */) => {


### PR DESCRIPTION
Reverts microsoft/fluentui-react-native#1804

This broke some tests downstream.