### PR TITLE
[Avatar] A11y test fix

### DIFF
--- a/apps/fluent-tester/src/E2E/Avatar/specs/Avatar.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Avatar/specs/Avatar.spec.win.ts
@@ -38,22 +38,24 @@ describe('Avatar Accessibility Testing', () => {
     AvatarPageObject.scrollToTestElement();
     AvatarPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
   });
-  afterEach(() => {
-    expect(AvatarPageObject.didAssertPopup()).toBeFalsy(AvatarPageObject.ERRORMESSAGE_ASSERT);
-  });
   it('Validate accessibilityLabel', () => {
     expect(AvatarPageObject.getPrimaryComponentAttribute(ACCESSIBILITY_LABEL_ATTR)).toEqual(AVATAR_ACCESSIBILITY_LABEL);
+    expect(AvatarPageObject.didAssertPopup()).toBeFalsy(AvatarPageObject.ERRORMESSAGE_ASSERT);
   });
   it('Validate accessibilityLabel from `name` prop', () => {
     expect(AvatarPageObject.getSecondaryComponentAttribute(ACCESSIBILITY_LABEL_ATTR)).toEqual(AVATAR_ACCESSIBILITY_LABEL_BY_NAME);
+    expect(AvatarPageObject.didAssertPopup()).toBeFalsy(AvatarPageObject.ERRORMESSAGE_ASSERT);
   });
   it('Validate accessibilityHint', () => {
     expect(AvatarPageObject.getPrimaryComponentAttribute(ACCESSIBILITY_HINT_ATTRIBUTE)).toEqual(AVATAR_ACCESSIBILITY_HINT);
+    expect(AvatarPageObject.didAssertPopup()).toBeFalsy(AvatarPageObject.ERRORMESSAGE_ASSERT);
   });
   it('Validate accessibilityRole', () => {
     expect(AvatarPageObject.getPrimaryComponentAttribute(ACCESSIBILITY_ROLE_ATTRIBUTE)).toEqual(ACCESSIBILITY_ROLE_LINK);
+    expect(AvatarPageObject.didAssertPopup()).toBeFalsy(AvatarPageObject.ERRORMESSAGE_ASSERT);
   });
   it('Validate default accessibilityRole', () => {
     expect(AvatarPageObject.getSecondaryComponentAttribute(ACCESSIBILITY_ROLE_ATTRIBUTE)).toEqual(ACCESSIBILITY_ROLE_IMAGE);
+    expect(AvatarPageObject.didAssertPopup()).toBeFalsy(AvatarPageObject.ERRORMESSAGE_ASSERT);
   });
 });

--- a/change/@fluentui-react-native-tester-457c2544-0aec-432a-a98f-6c07e97f4bdd.json
+++ b/change/@fluentui-react-native-tester-457c2544-0aec-432a-a98f-6c07e97f4bdd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed a11y test for the Avatar",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "v.kozova13@gmail.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
Removed the check from afterEach according to Sammy's comment:
https://github.com/microsoft/fluentui-react-native/commit/f27d62a7c59b847cb0fbca246c0201171d8992ad#r77196756

### Verification


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
