### PR TITLE
Fix Apple nuget by disabling flipper  

### DIFF
--- a/apps/fluent-tester/ios/Podfile
+++ b/apps/fluent-tester/ios/Podfile
@@ -18,7 +18,7 @@ if [ -z "${RCT_NO_LAUNCH_PACKAGER+xxx}" ] ; then
   fi
 fi
 }
-
+use_flipper!(false)
 use_test_app! do |target|
   target.app do
     platform :ios, '14.0'

--- a/apps/fluent-tester/ios/Podfile.lock
+++ b/apps/fluent-tester/ios/Podfile.lock
@@ -1,6 +1,5 @@
 PODS:
   - boost (1.76.0)
-  - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.66.4)
   - FBReactNativeSpec (0.66.4):
@@ -10,66 +9,6 @@ PODS:
     - React-Core (= 0.66.4)
     - React-jsi (= 0.66.4)
     - ReactCommon/turbomodule/core (= 0.66.4)
-  - Flipper (0.99.0):
-    - Flipper-Folly (~> 2.6)
-    - Flipper-RSocket (~> 1.4)
-  - Flipper-Boost-iOSX (1.76.0.1.11)
-  - Flipper-DoubleConversion (3.1.7)
-  - Flipper-Fmt (7.1.7)
-  - Flipper-Folly (2.6.7):
-    - Flipper-Boost-iOSX
-    - Flipper-DoubleConversion
-    - Flipper-Fmt (= 7.1.7)
-    - Flipper-Glog
-    - libevent (~> 2.1.12)
-    - OpenSSL-Universal (= 1.1.180)
-  - Flipper-Glog (0.3.6)
-  - Flipper-PeerTalk (0.0.4)
-  - Flipper-RSocket (1.4.3):
-    - Flipper-Folly (~> 2.6)
-  - FlipperKit (0.99.0):
-    - FlipperKit/Core (= 0.99.0)
-  - FlipperKit/Core (0.99.0):
-    - Flipper (~> 0.99.0)
-    - FlipperKit/CppBridge
-    - FlipperKit/FBCxxFollyDynamicConvert
-    - FlipperKit/FBDefines
-    - FlipperKit/FKPortForwarding
-  - FlipperKit/CppBridge (0.99.0):
-    - Flipper (~> 0.99.0)
-  - FlipperKit/FBCxxFollyDynamicConvert (0.99.0):
-    - Flipper-Folly (~> 2.6)
-  - FlipperKit/FBDefines (0.99.0)
-  - FlipperKit/FKPortForwarding (0.99.0):
-    - CocoaAsyncSocket (~> 7.6)
-    - Flipper-PeerTalk (~> 0.0.4)
-  - FlipperKit/FlipperKitHighlightOverlay (0.99.0)
-  - FlipperKit/FlipperKitLayoutHelpers (0.99.0):
-    - FlipperKit/Core
-    - FlipperKit/FlipperKitHighlightOverlay
-    - FlipperKit/FlipperKitLayoutTextSearchable
-  - FlipperKit/FlipperKitLayoutIOSDescriptors (0.99.0):
-    - FlipperKit/Core
-    - FlipperKit/FlipperKitHighlightOverlay
-    - FlipperKit/FlipperKitLayoutHelpers
-    - YogaKit (~> 1.18)
-  - FlipperKit/FlipperKitLayoutPlugin (0.99.0):
-    - FlipperKit/Core
-    - FlipperKit/FlipperKitHighlightOverlay
-    - FlipperKit/FlipperKitLayoutHelpers
-    - FlipperKit/FlipperKitLayoutIOSDescriptors
-    - FlipperKit/FlipperKitLayoutTextSearchable
-    - YogaKit (~> 1.18)
-  - FlipperKit/FlipperKitLayoutTextSearchable (0.99.0)
-  - FlipperKit/FlipperKitNetworkPlugin (0.99.0):
-    - FlipperKit/Core
-  - FlipperKit/FlipperKitReactPlugin (0.99.0):
-    - FlipperKit/Core
-  - FlipperKit/FlipperKitUserDefaultsPlugin (0.99.0):
-    - FlipperKit/Core
-  - FlipperKit/SKIOSNetworkPlugin (0.99.0):
-    - FlipperKit/Core
-    - FlipperKit/FlipperKitNetworkPlugin
   - fmt (6.2.1)
   - FRNAvatar (0.16.0):
     - MicrosoftFluentUI (= 0.5.2)
@@ -79,7 +18,6 @@ PODS:
     - MicrosoftFluentUI (= 0.5.2)
     - React
   - glog (0.3.5)
-  - libevent (2.1.12)
   - MicrosoftFluentUI (0.5.2):
     - MicrosoftFluentUI/ActivityIndicator_ios (= 0.5.2)
     - MicrosoftFluentUI/Appearance_mac (= 0.5.2)
