### PR TITLE
useViewCommandFocus: Check that Focus exists in ViewManager first

### DIFF
--- a/change/@fluentui-react-native-interactive-hooks-c97fe285-b501-4bdf-a702-fc76934057ce.json
+++ b/change/@fluentui-react-native-interactive-hooks-c97fe285-b501-4bdf-a702-fc76934057ce.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "useViewCommandFocus: check focus command exists on RCTView first",
+  "packageName": "@fluentui-react-native/interactive-hooks",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/utils/interactive-hooks/src/useViewCommandFocus.ts
+++ b/packages/utils/interactive-hooks/src/useViewCommandFocus.ts
@@ -29,9 +29,12 @@ export function useViewCommandFocus(
        * Add focus() as a callable function to the forwarded reference.
        */
       if (localRef) {
-        localRef.focus = () => {
-          UIManager.dispatchViewManagerCommand(findNodeHandle(localRef), UIManager.getViewManagerConfig('RCTView').Commands.focus, null);
-        };
+        const focusCommand = UIManager.getViewManagerConfig('RCTView').Commands.focus;
+        if (localRef && focusCommand) {
+          localRef.focus = () => {
+            UIManager.dispatchViewManagerCommand(findNodeHandle(localRef), focusCommand, null);
+          };
+        }
       }
     },
   });

--- a/packages/utils/interactive-hooks/src/useViewCommandFocus.ts
+++ b/packages/utils/interactive-hooks/src/useViewCommandFocus.ts
@@ -29,12 +29,12 @@ export function useViewCommandFocus(
        * Add focus() as a callable function to the forwarded reference.
        */
       if (localRef) {
-        const commands = UIManager.getViewManagerConfig('RCTView').Commands;
-        if ('focus' in commands) {
-          localRef.focus = () => {
+        localRef.focus = () => {
+          const commands = UIManager.getViewManagerConfig('RCTView').Commands;
+          if ('focus' in commands) {
             UIManager.dispatchViewManagerCommand(findNodeHandle(localRef), commands.focus, null);
-          };
-        }
+          }
+        };
       }
     },
   });

--- a/packages/utils/interactive-hooks/src/useViewCommandFocus.ts
+++ b/packages/utils/interactive-hooks/src/useViewCommandFocus.ts
@@ -29,12 +29,14 @@ export function useViewCommandFocus(
        * Add focus() as a callable function to the forwarded reference.
        */
       if (localRef) {
-        const focusCommand = UIManager.getViewManagerConfig('RCTView').Commands.focus;
-        if (localRef && focusCommand) {
-          localRef.focus = () => {
-            UIManager.dispatchViewManagerCommand(findNodeHandle(localRef), focusCommand, null);
-          };
-        }
+        localRef.focus = () => {
+          const commands = UIManager.getViewManagerConfig('RCTView').Commands;
+          if (localRef && 'focus' in commands) {
+            localRef.focus = () => {
+              UIManager.dispatchViewManagerCommand(findNodeHandle(localRef), commands.focus, null);
+            };
+          }
+        };
       }
     },
   });

--- a/packages/utils/interactive-hooks/src/useViewCommandFocus.ts
+++ b/packages/utils/interactive-hooks/src/useViewCommandFocus.ts
@@ -29,14 +29,12 @@ export function useViewCommandFocus(
        * Add focus() as a callable function to the forwarded reference.
        */
       if (localRef) {
-        localRef.focus = () => {
-          const commands = UIManager.getViewManagerConfig('RCTView').Commands;
-          if ('focus' in commands) {
-            localRef.focus = () => {
-              UIManager.dispatchViewManagerCommand(findNodeHandle(localRef), commands.focus, null);
-            };
-          }
-        };
+        const commands = UIManager.getViewManagerConfig('RCTView').Commands;
+        if ('focus' in commands) {
+          localRef.focus = () => {
+            UIManager.dispatchViewManagerCommand(findNodeHandle(localRef), commands.focus, null);
+          };
+        }
       }
     },
   });

--- a/packages/utils/interactive-hooks/src/useViewCommandFocus.ts
+++ b/packages/utils/interactive-hooks/src/useViewCommandFocus.ts
@@ -31,7 +31,7 @@ export function useViewCommandFocus(
       if (localRef) {
         localRef.focus = () => {
           const commands = UIManager.getViewManagerConfig('RCTView').Commands;
-          if (localRef && 'focus' in commands) {
+          if ('focus' in commands) {
             localRef.focus = () => {
               UIManager.dispatchViewManagerCommand(findNodeHandle(localRef), commands.focus, null);
             };

--- a/packages/utils/interactive-hooks/src/useViewCommandFocus.win32.ts
+++ b/packages/utils/interactive-hooks/src/useViewCommandFocus.win32.ts
@@ -30,10 +30,10 @@ export function useViewCommandFocus(
        */
       if (localRef) {
         localRef.focus = () => {
-          const focusCommand = UIManager.getViewManagerConfig('RCTView').Commands.focus;
-          if (localRef && focusCommand) {
+          const commands = UIManager.getViewManagerConfig('RCTView').Commands;
+          if (localRef && 'focus' in commands) {
             localRef.focus = () => {
-              UIManager.dispatchViewManagerCommand(findNodeHandle(localRef), focusCommand, null);
+              UIManager.dispatchViewManagerCommand(findNodeHandle(localRef), commands.focus, null);
             };
           }
         };

--- a/packages/utils/interactive-hooks/src/useViewCommandFocus.win32.ts
+++ b/packages/utils/interactive-hooks/src/useViewCommandFocus.win32.ts
@@ -30,7 +30,12 @@ export function useViewCommandFocus(
        */
       if (localRef) {
         localRef.focus = () => {
-          UIManager.dispatchViewManagerCommand(findNodeHandle(localRef), UIManager.getViewManagerConfig('RCTView').Commands.focus, null);
+          const focusCommand = UIManager.getViewManagerConfig('RCTView').Commands.focus;
+          if (localRef && focusCommand) {
+            localRef.focus = () => {
+              UIManager.dispatchViewManagerCommand(findNodeHandle(localRef), focusCommand, null);
+            };
+          }
         };
       }
     },

--- a/packages/utils/interactive-hooks/src/useViewCommandFocus.win32.ts
+++ b/packages/utils/interactive-hooks/src/useViewCommandFocus.win32.ts
@@ -30,12 +30,7 @@ export function useViewCommandFocus(
        */
       if (localRef) {
         localRef.focus = () => {
-          const commands = UIManager.getViewManagerConfig('RCTView').Commands;
-          if (localRef && 'focus' in commands) {
-            localRef.focus = () => {
-              UIManager.dispatchViewManagerCommand(findNodeHandle(localRef), commands.focus, null);
-            };
-          }
+          UIManager.dispatchViewManagerCommand(findNodeHandle(localRef), UIManager.getViewManagerConfig('RCTView').Commands.focus, null);
         };
       }
     },


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

See: https://github.com/microsoft/fluentui-react-native/pull/1535#pullrequestreview-1047650737

This change should prevent some crashes we see on Platforms where RCTView doesn't have a `focus` command exposed. This also happens to fix the Redbox we kept seeing on iOS :)  

### Verification

E2E tests in CI should be good.

iOS no longer Redboxes on button clicks

https://user-images.githubusercontent.com/6722175/180575666-cdb2b8a3-7399-4768-8cf4-2807032f140e.mov



### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
