### PR TITLE
Don't put Flatlists inside Scrollviews in FluentTester

### DIFF
--- a/apps/fluent-tester/src/FluentTester/TestComponents/Theme/ThemeTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Theme/ThemeTest.tsx
@@ -91,9 +91,7 @@ const SwatchList: React.FunctionComponent = () => {
   return (
     <View style={[commonTestStyles.view]}>
       <Text>getHostSettingsWin32(theme: ITheme).palette</Text>
-      <View style={themedStyles.stackStyle}>
-        <FlatList data={paletteAsArray} renderItem={renderSwatch} />
-      </View>
+      <View style={themedStyles.stackStyle}>{paletteAsArray.map((item) => renderSwatch({ item }))}</View>
     </View>
   );
 };

--- a/apps/fluent-tester/src/FluentTester/TestComponents/Theme/ThemeTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Theme/ThemeTest.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FlatList, View, ViewStyle, StyleSheet, ColorValue } from 'react-native';
+import { View, ViewStyle, StyleSheet, ColorValue } from 'react-native';
 import { useTheme, Theme } from '@fluentui-react-native/theme-types';
 import { themedStyleSheet } from '@fluentui-react-native/themed-stylesheet';
 import { commonTestStyles } from '../Common/styles';

--- a/apps/fluent-tester/src/FluentTester/TestComponents/Tokens/TokenTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Tokens/TokenTest.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FlatList, View, ViewStyle, StyleSheet, ColorValue } from 'react-native';
+import { View, ViewStyle, StyleSheet, ColorValue } from 'react-native';
 import { useTheme, Theme } from '@fluentui-react-native/theme-types';
 import { themedStyleSheet } from '@fluentui-react-native/themed-stylesheet';
 import { getCurrentAppearance } from '@fluentui-react-native/theming-utils';

--- a/apps/fluent-tester/src/FluentTester/TestComponents/Tokens/TokenTest.tsx
+++ b/apps/fluent-tester/src/FluentTester/TestComponents/Tokens/TokenTest.tsx
@@ -87,9 +87,7 @@ const AliasTokensSwatchList: React.FunctionComponent = () => {
   return (
     <View style={[commonTestStyles.view]}>
       <Text>Alias Color Tokens from Token Pipeline</Text>
-      <View style={themedStyles.stackStyle}>
-        <FlatList data={aliasTokensAsArray} renderItem={renderSwatch} />
-      </View>
+      <View style={themedStyles.stackStyle}>{aliasTokensAsArray.map((item) => renderSwatch({ item }))}</View>
     </View>
   );
 };

--- a/apps/macos/src/Podfile.lock
+++ b/apps/macos/src/Podfile.lock
@@ -2,14 +2,14 @@ PODS:
   - boost (1.76.0)
   - boost-for-react-native (1.63.0)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.66.60)
-  - FBReactNativeSpec (0.66.60):
+  - FBLazyVector (0.66.61)
+  - FBReactNativeSpec (0.66.61):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.66.60)
-    - RCTTypeSafety (= 0.66.60)
-    - React-Core (= 0.66.60)
-    - React-jsi (= 0.66.60)
-    - ReactCommon/turbomodule/core (= 0.66.60)
+    - RCTRequired (= 0.66.61)
+    - RCTTypeSafety (= 0.66.61)
+    - React-Core (= 0.66.61)
+    - React-jsi (= 0.66.61)
+    - ReactCommon/turbomodule/core (= 0.66.61)
   - fmt (6.2.1)
   - FRNAvatar (0.16.0):
     - MicrosoftFluentUI (= 0.5.2)
@@ -105,258 +105,258 @@ PODS:
     - glog
   - RCTFocusZone (0.10.0):
     - React
