### PR TITLE
[Avatar] Fixed redundant margin

### DIFF
--- a/change/@fluentui-react-native-avatar-6a1dfd86-dcd0-42a4-8d93-9e05517e2b83.json
+++ b/change/@fluentui-react-native-avatar-6a1dfd86-dcd0-42a4-8d93-9e05517e2b83.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "removed redundunt margin for Avatar and added aspectRatio to presence Badge",
+  "packageName": "@fluentui-react-native/avatar",
+  "email": "v.kozova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-badge-77ffab67-b56c-4ff4-8505-fcfe7aeedbe8.json
+++ b/change/@fluentui-react-native-badge-77ffab67-b56c-4ff4-8505-fcfe7aeedbe8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "removed redundunt margin for Avatar and added aspectRatio to presence Badge",
+  "packageName": "@fluentui-react-native/badge",
+  "email": "v.kozova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Avatar/src/Avatar.styling.ts
+++ b/packages/components/Avatar/src/Avatar.styling.ts
@@ -85,7 +85,6 @@ export const stylingSettings: UseStylingOptions<AvatarProps, AvatarSlotProps, Av
           !avatarColor || AvatarColors.includes(avatarColor as AvatarNamedColor) || ColorSchemes.includes(avatarColor as AvatarColorSchemes)
             ? backgroundColor
             : avatarColor;
-        const ringConfig = getRingConfig(tokens);
 
         return {
           style: {
@@ -97,8 +96,7 @@ export const stylingSettings: UseStylingOptions<AvatarProps, AvatarSlotProps, Av
             backgroundColor: _avatarColor,
             borderWidth: tokens.borderWidth,
             borderColor: tokens.borderColor,
-            marginTop: ringConfig.ringThickness,
-            marginLeft: ringConfig.ringThickness,
+            ...getRingSpacing(tokens),
             aspectRatio: 1,
           },
         };
@@ -108,7 +106,6 @@ export const stylingSettings: UseStylingOptions<AvatarProps, AvatarSlotProps, Av
     image: buildProps(
       (tokens: AvatarTokens) => {
         const { borderRadius, size, borderWidth, borderColor } = tokens;
-        const ringConfig = getRingConfig(tokens);
         return {
           style: {
             borderRadius: borderRadius,
@@ -116,8 +113,7 @@ export const stylingSettings: UseStylingOptions<AvatarProps, AvatarSlotProps, Av
             minHeight: size,
             borderWidth: borderWidth,
             borderColor: borderColor,
-            marginTop: ringConfig.ringThickness,
-            marginLeft: ringConfig.ringThickness,
+            ...getRingSpacing(tokens),
             aspectRatio: 1,
           },
         };
@@ -220,4 +216,14 @@ function getIconStyles(tokens: AvatarTokens) {
     width: tokens.iconSize,
     height: tokens.iconSize,
   };
+}
+
+function getRingSpacing(tokens: AvatarTokens) {
+  const ringConfig = getRingConfig(tokens);
+  return tokens.active === 'active'
+    ? {
+        marginTop: ringConfig.ringThickness,
+        marginLeft: ringConfig.ringThickness,
+      }
+    : {};
 }

--- a/packages/components/Avatar/src/__tests__/__snapshots__/Avatar.test.jsx.snap
+++ b/packages/components/Avatar/src/__tests__/__snapshots__/Avatar.test.jsx.snap
@@ -32,8 +32,6 @@ exports[`Avatar rendering renders Avatar 1`] = `
         "borderRadius": 9999,
         "borderWidth": 0,
         "justifyContent": "center",
-        "marginLeft": 2,
-        "marginTop": 2,
         "minHeight": 24,
         "minWidth": 24,
       }

--- a/packages/experimental/Badge/src/PresenceBadge/PresenceBadge.styling.ts
+++ b/packages/experimental/Badge/src/PresenceBadge/PresenceBadge.styling.ts
@@ -39,6 +39,7 @@ export const stylingSettings: UseStylingOptions<PresenceBadgeProps, PresenceBadg
             backgroundColor: tokens.backgroundColor,
             ...borderStyles.from(tokens, theme),
             paddingHorizontal: tokens.paddingHorizontal,
+            aspectRatio: 1,
           },
         };
       },
@@ -50,6 +51,7 @@ export const stylingSettings: UseStylingOptions<PresenceBadgeProps, PresenceBadg
           width: tokens.width,
           height: tokens.height,
           color: tokens.iconColor,
+          aspectRatio: 1,
         },
       }),
       ['width', 'height', 'iconColor'],


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
- Fixed redundant margin for the avatar
- Added aspectRatio for presenceBadge (but it didn't help with the icon bug)

### Verification
**Before**
<img width="140" alt="image" src="https://user-images.githubusercontent.com/11574680/179994949-0194ddbb-e1a9-4e32-9d9e-702a7187f8ba.png">

**After**
![image](https://user-images.githubusercontent.com/11574680/179994888-e55d39df-2e2f-4e4b-8565-2644a0f923b0.png)


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