@@ -239,7 +177,6 @@ PODS:
     - MicrosoftFluentUI/EasyTapButton_ios
     - MicrosoftFluentUI/Label_ios
   - MicrosoftFluentUI/Utilities_ios (0.5.2)
-  - OpenSSL-Universal (1.1.180)
   - RCT-Folly (2021.06.28.00-v2):
     - boost
     - DoubleConversion
@@ -517,35 +454,12 @@ PODS:
     - React-Core
   - SwiftLint (0.47.1)
   - Yoga (1.14.0)
-  - YogaKit (1.18.1):
-    - Yoga (~> 1.14)
 
 DEPENDENCIES:
   - boost (from `../../../node_modules/react-native/third-party-podspecs/boost.podspec`)
   - DoubleConversion (from `../../../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../../../node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../../../node_modules/react-native/React/FBReactNativeSpec`)
-  - Flipper (= 0.99.0)
-  - Flipper-Boost-iOSX (= 1.76.0.1.11)
-  - Flipper-DoubleConversion (= 3.1.7)
-  - Flipper-Fmt (= 7.1.7)
-  - Flipper-Folly (= 2.6.7)
-  - Flipper-Glog (= 0.3.6)
-  - Flipper-PeerTalk (= 0.0.4)
-  - Flipper-RSocket (= 1.4.3)
-  - FlipperKit (= 0.99.0)
-  - FlipperKit/Core (= 0.99.0)
-  - FlipperKit/CppBridge (= 0.99.0)
-  - FlipperKit/FBCxxFollyDynamicConvert (= 0.99.0)
-  - FlipperKit/FBDefines (= 0.99.0)
-  - FlipperKit/FKPortForwarding (= 0.99.0)
-  - FlipperKit/FlipperKitHighlightOverlay (= 0.99.0)
-  - FlipperKit/FlipperKitLayoutPlugin (= 0.99.0)
-  - FlipperKit/FlipperKitLayoutTextSearchable (= 0.99.0)
-  - FlipperKit/FlipperKitNetworkPlugin (= 0.99.0)
-  - FlipperKit/FlipperKitReactPlugin (= 0.99.0)
-  - FlipperKit/FlipperKitUserDefaultsPlugin (= 0.99.0)
-  - FlipperKit/SKIOSNetworkPlugin (= 0.99.0)
   - FRNAvatar (from `../../../packages/experimental/Avatar/FRNAvatar.podspec`)
   - FRNDatePicker (from `../../../packages/experimental/NativeDatePicker/FRNDatePicker.podspec`)
   - glog (from `../../../node_modules/react-native/third-party-podspecs/glog.podspec`)
@@ -586,22 +500,9 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
-    - CocoaAsyncSocket
-    - Flipper
-    - Flipper-Boost-iOSX
-    - Flipper-DoubleConversion
-    - Flipper-Fmt
-    - Flipper-Folly
-    - Flipper-Glog
-    - Flipper-PeerTalk
-    - Flipper-RSocket
-    - FlipperKit
     - fmt
-    - libevent
     - MicrosoftFluentUI
-    - OpenSSL-Universal
     - SwiftLint
-    - YogaKit
 
 EXTERNAL SOURCES:
   boost:
@@ -683,26 +584,14 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
-  CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
   FBLazyVector: e5569e42a1c79ca00521846c223173a57aca1fe1
   FBReactNativeSpec: fe08c1cd7e2e205718d77ad14b34957cce949b58
-  Flipper: 30e8eeeed6abdc98edaf32af0cda2f198be4b733
-  Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
-  Flipper-DoubleConversion: 57ffbe81ef95306cc9e69c4aa3aeeeeb58a6a28c
-  Flipper-Fmt: 60cbdd92fc254826e61d669a5d87ef7015396a9b
-  Flipper-Folly: 83af37379faa69497529e414bd43fbfc7cae259a
-  Flipper-Glog: 1dfd6abf1e922806c52ceb8701a3599a79a200a6
-  Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
-  Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
-  FlipperKit: d8d346844eca5d9120c17d441a2f38596e8ed2b9
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   FRNAvatar: 827ebe75e839ce442c88cc6a23940aa614ca7946
   FRNDatePicker: 5bb2c380d093abc21aa3b930074727ed1d9db425
   glog: 5337263514dd6f09803962437687240c5dc39aa4
-  libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   MicrosoftFluentUI: 2f4c624fd4606aa2392c09be69a45e297a41f593
-  OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
   RCT-Folly: a21c126816d8025b547704b777a2ba552f3d9fa9
   RCTRequired: 4bf86c70714490bca4bf2696148638284622644b
   RCTTypeSafety: c475a7059eb77935fa53d2c17db299893f057d5d
@@ -735,8 +624,7 @@ SPEC CHECKSUMS:
   RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
   Yoga: e7dc4e71caba6472ff48ad7d234389b91dadc280