-  - RCTRequired (0.66.60)
-  - RCTTypeSafety (0.66.60):
-    - FBLazyVector (= 0.66.60)
+  - RCTRequired (0.66.61)
+  - RCTTypeSafety (0.66.61):
+    - FBLazyVector (= 0.66.61)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.66.60)
-    - React-Core (= 0.66.60)
-  - React (0.66.60):
-    - React-Core (= 0.66.60)
-    - React-Core/DevSupport (= 0.66.60)
-    - React-Core/RCTWebSocket (= 0.66.60)
-    - React-RCTActionSheet (= 0.66.60)
-    - React-RCTAnimation (= 0.66.60)
-    - React-RCTBlob (= 0.66.60)
-    - React-RCTImage (= 0.66.60)
-    - React-RCTLinking (= 0.66.60)
-    - React-RCTNetwork (= 0.66.60)
-    - React-RCTSettings (= 0.66.60)
-    - React-RCTText (= 0.66.60)
-    - React-RCTVibration (= 0.66.60)
-  - React-callinvoker (0.66.60)
-  - React-Core (0.66.60):
+    - RCTRequired (= 0.66.61)
+    - React-Core (= 0.66.61)
+  - React (0.66.61):
+    - React-Core (= 0.66.61)
+    - React-Core/DevSupport (= 0.66.61)
+    - React-Core/RCTWebSocket (= 0.66.61)
+    - React-RCTActionSheet (= 0.66.61)
+    - React-RCTAnimation (= 0.66.61)
+    - React-RCTBlob (= 0.66.61)
+    - React-RCTImage (= 0.66.61)
+    - React-RCTLinking (= 0.66.61)
+    - React-RCTNetwork (= 0.66.61)
+    - React-RCTSettings (= 0.66.61)
+    - React-RCTText (= 0.66.61)
+    - React-RCTVibration (= 0.66.61)
+  - React-callinvoker (0.66.61)
+  - React-Core (0.66.61):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.66.60)
-    - React-cxxreact (= 0.66.60)
-    - React-jsi (= 0.66.60)
-    - React-jsiexecutor (= 0.66.60)
-    - React-perflogger (= 0.66.60)
+    - React-Core/Default (= 0.66.61)
+    - React-cxxreact (= 0.66.61)
+    - React-jsi (= 0.66.61)
+    - React-jsiexecutor (= 0.66.61)
+    - React-perflogger (= 0.66.61)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.66.60):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default
-    - React-cxxreact (= 0.66.60)
-    - React-jsi (= 0.66.60)
-    - React-jsiexecutor (= 0.66.60)
-    - React-perflogger (= 0.66.60)
-    - Yoga
-  - React-Core/Default (0.66.60):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.66.60)
-    - React-jsi (= 0.66.60)
-    - React-jsiexecutor (= 0.66.60)
-    - React-perflogger (= 0.66.60)
-    - Yoga
-  - React-Core/DevSupport (0.66.60):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.66.60)
-    - React-Core/RCTWebSocket (= 0.66.60)
-    - React-cxxreact (= 0.66.60)
-    - React-jsi (= 0.66.60)
-    - React-jsiexecutor (= 0.66.60)
-    - React-jsinspector (= 0.66.60)
-    - React-perflogger (= 0.66.60)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.66.60):
+  - React-Core/CoreModulesHeaders (0.66.61):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.60)
-    - React-jsi (= 0.66.60)
-    - React-jsiexecutor (= 0.66.60)
-    - React-perflogger (= 0.66.60)
+    - React-cxxreact (= 0.66.61)
+    - React-jsi (= 0.66.61)
+    - React-jsiexecutor (= 0.66.61)
+    - React-perflogger (= 0.66.61)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.66.60):
+  - React-Core/Default (0.66.61):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-cxxreact (= 0.66.61)
+    - React-jsi (= 0.66.61)
+    - React-jsiexecutor (= 0.66.61)
+    - React-perflogger (= 0.66.61)
+    - Yoga
+  - React-Core/DevSupport (0.66.61):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-Core/Default (= 0.66.61)
+    - React-Core/RCTWebSocket (= 0.66.61)
+    - React-cxxreact (= 0.66.61)
+    - React-jsi (= 0.66.61)
+    - React-jsiexecutor (= 0.66.61)
+    - React-jsinspector (= 0.66.61)
+    - React-perflogger (= 0.66.61)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.66.61):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.60)
-    - React-jsi (= 0.66.60)
-    - React-jsiexecutor (= 0.66.60)
-    - React-perflogger (= 0.66.60)
+    - React-cxxreact (= 0.66.61)
+    - React-jsi (= 0.66.61)
+    - React-jsiexecutor (= 0.66.61)
+    - React-perflogger (= 0.66.61)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.66.60):
+  - React-Core/RCTAnimationHeaders (0.66.61):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.60)
-    - React-jsi (= 0.66.60)
-    - React-jsiexecutor (= 0.66.60)
-    - React-perflogger (= 0.66.60)
+    - React-cxxreact (= 0.66.61)
+    - React-jsi (= 0.66.61)
+    - React-jsiexecutor (= 0.66.61)
+    - React-perflogger (= 0.66.61)
     - Yoga
