### PR TITLE
[Avatar] Fixed bug with text-scaling

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/Avatar/BasicAvatar.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Avatar/BasicAvatar.tsx
@@ -1,13 +1,13 @@
 import React, { useState, useCallback, FunctionComponent } from 'react';
 import { AvatarSize, AvatarSizes, AvatarColor, AvatarColors, Avatar, AvatarActive } from '@fluentui-react-native/avatar';
 import { PresenceBadgeStatuses, PresenceBadgeStatus } from '@fluentui-react-native/badge';
-import { Switch, View, Text, ColorValue, Platform } from 'react-native';
+import { View, Text, Platform } from 'react-native';
 import { satyaPhotoUrl, undefinedText } from './../PersonaCoin/styles';
 import { commonTestStyles as commonStyles } from '../Common/styles';
-import { useTheme } from '@fluentui-react-native/theme-types';
 import TestSvg from '../../test-data/test.svg';
 import { SvgIconProps } from '@fluentui-react-native/icon';
 import { StyledPicker } from '../Common/StyledPicker';
+import { ToggleButton } from '@fluentui/react-native';
 
 type WithUndefined<T> = T | typeof undefinedText;
 
@@ -31,9 +31,6 @@ export const StandardUsage: FunctionComponent = () => {
   const onSizeChange = useCallback((value) => setImageSize(value), []);
 
   const onPresenceChange = useCallback((value) => setPresence(value), []);
-
-  const theme = useTheme();
-  const textStyles = { color: theme.colors.inputText as ColorValue };
   const avatarSizesForPicker = allSizes.map((size) => size.toString());
 
   const activeAppearance = 'ring';
@@ -53,18 +50,15 @@ export const StandardUsage: FunctionComponent = () => {
   return (
     <View style={commonStyles.root}>
       <View style={commonStyles.settingsPicker}>
-        <View style={commonStyles.switch}>
-          <Text style={textStyles}>Show image</Text>
-          <Switch value={showImage} onValueChange={setShowImage} />
-        </View>
-        <View style={commonStyles.switch}>
-          <Text style={textStyles}>Set square Avatar</Text>
-          <Switch value={isSquare} onValueChange={() => setSquare(!isSquare)} />
-        </View>
-        <View style={commonStyles.switch}>
-          <Text style={textStyles}>Set outOfOffice</Text>
-          <Switch value={outOfOffice} onValueChange={() => setOutOfOffice(!outOfOffice)} />
-        </View>
+        <ToggleButton onClick={() => setShowImage(!showImage)} checked={showImage} style={commonStyles.vmargin}>
+          {showImage ? 'Hide' : 'Show'} image
+        </ToggleButton>
+        <ToggleButton onClick={() => setSquare(!isSquare)} checked={isSquare} style={commonStyles.vmargin}>
+          Set {isSquare ? ' circle' : ' square'} Avatar
+        </ToggleButton>
+        <ToggleButton onClick={() => setOutOfOffice(!outOfOffice)} checked={outOfOffice} style={commonStyles.vmargin}>
+          Set {outOfOffice ? ' In office' : ' Out of office'}
+        </ToggleButton>
 
         <StyledPicker prompt="Size" selected={imageSize.toString()} onChange={onSizeChange} collection={avatarSizesForPicker} />
         <StyledPicker prompt="Active" selected={active} onChange={onActiveChange} collection={avatarActive} />

--- a/apps/fluent-tester/src/FluentTester/TestComponents/Avatar/CustomizedAvatar.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Avatar/CustomizedAvatar.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useMemo } from 'react';
 import { Avatar, AvatarSize } from '@fluentui-react-native/avatar';
-import { Switch, View, Text, TextInput, Platform } from 'react-native';
+import { View, Text, TextInput, Platform } from 'react-native';
 import { steveBallmerPhotoUrl } from './../PersonaCoin/styles';
 import { commonTestStyles as commonStyles } from '../Common/styles';
 import { FontWeight } from '@fluentui-react-native/theme-types';
 import { SvgIconProps } from '@fluentui-react-native/icon';
 import TestSvg from '../../test-data/test.svg';
+import { ToggleButton } from '@fluentui/react-native';
 
 export const CustomizeUsage: React.FunctionComponent = () => {
   const [showImage, setShowImage] = useState(true);
@@ -64,19 +65,15 @@ export const CustomizeUsage: React.FunctionComponent = () => {
   return (
     <View style={commonStyles.root}>
       <View style={commonStyles.settings}>
-        <View style={commonStyles.switch}>
-          <Text>Show image</Text>
-          <Switch value={showImage} onValueChange={setShowImage} />
-        </View>
-        <View style={commonStyles.switch}>
-          <Text>Show initials</Text>
-          <Switch value={showInitials} onValueChange={setShowInitials} />
-        </View>
-
-        <View style={commonStyles.switch}>
-          <Text>Show rings</Text>
-          <Switch value={showRing} onValueChange={setShowRing} />
-        </View>
+        <ToggleButton onClick={() => setShowImage(!showImage)} checked={showImage} style={commonStyles.vmargin}>
+          {showImage ? 'Hide' : 'Show'} image
+        </ToggleButton>
+        <ToggleButton onClick={() => setShowInitials(!showInitials)} checked={showInitials} style={commonStyles.vmargin}>
+          {showInitials ? 'Hide' : 'Show'} initials
+        </ToggleButton>
+        <ToggleButton onClick={() => setShowRing(!showRing)} checked={showRing} style={commonStyles.vmargin}>
+          {showRing ? 'Hide' : 'Show'} ring
+        </ToggleButton>
         <View style={{ flexDirection: 'row' }}>
           <View>
             <TextInput

--- a/change/@fluentui-react-native-avatar-73bf7d2a-6667-4a91-9259-28dbd3d3b45b.json
+++ b/change/@fluentui-react-native-avatar-73bf7d2a-6667-4a91-9259-28dbd3d3b45b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed bug with text-scaling",
+  "packageName": "@fluentui-react-native/avatar",
+  "email": "v.kozova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-d1b8bc41-1d9c-4f7a-8dfd-1fefea5a3d0d.json
+++ b/change/@fluentui-react-native-tester-d1b8bc41-1d9c-4f7a-8dfd-1fefea5a3d0d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed tester with Toggle buttons",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "v.kozova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Avatar/src/Avatar.styling.ts
+++ b/packages/components/Avatar/src/Avatar.styling.ts
@@ -53,9 +53,10 @@ export const stylingSettings: UseStylingOptions<AvatarProps, AvatarSlotProps, Av
           style: {
             alignItems: 'center',
             justifyContent: 'center',
-            width: avatarSize,
-            height: avatarSize,
+            minWidth: avatarSize,
+            minHeight: avatarSize,
             opacity: avatarOpacity,
+            aspectRatio: 1,
           },
         };
       },
@@ -85,8 +86,8 @@ export const stylingSettings: UseStylingOptions<AvatarProps, AvatarSlotProps, Av
         return {
           style: {
             ...borderStyles.from(tokens, theme),
-            width: size,
-            height: size,
+            minWidth: size,
+            minHeight: size,
             justifyContent: 'center',
             alignItems: 'center',
             backgroundColor: _avatarColor,
@@ -106,8 +107,8 @@ export const stylingSettings: UseStylingOptions<AvatarProps, AvatarSlotProps, Av
         return {
           style: {
             borderRadius: borderRadius,
-            width: size,
-            height: size,
+            minWidth: size,
+            minHeight: size,
             borderWidth: borderWidth,
             borderColor: borderColor,
             marginTop: ringConfig.ringThickness,
@@ -142,8 +143,8 @@ export const stylingSettings: UseStylingOptions<AvatarProps, AvatarSlotProps, Av
         return {
           style: {
             borderStyle: 'solid',
-            width: ringConfig.size,
-            height: ringConfig.size,
+            minWidth: ringConfig.size,
+            minHeight: ringConfig.size,
             ...borderStyles.from(tokens, theme),
             borderWidth: ringConfig.ringThickness,
             backgroundColor: ringBackgroundColor || 'transparent',

--- a/packages/components/Avatar/src/Avatar.styling.ts
+++ b/packages/components/Avatar/src/Avatar.styling.ts
@@ -53,6 +53,8 @@ export const stylingSettings: UseStylingOptions<AvatarProps, AvatarSlotProps, Av
           style: {
             alignItems: 'center',
             justifyContent: 'center',
+            flexDirection: 'row',
+            alignSelf: 'flex-start',
             minWidth: avatarSize,
             minHeight: avatarSize,
             opacity: avatarOpacity,
@@ -95,6 +97,7 @@ export const stylingSettings: UseStylingOptions<AvatarProps, AvatarSlotProps, Av
             borderColor: tokens.borderColor,
             marginTop: ringConfig.ringThickness,
             marginLeft: ringConfig.ringThickness,
+            aspectRatio: 1,
           },
         };
       },
@@ -113,6 +116,7 @@ export const stylingSettings: UseStylingOptions<AvatarProps, AvatarSlotProps, Av
             borderColor: borderColor,
             marginTop: ringConfig.ringThickness,
             marginLeft: ringConfig.ringThickness,
+            aspectRatio: 1,
           },
         };
       },
@@ -149,6 +153,7 @@ export const stylingSettings: UseStylingOptions<AvatarProps, AvatarSlotProps, Av
             borderWidth: ringConfig.ringThickness,
             backgroundColor: ringBackgroundColor || 'transparent',
             borderColor: ringColor,
+            aspectRatio: 1,
           },
         };
       },

--- a/packages/components/Avatar/src/__tests__/__snapshots__/Avatar.test.jsx.snap
+++ b/packages/components/Avatar/src/__tests__/__snapshots__/Avatar.test.jsx.snap
@@ -11,10 +11,11 @@ exports[`Avatar rendering renders Avatar 1`] = `
   style={
     Object {
       "alignItems": "center",
-      "height": 24,
+      "aspectRatio": 1,
       "justifyContent": "center",
+      "minHeight": 24,
+      "minWidth": 24,
       "opacity": 1,
-      "width": 24,
     }
   }
 >
@@ -27,11 +28,11 @@ exports[`Avatar rendering renders Avatar 1`] = `
         "borderColor": "#ffffff",
         "borderRadius": 9999,
         "borderWidth": 0,
-        "height": 24,
         "justifyContent": "center",
         "marginLeft": 2,
         "marginTop": 2,
-        "width": 24,
+        "minHeight": 24,
+        "minWidth": 24,
       }
     }
   >