-  YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 4121241db9ed0bc6d8678f91cd390535441b8c40
+PODFILE CHECKSUM: 471bcded6dd3e64a1865525c60e6a27d0b4961a9
 
 COCOAPODS: 1.11.3

--- a/apps/fluent-tester/macos/Podfile
+++ b/apps/fluent-tester/macos/Podfile
@@ -19,6 +19,7 @@ if [ -z "${RCT_NO_LAUNCH_PACKAGER+xxx}" ] ; then
 fi
 }
 
+use_flipper!(false)
 use_test_app! do |target|
   target.app do
     platform :osx, '10.15'

--- a/apps/fluent-tester/macos/Podfile.lock
+++ b/apps/fluent-tester/macos/Podfile.lock
@@ -2,26 +2,26 @@ PODS:
   - boost (1.76.0)
   - boost-for-react-native (1.63.0)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.66.61)
-  - FBReactNativeSpec (0.66.61):
+  - FBLazyVector (0.66.64)
+  - FBReactNativeSpec (0.66.64):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.66.61)
-    - RCTTypeSafety (= 0.66.61)
-    - React-Core (= 0.66.61)
-    - React-jsi (= 0.66.61)
-    - ReactCommon/turbomodule/core (= 0.66.61)
+    - RCTRequired (= 0.66.64)
+    - RCTTypeSafety (= 0.66.64)
+    - React-Core (= 0.66.64)
+    - React-jsi (= 0.66.64)
+    - ReactCommon/turbomodule/core (= 0.66.64)
   - fmt (6.2.1)
   - FRNAvatar (0.16.0):
     - MicrosoftFluentUI (= 0.5.2)
     - MicrosoftFluentUI/Avatar_ios (= 0.5.2)
     - React
-  - FRNCallout (0.21.1):
+  - FRNCallout (0.21.4):
     - React
-  - FRNCheckbox (0.12.3):
+  - FRNCheckbox (0.12.6):
     - React
-  - FRNMenuButton (0.8.6):
+  - FRNMenuButton (0.8.11):
     - React
-  - FRNRadioButton (0.15.1):
+  - FRNRadioButton (0.15.4):
     - React
   - glog (0.3.5)
   - MicrosoftFluentUI (0.5.2):
@@ -103,260 +103,260 @@ PODS:
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
-  - RCTFocusZone (0.10.1):
+  - RCTFocusZone (0.10.4):
     - React