-  - React-Core/RCTImageHeaders (0.66.60):
+  - React-Core/RCTBlobHeaders (0.66.61):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.60)
-    - React-jsi (= 0.66.60)
-    - React-jsiexecutor (= 0.66.60)
-    - React-perflogger (= 0.66.60)
+    - React-cxxreact (= 0.66.61)
+    - React-jsi (= 0.66.61)
+    - React-jsiexecutor (= 0.66.61)
+    - React-perflogger (= 0.66.61)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.66.60):
+  - React-Core/RCTImageHeaders (0.66.61):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.60)
-    - React-jsi (= 0.66.60)
-    - React-jsiexecutor (= 0.66.60)
-    - React-perflogger (= 0.66.60)
+    - React-cxxreact (= 0.66.61)
+    - React-jsi (= 0.66.61)
+    - React-jsiexecutor (= 0.66.61)
+    - React-perflogger (= 0.66.61)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.66.60):
+  - React-Core/RCTLinkingHeaders (0.66.61):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.60)
-    - React-jsi (= 0.66.60)
-    - React-jsiexecutor (= 0.66.60)
-    - React-perflogger (= 0.66.60)
+    - React-cxxreact (= 0.66.61)
+    - React-jsi (= 0.66.61)
+    - React-jsiexecutor (= 0.66.61)
+    - React-perflogger (= 0.66.61)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.66.60):
+  - React-Core/RCTNetworkHeaders (0.66.61):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.60)
-    - React-jsi (= 0.66.60)
-    - React-jsiexecutor (= 0.66.60)
-    - React-perflogger (= 0.66.60)
+    - React-cxxreact (= 0.66.61)
+    - React-jsi (= 0.66.61)
+    - React-jsiexecutor (= 0.66.61)
+    - React-perflogger (= 0.66.61)
     - Yoga
-  - React-Core/RCTTextHeaders (0.66.60):
+  - React-Core/RCTSettingsHeaders (0.66.61):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.60)
-    - React-jsi (= 0.66.60)
-    - React-jsiexecutor (= 0.66.60)
-    - React-perflogger (= 0.66.60)
+    - React-cxxreact (= 0.66.61)
+    - React-jsi (= 0.66.61)
+    - React-jsiexecutor (= 0.66.61)
+    - React-perflogger (= 0.66.61)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.66.60):
+  - React-Core/RCTTextHeaders (0.66.61):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.60)
-    - React-jsi (= 0.66.60)
-    - React-jsiexecutor (= 0.66.60)
-    - React-perflogger (= 0.66.60)
+    - React-cxxreact (= 0.66.61)
+    - React-jsi (= 0.66.61)
+    - React-jsiexecutor (= 0.66.61)
+    - React-perflogger (= 0.66.61)
     - Yoga
-  - React-Core/RCTWebSocket (0.66.60):
+  - React-Core/RCTVibrationHeaders (0.66.61):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.66.60)
-    - React-cxxreact (= 0.66.60)
-    - React-jsi (= 0.66.60)
-    - React-jsiexecutor (= 0.66.60)
-    - React-perflogger (= 0.66.60)
+    - React-Core/Default
+    - React-cxxreact (= 0.66.61)
+    - React-jsi (= 0.66.61)
+    - React-jsiexecutor (= 0.66.61)
+    - React-perflogger (= 0.66.61)
     - Yoga
