### PR TITLE
[Avatar] Fixed size for the font icon

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Avatar/BasicAvatar.tsx
+++ b/apps/fluent-tester/src/TestComponents/Avatar/BasicAvatar.tsx
@@ -93,6 +93,26 @@ export const StandardUsage: FunctionComponent = () => {
           avatarColor="#ff0099"
           initialsColor="yellow"
         />
+        <Avatar
+          active={active}
+          activeAppearance={activeAppearance}
+          size={36}
+          shape={isSquare ? 'square' : 'circular'}
+          accessibilityLabel="SVG Icon"
+          icon={{ fontSource: { ...fontBuiltInProps } }}
+          avatarColor={avatarColor}
+          badge={{ status: 'outOfOffice', outOfOffice }}
+        />
+        <Avatar
+          active={active}
+          activeAppearance={activeAppearance}
+          size={imageSize === undefinedText ? undefined : imageSize}
+          shape={isSquare ? 'square' : 'circular'}
+          accessibilityLabel="SVG Icon"
+          icon={{ fontSource: { ...fontBuiltInProps }, color: 'green' }}
+          avatarColor={avatarColor}
+          badge={{ status: 'outOfOffice', outOfOffice }}
+        />
         {svgIconsEnabled && (
           <>
             <Avatar
@@ -101,7 +121,7 @@ export const StandardUsage: FunctionComponent = () => {
               size={imageSize === undefinedText ? undefined : imageSize}
               shape={isSquare ? 'square' : 'circular'}
               accessibilityLabel="SVG Icon"
-              icon={{ fontSource: { ...fontBuiltInProps, fontSize: 32 }, color: 'red' }}
+              icon={{ fontSource: { ...fontBuiltInProps, fontSize: 16 }, color: 'red' }}
               avatarColor={avatarColor}
               badge={{ status: 'outOfOffice', outOfOffice }}
             />

--- a/change/@fluentui-react-native-avatar-12d28f82-ea65-4eb2-a830-971d34625b56.json
+++ b/change/@fluentui-react-native-avatar-12d28f82-ea65-4eb2-a830-971d34625b56.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed bug with size of font icon",
+  "packageName": "@fluentui-react-native/avatar",
+  "email": "v.kozova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-987f88f2-5453-4a35-b575-942bbb04173d.json
+++ b/change/@fluentui-react-native-tester-987f88f2-5453-4a35-b575-942bbb04173d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed bug with size of font icon",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "v.kozova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Avatar/src/useAvatar.ts
+++ b/packages/components/Avatar/src/useAvatar.ts
@@ -54,7 +54,7 @@ export const useAvatar = (props: AvatarProps): AvatarInfo => {
 
     iconProps = {
       fontSource: {
-        fontSize: fontSource.fontSize ?? getIconSize(size),
+        fontSize: fontSource.fontSize ?? getFontIconSize(size),
         ...iconProps.fontSource,
       },
       ...restIconProps,
@@ -141,7 +141,7 @@ export const removeTitlesFromName = (words: string[]): string[] => {
   return words.filter((word) => !titles.has(word));
 };
 
-function getIconSize(size: AvatarSize) {
+function getFontIconSize(size: AvatarSize) {
   if (size >= 25 && size <= 47) {
     return 20;
   } else if (size === 48) {

--- a/packages/components/Avatar/src/useAvatar.ts
+++ b/packages/components/Avatar/src/useAvatar.ts
@@ -1,4 +1,4 @@
-import { AvatarProps, AvatarInfo, AvatarState, AvatarColors } from './Avatar.types';
+import { AvatarProps, AvatarInfo, AvatarState, AvatarColors, AvatarSize } from './Avatar.types';
 import { PresenceBadgeProps } from '@fluentui-react-native/badge';
 import { titles } from './titles';
 import { getHashCodeWeb } from './getHashCode';
@@ -24,6 +24,7 @@ export const useAvatar = (props: AvatarProps): AvatarInfo => {
     shape,
     transparentRing,
     icon,
+    size,
     ...rest
   } = props;
 
@@ -46,7 +47,19 @@ export const useAvatar = (props: AvatarProps): AvatarInfo => {
   const avatarColorsIdx = getHashCodeWeb(idForColor ?? name ?? '') % AvatarColors.length;
   const _avatarColor = avatarColor === 'colorful' ? AvatarColors[avatarColorsIdx] : avatarColor;
 
-  const iconProps = createIconProps(icon);
+  let iconProps = createIconProps(icon);
+  const isFontIcon = !!(iconProps && iconProps.fontSource);
+  if (isFontIcon) {
+    const { fontSource, ...restIconProps } = iconProps;
+
+    iconProps = {
+      fontSource: {
+        fontSize: fontSource.fontSize ?? getIconSize(size),
+        ...iconProps.fontSource,
+      },
+      ...restIconProps,
+    };
+  }
 
   return {
     props: {
@@ -62,6 +75,7 @@ export const useAvatar = (props: AvatarProps): AvatarInfo => {
       icon: iconProps,
       outOfOffice: badge?.outOfOffice,
       shape: shape ?? 'circular',
+      size,
       ...rest,
     },
     state: {
@@ -126,3 +140,18 @@ export const removeRedundantCharacters = (name: string): string[] => {
 export const removeTitlesFromName = (words: string[]): string[] => {
   return words.filter((word) => !titles.has(word));
 };
+
+function getIconSize(size: AvatarSize) {
+  if (size >= 25 && size <= 47) {
+    return 20;
+  } else if (size === 48) {
+    return 24;
+  } else if (size === 56) {
+    return 28;
+  } else if (size >= 57 && size <= 72) {
+    return 32;
+  } else if (size >= 73) {
+    return 48;
+  }
+  return 16;
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS
- [X] win32 (Office)
- [X] windows
- [ ] android

### Description of changes
Fixed bug with size of the font icon.
But this bug is partially fixed. Icon size is counted depending on Avatar size, but if I change size of the Avatar in Tester - icon size doesn't change. I don't know why it's happening. Looks like icon size caches somewhere. Anyway this is better than it was before

### Verification
![image](https://user-images.githubusercontent.com/11574680/180471648-2aa4fdf3-ecde-4c72-a7ae-ce6ec94be7dc.png)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