-  - RCTRequired (0.66.61)
-  - RCTTypeSafety (0.66.61):
-    - FBLazyVector (= 0.66.61)
+  - RCTRequired (0.66.64)
+  - RCTTypeSafety (0.66.64):
+    - FBLazyVector (= 0.66.64)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.66.61)
-    - React-Core (= 0.66.61)
-  - React (0.66.61):
-    - React-Core (= 0.66.61)
-    - React-Core/DevSupport (= 0.66.61)
-    - React-Core/RCTWebSocket (= 0.66.61)
-    - React-RCTActionSheet (= 0.66.61)
-    - React-RCTAnimation (= 0.66.61)
-    - React-RCTBlob (= 0.66.61)
-    - React-RCTImage (= 0.66.61)
-    - React-RCTLinking (= 0.66.61)
-    - React-RCTNetwork (= 0.66.61)
-    - React-RCTSettings (= 0.66.61)
-    - React-RCTText (= 0.66.61)
-    - React-RCTVibration (= 0.66.61)
-  - React-callinvoker (0.66.61)
-  - React-Core (0.66.61):
+    - RCTRequired (= 0.66.64)
+    - React-Core (= 0.66.64)
+  - React (0.66.64):
+    - React-Core (= 0.66.64)
+    - React-Core/DevSupport (= 0.66.64)
+    - React-Core/RCTWebSocket (= 0.66.64)
+    - React-RCTActionSheet (= 0.66.64)
+    - React-RCTAnimation (= 0.66.64)
+    - React-RCTBlob (= 0.66.64)
+    - React-RCTImage (= 0.66.64)
+    - React-RCTLinking (= 0.66.64)
+    - React-RCTNetwork (= 0.66.64)
+    - React-RCTSettings (= 0.66.64)
+    - React-RCTText (= 0.66.64)
+    - React-RCTVibration (= 0.66.64)
+  - React-callinvoker (0.66.64)
+  - React-Core (0.66.64):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.66.61)
-    - React-cxxreact (= 0.66.61)
-    - React-jsi (= 0.66.61)
-    - React-jsiexecutor (= 0.66.61)
-    - React-perflogger (= 0.66.61)
+    - React-Core/Default (= 0.66.64)
+    - React-cxxreact (= 0.66.64)
+    - React-jsi (= 0.66.64)
+    - React-jsiexecutor (= 0.66.64)
+    - React-perflogger (= 0.66.64)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.66.61):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default
-    - React-cxxreact (= 0.66.61)
-    - React-jsi (= 0.66.61)
-    - React-jsiexecutor (= 0.66.61)
-    - React-perflogger (= 0.66.61)
-    - Yoga
-  - React-Core/Default (0.66.61):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.66.61)
-    - React-jsi (= 0.66.61)
-    - React-jsiexecutor (= 0.66.61)
-    - React-perflogger (= 0.66.61)
-    - Yoga
-  - React-Core/DevSupport (0.66.61):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.66.61)
-    - React-Core/RCTWebSocket (= 0.66.61)
-    - React-cxxreact (= 0.66.61)
-    - React-jsi (= 0.66.61)
-    - React-jsiexecutor (= 0.66.61)
-    - React-jsinspector (= 0.66.61)
-    - React-perflogger (= 0.66.61)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.66.61):
+  - React-Core/CoreModulesHeaders (0.66.64):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.61)
-    - React-jsi (= 0.66.61)
-    - React-jsiexecutor (= 0.66.61)
-    - React-perflogger (= 0.66.61)
+    - React-cxxreact (= 0.66.64)
+    - React-jsi (= 0.66.64)
+    - React-jsiexecutor (= 0.66.64)
+    - React-perflogger (= 0.66.64)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.66.61):
+  - React-Core/Default (0.66.64):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-cxxreact (= 0.66.64)
+    - React-jsi (= 0.66.64)
+    - React-jsiexecutor (= 0.66.64)
+    - React-perflogger (= 0.66.64)
+    - Yoga
+  - React-Core/DevSupport (0.66.64):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-Core/Default (= 0.66.64)
+    - React-Core/RCTWebSocket (= 0.66.64)
+    - React-cxxreact (= 0.66.64)
+    - React-jsi (= 0.66.64)
+    - React-jsiexecutor (= 0.66.64)
+    - React-jsinspector (= 0.66.64)
+    - React-perflogger (= 0.66.64)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.66.64):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.61)
-    - React-jsi (= 0.66.61)
-    - React-jsiexecutor (= 0.66.61)
-    - React-perflogger (= 0.66.61)
+    - React-cxxreact (= 0.66.64)
+    - React-jsi (= 0.66.64)
+    - React-jsiexecutor (= 0.66.64)
+    - React-perflogger (= 0.66.64)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.66.61):
+  - React-Core/RCTAnimationHeaders (0.66.64):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.61)
-    - React-jsi (= 0.66.61)
-    - React-jsiexecutor (= 0.66.61)
-    - React-perflogger (= 0.66.61)
+    - React-cxxreact (= 0.66.64)
+    - React-jsi (= 0.66.64)
+    - React-jsiexecutor (= 0.66.64)
+    - React-perflogger (= 0.66.64)
     - Yoga
-  - React-Core/RCTImageHeaders (0.66.61):
+  - React-Core/RCTBlobHeaders (0.66.64):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.61)
-    - React-jsi (= 0.66.61)
-    - React-jsiexecutor (= 0.66.61)
-    - React-perflogger (= 0.66.61)
+    - React-cxxreact (= 0.66.64)
+    - React-jsi (= 0.66.64)
+    - React-jsiexecutor (= 0.66.64)
+    - React-perflogger (= 0.66.64)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.66.61):
+  - React-Core/RCTImageHeaders (0.66.64):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.61)
-    - React-jsi (= 0.66.61)
-    - React-jsiexecutor (= 0.66.61)
-    - React-perflogger (= 0.66.61)
+    - React-cxxreact (= 0.66.64)
+    - React-jsi (= 0.66.64)
+    - React-jsiexecutor (= 0.66.64)
+    - React-perflogger (= 0.66.64)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.66.61):
+  - React-Core/RCTLinkingHeaders (0.66.64):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.61)
-    - React-jsi (= 0.66.61)
-    - React-jsiexecutor (= 0.66.61)
-    - React-perflogger (= 0.66.61)
+    - React-cxxreact (= 0.66.64)
+    - React-jsi (= 0.66.64)
+    - React-jsiexecutor (= 0.66.64)
+    - React-perflogger (= 0.66.64)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.66.61):
+  - React-Core/RCTNetworkHeaders (0.66.64):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.61)
-    - React-jsi (= 0.66.61)
-    - React-jsiexecutor (= 0.66.61)
-    - React-perflogger (= 0.66.61)
+    - React-cxxreact (= 0.66.64)
+    - React-jsi (= 0.66.64)
+    - React-jsiexecutor (= 0.66.64)
+    - React-perflogger (= 0.66.64)
     - Yoga