-  - React-CoreModules (0.66.60):
-    - FBReactNativeSpec (= 0.66.60)
+  - React-Core/RCTWebSocket (0.66.61):
+    - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.66.60)
-    - React-Core/CoreModulesHeaders (= 0.66.60)
-    - React-jsi (= 0.66.60)
-    - React-RCTImage (= 0.66.60)
-    - ReactCommon/turbomodule/core (= 0.66.60)
-  - React-cxxreact (0.66.60):
+    - React-Core/Default (= 0.66.61)
+    - React-cxxreact (= 0.66.61)
+    - React-jsi (= 0.66.61)
+    - React-jsiexecutor (= 0.66.61)
+    - React-perflogger (= 0.66.61)
+    - Yoga
+  - React-CoreModules (0.66.61):
+    - FBReactNativeSpec (= 0.66.61)
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - RCTTypeSafety (= 0.66.61)
+    - React-Core/CoreModulesHeaders (= 0.66.61)
+    - React-jsi (= 0.66.61)
+    - React-RCTImage (= 0.66.61)
+    - ReactCommon/turbomodule/core (= 0.66.61)
+  - React-cxxreact (0.66.61):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.66.60)
-    - React-jsi (= 0.66.60)
-    - React-jsinspector (= 0.66.60)
-    - React-logger (= 0.66.60)
-    - React-perflogger (= 0.66.60)
-    - React-runtimeexecutor (= 0.66.60)
-  - React-jsi (0.66.60):
+    - React-callinvoker (= 0.66.61)
+    - React-jsi (= 0.66.61)
+    - React-jsinspector (= 0.66.61)
+    - React-logger (= 0.66.61)
+    - React-perflogger (= 0.66.61)
+    - React-runtimeexecutor (= 0.66.61)
+  - React-jsi (0.66.61):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-jsi/Default (= 0.66.60)
-  - React-jsi/Default (0.66.60):
+    - React-jsi/Default (= 0.66.61)
+  - React-jsi/Default (0.66.61):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-  - React-jsiexecutor (0.66.60):
+  - React-jsiexecutor (0.66.61):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.66.60)
-    - React-jsi (= 0.66.60)
-    - React-perflogger (= 0.66.60)
-  - React-jsinspector (0.66.60)
-  - React-logger (0.66.60):
+    - React-cxxreact (= 0.66.61)
+    - React-jsi (= 0.66.61)
+    - React-perflogger (= 0.66.61)
+  - React-jsinspector (0.66.61)
+  - React-logger (0.66.61):
     - glog
