### PR TITLE
[Avatar] Fixed PresenceBadge according to the Avatar design

### DIFF
--- a/change/@fluentui-react-native-avatar-b1fb5b88-87f5-4bf0-a4a4-6fbdae7c6045.json
+++ b/change/@fluentui-react-native-avatar-b1fb5b88-87f5-4bf0-a4a4-6fbdae7c6045.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "UI fixes",
+  "packageName": "@fluentui-react-native/avatar",
+  "email": "v.kozova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-badge-2fec3fb6-50f2-4b49-bf9f-e280c1b89a7e.json
+++ b/change/@fluentui-react-native-badge-2fec3fb6-50f2-4b49-bf9f-e280c1b89a7e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "UI fixes",
+  "packageName": "@fluentui-react-native/badge",
+  "email": "v.kozova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Avatar/src/AvatarTokens.win32.ts
+++ b/packages/components/Avatar/src/AvatarTokens.win32.ts
@@ -75,7 +75,7 @@ export const defaultAvatarTokens: TokenSettings<AvatarTokens, Theme> = (t: Theme
     },
     size56: {
       size: 56,
-      badgeSize: 'small',
+      badgeSize: 'medium',
       iconSize: 28,
       fontSize: globalTokens.font.size[400],
       square: {
@@ -84,7 +84,7 @@ export const defaultAvatarTokens: TokenSettings<AvatarTokens, Theme> = (t: Theme
     },
     size64: {
       size: 64,
-      badgeSize: 'medium',
+      badgeSize: 'large',
       iconSize: 32,
       fontSize: globalTokens.font.size[500],
       square: {
@@ -93,7 +93,7 @@ export const defaultAvatarTokens: TokenSettings<AvatarTokens, Theme> = (t: Theme
     },
     size72: {
       size: 72,
-      badgeSize: 'medium',
+      badgeSize: 'large',
       iconSize: 32,
       fontSize: globalTokens.font.size[500],
       square: {

--- a/packages/experimental/Badge/src/PresenceBadge/PresenceBadge.styling.ts
+++ b/packages/experimental/Badge/src/PresenceBadge/PresenceBadge.styling.ts
@@ -1,6 +1,6 @@
 import { PresenceBadgeTokens, PresenceBadgeSlotProps, PresenceBadgeProps, presenceBadgeName } from './PresenceBadge.types';
 import { UseStylingOptions, buildProps, Theme } from '@fluentui-react-native/framework';
-import { borderStyles, layoutStyles } from '@fluentui-react-native/tokens';
+import { borderStyles } from '@fluentui-react-native/tokens';
 import { defaultBadgeTokens } from '../BadgeTokens';
 import { defaultPresenceBadgeTokens } from './PresenceBadgeTokens';
 import { coreBadgeStates, getBadgePosition } from '../Badge.styling';
@@ -24,14 +24,13 @@ export const stylingSettings: UseStylingOptions<PresenceBadgeProps, PresenceBadg
   slotProps: {
     root: buildProps(
       (tokens: PresenceBadgeTokens, theme: Theme) => {
-        const { width, height, borderWidth, right, bottom } = tokens;
+        const { width, height, borderWidth } = tokens;
         const borderGap = borderWidth * 2;
         return {
           style: {
             ...getBadgePosition(tokens),
             width: width + borderGap,
             height: height + borderGap,
-            display: 'flex',
             alignItems: 'center',
             flexDirection: 'row',
             alignSelf: 'flex-start',
@@ -39,13 +38,11 @@ export const stylingSettings: UseStylingOptions<PresenceBadgeProps, PresenceBadg
             position: 'absolute',
             backgroundColor: tokens.backgroundColor,
             ...borderStyles.from(tokens, theme),
-            ...layoutStyles.from(tokens, theme),
-            right,
-            bottom,
+            paddingHorizontal: tokens.paddingHorizontal,
           },
         };
       },
-      ['backgroundColor', 'width', 'height', 'bottom', 'right', 'top', 'left', ...borderStyles.keys, ...layoutStyles.keys],
+      ['backgroundColor', 'width', 'height', 'bottom', 'right', 'top', 'left', 'borderWidth', 'paddingHorizontal', ...borderStyles.keys],
     ),
     svg: buildProps(
       (tokens: PresenceBadgeTokens) => ({

--- a/packages/experimental/Badge/src/PresenceBadge/PresenceBadge.styling.ts
+++ b/packages/experimental/Badge/src/PresenceBadge/PresenceBadge.styling.ts
@@ -42,7 +42,7 @@ export const stylingSettings: UseStylingOptions<PresenceBadgeProps, PresenceBadg
           },
         };
       },
-      ['backgroundColor', 'width', 'height', 'bottom', 'right', 'top', 'left', 'borderWidth', 'paddingHorizontal', ...borderStyles.keys],
+      ['backgroundColor', 'width', 'height', 'bottom', 'right', 'top', 'left', 'paddingHorizontal', ...borderStyles.keys],
     ),
     svg: buildProps(
       (tokens: PresenceBadgeTokens) => ({

--- a/packages/experimental/Badge/src/PresenceBadge/PresenceBadgeTokens.macos.ts
+++ b/packages/experimental/Badge/src/PresenceBadge/PresenceBadgeTokens.macos.ts
@@ -4,7 +4,7 @@ import { PresenceBadgeTokens } from './PresenceBadge.types';
 
 export const defaultPresenceBadgeTokens: TokenSettings<PresenceBadgeTokens> = (): PresenceBadgeTokens =>
   ({
-    borderWidth: 2,
+    borderWidth: 1,
     borderColor: globalTokens.color.white,
     bottom: globalTokens.spacing.none,
     right: globalTokens.spacing.none,
@@ -13,7 +13,6 @@ export const defaultPresenceBadgeTokens: TokenSettings<PresenceBadgeTokens> = ()
     smallest: {
       width: 6,
       height: 6,
-      borderWidth: 1,
     },
     smaller: {
       width: 10,
@@ -24,15 +23,17 @@ export const defaultPresenceBadgeTokens: TokenSettings<PresenceBadgeTokens> = ()
       height: 12,
     },
     medium: {
-      width: 20,
-      height: 20,
+      width: 16,
+      height: 16,
     },
     large: {
-      width: 24,
-      height: 24,
+      width: 20,
+      height: 20,
+      borderWidth: 2,
     },
     largest: {
       width: 28,
       height: 28,
+      borderWidth: 2,
     },
   } as PresenceBadgeTokens);

--- a/packages/experimental/Badge/src/PresenceBadge/PresenceBadgeTokens.ts
+++ b/packages/experimental/Badge/src/PresenceBadge/PresenceBadgeTokens.ts
@@ -4,43 +4,42 @@ import { PresenceBadgeTokens } from './PresenceBadge.types';
 
 export const defaultPresenceBadgeTokens: TokenSettings<PresenceBadgeTokens> = (t: Theme): PresenceBadgeTokens =>
   ({
-    borderWidth: 2,
+    borderWidth: 1,
     borderColor: isHighContrast(t) ? 'transparent' : globalTokens.color.white,
-    bottom: -globalTokens.spacing.xs,
-    right: -globalTokens.spacing.xs,
+    bottom: -1,
+    right: -1,
     paddingHorizontal: globalTokens.spacing.none,
     backgroundColor: t.colors.neutralBackground1,
     ...getBadgeColor('lightGreen', t),
     smallest: {
       width: 6,
       height: 6,
-      borderWidth: 1,
-      bottom: -globalTokens.spacing.xxs,
-      right: -globalTokens.spacing.xxs,
     },
     smaller: {
       width: 10,
       height: 10,
-      bottom: -globalTokens.spacing.xxs,
-      right: -globalTokens.spacing.xxs,
     },
     small: {
       width: 12,
       height: 12,
+    },
+    medium: {
+      width: 16,
+      height: 16,
+    },
+    large: {
+      borderWidth: 2,
+      width: 20,
+      height: 20,
       bottom: -globalTokens.spacing.xxs,
       right: -globalTokens.spacing.xxs,
     },
-    medium: {
-      width: 20,
-      height: 20,
-    },
-    large: {
-      width: 24,
-      height: 24,
-    },
     largest: {
+      borderWidth: 2,
       width: 28,
       height: 28,
+      bottom: -globalTokens.spacing.xxs,
+      right: -globalTokens.spacing.xxs,
     },
     available: getBadgeColor('lightGreen', t),
     away: getBadgeColor('marigold', t),

--- a/packages/experimental/Badge/src/PresenceBadge/PresenceBadgeTokens.win32.ts
+++ b/packages/experimental/Badge/src/PresenceBadge/PresenceBadgeTokens.win32.ts
@@ -4,10 +4,10 @@ import { PresenceBadgeTokens } from './PresenceBadge.types';
 
 export const defaultPresenceBadgeTokens: TokenSettings<PresenceBadgeTokens> = (t: Theme): PresenceBadgeTokens =>
   ({
-    borderWidth: 2,
+    borderWidth: 1,
     borderColor: isHighContrast(t) ? 'transparent' : globalTokens.color.white,
-    bottom: globalTokens.spacing.none,
-    right: globalTokens.spacing.none,
+    bottom: -1,
+    right: -1,
     paddingHorizontal: globalTokens.spacing.none,
     backgroundColor: t.colors.neutralBackground1,
     ...getBadgeColor('lightGreen', t),
@@ -20,20 +20,26 @@ export const defaultPresenceBadgeTokens: TokenSettings<PresenceBadgeTokens> = (t
       height: 10,
     },
     small: {
+      width: 12,
+      height: 12,
+    },
+    medium: {
       width: 16,
       height: 16,
     },
-    medium: {
+    large: {
       width: 20,
       height: 20,
-    },
-    large: {
-      width: 24,
-      height: 24,
+      borderWidth: 2,
+      bottom: -globalTokens.spacing.xxs,
+      right: -globalTokens.spacing.xxs,
     },
     largest: {
-      width: 32,
-      height: 32,
+      width: 28,
+      height: 28,
+      borderWidth: 2,
+      bottom: -globalTokens.spacing.xxs,
+      right: -globalTokens.spacing.xxs,
     },
     available: getBadgeColor('lightGreen', t),
     away: getBadgeColor('marigold', t),
@@ -45,9 +51,7 @@ export const defaultPresenceBadgeTokens: TokenSettings<PresenceBadgeTokens> = (t
     offline: {
       iconColor: isHighContrast(t) ? t.colors.neutralForeground3 : globalTokens.color.grey[38],
     },
-    outOfOffice: {
-      ...getBadgeColor('berry', t),
-    },
+    outOfOffice: getBadgeColor('berry', t),
   } as PresenceBadgeTokens);
 
 function getBadgeColor(color: string, t: Theme) {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [X] windows
- [ ] android

### Description of changes
Because of the differences in Avatar and Badge readlines I had to redesign this component.
Originally it was done according to the Badge design. This version refers to the Avatar.

### Verification
**DPI 150%**
<img width="298" alt="image" src="https://user-images.githubusercontent.com/11574680/178504868-548f9a95-67ca-41b4-a006-8c778b5a8a9a.png"><img width="122" alt="image" src="https://user-images.githubusercontent.com/11574680/178504931-d85e3206-36f7-42f6-983d-971f91f9be6d.png"><img width="54" alt="image" src="https://user-images.githubusercontent.com/11574680/178504965-6a4e981f-2ccc-4347-b225-c48ed8c9b783.png"><img width="41" alt="image" src="https://user-images.githubusercontent.com/11574680/178505005-da414751-e49a-49a8-b27f-a84f2c528c39.png"><img width="33" alt="image" src="https://user-images.githubusercontent.com/11574680/178505049-6248c6f3-8f78-4170-aa11-d4265dbaacad.png"><img width="33" alt="image" src="https://user-images.githubusercontent.com/11574680/178505087-21286a3e-1726-45fa-b335-a2c178783684.png"><img width="23" alt="image" src="https://user-images.githubusercontent.com/11574680/178505127-a045c123-6f60-46f6-be35-4d56436adcfd.png">

**DPI 125%:**
![image](https://user-images.githubusercontent.com/11574680/178505379-4efcfba4-5934-4717-966e-1fb978c84134.png)
![image](https://user-images.githubusercontent.com/11574680/178505413-a3a8e3fd-bf81-4543-a44a-d14a9689efa7.png)
![image](https://user-images.githubusercontent.com/11574680/178505456-dcbaca47-49b8-4393-a2cc-08b73f2977d0.png)
![image](https://user-images.githubusercontent.com/11574680/178505505-68128126-39b9-40cc-92e3-d8b47c301cba.png)
![image](https://user-images.githubusercontent.com/11574680/178505560-802103ee-70a1-498e-bdd9-ac3bf65d185b.png)
![image](https://user-images.githubusercontent.com/11574680/178505340-42c05483-4204-4fe4-a613-8b39dc32519f.png)

**DPI 300%:**
![image](https://user-images.githubusercontent.com/11574680/178505819-29b24844-7326-40df-8df3-3df176435f49.png)![image](https://user-images.githubusercontent.com/11574680/178505858-5276d8f6-9909-4a65-82f5-c9207099e13a.png)![image](https://user-images.githubusercontent.com/11574680/178505898-2c75c347-4fb7-4630-a5ab-a19317179f60.png)![image](https://user-images.githubusercontent.com/11574680/178505949-586eac43-cbcc-4201-83b7-62efcbbbda3d.png)![image](https://user-images.githubusercontent.com/11574680/178505988-5e1ee214-89a6-4cba-8f9c-5af56a54a780.png)![image](https://user-images.githubusercontent.com/11574680/178506048-dc6bb89b-f779-4b0c-b00c-a16e74d4ff19.png)![image](https://user-images.githubusercontent.com/11574680/178505778-ca4f3f0e-2a79-4add-bd94-7b1d3a1556da.png)



### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
