### PR TITLE
Open ContextualMenu submenu with space or enter

### DIFF
--- a/change/@fluentui-react-native-contextual-menu-cb147792-86fd-4a3f-a77c-519311345d49.json
+++ b/change/@fluentui-react-native-contextual-menu-cb147792-86fd-4a3f-a77c-519311345d49.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Enable the Space and Enter keys to open SubmenuItems",
+  "packageName": "@fluentui-react-native/contextual-menu",
+  "email": "patboyd@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/ContextualMenu/src/SubmenuItem.tsx
+++ b/packages/components/ContextualMenu/src/SubmenuItem.tsx
@@ -110,10 +110,11 @@ export const SubmenuItem = compose<SubmenuItemType>({
       icon: !!icon,
     };
 
-    const showWithArrowKey = React.useCallback(
+    const showSubmenuOnKeyDown = React.useCallback(
       (e: any) => {
-        const arrowKey = I18nManager.isRTL ? 'ArrowLeft' : 'ArrowRight';
-        if (e.nativeEvent.key === arrowKey) {
+        const rtlOpenArrowKey = I18nManager.isRTL ? 'ArrowLeft' : 'ArrowRight';
+
+        if (e.nativeEvent.key === rtlOpenArrowKey || e.nativeEvent.key === ' ' || e.nativeEvent.key === 'Enter') {
           onItemHoverIn(e);
         }
       },
@@ -137,7 +138,7 @@ export const SubmenuItem = compose<SubmenuItemType>({
      * SubmenuItem launches the submenu onMouseEnter event. Submenu should be launched with Spacebar, Enter, or right arrow (flipped for RTL).
      * Explicitly override onKeyDown to override the native windows behavior of moving focus with arrow keys.
      */
-    const onKeyDownProps = useKeyDownProps(showWithArrowKey, ' ', 'Enter', 'ArrowLeft', 'ArrowRight');
+    const onKeyDownProps = useKeyDownProps(showSubmenuOnKeyDown, ' ', 'Enter', 'ArrowLeft', 'ArrowRight');
     const onAccTap = onAccessibilityTap ?? onItemPress;
 
     // grab the styling information, referencing the state as well as the props

--- a/packages/components/ContextualMenu/src/SubmenuItem.tsx
+++ b/packages/components/ContextualMenu/src/SubmenuItem.tsx
@@ -112,9 +112,9 @@ export const SubmenuItem = compose<SubmenuItemType>({
 
     const showSubmenuOnKeyDown = React.useCallback(
       (e: any) => {
-        const rtlOpenArrowKey = I18nManager.isRTL ? 'ArrowLeft' : 'ArrowRight';
+        const rtlAwareOpenArrowKey = I18nManager.isRTL ? 'ArrowLeft' : 'ArrowRight';
 
-        if (e.nativeEvent.key === rtlOpenArrowKey || e.nativeEvent.key === ' ' || e.nativeEvent.key === 'Enter') {
+        if (e.nativeEvent.key === rtlAwareOpenArrowKey || e.nativeEvent.key === ' ' || e.nativeEvent.key === 'Enter') {
           onItemHoverIn(e);
         }
       },


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [ ] android

### Description of changes

While the callback is fired when space or enter is hit, it only opens the submenu for arrow key invocations.

### Verification

Manually

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [x] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