-  - React-perflogger (0.66.60)
-  - React-RCTActionSheet (0.66.60):
-    - React-Core/RCTActionSheetHeaders (= 0.66.60)
-  - React-RCTAnimation (0.66.60):
-    - FBReactNativeSpec (= 0.66.60)
+  - React-perflogger (0.66.61)
+  - React-RCTActionSheet (0.66.61):
+    - React-Core/RCTActionSheetHeaders (= 0.66.61)
+  - React-RCTAnimation (0.66.61):
+    - FBReactNativeSpec (= 0.66.61)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.66.60)
-    - React-Core/RCTAnimationHeaders (= 0.66.60)
-    - React-jsi (= 0.66.60)
-    - ReactCommon/turbomodule/core (= 0.66.60)
-  - React-RCTBlob (0.66.60):
-    - FBReactNativeSpec (= 0.66.60)
+    - RCTTypeSafety (= 0.66.61)
+    - React-Core/RCTAnimationHeaders (= 0.66.61)
+    - React-jsi (= 0.66.61)
+    - ReactCommon/turbomodule/core (= 0.66.61)
+  - React-RCTBlob (0.66.61):
+    - FBReactNativeSpec (= 0.66.61)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/RCTBlobHeaders (= 0.66.60)
-    - React-Core/RCTWebSocket (= 0.66.60)
-    - React-jsi (= 0.66.60)
-    - React-RCTNetwork (= 0.66.60)
-    - ReactCommon/turbomodule/core (= 0.66.60)
-  - React-RCTImage (0.66.60):
-    - FBReactNativeSpec (= 0.66.60)
+    - React-Core/RCTBlobHeaders (= 0.66.61)
+    - React-Core/RCTWebSocket (= 0.66.61)
+    - React-jsi (= 0.66.61)
+    - React-RCTNetwork (= 0.66.61)
+    - ReactCommon/turbomodule/core (= 0.66.61)
+  - React-RCTImage (0.66.61):
+    - FBReactNativeSpec (= 0.66.61)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.66.60)
-    - React-Core/RCTImageHeaders (= 0.66.60)
-    - React-jsi (= 0.66.60)
-    - React-RCTNetwork (= 0.66.60)
-    - ReactCommon/turbomodule/core (= 0.66.60)
-  - React-RCTLinking (0.66.60):
-    - FBReactNativeSpec (= 0.66.60)
-    - React-Core/RCTLinkingHeaders (= 0.66.60)
-    - React-jsi (= 0.66.60)
-    - ReactCommon/turbomodule/core (= 0.66.60)
-  - React-RCTNetwork (0.66.60):
-    - FBReactNativeSpec (= 0.66.60)
+    - RCTTypeSafety (= 0.66.61)
+    - React-Core/RCTImageHeaders (= 0.66.61)
+    - React-jsi (= 0.66.61)
+    - React-RCTNetwork (= 0.66.61)
+    - ReactCommon/turbomodule/core (= 0.66.61)
+  - React-RCTLinking (0.66.61):
+    - FBReactNativeSpec (= 0.66.61)
+    - React-Core/RCTLinkingHeaders (= 0.66.61)
+    - React-jsi (= 0.66.61)
+    - ReactCommon/turbomodule/core (= 0.66.61)
+  - React-RCTNetwork (0.66.61):
+    - FBReactNativeSpec (= 0.66.61)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.66.60)
-    - React-Core/RCTNetworkHeaders (= 0.66.60)
-    - React-jsi (= 0.66.60)
-    - ReactCommon/turbomodule/core (= 0.66.60)
-  - React-RCTSettings (0.66.60):
-    - FBReactNativeSpec (= 0.66.60)
+    - RCTTypeSafety (= 0.66.61)
+    - React-Core/RCTNetworkHeaders (= 0.66.61)
+    - React-jsi (= 0.66.61)
+    - ReactCommon/turbomodule/core (= 0.66.61)
+  - React-RCTSettings (0.66.61):
+    - FBReactNativeSpec (= 0.66.61)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.66.60)
-    - React-Core/RCTSettingsHeaders (= 0.66.60)
-    - React-jsi (= 0.66.60)
-    - ReactCommon/turbomodule/core (= 0.66.60)
-  - React-RCTText (0.66.60):
-    - React-Core/RCTTextHeaders (= 0.66.60)
-  - React-RCTVibration (0.66.60):
-    - FBReactNativeSpec (= 0.66.60)
+    - RCTTypeSafety (= 0.66.61)
+    - React-Core/RCTSettingsHeaders (= 0.66.61)
+    - React-jsi (= 0.66.61)
+    - ReactCommon/turbomodule/core (= 0.66.61)
+  - React-RCTText (0.66.61):
+    - React-Core/RCTTextHeaders (= 0.66.61)
+  - React-RCTVibration (0.66.61):
+    - FBReactNativeSpec (= 0.66.61)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/RCTVibrationHeaders (= 0.66.60)
-    - React-jsi (= 0.66.60)
-    - ReactCommon/turbomodule/core (= 0.66.60)
-  - React-runtimeexecutor (0.66.60):
-    - React-jsi (= 0.66.60)
-  - ReactCommon/turbomodule/core (0.66.60):
+    - React-Core/RCTVibrationHeaders (= 0.66.61)
+    - React-jsi (= 0.66.61)
+    - ReactCommon/turbomodule/core (= 0.66.61)
+  - React-runtimeexecutor (0.66.61):
+    - React-jsi (= 0.66.61)
+  - ReactCommon/turbomodule/core (0.66.61):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.66.60)
-    - React-Core (= 0.66.60)
-    - React-cxxreact (= 0.66.60)
-    - React-jsi (= 0.66.60)
-    - React-logger (= 0.66.60)
-    - React-perflogger (= 0.66.60)
+    - React-callinvoker (= 0.66.61)
+    - React-Core (= 0.66.61)
+    - React-cxxreact (= 0.66.61)
+    - React-jsi (= 0.66.61)
+    - React-logger (= 0.66.61)
+    - React-perflogger (= 0.66.61)
   - ReactTestApp-DevSupport (1.4.6):
     - React-Core
     - React-jsi
