### PR TITLE
Fix submenu close bug

### DIFF
--- a/change/@fluentui-react-native-menu-95d5a75f-388f-48f6-b5db-20ce07b0ff4a.json
+++ b/change/@fluentui-react-native-menu-95d5a75f-388f-48f6-b5db-20ce07b0ff4a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix submenu close bug",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/MenuItem/useMenuItem.ts
+++ b/packages/components/Menu/src/MenuItem/useMenuItem.ts
@@ -42,7 +42,7 @@ export const useMenuItem = (props: MenuItemProps): MenuItemState => {
       }
 
       if (!hasSubmenu && !isArrowKey && !shouldPersist) {
-        setOpen(e, false /*isOpen*/, false /*bubble*/);
+        setOpen(e, false /*isOpen*/, true /*bubble*/);
       }
 
       const isArrowClose =


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Due to typo, submenu doesn't dismiss all parents when one of its MenuItems is clicked.
Change bubble from false to true to fix.

### Verification

Tested keyboarding and click scenarios on submenu. Also tested arrow keys and made sure that it doesn't dismiss the entire menu when an arrow key is used to dismiss a submenu.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
