### PR TITLE
Revert "Add support for onAccessibilityTap on Text"

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/TextExperimental/CustomizeUsage.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/TextExperimental/CustomizeUsage.tsx
@@ -50,7 +50,7 @@ export const CustomizeUsage: React.FunctionComponent = () => {
   const BlockText = () => {
     return (
       <>
-        <Text style={{ textTransform: 'uppercase' }} font="base" weight="medium" truncate>
+        <Text style={{ textTransform: 'uppercase' }} font="base" weight="medium">
           I am going to be truncated since I am a very very very very very very very very very very very very very very very very very very
           very very very very very very very very very very very very very very very very very very very very very very very very very very
           very very very very very very very very very very very very very very very very long block text.

--- a/apps/fluent-tester/src/FluentTester/TestComponents/TextExperimental/PressableUsage.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/TextExperimental/PressableUsage.tsx
@@ -18,10 +18,6 @@ export const PressableUsage: React.FunctionComponent = () => {
     Alert.alert('Alert', 'Success!');
   };
 
-  const _onPress3 = (): void => {
-    Alert.alert('Alert', 'onAccessibilityTap invoked!');
-  };
-
   const _onKeyDown2 = (ev: IKeyboardEvent) => {
     if (ev.nativeEvent.key === 'Enter' || ev.nativeEvent.key == ' ') Alert.alert('Alert', 'Success!');
   };
@@ -33,14 +29,7 @@ export const PressableUsage: React.FunctionComponent = () => {
       <Stack style={stackStyle} gap={5}>
         <Text variant={'bodyStandard'}>
           To learn more about microsoft, visit this{' '}
-          <Text
-            focusable
-            variant={'bodyStandard'}
-            color="blue"
-            keyDownEvents={handledNativeKeyboardEvents}
-            onPress={_onPress}
-            onKeyDown={_onKeyDown}
-          >
+          <Text variant={'bodyStandard'} color="blue" keyDownEvents={handledNativeKeyboardEvents} onPress={_onPress} onKeyDown={_onKeyDown}>
             webpage
           </Text>{' '}
           for more details.
@@ -53,7 +42,6 @@ export const PressableUsage: React.FunctionComponent = () => {
             keyDownEvents={handledNativeKeyboardEvents}
             onPress={_onPress2}
             onKeyDown={_onKeyDown2}
-            onAccessibilityTap={_onPress3}
           >
             here
           </Text>{' '}

--- a/change/@fluentui-react-native-badge-dbf7b2e8-9555-4433-a1c4-1d2cc3aa7ad0.json
+++ b/change/@fluentui-react-native-badge-dbf7b2e8-9555-4433-a1c4-1d2cc3aa7ad0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Revert \"Add support for onAccessibilityTap on Text\" ",
+  "packageName": "@fluentui-react-native/badge",
+  "email": "amchiu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-button-32617ab6-d3f3-4dc6-998b-9c861b874590.json
+++ b/change/@fluentui-react-native-button-32617ab6-d3f3-4dc6-998b-9c861b874590.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Revert \"Add support for onAccessibilityTap on Text\" ",
+  "packageName": "@fluentui-react-native/button",
+  "email": "amchiu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-menu-button-ce902708-d08b-4179-9a17-6b8579e2ca58.json
+++ b/change/@fluentui-react-native-experimental-menu-button-ce902708-d08b-4179-9a17-6b8579e2ca58.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Revert \"Add support for onAccessibilityTap on Text\" ",
+  "packageName": "@fluentui-react-native/experimental-menu-button",
+  "email": "amchiu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-tabs-0fc22c26-c468-4e3c-9c56-da0cdb9c07ab.json
+++ b/change/@fluentui-react-native-experimental-tabs-0fc22c26-c468-4e3c-9c56-da0cdb9c07ab.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Revert \"Add support for onAccessibilityTap on Text\" ",
+  "packageName": "@fluentui-react-native/experimental-tabs",
+  "email": "amchiu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-text-0851fafd-4318-4268-ae3d-106b23cd9c07.json
+++ b/change/@fluentui-react-native-experimental-text-0851fafd-4318-4268-ae3d-106b23cd9c07.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Revert \"Add support for onAccessibilityTap on Text\" ",
+  "packageName": "@fluentui-react-native/experimental-text",
+  "email": "amchiu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-menu-1f174bc4-2111-4436-91e3-7a0ea8ecd354.json
+++ b/change/@fluentui-react-native-menu-1f174bc4-2111-4436-91e3-7a0ea8ecd354.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Revert \"Add support for onAccessibilityTap on Text\" ",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "amchiu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-notification-b0504f22-fe51-4e4b-ae33-4afd9552d562.json
+++ b/change/@fluentui-react-native-notification-b0504f22-fe51-4e4b-ae33-4afd9552d562.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Revert \"Add support for onAccessibilityTap on Text\" ",
+  "packageName": "@fluentui-react-native/notification",
+  "email": "amchiu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-5f4ae3a5-408f-4bb9-be65-4722908212f1.json
+++ b/change/@fluentui-react-native-tester-5f4ae3a5-408f-4bb9-be65-4722908212f1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Revert \"Add support for onAccessibilityTap on Text\"",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "amchiu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Button/src/CompoundButton/__snapshots__/CompoundButton.test.tsx.snap
+++ b/packages/components/Button/src/CompoundButton/__snapshots__/CompoundButton.test.tsx.snap
@@ -52,7 +52,6 @@ exports[`CompoundButton default 1`] = `
     <Text
       ellipsizeMode="tail"
       numberOfLines={0}
-      onAccessibilityTap={[Function]}
       style={
         Object {
           "color": "#323130",
@@ -72,7 +71,6 @@ exports[`CompoundButton default 1`] = `
     <Text
       ellipsizeMode="tail"
       numberOfLines={0}
-      onAccessibilityTap={[Function]}
       style={
         Object {
           "fontFamily": "Segoe UI",

--- a/packages/components/Button/src/ToggleButton/__snapshots__/ToggleButton.test.tsx.snap
+++ b/packages/components/Button/src/ToggleButton/__snapshots__/ToggleButton.test.tsx.snap
@@ -53,7 +53,6 @@ exports[`ToggleButton default 1`] = `
   <Text
     ellipsizeMode="tail"
     numberOfLines={0}
-    onAccessibilityTap={[Function]}
     style={
       Object {
         "color": "#323130",

--- a/packages/components/Button/src/__snapshots__/Button.test.tsx.snap
+++ b/packages/components/Button/src/__snapshots__/Button.test.tsx.snap
@@ -45,7 +45,6 @@ exports[`Button component tests Button circular 1`] = `
   <Text
     ellipsizeMode="tail"
     numberOfLines={0}
-    onAccessibilityTap={[Function]}
     style={
       Object {
         "color": "#323130",
@@ -169,7 +168,6 @@ exports[`Button component tests Button customized 1`] = `
   <Text
     ellipsizeMode="tail"
     numberOfLines={0}
-    onAccessibilityTap={[Function]}
     style={
       Object {
         "color": "#323130",
@@ -233,7 +231,6 @@ exports[`Button component tests Button default 1`] = `
   <Text
     ellipsizeMode="tail"
     numberOfLines={0}
-    onAccessibilityTap={[Function]}
     style={
       Object {
         "color": "#323130",
@@ -298,7 +295,6 @@ exports[`Button component tests Button large 1`] = `
   <Text
     ellipsizeMode="tail"
     numberOfLines={0}
-    onAccessibilityTap={[Function]}
     style={
       Object {
         "color": "#323130",
@@ -363,7 +359,6 @@ exports[`Button component tests Button primary 1`] = `
   <Text
     ellipsizeMode="tail"
     numberOfLines={0}
-    onAccessibilityTap={[Function]}
     style={
       Object {
         "color": "#ffffff",
@@ -428,7 +423,6 @@ exports[`Button component tests Button small 1`] = `
   <Text
     ellipsizeMode="tail"
     numberOfLines={0}
-    onAccessibilityTap={[Function]}
     style={
       Object {
         "color": "#323130",
@@ -493,7 +487,6 @@ exports[`Button component tests Button square 1`] = `
   <Text
     ellipsizeMode="tail"
     numberOfLines={0}
-    onAccessibilityTap={[Function]}
     style={
       Object {
         "color": "#323130",
@@ -558,7 +551,6 @@ exports[`Button component tests Button subtle 1`] = `
   <Text
     ellipsizeMode="tail"
     numberOfLines={0}
-    onAccessibilityTap={[Function]}
     style={
       Object {
         "color": "#323130",

--- a/packages/components/Menu/src/__tests__/__snapshots__/Menu.test.tsx.snap
+++ b/packages/components/Menu/src/__tests__/__snapshots__/Menu.test.tsx.snap
@@ -50,7 +50,6 @@ exports[`Checkbox component tests Menu default 1`] = `
   <Text
     ellipsizeMode="tail"
     numberOfLines={0}
-    onAccessibilityTap={[Function]}
     style={
       Object {
         "color": "#323130",
@@ -121,7 +120,6 @@ Array [
     <Text
       ellipsizeMode="tail"
       numberOfLines={0}
-      onAccessibilityTap={[Function]}
       style={
         Object {
           "color": "#323130",
@@ -211,7 +209,6 @@ Array [
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
-            onAccessibilityTap={[Function]}
             style={
               Object {
                 "color": "#424242",
@@ -267,7 +264,6 @@ Array [
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
-            onAccessibilityTap={[Function]}
             style={
               Object {
                 "color": "#bdbdbd",
@@ -339,7 +335,6 @@ Array [
     <Text
       ellipsizeMode="tail"
       numberOfLines={0}
-      onAccessibilityTap={[Function]}
       style={
         Object {
           "color": "#323130",
@@ -435,7 +430,6 @@ Array [
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
-            onAccessibilityTap={[Function]}
             style={
               Object {
                 "color": "#424242",
@@ -507,7 +501,6 @@ Array [
     <Text
       ellipsizeMode="tail"
       numberOfLines={0}
-      onAccessibilityTap={[Function]}
       style={
         Object {
           "color": "#323130",
@@ -663,7 +656,6 @@ Array [
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
-            onAccessibilityTap={[Function]}
             style={
               Object {
                 "color": "#424242",
@@ -791,7 +783,6 @@ Array [
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
-            onAccessibilityTap={[Function]}
             style={
               Object {
                 "color": "#bdbdbd",
@@ -863,7 +854,6 @@ Array [
     <Text
       ellipsizeMode="tail"
       numberOfLines={0}
-      onAccessibilityTap={[Function]}
       style={
         Object {
           "color": "#323130",
@@ -1019,7 +1009,6 @@ Array [
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
-            onAccessibilityTap={[Function]}
             style={
               Object {
                 "color": "#424242",
@@ -1146,7 +1135,6 @@ Array [
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
-            onAccessibilityTap={[Function]}
             style={
               Object {
                 "color": "#424242",
@@ -1218,7 +1206,6 @@ Array [
     <Text
       ellipsizeMode="tail"
       numberOfLines={0}
-      onAccessibilityTap={[Function]}
       style={
         Object {
           "color": "#323130",
@@ -1374,7 +1361,6 @@ Array [
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
-            onAccessibilityTap={[Function]}
             style={
               Object {
                 "color": "#424242",
@@ -1501,7 +1487,6 @@ Array [
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
-            onAccessibilityTap={[Function]}
             style={
               Object {
                 "color": "#424242",
@@ -1573,7 +1558,6 @@ Array [
     <Text
       ellipsizeMode="tail"
       numberOfLines={0}
-      onAccessibilityTap={[Function]}
       style={
         Object {
           "color": "#323130",
@@ -1729,7 +1713,6 @@ Array [
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
-            onAccessibilityTap={[Function]}
             style={
               Object {
                 "color": "#424242",
@@ -1844,7 +1827,6 @@ Array [
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
-            onAccessibilityTap={[Function]}
             style={
               Object {
                 "color": "#424242",
@@ -1916,7 +1898,6 @@ Array [
     <Text
       ellipsizeMode="tail"
       numberOfLines={0}
-      onAccessibilityTap={[Function]}
       style={
         Object {
           "color": "#323130",
@@ -2012,7 +1993,6 @@ Array [
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
-            onAccessibilityTap={[Function]}
             style={
               Object {
                 "color": "#424242",
@@ -2071,7 +2051,6 @@ Array [
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
-            onAccessibilityTap={[Function]}
             style={
               Object {
                 "color": "#424242",

--- a/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
+++ b/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
@@ -1,5 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+// moving marginHorizontal into style object prompts the error "Shallow compare failed for Notification, key: style"
 exports[`Notification component tests Notification default 1`] = `
 <View
   marginHorizontal={16}
@@ -37,7 +38,6 @@ exports[`Notification component tests Notification default 1`] = `
     <Text
       ellipsizeMode="tail"
       numberOfLines={0}
-      onAccessibilityTap={[Function]}
       style={
         Object {
           "alignSelf": "flex-start",
@@ -101,7 +101,6 @@ exports[`Notification component tests Notification default 1`] = `
     <Text
       ellipsizeMode="tail"
       numberOfLines={0}
-      onAccessibilityTap={[Function]}
       style={
         Object {
           "color": "#323130",

--- a/packages/experimental/Badge/src/__tests__/__snapshots__/Badge.test.tsx.snap
+++ b/packages/experimental/Badge/src/__tests__/__snapshots__/Badge.test.tsx.snap
@@ -42,7 +42,6 @@ exports[`Badge component tests Badge all props 1`] = `
   <Text
     ellipsizeMode="tail"
     numberOfLines={0}
-    onAccessibilityTap={[Function]}
     style={
       Object {
         "color": "#0078d4",
@@ -87,7 +86,6 @@ exports[`Badge component tests Badge tokens 1`] = `
   <Text
     ellipsizeMode="tail"
     numberOfLines={0}
-    onAccessibilityTap={[Function]}
     style={
       Object {
         "color": "#ffffff",

--- a/packages/experimental/MenuButton/src/__tests__/__snapshots__/MenuButton.test.tsx.snap
+++ b/packages/experimental/MenuButton/src/__tests__/__snapshots__/MenuButton.test.tsx.snap
@@ -45,7 +45,6 @@ exports[`ContextualMenu default 1`] = `
   <Text
     ellipsizeMode="tail"
     numberOfLines={0}
-    onAccessibilityTap={[Function]}
     style={
       Object {
         "color": "#323130",

--- a/packages/experimental/Tabs/src/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/experimental/Tabs/src/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -818,7 +818,6 @@ exports[`Tabs header text and count 1`] = `
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
-            onAccessibilityTap={[Function]}
             style={
               Object {
                 "color": "#242424",
@@ -905,7 +904,6 @@ exports[`Tabs header text and count 1`] = `
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
-            onAccessibilityTap={[Function]}
             style={
               Object {
                 "color": "#616161",
@@ -992,7 +990,6 @@ exports[`Tabs header text and count 1`] = `
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
-            onAccessibilityTap={[Function]}
             style={
               Object {
                 "color": "#616161",
@@ -1291,7 +1288,6 @@ exports[`Tabs props 1`] = `
   <Text
     ellipsizeMode="tail"
     numberOfLines={0}
-    onAccessibilityTap={[Function]}
     style={
       Object {
         "color": "#323130",
@@ -1375,7 +1371,6 @@ exports[`Tabs props 1`] = `
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
-            onAccessibilityTap={[Function]}
             style={
               Object {
                 "color": "#bdbdbd",
@@ -1462,7 +1457,6 @@ exports[`Tabs props 1`] = `
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
-            onAccessibilityTap={[Function]}
             style={
               Object {
                 "color": "#242424",
@@ -1549,7 +1543,6 @@ exports[`Tabs props 1`] = `
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
-            onAccessibilityTap={[Function]}
             style={
               Object {
                 "color": "#616161",

--- a/packages/experimental/Text/src/Text.tsx
+++ b/packages/experimental/Text/src/Text.tsx
@@ -23,7 +23,6 @@ export const Text = compressible<TextProps, TextTokens>((props: TextProps, useTo
     color,
     font,
     italic,
-    onAccessibilityTap,
     size,
     strikethrough,
     style,
@@ -50,15 +49,6 @@ export const Text = compressible<TextProps, TextTokens>((props: TextProps, useTo
     : align === 'end'
     ? 'right'
     : align;
-
-  const onAccTap =
-    onAccessibilityTap ??
-    React.useCallback(
-      (event?) => {
-        props.onPress(event);
-      },
-      [props.onPress],
-    );
 
   // override tokens from props
   [tokens, cache] = patchTokens(tokens, cache, {
@@ -92,7 +82,6 @@ export const Text = compressible<TextProps, TextTokens>((props: TextProps, useTo
     const mergedProps = {
       numberOfLines: truncate || !wrap ? 1 : 0,
       onKeyDown: Platform.OS === (('win32' as any) || 'windows') ? onKeyDown : undefined,
-      onAccessibilityTap: onAccTap,
       ...rest,
       ...extra,
       style: mergeStyles(tokenStyle, props.style, extra?.style),

--- a/packages/experimental/Text/src/__tests__/__snapshots__/Text.test.tsx.snap
+++ b/packages/experimental/Text/src/__tests__/__snapshots__/Text.test.tsx.snap
@@ -4,7 +4,6 @@ exports[`Text component tests Text all props 1`] = `
 <Text
   ellipsizeMode="tail"
   numberOfLines={0}
-  onAccessibilityTap={[Function]}
   style={
     Object {
       "color": "#323130",
@@ -26,7 +25,6 @@ exports[`Text component tests Text all tokens 1`] = `
 <Text
   ellipsizeMode="tail"
   numberOfLines={0}
-  onAccessibilityTap={[Function]}
   style={
     Object {
       "color": "#323130",
@@ -48,7 +46,6 @@ exports[`Text component tests Text default 1`] = `
 <Text
   ellipsizeMode="tail"
   numberOfLines={0}
-  onAccessibilityTap={[Function]}
   style={
     Object {
       "color": "#323130",
@@ -70,7 +67,6 @@ exports[`Text component tests Text variants render correctly with style 1`] = `
 <Text
   ellipsizeMode="tail"
   numberOfLines={0}
-  onAccessibilityTap={[Function]}
   style={
     Object {
       "color": "blue",


### PR DESCRIPTION
Reverts microsoft/fluentui-react-native#1832

This change broke FluentTester on macOS.