-  - React-Core/RCTTextHeaders (0.66.61):
+  - React-Core/RCTSettingsHeaders (0.66.64):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.61)
-    - React-jsi (= 0.66.61)
-    - React-jsiexecutor (= 0.66.61)
-    - React-perflogger (= 0.66.61)
+    - React-cxxreact (= 0.66.64)
+    - React-jsi (= 0.66.64)
+    - React-jsiexecutor (= 0.66.64)
+    - React-perflogger (= 0.66.64)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.66.61):
+  - React-Core/RCTTextHeaders (0.66.64):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.61)
-    - React-jsi (= 0.66.61)
-    - React-jsiexecutor (= 0.66.61)
-    - React-perflogger (= 0.66.61)
+    - React-cxxreact (= 0.66.64)
+    - React-jsi (= 0.66.64)
+    - React-jsiexecutor (= 0.66.64)
+    - React-perflogger (= 0.66.64)
     - Yoga
-  - React-Core/RCTWebSocket (0.66.61):
+  - React-Core/RCTVibrationHeaders (0.66.64):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.66.61)
-    - React-cxxreact (= 0.66.61)
-    - React-jsi (= 0.66.61)
-    - React-jsiexecutor (= 0.66.61)
-    - React-perflogger (= 0.66.61)
+    - React-Core/Default
+    - React-cxxreact (= 0.66.64)
+    - React-jsi (= 0.66.64)
+    - React-jsiexecutor (= 0.66.64)
+    - React-perflogger (= 0.66.64)
     - Yoga
-  - React-CoreModules (0.66.61):
-    - FBReactNativeSpec (= 0.66.61)
+  - React-Core/RCTWebSocket (0.66.64):
+    - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.66.61)
-    - React-Core/CoreModulesHeaders (= 0.66.61)
-    - React-jsi (= 0.66.61)
-    - React-RCTImage (= 0.66.61)
-    - ReactCommon/turbomodule/core (= 0.66.61)
-  - React-cxxreact (0.66.61):
+    - React-Core/Default (= 0.66.64)
+    - React-cxxreact (= 0.66.64)
+    - React-jsi (= 0.66.64)
+    - React-jsiexecutor (= 0.66.64)
+    - React-perflogger (= 0.66.64)
+    - Yoga
+  - React-CoreModules (0.66.64):
+    - FBReactNativeSpec (= 0.66.64)
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - RCTTypeSafety (= 0.66.64)
+    - React-Core/CoreModulesHeaders (= 0.66.64)
+    - React-jsi (= 0.66.64)
+    - React-RCTImage (= 0.66.64)
+    - ReactCommon/turbomodule/core (= 0.66.64)
+  - React-cxxreact (0.66.64):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.66.61)
-    - React-jsi (= 0.66.61)
-    - React-jsinspector (= 0.66.61)
-    - React-logger (= 0.66.61)
-    - React-perflogger (= 0.66.61)
-    - React-runtimeexecutor (= 0.66.61)
-  - React-jsi (0.66.61):
+    - React-callinvoker (= 0.66.64)
+    - React-jsi (= 0.66.64)
+    - React-jsinspector (= 0.66.64)
+    - React-logger (= 0.66.64)
+    - React-perflogger (= 0.66.64)
+    - React-runtimeexecutor (= 0.66.64)
+  - React-jsi (0.66.64):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-jsi/Default (= 0.66.61)
-  - React-jsi/Default (0.66.61):
+    - React-jsi/Default (= 0.66.64)
+  - React-jsi/Default (0.66.64):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-  - React-jsiexecutor (0.66.61):
+  - React-jsiexecutor (0.66.64):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.66.61)
-    - React-jsi (= 0.66.61)
-    - React-perflogger (= 0.66.61)
-  - React-jsinspector (0.66.61)
-  - React-logger (0.66.61):
+    - React-cxxreact (= 0.66.64)
+    - React-jsi (= 0.66.64)
+    - React-perflogger (= 0.66.64)
+  - React-jsinspector (0.66.64)
+  - React-logger (0.66.64):
     - glog
