### PR TITLE
Changed Badge sizes according to Web

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Badge/BadgeTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Badge/BadgeTest.tsx
@@ -44,12 +44,12 @@ export const BasicBadge: React.FunctionComponent = () => {
       <Badge shape="rounded">Rounded badge</Badge>
       <Badge shape="square">Square badge</Badge>
       <Text>Size</Text>
-      <Badge size="smallest" shape="circular" />
-      <Badge size="smaller" shape="circular" />
+      <Badge size="tiny" shape="circular" />
+      <Badge size="extraSmall" shape="circular" />
       <Badge size="small">Small</Badge>
       <Badge size="medium">Medium</Badge>
       <Badge size="large">Large</Badge>
-      <Badge size="largest">Largest</Badge>
+      <Badge size="extraLarge">Extra Large</Badge>
       {svgIconsEnabled && (
         <>
           <Text>Badge with icon</Text>
@@ -65,11 +65,11 @@ export const BasicBadge: React.FunctionComponent = () => {
       {svgIconsEnabled && (
         <>
           <Text>Presence Badge</Text>
-          <PresenceBadge status="available" size="largest" />
+          <PresenceBadge status="available" size="extraLarge" />
           <PresenceBadge status="available" outOfOffice={true} size="large" />
           <PresenceBadge status="doNotDisturb" outOfOffice={true} />
           <PresenceBadge status="away" size="small" />
-          <PresenceBadge status="busy" size="smallest" />
+          <PresenceBadge status="busy" size="tiny" />
           <PresenceBadge status="offline" />
           <PresenceBadge status="outOfOffice" />
           <PresenceBadge status="away" />

--- a/change/@fluentui-react-native-avatar-3d250182-e0f0-4fa5-a615-2c68d929b984.json
+++ b/change/@fluentui-react-native-avatar-3d250182-e0f0-4fa5-a615-2c68d929b984.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Changed Badge sizes according to Web",
+  "packageName": "@fluentui-react-native/avatar",
+  "email": "v.kozova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-badge-458aec04-2bb6-415f-95ae-46aea11a5cea.json
+++ b/change/@fluentui-react-native-badge-458aec04-2bb6-415f-95ae-46aea11a5cea.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Changed Badge sizes according to Web",
+  "packageName": "@fluentui-react-native/badge",
+  "email": "v.kozova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-89dec764-5b6d-4e44-9d1c-987d406ec7e1.json
+++ b/change/@fluentui-react-native-tester-89dec764-5b6d-4e44-9d1c-987d406ec7e1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Changed Badge sizes according to Web",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "v.kozova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Avatar/src/AvatarTokens.ts
+++ b/packages/components/Avatar/src/AvatarTokens.ts
@@ -28,7 +28,7 @@ export const defaultAvatarTokens: TokenSettings<AvatarTokens, Theme> = (t: Theme
     },
     size20: {
       size: 20,
-      badgeSize: 'smallest',
+      badgeSize: 'tiny',
       iconSize: 16,
       fontSize: globalTokens.font.size[100],
       square: {
@@ -37,7 +37,7 @@ export const defaultAvatarTokens: TokenSettings<AvatarTokens, Theme> = (t: Theme
     },
     size24: {
       size: 24,
-      badgeSize: 'smallest',
+      badgeSize: 'tiny',
       iconSize: 16,
       fontSize: globalTokens.font.size[100],
       square: {
@@ -46,20 +46,20 @@ export const defaultAvatarTokens: TokenSettings<AvatarTokens, Theme> = (t: Theme
     },
     size28: {
       size: 28,
-      badgeSize: 'smaller',
+      badgeSize: 'extraSmall',
       iconSize: 20,
       fontWeight: globalTokens.font.weight.semibold,
       fontSize: globalTokens.font.size[100],
     },
     size32: {
       size: 32,
-      badgeSize: 'smaller',
+      badgeSize: 'extraSmall',
       iconSize: 20,
       fontSize: globalTokens.font.size[100],
     },
     size36: {
       size: 36,
-      badgeSize: 'smaller',
+      badgeSize: 'extraSmall',
       iconSize: 20,
     },
     size40: {
@@ -101,7 +101,7 @@ export const defaultAvatarTokens: TokenSettings<AvatarTokens, Theme> = (t: Theme
     },
     size96: {
       size: 96,
-      badgeSize: 'largest',
+      badgeSize: 'extraLarge',
       iconSize: 48,
       fontWeight: globalTokens.font.weight.regular,
       fontSize: globalTokens.font.size[700],
@@ -111,7 +111,7 @@ export const defaultAvatarTokens: TokenSettings<AvatarTokens, Theme> = (t: Theme
     },
     size120: {
       size: 120,
-      badgeSize: 'largest',
+      badgeSize: 'extraLarge',
       iconSize: 48,
       fontWeight: globalTokens.font.weight.regular,
       fontSize: globalTokens.font.size[900],

--- a/packages/components/Avatar/src/AvatarTokens.win32.ts
+++ b/packages/components/Avatar/src/AvatarTokens.win32.ts
@@ -5,7 +5,7 @@ import { globalTokens } from '@fluentui-react-native/theme-tokens';
 
 export const defaultAvatarTokens: TokenSettings<AvatarTokens, Theme> = (t: Theme) =>
   ({
-    badgeSize: 'smallest',
+    badgeSize: 'tiny',
     color: t.colors.neutralForeground3,
     backgroundColor: t.colors.neutralBackground6,
     avatarOpacity: 1,
@@ -29,7 +29,7 @@ export const defaultAvatarTokens: TokenSettings<AvatarTokens, Theme> = (t: Theme
     },
     size20: {
       size: 20,
-      badgeSize: 'smallest',
+      badgeSize: 'tiny',
       iconSize: 16,
       fontSize: globalTokens.font.size[100],
       square: {
@@ -38,7 +38,7 @@ export const defaultAvatarTokens: TokenSettings<AvatarTokens, Theme> = (t: Theme
     },
     size24: {
       size: 24,
-      badgeSize: 'smallest',
+      badgeSize: 'tiny',
       iconSize: 16,
       fontSize: globalTokens.font.size[100],
       square: {
@@ -47,20 +47,20 @@ export const defaultAvatarTokens: TokenSettings<AvatarTokens, Theme> = (t: Theme
     },
     size28: {
       size: 28,
-      badgeSize: 'smaller',
+      badgeSize: 'extraSmall',
       iconSize: 20,
       fontWeight: globalTokens.font.weight.semibold,
       fontSize: globalTokens.font.size[100],
     },
     size32: {
       size: 32,
-      badgeSize: 'smaller',
+      badgeSize: 'extraSmall',
       iconSize: 20,
       fontSize: globalTokens.font.size[100],
     },
     size36: {
       size: 36,
-      badgeSize: 'smaller',
+      badgeSize: 'extraSmall',
       iconSize: 20,
     },
     size40: {
@@ -102,7 +102,7 @@ export const defaultAvatarTokens: TokenSettings<AvatarTokens, Theme> = (t: Theme
     },
     size96: {
       size: 96,
-      badgeSize: 'largest',
+      badgeSize: 'extraLarge',
       iconSize: 48,
       fontWeight: globalTokens.font.weight.regular,
       fontSize: globalTokens.font.size[700],
@@ -112,7 +112,7 @@ export const defaultAvatarTokens: TokenSettings<AvatarTokens, Theme> = (t: Theme
     },
     size120: {
       size: 120,
-      badgeSize: 'largest',
+      badgeSize: 'extraLarge',
       iconSize: 48,
       fontWeight: globalTokens.font.weight.regular,
       fontSize: globalTokens.font.size[900],

--- a/packages/experimental/Badge/src/Badge.styling.ts
+++ b/packages/experimental/Badge/src/Badge.styling.ts
@@ -5,12 +5,12 @@ import { defaultBadgeTokens } from './BadgeTokens';
 import { defaultBadgeColorTokens } from './BadgeColorTokens';
 
 export const coreBadgeStates: (keyof BadgeCoreTokens)[] = [
-  'smallest',
-  'smaller',
+  'tiny',
+  'extraSmall',
   'small',
   'medium',
   'large',
-  'largest',
+  'extraLarge',
   'rounded',
   'circular',
   'square',

--- a/packages/experimental/Badge/src/Badge.types.ts
+++ b/packages/experimental/Badge/src/Badge.types.ts
@@ -5,7 +5,7 @@ import { IViewProps } from '@fluentui-react-native/adapters';
 import { IconProps, IconSourcesType } from '@fluentui-react-native/icon';
 
 export const badgeName = 'Badge';
-export const BadgeSizes = ['smallest', 'smaller', 'small', 'medium', 'large', 'largest'] as const;
+export const BadgeSizes = ['tiny', 'extraSmall', 'small', 'medium', 'large', 'extraLarge'] as const;
 export const BadgeAppearances = ['filled', 'outline', 'tint', 'ghost', 'filledInverted'] as const;
 export const BadgeShapes = ['rounded', 'circular', 'square'] as const;
 export const BadgeColors = ['brand', 'danger', 'important', 'informative', 'severe', 'subtle', 'success', 'warning'] as const;
@@ -88,12 +88,12 @@ export interface BadgeCoreTokens extends LayoutTokens, FontTokens, IBorderTokens
   /**
    * Sizes of the Badge
    */
-  smallest?: BadgeTokens;
-  smaller?: BadgeTokens;
+  tiny?: BadgeTokens;
+  extraSmall?: BadgeTokens;
   small?: BadgeTokens;
   medium?: BadgeTokens;
   large?: BadgeTokens;
-  largest?: BadgeTokens;
+  extraLarge?: BadgeTokens;
 
   /**
    * Shapes of the Badge

--- a/packages/experimental/Badge/src/BadgeTokens.ts
+++ b/packages/experimental/Badge/src/BadgeTokens.ts
@@ -8,11 +8,11 @@ export const defaultBadgeTokens: TokenSettings<BadgeTokens> = () =>
     borderWidth: globalTokens.stroke.width.thin,
     bottom: globalTokens.spacing.none,
     right: globalTokens.spacing.none,
-    smallest: {
+    tiny: {
       minWidth: 6,
       height: 6,
     },
-    smaller: {
+    extraSmall: {
       minWidth: 10,
       height: 10,
     },
@@ -36,7 +36,7 @@ export const defaultBadgeTokens: TokenSettings<BadgeTokens> = () =>
       paddingHorizontal: globalTokens.spacing.xs,
       iconSize: 16,
     },
-    largest: {
+    extraLarge: {
       minWidth: 32,
       height: 32,
       paddingHorizontal: globalTokens.spacing.sNudge,

--- a/packages/experimental/Badge/src/PresenceBadge/PresenceBadgeTokens.macos.ts
+++ b/packages/experimental/Badge/src/PresenceBadge/PresenceBadgeTokens.macos.ts
@@ -10,11 +10,11 @@ export const defaultPresenceBadgeTokens: TokenSettings<PresenceBadgeTokens> = ()
     right: globalTokens.spacing.none,
     paddingHorizontal: globalTokens.spacing.none,
     backgroundColor: globalTokens.color.white,
-    smallest: {
+    tiny: {
       width: 6,
       height: 6,
     },
-    smaller: {
+    extraSmall: {
       width: 10,
       height: 10,
     },
@@ -31,7 +31,7 @@ export const defaultPresenceBadgeTokens: TokenSettings<PresenceBadgeTokens> = ()
       height: 20,
       borderWidth: 2,
     },
-    largest: {
+    extraLarge: {
       width: 28,
       height: 28,
       borderWidth: 2,

--- a/packages/experimental/Badge/src/PresenceBadge/PresenceBadgeTokens.ts
+++ b/packages/experimental/Badge/src/PresenceBadge/PresenceBadgeTokens.ts
@@ -11,11 +11,11 @@ export const defaultPresenceBadgeTokens: TokenSettings<PresenceBadgeTokens> = (t
     paddingHorizontal: globalTokens.spacing.none,
     backgroundColor: t.colors.neutralBackground1,
     ...getBadgeColor('lightGreen', t),
-    smallest: {
+    tiny: {
       width: 6,
       height: 6,
     },
-    smaller: {
+    extraSmall: {
       width: 10,
       height: 10,
     },
@@ -34,7 +34,7 @@ export const defaultPresenceBadgeTokens: TokenSettings<PresenceBadgeTokens> = (t
       bottom: -globalTokens.spacing.xxs,
       right: -globalTokens.spacing.xxs,
     },
-    largest: {
+    extraLarge: {
       borderWidth: 2,
       width: 28,
       height: 28,

--- a/packages/experimental/Badge/src/PresenceBadge/PresenceBadgeTokens.win32.ts
+++ b/packages/experimental/Badge/src/PresenceBadge/PresenceBadgeTokens.win32.ts
@@ -11,11 +11,11 @@ export const defaultPresenceBadgeTokens: TokenSettings<PresenceBadgeTokens> = (t
     paddingHorizontal: globalTokens.spacing.none,
     backgroundColor: t.colors.neutralBackground1,
     ...getBadgeColor('lightGreen', t),
-    smallest: {
+    tiny: {
       width: 6,
       height: 6,
     },
-    smaller: {
+    extraSmall: {
       width: 10,
       height: 10,
     },
@@ -34,7 +34,7 @@ export const defaultPresenceBadgeTokens: TokenSettings<PresenceBadgeTokens> = (t
       bottom: -globalTokens.spacing.xxs,
       right: -globalTokens.spacing.xxs,
     },
-    largest: {
+    extraLarge: {
       width: 28,
       height: 28,
       borderWidth: 2,


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
Changed Badge sizes according to Web - https://github.com/microsoft/fluentui/blob/ce3a133444131aa479d4810d3e49d9dcd7944b33/packages/react-components/react-badge/src/components/Badge/Badge.types.ts#L39

### Verification
![image](https://user-images.githubusercontent.com/11574680/180823024-82946897-b8a2-4d1b-b149-a297dadc498d.png)
![image](https://user-images.githubusercontent.com/11574680/180823069-dd091d03-398e-4bf7-ba82-218c053a2e6c.png)


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