@@ -505,8 +505,8 @@ SPEC CHECKSUMS:
   boost: 613e39eac4239cc72b15421247b5ab05361266a2
   boost-for-react-native: 8f7c9ecfe357664c072ffbe2432569667cbf1f1b
   DoubleConversion: ed15e075aa758ac0e4c1f8b830bd4e4d40d669e8
-  FBLazyVector: 32d2fc7dba43116e724d716c8d695b342d9c27cf
-  FBReactNativeSpec: 9293ad934f3722cfe02332fc9383dd0a66072038
+  FBLazyVector: 1f65a0f0cea22915507bdbbc44ca4af673d9ce7f
+  FBReactNativeSpec: 768546ea603d7382d39bce4acf11897140b5e977
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   FRNAvatar: 827ebe75e839ce442c88cc6a23940aa614ca7946
   FRNCallout: 9457c30fa1714c715908e8527ceea18ac3766047
@@ -517,34 +517,34 @@ SPEC CHECKSUMS:
   MicrosoftFluentUI: 2f4c624fd4606aa2392c09be69a45e297a41f593
   RCT-Folly: 43adc9ce880eb76792f88c011773cb5c664c1419
   RCTFocusZone: 1784b033ecfe09ae0e325164b1bf4502e5fe152e
-  RCTRequired: 72d931643dd5c55bcb3c80ee02d931b6b4a23fe5
-  RCTTypeSafety: c75d6024655d294501bbf2d5432d440b25390cee
-  React: e35ef6d43828f69a2ec9372608b2fa1dbacc9313
-  React-callinvoker: d09519bb2f5f3917238e08dd2722d3f530189475
-  React-Core: bb3e4c9a85939d4ca389e2473f5a58de7077c177
-  React-CoreModules: ebb8de501639d8471d20e55bc966273cacc3892b
-  React-cxxreact: 419f74f903c6b0969875a2bdc1ee0a3129414668
-  React-jsi: ed9726ac296d684e7655ddecc46757deab125020
-  React-jsiexecutor: 1512ff576675045c781b99be14ec257a59b07100
-  React-jsinspector: 145d3d7ff700b3a2713e4443f6d1efc7927db3a5
-  React-logger: 69cecbc86e4621f02ab34b642d78ea3f5b61300e
-  React-perflogger: 959b0917d388fcf0e37eb01e7d01cb11e8c36f5f
-  React-RCTActionSheet: c181c88d23632791a00e84a0e75e604d67e2f94d
-  React-RCTAnimation: 7e39ff7ed1a7943ddebad7403a9f9c0148cec4f4
-  React-RCTBlob: 4c92d608b8fccd1fedcba8f57566833c29703ee0
-  React-RCTImage: 55e5b86705b187fed5430e91099e0395e9be43a6
-  React-RCTLinking: e6934ca0e81cdb609af1913680ad8252d8fc6c8a
-  React-RCTNetwork: 88a6c09f9b89850b53e217c32c188930e73cff57
-  React-RCTSettings: e5cd8a242280b371a9c8770c35f1219afabe0508
-  React-RCTText: 2033d56635d117fb0b5247bd8689edc59a0ddb27
-  React-RCTVibration: 6524873d7c8862650677cb35062ffdf1ecca67e9
-  React-runtimeexecutor: b0b83f1c6282917483a59dd9262c6f6a04a08f1d
-  ReactCommon: b0ea136d9b75db619d07bf02ee0653ce4248c829
+  RCTRequired: 5d9c6fe63ff2606a93e9e2812cfede283ff98571
+  RCTTypeSafety: 31e44236c2161f101e1135696c3e8f35bb705430
+  React: 68fcf6fed1c1607eb7dbf6bf8259b04cc440295a
+  React-callinvoker: 4f80cd6a9ef8164fa2502dca6a9a3ebdcc861f55
+  React-Core: fa084e35b27bc8ed20966b06e84cda209ebeb478
+  React-CoreModules: 76a1f339d3c8bd74f6943cababe9c67c1dff42f0
+  React-cxxreact: 608ebe8e015754a8d9b237c6503be71c30fef514
+  React-jsi: c9bff10d5b445507a52c0802e183b60ff032983e
+  React-jsiexecutor: 6d28bb97c1610217cac530233512c3a467b4ee18
+  React-jsinspector: 9986f330f32d8ca81d8c8ba8b1fb6f8f4a5f9931
+  React-logger: cef51d1376f36a83f74890c980796df8f7204bc6
+  React-perflogger: 96f294886cef5cb6dc2478a6040c4a05bd7599c6
+  React-RCTActionSheet: c2fe7084562d9c36201f25e22d40528bca18d628
+  React-RCTAnimation: 3eeb3da96f84a2e0a87dedebd24b0f28f22bc1ac
+  React-RCTBlob: b25ed7d11f2b42048a8db056d08c929e9c3c4786
+  React-RCTImage: 82ec5d6bd98e998bbf3ca225865f6d37c69c9c1d
+  React-RCTLinking: a26477bdb61bd6879d8dc610e38bf182f1746cb4
+  React-RCTNetwork: 63ccc51ee85107094cbef899ec96fcca18e3c4cc
+  React-RCTSettings: 7f0ef7b9e67a131affb717c1c97833495208a589
+  React-RCTText: cfed8e661234bfc7d506638e7c6dde42dba7d0cc
+  React-RCTVibration: bc44b271a6c6eb0e5ef9eaf9a5affa2a363b38c6
+  React-runtimeexecutor: 84c09cebad207a59744dde577090074b96ea5f39
+  ReactCommon: 3073497b51310a92e0b02070396434036264248e
   ReactTestApp-DevSupport: cd2670f54856f1ee273585fe2498b1a32ad47d3f
   ReactTestApp-Resources: 8c0164a3cc5052418c92018e2af0e05d564aa307
   RNCPicker: 0250e95ad170569a96f5b0555cdd5e65b9084dca
   RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8