-  - React-perflogger (0.66.61)
-  - React-RCTActionSheet (0.66.61):
-    - React-Core/RCTActionSheetHeaders (= 0.66.61)
-  - React-RCTAnimation (0.66.61):
-    - FBReactNativeSpec (= 0.66.61)
+  - React-perflogger (0.66.64)
+  - React-RCTActionSheet (0.66.64):
+    - React-Core/RCTActionSheetHeaders (= 0.66.64)
+  - React-RCTAnimation (0.66.64):
+    - FBReactNativeSpec (= 0.66.64)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.66.61)
-    - React-Core/RCTAnimationHeaders (= 0.66.61)
-    - React-jsi (= 0.66.61)
-    - ReactCommon/turbomodule/core (= 0.66.61)
-  - React-RCTBlob (0.66.61):
-    - FBReactNativeSpec (= 0.66.61)
+    - RCTTypeSafety (= 0.66.64)
+    - React-Core/RCTAnimationHeaders (= 0.66.64)
+    - React-jsi (= 0.66.64)
+    - ReactCommon/turbomodule/core (= 0.66.64)
+  - React-RCTBlob (0.66.64):
+    - FBReactNativeSpec (= 0.66.64)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/RCTBlobHeaders (= 0.66.61)
-    - React-Core/RCTWebSocket (= 0.66.61)
-    - React-jsi (= 0.66.61)
-    - React-RCTNetwork (= 0.66.61)
-    - ReactCommon/turbomodule/core (= 0.66.61)
-  - React-RCTImage (0.66.61):
-    - FBReactNativeSpec (= 0.66.61)
+    - React-Core/RCTBlobHeaders (= 0.66.64)
+    - React-Core/RCTWebSocket (= 0.66.64)
+    - React-jsi (= 0.66.64)
+    - React-RCTNetwork (= 0.66.64)
+    - ReactCommon/turbomodule/core (= 0.66.64)
+  - React-RCTImage (0.66.64):
+    - FBReactNativeSpec (= 0.66.64)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.66.61)
-    - React-Core/RCTImageHeaders (= 0.66.61)
-    - React-jsi (= 0.66.61)
-    - React-RCTNetwork (= 0.66.61)
-    - ReactCommon/turbomodule/core (= 0.66.61)
-  - React-RCTLinking (0.66.61):
-    - FBReactNativeSpec (= 0.66.61)
-    - React-Core/RCTLinkingHeaders (= 0.66.61)
-    - React-jsi (= 0.66.61)
-    - ReactCommon/turbomodule/core (= 0.66.61)
-  - React-RCTNetwork (0.66.61):
-    - FBReactNativeSpec (= 0.66.61)
+    - RCTTypeSafety (= 0.66.64)
+    - React-Core/RCTImageHeaders (= 0.66.64)
+    - React-jsi (= 0.66.64)
+    - React-RCTNetwork (= 0.66.64)
+    - ReactCommon/turbomodule/core (= 0.66.64)
+  - React-RCTLinking (0.66.64):
+    - FBReactNativeSpec (= 0.66.64)
+    - React-Core/RCTLinkingHeaders (= 0.66.64)
+    - React-jsi (= 0.66.64)
+    - ReactCommon/turbomodule/core (= 0.66.64)
+  - React-RCTNetwork (0.66.64):
+    - FBReactNativeSpec (= 0.66.64)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.66.61)
-    - React-Core/RCTNetworkHeaders (= 0.66.61)
-    - React-jsi (= 0.66.61)
-    - ReactCommon/turbomodule/core (= 0.66.61)
-  - React-RCTSettings (0.66.61):
-    - FBReactNativeSpec (= 0.66.61)
+    - RCTTypeSafety (= 0.66.64)
+    - React-Core/RCTNetworkHeaders (= 0.66.64)
+    - React-jsi (= 0.66.64)
+    - ReactCommon/turbomodule/core (= 0.66.64)
+  - React-RCTSettings (0.66.64):
+    - FBReactNativeSpec (= 0.66.64)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.66.61)
-    - React-Core/RCTSettingsHeaders (= 0.66.61)
-    - React-jsi (= 0.66.61)
-    - ReactCommon/turbomodule/core (= 0.66.61)
-  - React-RCTText (0.66.61):
-    - React-Core/RCTTextHeaders (= 0.66.61)
-  - React-RCTVibration (0.66.61):
-    - FBReactNativeSpec (= 0.66.61)
+    - RCTTypeSafety (= 0.66.64)
+    - React-Core/RCTSettingsHeaders (= 0.66.64)
+    - React-jsi (= 0.66.64)
+    - ReactCommon/turbomodule/core (= 0.66.64)
+  - React-RCTText (0.66.64):
+    - React-Core/RCTTextHeaders (= 0.66.64)
+  - React-RCTVibration (0.66.64):
+    - FBReactNativeSpec (= 0.66.64)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/RCTVibrationHeaders (= 0.66.61)
-    - React-jsi (= 0.66.61)
-    - ReactCommon/turbomodule/core (= 0.66.61)
-  - React-runtimeexecutor (0.66.61):
-    - React-jsi (= 0.66.61)
-  - ReactCommon/turbomodule/core (0.66.61):
+    - React-Core/RCTVibrationHeaders (= 0.66.64)
+    - React-jsi (= 0.66.64)
+    - ReactCommon/turbomodule/core (= 0.66.64)
+  - React-runtimeexecutor (0.66.64):
+    - React-jsi (= 0.66.64)
+  - ReactCommon/turbomodule/core (0.66.64):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.66.61)
-    - React-Core (= 0.66.61)
-    - React-cxxreact (= 0.66.61)
-    - React-jsi (= 0.66.61)
-    - React-logger (= 0.66.61)
-    - React-perflogger (= 0.66.61)
+    - React-callinvoker (= 0.66.64)
+    - React-Core (= 0.66.64)
+    - React-cxxreact (= 0.66.64)
+    - React-jsi (= 0.66.64)
+    - React-logger (= 0.66.64)
+    - React-perflogger (= 0.66.64)
   - ReactTestApp-DevSupport (1.4.0):
     - React-Core
     - React-jsi
