### PR TITLE
Clear timers when unmounting components

### DIFF
--- a/change/@fluentui-react-native-menu-0c03af37-a61f-4e6e-9e07-076e3d9e1f9d.json
+++ b/change/@fluentui-react-native-menu-0c03af37-a61f-4e6e-9e07-076e3d9e1f9d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Cancel timers when unmounting popover",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
+++ b/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
@@ -55,9 +55,7 @@ export const useMenuPopover = (_props: MenuPopoverProps): MenuPopoverState => {
 
   React.useEffect(() => {
     return function cleanup() {
-      clearTimeout(triggerHoverOutTimer);
       clearTimeout(popoverHoverOutTimer);
-      clearTimeout(parentPopoverHoverOutTimer);
     };
   });
 

--- a/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
+++ b/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
@@ -53,6 +53,14 @@ export const useMenuPopover = (_props: MenuPopoverProps): MenuPopoverState => {
     setCanFocusOnPopover(false);
   }, [setCanFocusOnPopover]);
 
+  React.useEffect(() => {
+    return function cleanup() {
+      clearTimeout(triggerHoverOutTimer);
+      clearTimeout(popoverHoverOutTimer);
+      clearTimeout(parentPopoverHoverOutTimer);
+    };
+  });
+
   return {
     props: {
       accessibilityRole,

--- a/packages/components/Menu/src/MenuTrigger/useMenuTrigger.ts
+++ b/packages/components/Menu/src/MenuTrigger/useMenuTrigger.ts
@@ -76,6 +76,12 @@ export const useMenuTrigger = (): MenuTriggerState => {
     [open, setOpen],
   );
 
+  React.useEffect(() => {
+    return function cleanup() {
+      clearTimeout(triggerHoverOutTimer);
+    };
+  });
+
   return {
     props: {
       onClick,


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Forgot to clear the timeouts when unmounting components. This causes warnings to come up from React about being unable to change the state of unmounted components.
Clear timeouts when unmounting the component which creates them.

### Verification

Tried reproducing using client provided repro steps and unable to repro.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