--- a/packages/components/Avatar/src/__tests__/__snapshots__/Avatar.test.jsx.snap
+++ b/packages/components/Avatar/src/__tests__/__snapshots__/Avatar.test.jsx.snap
@@ -11,7 +11,9 @@ exports[`Avatar rendering renders Avatar 1`] = `
   style={
     Object {
       "alignItems": "center",
+      "alignSelf": "flex-start",
       "aspectRatio": 1,
+      "flexDirection": "row",
       "justifyContent": "center",
       "minHeight": 24,
       "minWidth": 24,
@@ -24,6 +26,7 @@ exports[`Avatar rendering renders Avatar 1`] = `
     style={
       Object {
         "alignItems": "center",
+        "aspectRatio": 1,
         "backgroundColor": "#e6e6e6",
         "borderColor": "#ffffff",
         "borderRadius": 9999,


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
Fixed bug with initials when text scaling is bigger.
There still should be paddings added.

### Verification
Before:
![image](https://user-images.githubusercontent.com/11574680/177830939-b32d45e5-f88b-4f09-bcb8-151e9ad24da4.png)

**After:**
![image](https://user-images.githubusercontent.com/11574680/177830955-1d7ee6b8-0837-43ae-9117-3b7790e4675f.png)
![image](https://user-images.githubusercontent.com/11574680/177830782-595e43a8-ca16-4196-b9b8-bcb4b54eb549.png)
<img width="1240" alt="image" src="https://user-images.githubusercontent.com/11574680/177986681-efef026e-2847-4694-b083-b7fff84753ec.png">


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