@@ -508,48 +508,48 @@ SPEC CHECKSUMS:
   boost: 613e39eac4239cc72b15421247b5ab05361266a2
   boost-for-react-native: 8f7c9ecfe357664c072ffbe2432569667cbf1f1b
   DoubleConversion: ed15e075aa758ac0e4c1f8b830bd4e4d40d669e8
-  FBLazyVector: 1f65a0f0cea22915507bdbbc44ca4af673d9ce7f
-  FBReactNativeSpec: 768546ea603d7382d39bce4acf11897140b5e977
+  FBLazyVector: 269032fe4980555b1a6675ed556dcf9d78353a78
+  FBReactNativeSpec: 8ea3aaffceb4bd261cf9c5df534d74714f6e485e
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   FRNAvatar: 827ebe75e839ce442c88cc6a23940aa614ca7946
-  FRNCallout: d7f7c2f2ca08c564898b4fa877bbde9975ab8457
-  FRNCheckbox: e7050c7db1b4c48b92437f012bf034e5f297ae59
-  FRNMenuButton: c736bbb42dc3a1965eca2cea997561438f489103
-  FRNRadioButton: f9bb2366b8077c045d5c6a120eeb0b01b96529b8
+  FRNCallout: 249365dd056e7a1c8f5edaa1b70f1ac8329021c7
+  FRNCheckbox: b45089f6c385c2107a7e548415ccc770eae8748d
+  FRNMenuButton: adbaefda7450616d4875529e921b8e9640212bcc
+  FRNRadioButton: aeb75d9242cd3f0c1ad5982439d38a8cf1162ff9
   glog: 42c4bf47024808486e90b25ea9e5ac3959047641
   MicrosoftFluentUI: 2f4c624fd4606aa2392c09be69a45e297a41f593
   RCT-Folly: 43adc9ce880eb76792f88c011773cb5c664c1419
-  RCTFocusZone: 959220571a9994ca90490b994d28e79e30f41d2b
-  RCTRequired: 5d9c6fe63ff2606a93e9e2812cfede283ff98571
-  RCTTypeSafety: 31e44236c2161f101e1135696c3e8f35bb705430
-  React: 68fcf6fed1c1607eb7dbf6bf8259b04cc440295a
-  React-callinvoker: 4f80cd6a9ef8164fa2502dca6a9a3ebdcc861f55
-  React-Core: fa084e35b27bc8ed20966b06e84cda209ebeb478
-  React-CoreModules: 76a1f339d3c8bd74f6943cababe9c67c1dff42f0
-  React-cxxreact: 608ebe8e015754a8d9b237c6503be71c30fef514
-  React-jsi: c9bff10d5b445507a52c0802e183b60ff032983e
-  React-jsiexecutor: 6d28bb97c1610217cac530233512c3a467b4ee18
-  React-jsinspector: 9986f330f32d8ca81d8c8ba8b1fb6f8f4a5f9931
-  React-logger: cef51d1376f36a83f74890c980796df8f7204bc6
-  React-perflogger: 96f294886cef5cb6dc2478a6040c4a05bd7599c6
-  React-RCTActionSheet: c2fe7084562d9c36201f25e22d40528bca18d628
-  React-RCTAnimation: 3eeb3da96f84a2e0a87dedebd24b0f28f22bc1ac
-  React-RCTBlob: b25ed7d11f2b42048a8db056d08c929e9c3c4786
-  React-RCTImage: 82ec5d6bd98e998bbf3ca225865f6d37c69c9c1d
-  React-RCTLinking: a26477bdb61bd6879d8dc610e38bf182f1746cb4
-  React-RCTNetwork: 63ccc51ee85107094cbef899ec96fcca18e3c4cc
-  React-RCTSettings: 7f0ef7b9e67a131affb717c1c97833495208a589
-  React-RCTText: cfed8e661234bfc7d506638e7c6dde42dba7d0cc
-  React-RCTVibration: bc44b271a6c6eb0e5ef9eaf9a5affa2a363b38c6
-  React-runtimeexecutor: 84c09cebad207a59744dde577090074b96ea5f39
-  ReactCommon: 3073497b51310a92e0b02070396434036264248e
+  RCTFocusZone: fdeb094b06648e757aedf8828e93bc028cd43cc3
+  RCTRequired: 829ebe304e405e9d32b8e56eae62dedcaeba1b4c
+  RCTTypeSafety: 84a70a5f88d881fc8fcd1d8c3b641bfa0e9e1541
+  React: a445d40e3867d024a274784fb343891528960c54
+  React-callinvoker: b619135420297f76afe530a75b8fd271970d2cd6
+  React-Core: ac0d91b4a36c6960c3d7c3cb2183fec11d1f164a
+  React-CoreModules: 6d247f4a846ee268422c978781cf140ec7b9a805
+  React-cxxreact: f8f9a8991bb4a9a47785eb8ae233bd77e016bbc7
+  React-jsi: dfababc3beb0456a08e70be5c1593b33c98d6865
+  React-jsiexecutor: ccdc7580d3b7fec2a1c331439c024670947086d6
+  React-jsinspector: cacb63c18d235c41741ad80fa4c4bdfb7f1bef46
+  React-logger: 50315eae86186d952430ac9dd63a4ad2045bc633
+  React-perflogger: 1bae9dbc45505fd246a7d3ce673623b4a97cc1fe
+  React-RCTActionSheet: e315f9ecd1c411da44a277538343ab35afc15946
+  React-RCTAnimation: 04d14fc95f124f9f1c3d1feab406e72e58d493f3
+  React-RCTBlob: 7b0fa4ea6711628d8328986daf15919020a50f36
+  React-RCTImage: ddebef50d5370b8b1cbaed611e3e68a5cf16acc4
+  React-RCTLinking: b41354f49b8507dfadc4cd1687b270fdb8696950
+  React-RCTNetwork: b2ebc29698640abf674008f460ed7ef5cd7ecce1
+  React-RCTSettings: 77ac7c9777ab17260a116e359ac38a4ae7d1762b
+  React-RCTText: e540a98b779e8c1e7bffa2651b807aad2f9cb1c8
+  React-RCTVibration: 5a5061c8d53b0cdb0fdd6dd8e2a83a5e0e20a607
+  React-runtimeexecutor: 5316ac41f54c44581bb49b3ed4c4229ab1bd4b32
+  ReactCommon: ffb18b20873edd7c6c2702a9238fadf9a535dd8a
   ReactTestApp-DevSupport: f304d297706114319929405239789b443b5c2fee
   ReactTestApp-Resources: 320923a3635f7bf90caa1a28fd29765b577888d9
   RNCPicker: 0250e95ad170569a96f5b0555cdd5e65b9084dca
   RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
