### PR TITLE
Add optional icon to notification

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/Notification/NotificationTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Notification/NotificationTest.tsx
@@ -7,6 +7,7 @@ import PlayButton from './assets/play_button.svg';
 const svgProps: SvgIconProps = {
   src: PlayButton,
 };
+const iconProps = { svgSource: svgProps };
 
 const PrimaryTest: React.FunctionComponent = () => {
   return (
@@ -26,7 +27,7 @@ const PrimaryTestWithTitleAndIcon: React.FunctionComponent = () => {
   return (
     <Notification
       variant={'primary'}
-      icon={{ svgSource: svgProps }}
+      icon={iconProps}
       title="Kat's iPhone X"
       action="X"
       onPress={() => {

--- a/apps/fluent-tester/src/FluentTester/TestComponents/Notification/NotificationTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Notification/NotificationTest.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
 import { Notification } from '@fluentui-react-native/notification';
 import { Test, TestSection, PlatformStatus } from '../Test';
+import { SvgIconProps } from '@fluentui-react-native/icon';
+import PlayButton from './assets/play_button.svg';
+
+const svgProps: SvgIconProps = {
+  src: PlayButton,
+};
 
 const PrimaryTest: React.FunctionComponent = () => {
   return (
@@ -16,10 +22,11 @@ const PrimaryTest: React.FunctionComponent = () => {
   );
 };
 
-const PrimaryTestWithTitle: React.FunctionComponent = () => {
+const PrimaryTestWithTitleAndIcon: React.FunctionComponent = () => {
   return (
     <Notification
       variant={'primary'}
+      icon={{ svgSource: svgProps }}
       title="Kat's iPhone X"
       action="X"
       onPress={() => {
@@ -118,8 +125,8 @@ const notificationSections: TestSection[] = [
     component: PrimaryTest,
   },
   {
-    name: 'Primary With Title',
-    component: PrimaryTestWithTitle,
+    name: 'Primary with Title and Icon',
+    component: PrimaryTestWithTitleAndIcon,
   },
   {
     name: 'Neutral',

--- a/apps/fluent-tester/src/FluentTester/TestComponents/Notification/assets/play_button.svg
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Notification/assets/play_button.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#0F6CBD"><path d="M0 0h24v24H0z" fill="none"/><path d="M10 16.5l6-4.5-6-4.5v9zM12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"/></svg>

--- a/apps/fluent-tester/src/FluentTester/TestComponents/Notification/assets/play_button.svg
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Notification/assets/play_button.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#0F6CBD"><path d="M0 0h24v24H0z" fill="none"/><path d="M10 16.5l6-4.5-6-4.5v9zM12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M10 16.5l6-4.5-6-4.5v9zM12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"/></svg>

--- a/apps/ios/src/Podfile.lock
+++ b/apps/ios/src/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
     - React-Core (= 0.64.3)
     - React-jsi (= 0.64.3)
     - ReactCommon/turbomodule/core (= 0.64.3)
-  - FRNAvatar (0.15.1):
+  - FRNAvatar (0.15.3):
     - MicrosoftFluentUI (= 0.5.2)
     - MicrosoftFluentUI/Avatar_ios (= 0.5.2)
     - React
@@ -371,7 +371,7 @@ PODS:
   - React-jsinspector (0.64.3)
   - react-native-menu (0.1.2):
     - React
-  - react-native-slider (4.2.3):
+  - react-native-slider (4.2.4):
     - React-Core
   - React-perflogger (0.64.3)
   - React-RCTActionSheet (0.64.3):
@@ -574,7 +574,7 @@ SPEC CHECKSUMS:
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: c71c5917ec0ad2de41d5d06a5855f6d5eda06971
   FBReactNativeSpec: 2e23f365db4551ce59b5411a90f7ad9bc0aabffe
-  FRNAvatar: a532bbf467cf1c49c9762b1838808b1482a11835
+  FRNAvatar: 92dcf2c9e1790cfd13edd7633af280f2be6b2b1b
   FRNDatePicker: 961e96f437d1dcd25fe6d7a80790dade00ef714b
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   MicrosoftFluentUI: 2f4c624fd4606aa2392c09be69a45e297a41f593
@@ -590,7 +590,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: df6abc9fafbecb8e5b7a5fbc5e6d4bd017d594d5
   React-jsinspector: 34e23860273a23695342f58eed3ffd3ba10c31e0
   react-native-menu: 9fe07f72e075b250295eeae25425490cc9608951
-  react-native-slider: 98b724cd3e44c3454a6d0724e796d4e9c52189ce
+  react-native-slider: cecabb58ecffad671d2ad3ccc58c7f4d2d029e95
   React-perflogger: cc76a4254d19640f1d8ad1c66fdee800414b805c
   React-RCTActionSheet: 7448f049318d8d7e8a9a1ebb742ada721757eea8
   React-RCTAnimation: fb9b3fa1a4a9f5e6ab01b3368693ce69860ba76a

--- a/change/@fluentui-react-native-notification-f4826e4e-27fe-4975-be89-6cb67fa8aaed.json
+++ b/change/@fluentui-react-native-notification-f4826e4e-27fe-4975-be89-6cb67fa8aaed.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add optional icon",
+  "packageName": "@fluentui-react-native/notification",
+  "email": "joannaquu@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-8dda2086-649d-409f-8302-d2052dfd02e5.json
+++ b/change/@fluentui-react-native-tester-8dda2086-649d-409f-8302-d2052dfd02e5.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add optional icon",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "joannaquu@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Notification/package.json
+++ b/packages/components/Notification/package.json
@@ -30,6 +30,7 @@
     "@fluentui-react-native/button": ">=0.22.31 <1.0.0",
     "@fluentui-react-native/experimental-text": ">=0.9.2 <1.0.0",
     "@fluentui-react-native/framework": "0.7.32",
+    "@fluentui-react-native/icon": "0.12.3",
     "@fluentui-react-native/interactive-hooks": ">=0.16.5 <1.0.0",
     "@fluentui-react-native/pressable": ">=0.8.47 <1.0.0",
     "@fluentui-react-native/tokens": ">=0.15.1 <1.0.0",

--- a/packages/components/Notification/src/Notification.styling.ts
+++ b/packages/components/Notification/src/Notification.styling.ts
@@ -33,15 +33,18 @@ export const stylingSettings: UseStylingOptions<NotificationProps, NotificationS
       }),
       ['backgroundColor', ...borderStyles.keys, ...layoutStyles.keys],
     ),
-    icon: buildProps((tokens: NotificationTokens) => ({
-      style: {
-        alignSelf: 'center',
-        marginRight: 16,
-      },
-      color: tokens.color,
-      height: 24,
-      width: 24,
-    })),
+    icon: buildProps(
+      (tokens: NotificationTokens) => ({
+        style: {
+          alignSelf: 'center',
+          marginRight: 16,
+        },
+        color: tokens.color,
+        height: 24,
+        width: 24,
+      }),
+      ['color'],
+    ),
     contentContainer: buildProps(() => {
       return {
         style: {

--- a/packages/components/Notification/src/Notification.styling.ts
+++ b/packages/components/Notification/src/Notification.styling.ts
@@ -37,7 +37,7 @@ export const stylingSettings: UseStylingOptions<NotificationProps, NotificationS
       (tokens: NotificationTokens) => ({
         style: {
           alignSelf: 'center',
-          marginRight: 16,
+          marginEnd: 16,
         },
         color: tokens.color,
         height: 24,
@@ -86,7 +86,7 @@ export const stylingSettings: UseStylingOptions<NotificationProps, NotificationS
       return {
         style: {
           alignSelf: 'center',
-          marginLeft: 16,
+          marginStart: 16,
         },
         appearance: 'subtle',
         minWidth: 0,

--- a/packages/components/Notification/src/Notification.styling.ts
+++ b/packages/components/Notification/src/Notification.styling.ts
@@ -33,11 +33,12 @@ export const stylingSettings: UseStylingOptions<NotificationProps, NotificationS
       }),
       ['backgroundColor', ...borderStyles.keys, ...layoutStyles.keys],
     ),
-    icon: buildProps(() => ({
+    icon: buildProps((tokens: NotificationTokens) => ({
       style: {
         alignSelf: 'center',
         marginRight: 16,
       },
+      color: tokens.color,
       height: 24,
       width: 24,
     })),

--- a/packages/components/Notification/src/Notification.styling.ts
+++ b/packages/components/Notification/src/Notification.styling.ts
@@ -38,6 +38,8 @@ export const stylingSettings: UseStylingOptions<NotificationProps, NotificationS
         alignSelf: 'center',
         marginRight: 16,
       },
+      height: 24,
+      width: 24,
     })),
     contentContainer: buildProps(() => {
       return {

--- a/packages/components/Notification/src/Notification.styling.ts
+++ b/packages/components/Notification/src/Notification.styling.ts
@@ -33,6 +33,12 @@ export const stylingSettings: UseStylingOptions<NotificationProps, NotificationS
       }),
       ['backgroundColor', ...borderStyles.keys, ...layoutStyles.keys],
     ),
+    icon: buildProps(() => ({
+      style: {
+        alignSelf: 'center',
+        marginRight: 16,
+      },
+    })),
     contentContainer: buildProps(() => {
       return {
         style: {

--- a/packages/components/Notification/src/Notification.tsx
+++ b/packages/components/Notification/src/Notification.tsx
@@ -55,7 +55,7 @@ export const Notification = compose<NotificationType>({
 
       return (
         <Slots.root {...mergedProps}>
-          {icon && <Slots.icon {...iconProps}></Slots.icon>}
+          {icon && <Slots.icon {...iconProps} />}
           <Slots.contentContainer>
             {title && <Slots.title>{title}</Slots.title>}
             <Slots.message style={messageStyle}>{children}</Slots.message>

--- a/packages/components/Notification/src/Notification.tsx
+++ b/packages/components/Notification/src/Notification.tsx
@@ -8,6 +8,7 @@ import { ButtonV1 as Button } from '@fluentui-react-native/button';
 import { stylingSettings } from './Notification.styling';
 import { compose, mergeProps, withSlots, UseSlots } from '@fluentui-react-native/framework';
 import { useMemo } from 'react';
+import { createIconProps } from '@fluentui-react-native/interactive-hooks';
 
 /**
  * A function which determines if a set of styles should be applied to the component given the current state and props of the Notification.
@@ -49,11 +50,12 @@ export const Notification = compose<NotificationType>({
 
     return (final: NotificationProps, ...children: React.ReactNode[]) => {
       const { variant, icon, title, action, ...rest } = mergeProps(userProps, final);
+      const iconProps = createIconProps(icon);
       const mergedProps = mergeProps<PressableProps>(rest, rootStyle);
 
       return (
         <Slots.root {...mergedProps}>
-          {icon && <Slots.icon {...icon} width={24} height={24}></Slots.icon>}
+          {icon && <Slots.icon {...iconProps}></Slots.icon>}
           <Slots.contentContainer>
             {title && <Slots.title>{title}</Slots.title>}
             <Slots.message style={messageStyle}>{children}</Slots.message>

--- a/packages/components/Notification/src/Notification.tsx
+++ b/packages/components/Notification/src/Notification.tsx
@@ -2,6 +2,7 @@
 import { notification, NotificationType, NotificationProps } from './Notification.types';
 import { Pressable } from '@fluentui-react-native/pressable';
 import { PressableProps, View, ViewStyle } from 'react-native';
+import { Icon } from '@fluentui-react-native/icon';
 import { Text } from '@fluentui-react-native/experimental-text';
 import { ButtonV1 as Button } from '@fluentui-react-native/button';
 import { stylingSettings } from './Notification.styling';
@@ -28,6 +29,7 @@ export const Notification = compose<NotificationType>({
   ...stylingSettings,
   slots: {
     root: Pressable,
+    icon: Icon,
     contentContainer: View,
     title: Text,
     message: Text,
@@ -46,11 +48,12 @@ export const Notification = compose<NotificationType>({
     }, ['isBar']);
 
     return (final: NotificationProps, ...children: React.ReactNode[]) => {
-      const { variant, title, action, ...rest } = mergeProps(userProps, final);
+      const { variant, icon, title, action, ...rest } = mergeProps(userProps, final);
       const mergedProps = mergeProps<PressableProps>(rest, rootStyle);
 
       return (
         <Slots.root {...mergedProps}>
+          {icon && <Slots.icon {...icon} width={24} height={24}></Slots.icon>}
           <Slots.contentContainer>
             {title && <Slots.title>{title}</Slots.title>}
             <Slots.message style={messageStyle}>{children}</Slots.message>

--- a/packages/components/Notification/src/Notification.types.ts
+++ b/packages/components/Notification/src/Notification.types.ts
@@ -1,4 +1,5 @@
 import { PressableProps } from 'react-native';
+import { IconProps, IconSourcesType } from '@fluentui-react-native/icon';
 import { IViewProps, ITextProps } from '@fluentui-react-native/adapters';
 import { ButtonProps } from '@fluentui-react-native/button';
 import { FontTokens, IBorderTokens, IColorTokens, LayoutTokens } from '@fluentui-react-native/tokens';
@@ -25,6 +26,7 @@ export interface NotificationProps {
    * Notification variants: 'primary' | 'neutral' | 'primaryBar' | 'primaryOutlineBar' | 'neutralBar' | 'danger' | 'warning'
    */
   variant: NotificationVariant;
+  icon?: IconSourcesType;
   title?: string;
   action?: string;
   onPress?: (e: InteractionEvent) => void;
@@ -32,6 +34,7 @@ export interface NotificationProps {
 
 export interface NotificationSlotProps {
   root: PressableProps;
+  icon?: IconProps;
   contentContainer: IViewProps;
   title?: ITextProps;
   message: ITextProps;

--- a/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
+++ b/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
@@ -91,7 +91,7 @@ exports[`Notification component tests Notification default 1`] = `
         "display": "flex",
         "flexDirection": "row",
         "justifyContent": "center",
-        "marginLeft": 16,
+        "marginStart": 16,
         "minWidth": 96,
         "padding": 5,
         "paddingHorizontal": 11,


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Added optional icon to notification component.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before](https://user-images.githubusercontent.com/55368679/178346706-2feb5305-4b25-4baa-9311-9fc4a551c754.png) | ![9 - Icon](https://user-images.githubusercontent.com/55368679/178346695-9480ed29-55a3-4801-9f6b-98f8aeee5edc.png) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
