### PR TITLE
Apple nuget: Fix publish overrides for iPhone simulator

### DIFF
--- a/.ado/templates/apple-nuget-publish.yml
+++ b/.ado/templates/apple-nuget-publish.yml
@@ -54,7 +54,7 @@ steps:
       xcode_actions: 'build'
       xcode_scheme: 'FluentTester'
       xcode_configuration: 'Release'
-      xcode_extraArgs: ''
+      xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/publish_overrides.xcconfig'
 
   # iPhone Device Release
   - template: apple-xcode-build.yml
@@ -99,4 +99,3 @@ steps:
       command: push
       packagesToPush: '$(Build.ArtifactStagingDirectory)/Microsoft.FluentUI.ReactNative.*.nupkg'
       publishVstsFeed: Office
-


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Our Nuget package containing the static libraries for FURN libraries were missing the ARM64 slice on iPhone simulator. This one line fix should fix that.

### Verification

CI change.. can't really test till it's checked in. 

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