-  Yoga: bd724262da8fcf3e805f99e28af79842b4b73cd4
+  Yoga: d030f4c37fae1eff9cfecaa9fa5d10f836b63143
 
-PODFILE CHECKSUM: ac74310bf0d010aed993b871044c8c9934a651c1
+PODFILE CHECKSUM: 553ec4eec9578ceafbc92e27e0789d7ddcd88c74
 
 COCOAPODS: 1.11.3

--- a/change/@fluentui-react-native-tester-455ef151-eed5-415e-9b7c-5dabba98f12a.json
+++ b/change/@fluentui-react-native-tester-455ef151-eed5-415e-9b7c-5dabba98f12a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Disable Flipper on iOS and macOS test apps",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/scripts/nuget_pack_apple.sh
+++ b/scripts/nuget_pack_apple.sh
@@ -211,12 +211,12 @@ function do_prerequisites
 	run_subprocess "${git_root}/.ado/scripts/xcode_select_current_version.sh"
 
 	log_action 📦 "Installing CocoaPods dependencies for macOS"
-	run_subprocess pushd "${git_root}/apps/macos/src"
+	run_subprocess pushd "${git_root}/apps/fluent-tester/macos"
 	run_subprocess pod install $verbosity_arg
 	run_subprocess popd
 
 	log_action 📦 "Installing CocoaPods dependencies for iOS"
-	run_subprocess pushd "${git_root}/apps/ios/src"
+	run_subprocess pushd "${git_root}/apps/fluent-tester/ios"
 	run_subprocess pod install $verbosity_arg
 	run_subprocess popd
 }
@@ -318,7 +318,7 @@ function build_and_copy_output()
 function build_and_copy_macos()
 {
 	build_and_copy_output \
-	"${git_root}/apps/macos/src/FluentTester.xcworkspace" \
+	"${git_root}/apps/fluent-tester/macos/FluentTester.xcworkspace" \
 	FluentTester \
 	"$1" \
 	macosx \
@@ -332,7 +332,7 @@ function build_and_copy_macos()
 function build_and_copy_ios_device()
 {
 	build_and_copy_output \
-	"${git_root}/apps/ios/src/FluentTester.xcworkspace" \
+	"${git_root}/apps/fluent-tester/ios/FluentTester.xcworkspace" \
 	FluentTester \
 	"$1" \
 	iphoneos \
@@ -346,7 +346,7 @@ function build_and_copy_ios_device()
 function build_and_copy_ios_simulator()
 {
 	build_and_copy_output \
-	"${git_root}/apps/ios/src/FluentTester.xcworkspace" \
+	"${git_root}/apps/fluent-tester/ios/FluentTester.xcworkspace" \
 	FluentTester \
 	"$1" \
 	iphonesimulator \


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Our nuget is failing to build for iphoneos-release. The error looks like the kind of error that can be fixed by disabling flipper. This seems to be a regression from #1535 , where flipper was disabled before that change. 

### Verification

Locally ran our nuget build script, and saw it passes. 

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