-  Yoga: ee53639e611ce152d8eec9f6c7bfc7d456f41da2
+  Yoga: bd724262da8fcf3e805f99e28af79842b4b73cd4
 
 PODFILE CHECKSUM: 568704fb95966cf7ad6daa54a1d36eb2d5c3bba6
 

--- a/change/@fluentui-react-native-apple-theme-ad048689-99b1-47fc-851d-ecc00c90b80c.json
+++ b/change/@fluentui-react-native-apple-theme-ad048689-99b1-47fc-851d-ecc00c90b80c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix dead link",
+  "packageName": "@fluentui-react-native/apple-theme",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-1599a403-c732-41a9-87f4-f4f55906063c.json
+++ b/change/@fluentui-react-native-tester-1599a403-c732-41a9-87f4-f4f55906063c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "remove flatlist usage",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/theming/apple-theme/README.md
+++ b/packages/theming/apple-theme/README.md
@@ -9,4 +9,4 @@ Some heuristics followed in this theme:
 - For most tokens, we default to prefer the apple system colors, using the FluentUI Apple Palette where it makes sense. These mappings are subject to change as we increment on the design.
 - On apple platforms, there tends to not be a "hover" state for components such as Button, so those tokens are mapped to be identical to the rest state (normal state) tokens.
 - Similarly, there is not a "checked" state for most components, so those tokens are mapped to the rest state tokens.
-- The typography is designed to match the variants provided by the [Apple HIG](https://developer.apple.com/design/human-interface-guidelines/macos/visual-design/typography/) for regular and "emphasized". As such, the "Semibold" variants do not always map to the semibold weight, but whatever weight the Apple HIG specifies.
+- The typography is designed to match the variants provided by the [Apple HIG](https://developer.apple.com/design/human-interface-guidelines/foundations/typography/) for regular and "emphasized". As such, the "Semibold" variants do not always map to the semibold weight, but whatever weight the Apple HIG specifies.


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

Another followup from #1535 

Fix a longstanding yellow box error we had where we rendered a Flatlist inside a ScrollView. Flatlist doesn't like that. The two test pages have few enough items that we shouldn't see terrible performance.

### Verification

No longer see the yellow box on TokenTest and ThemeTest

Scrolling on my M1 Mac mini seems fine.

https://user-images.githubusercontent.com/6722175/180578902-0be0ffa6-5e51-4c68-a695-b89b9af08edd.mov



### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
