### PR TITLE
Fix a11y actions type error in MenuTrigger

### DIFF
--- a/change/@fluentui-react-native-menu-1f4781f0-a1ab-48cb-99f6-a366feaa9e87.json
+++ b/change/@fluentui-react-native-menu-1f4781f0-a1ab-48cb-99f6-a366feaa9e87.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix accessibilityActions",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/MenuTrigger/MenuTrigger.tsx
+++ b/packages/components/Menu/src/MenuTrigger/MenuTrigger.tsx
@@ -37,7 +37,7 @@ function getRevisedPropsWorker(state: MenuTriggerState, props: any): MenuTrigger
   }
 
   if (props.accessibilityActions) {
-    revisedProps.accessibilityActions = { ...revisedProps.accessibilityActions, ...props.accessibilityActions };
+    revisedProps.accessibilityActions = [...revisedProps.accessibilityActions, ...props.accessibilityActions];
   }
 
   if (props.onAccessibilityAction) {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Accidentally created an object instead of an array for the modified accessibilityActions prop on the MenuTrigger, cause a type error when accessibilityActions are passed into the MenuTrigger's child.
Fix error by changing curly to square brackets.

### Verification

Tested repro provided by client, doesn't cause TypeError with fix.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
