### PR TITLE
[Badge] Changed API according to Web spec, removed text prop

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/Badge/BadgeTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Badge/BadgeTest.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { BADGE_TESTPAGE } from './consts';
 import { Test, TestSection, PlatformStatus } from '../Test';
 import { View, Platform, Text } from 'react-native';
-import { Badge, CompressibleBadge, PresenceBadge } from '@fluentui-react-native/badge';
+import { Badge, PresenceBadge } from '@fluentui-react-native/badge';
 import BadgeSvg from './oof.svg';
 
 import { SvgIconProps } from '@fluentui-react-native/icon';
@@ -38,18 +38,18 @@ export const BasicBadge: React.FunctionComponent = () => {
     <View>
       <Badge />
       <Text>Appearance</Text>
-      <Badge appearance="outline" text="Outline badge" />
+      <Badge appearance="outline">Outline badge</Badge>
       <Text>Shape</Text>
-      <Badge shape="circular" text="Circular badge" />
-      <Badge shape="rounded" text="rounded badge" />
-      <Badge shape="square" text="Square badge" />
+      <Badge shape="circular">Circular badge</Badge>
+      <Badge shape="rounded">Rounded badge</Badge>
+      <Badge shape="square">Square badge</Badge>
       <Text>Size</Text>
       <Badge size="smallest" shape="circular" />
       <Badge size="smaller" shape="circular" />
-      <Badge size="small" text="Small" />
-      <Badge size="medium" text="Medium" />
-      <Badge size="large" text="Large" />
-      <Badge size="largest" text="Largest" />
+      <Badge size="small">Small</Badge>
+      <Badge size="medium">Medium</Badge>
+      <Badge size="large">Large</Badge>
+      <Badge size="largest">Largest</Badge>
       {svgIconsEnabled && (
         <>
           <Text>Badge with icon</Text>
@@ -61,10 +61,7 @@ export const BasicBadge: React.FunctionComponent = () => {
           <BadgeNoBorder appearance="outline" icon={iconProps} />
         </>
       )}
-      <StyledBadge appearance="outline" text="styled badge" />
-      <Text>Compressible badge</Text>
-      <CompressibleBadge />
-      <CompressibleBadge text="Basic compressible" />
+      <StyledBadge appearance="outline">Styled badge</StyledBadge>
       {svgIconsEnabled && (
         <>
           <Text>Presence Badge</Text>

--- a/change/@fluentui-react-native-badge-c02b37e7-b57f-46dc-9a39-92bdd6fd18a8.json
+++ b/change/@fluentui-react-native-badge-c02b37e7-b57f-46dc-9a39-92bdd6fd18a8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Changed API of Badge according to latest Web component",
+  "packageName": "@fluentui-react-native/badge",
+  "email": "v.kozova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-17676039-11d9-47d2-adca-6d5a2cbf1faf.json
+++ b/change/@fluentui-react-native-tester-17676039-11d9-47d2-adca-6d5a2cbf1faf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Changed API of Badge according to latest Web component",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "v.kozova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Badge/src/Badge.tsx
+++ b/packages/experimental/Badge/src/Badge.tsx
@@ -1,20 +1,10 @@
 /** @jsx withSlots */
+// import { Children } from 'react';
+import * as React from 'react';
 import { View } from 'react-native';
 import { badgeName, BadgeType, BadgeProps } from './Badge.types';
 import { Text } from '@fluentui-react-native/experimental-text';
-import {
-  compose,
-  withSlots,
-  UseSlots,
-  mergeProps,
-  compressible,
-  UseTokens,
-  buildUseTokens,
-  useFluentTheme,
-  mergeStyles,
-  applyTokenLayers,
-} from '@fluentui-react-native/framework';
-import { BadgeTokens } from '.';
+import { compose, withSlots, UseSlots, mergeProps } from '@fluentui-react-native/framework';
 import { Icon } from '@fluentui-react-native/icon';
 import { createIconProps } from '@fluentui-react-native/interactive-hooks';
 import { stylingSettings } from './Badge.styling';
@@ -47,13 +37,12 @@ export const Badge = compose<BadgeType>({
     const Slots = useSlots(userProps, (layer) => badgeLookup(layer, userProps));
 
     return (final: BadgeProps, ...children: React.ReactNode[]) => {
-      const { text, icon, iconPosition = 'before', ...mergedProps } = mergeProps(badge, final);
+      const { icon, iconPosition = 'before', ...mergedProps } = mergeProps(badge, final);
       return (
         <Slots.root {...mergedProps}>
           {icon && iconPosition === 'before' && <Slots.icon {...iconProps} />}
-          {text && <Slots.text key="text">{text}</Slots.text>}
+          {React.Children.map(children, (child) => (typeof child === 'string' ? <Slots.text key="text">{child}</Slots.text> : child))}
           {icon && iconPosition === 'after' && <Slots.icon {...iconProps} />}
-          {children}
         </Slots.root>
       );
     };
@@ -61,50 +50,3 @@ export const Badge = compose<BadgeType>({
 });
 
 export default Badge;
-
-const useBadgeTokens = buildUseTokens<BadgeTokens>(
-  (t) => ({
-    backgroundColor: t.colors.brandBackground,
-    borderRadius: 9999,
-    minWidth: 32,
-    height: 32,
-  }),
-  badgeName,
-);
-
-// In future it'll be good to use compessible for Badge because it will make the component more flexible
-export const CompressibleBadge = compressible<BadgeProps, BadgeTokens>((props: BadgeProps, useTokens: UseTokens<BadgeTokens>) => {
-  const { text, ...rest } = props;
-  const theme = useFluentTheme();
-  let [tokens, cache] = useTokens(theme);
-
-  [tokens, cache] = applyTokenLayers(tokens, ['outline, filled, circular, square, rounded'], cache, (state) => props[state]);
-
-  const [tokenStyle] = cache(
-    () => ({
-      display: 'flex',
-      alignItems: 'center',
-      flexDirection: 'row',
-      alignSelf: 'flex-start',
-      justifyContent: 'center',
-      minWidth: tokens.minWidth,
-      height: tokens.height,
-      margin: 0,
-      backgroundColor: tokens.backgroundColor,
-      borderRadius: tokens.borderRadius,
-      color: '#fff',
-      paddingHorizontal: 20,
-    }),
-    ['borderRadius', 'minWidth', 'height', 'backgroundColor'],
-  );
-
-  return (extra: BadgeProps, children: React.ReactNode) => {
-    const mergedProps = { text, tokenStyle, ...rest, ...extra, style: mergeStyles(tokenStyle) };
-    return (
-      <View {...mergedProps}>
-        {text && <Text {...tokenStyle}>{text}</Text>}
-        {children}
-      </View>
-    );
-  };
-}, useBadgeTokens);

--- a/packages/experimental/Badge/src/Badge.tsx
+++ b/packages/experimental/Badge/src/Badge.tsx
@@ -1,6 +1,5 @@
 /** @jsx withSlots */
-// import { Children } from 'react';
-import * as React from 'react';
+import { Children, ReactNode } from 'react';
 import { View } from 'react-native';
 import { badgeName, BadgeType, BadgeProps } from './Badge.types';
 import { Text } from '@fluentui-react-native/experimental-text';
@@ -36,12 +35,12 @@ export const Badge = compose<BadgeType>({
 
     const Slots = useSlots(userProps, (layer) => badgeLookup(layer, userProps));
 
-    return (final: BadgeProps, ...children: React.ReactNode[]) => {
+    return (final: BadgeProps, ...children: ReactNode[]) => {
       const { icon, iconPosition = 'before', ...mergedProps } = mergeProps(badge, final);
       return (
         <Slots.root {...mergedProps}>
           {icon && iconPosition === 'before' && <Slots.icon {...iconProps} />}
-          {React.Children.map(children, (child) => (typeof child === 'string' ? <Slots.text key="text">{child}</Slots.text> : child))}
+          {Children.map(children, (child) => (typeof child === 'string' ? <Slots.text key="text">{child}</Slots.text> : child))}
           {icon && iconPosition === 'after' && <Slots.icon {...iconProps} />}
         </Slots.root>
       );

--- a/packages/experimental/Badge/src/Badge.types.ts
+++ b/packages/experimental/Badge/src/Badge.types.ts
@@ -8,10 +8,49 @@ export const badgeName = 'Badge';
 export const BadgeSizes = ['smallest', 'smaller', 'small', 'medium', 'large', 'largest'] as const;
 export const BadgeAppearances = ['filled', 'outline', 'tint', 'ghost', 'filledInverted'] as const;
 export const BadgeShapes = ['rounded', 'circular', 'square'] as const;
+export const BadgeColors = ['brand', 'danger', 'important', 'informative', 'severe', 'subtle', 'success', 'warning'] as const;
 export type BadgeSize = typeof BadgeSizes[number];
 export type BadgeAppearance = typeof BadgeAppearances[number];
 export type BadgeShape = typeof BadgeShapes[number];
+export type BadgeColor = typeof BadgeColors[number];
 
+export interface BadgeCoreProps {
+  /**
+   * A Badge can be square, circular or rounded.
+   * @defaultvalue circular
+   */
+  shape?: BadgeShape;
+
+  /** Sets style of Badge to a preset size style
+   * @defaultvalue medium
+   */
+  size?: BadgeSize;
+}
+export interface BadgeProps extends BadgeCoreProps {
+  /**
+   * A Badge can have its content and borders styled for greater emphasis or to be subtle.
+   * It can be filled, outline, ghost, inverted
+   * @defaultvalue filled
+   */
+  appearance?: BadgeAppearance;
+
+  /**
+   * A Badge can be one of preset colors
+   * @defaultvalue brand
+   */
+  color?: BadgeColor;
+
+  /*
+   * Source URL or name of the icon to show on the Badge.
+   */
+  icon?: IconSourcesType;
+
+  /**
+   * Icon can be placed before or after Badge's content.
+   * @default before
+   */
+  iconPosition?: 'before' | 'after';
+}
 export interface BadgeCoreTokens extends LayoutTokens, FontTokens, IBorderTokens, IShadowTokens, IColorTokens {
   /**
    * Set the bottom edge of the Badge
@@ -98,41 +137,6 @@ export interface BadgeTokens extends BadgeCoreTokens {
    */
   hovered?: BadgeTokens;
   focused?: BadgeTokens;
-}
-
-export interface BadgeCoreProps {
-  /**
-   * Badge shape: 'rounded' | 'circular' | 'square'
-   * @defaultvalue rounded
-   */
-  shape?: BadgeShape;
-
-  /** Sets style of Badge to a preset size style  */
-  size?: BadgeSize;
-}
-export interface BadgeProps extends BadgeCoreProps {
-  /**
-   * A Badge can have its content and borders styled for greater emphasis or to be subtle.
-   * filled -
-   * outline -
-   */
-  appearance?: BadgeAppearance;
-
-  /*
-   * Source URL or name of the icon to show on the Badge.
-   */
-  icon?: IconSourcesType;
-
-  /**
-   * Icon can be placed before or after Badge's content.
-   * @default before
-   */
-  iconPosition?: 'before' | 'after';
-
-  /*
-   * Text to show on the Badge.
-   */
-  text?: string;
 }
 
 export interface BadgeSlotProps {

--- a/packages/experimental/Badge/src/__tests__/Badge.test.tsx
+++ b/packages/experimental/Badge/src/__tests__/Badge.test.tsx
@@ -17,13 +17,9 @@ describe('Badge component tests', () => {
   it('Badge all props', () => {
     const tree = renderer
       .create(
-        <Badge
-          text="Badge"
-          size="large"
-          appearance="outline"
-          shape="rounded"
-          icon={{ fontSource: { ...fontBuiltInProps }, color: '#fff' }}
-        />,
+        <Badge size="large" appearance="outline" shape="rounded" icon={{ fontSource: { ...fontBuiltInProps }, color: '#fff' }}>
+          Badge
+        </Badge>,
       )
       .toJSON();
     expect(tree).toMatchSnapshot();
@@ -35,7 +31,7 @@ describe('Badge component tests', () => {
       borderColor: '#f09',
       borderWidth: 4,
     });
-    const tree = renderer.create(<BadgeStyled text="Badge Tokens" />).toJSON();
+    const tree = renderer.create(<BadgeStyled>Badge Tokens</BadgeStyled>).toJSON();
     expect(tree).toMatchSnapshot();
   });
 

--- a/packages/experimental/Badge/src/index.ts
+++ b/packages/experimental/Badge/src/index.ts
@@ -10,6 +10,6 @@ export type {
   BadgeTokens,
   BadgeType,
 } from './Badge.types';
-export { Badge, CompressibleBadge, badgeLookup } from './Badge';
+export { Badge, badgeLookup } from './Badge';
 export { PresenceBadge, presenceBadgeName, PresenceBadgeStatuses } from './PresenceBadge';
 export type { PresenceBadgeStatus, PresenceBadgeProps, PresenceBadgeSlotProps, PresenceBadgeType } from './PresenceBadge';


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
- Changed API according to the Web spec
- Removed text prop. Text should be passed as part of children prop

### Verification
![image](https://user-images.githubusercontent.com/11574680/179801626-5a6913ac-d87e-4662-ba75-ab15ef9c8d16.png)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
