### PR TITLE
Made Badge not accessibe

### DIFF
--- a/change/@fluentui-react-native-badge-7025fb28-9023-43a8-8e8a-54022ea43dd5.json
+++ b/change/@fluentui-react-native-badge-7025fb28-9023-43a8-8e8a-54022ea43dd5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Made Badge not accessible",
+  "packageName": "@fluentui-react-native/badge",
+  "email": "v.kozova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Badge/src/Badge.tsx
+++ b/packages/experimental/Badge/src/Badge.tsx
@@ -41,9 +41,17 @@ export const Badge = compose<BadgeType>({
       const { icon, iconPosition = 'before', ...mergedProps } = mergeProps(badge, final);
       return (
         <Slots.root {...mergedProps}>
-          {icon && iconPosition === 'before' && <Slots.icon {...iconProps} />}
-          {Children.map(children, (child) => (typeof child === 'string' ? <Slots.text key="text">{child}</Slots.text> : child))}
-          {icon && iconPosition === 'after' && <Slots.icon {...iconProps} />}
+          {icon && iconPosition === 'before' && <Slots.icon accessible={false} {...iconProps} />}
+          {Children.map(children, (child) =>
+            typeof child === 'string' ? (
+              <Slots.text accessible={false} key="text">
+                {child}
+              </Slots.text>
+            ) : (
+              child
+            ),
+          )}
+          {icon && iconPosition === 'after' && <Slots.icon accessible={false} {...iconProps} />}
         </Slots.root>
       );
     };

--- a/packages/experimental/Badge/src/__tests__/__snapshots__/Badge.test.tsx.snap
+++ b/packages/experimental/Badge/src/__tests__/__snapshots__/Badge.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`Badge component tests Badge all props 1`] = `
   }
 >
   <Text
-    accessible={true}
+    accessible={false}
     style={
       Object {
         "color": "#fff",
@@ -39,6 +39,7 @@ exports[`Badge component tests Badge all props 1`] = `
     ♣
   </Text>
   <Text
+    accessible={false}
     ellipsizeMode="tail"
     numberOfLines={0}
     style={
@@ -82,6 +83,7 @@ exports[`Badge component tests Badge tokens 1`] = `
   }
 >
   <Text
+    accessible={false}
     ellipsizeMode="tail"
     numberOfLines={0}
     style={


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
Set `accessibility=false` to text and icon elements of Badge
SPEC says that Badges do not receive focus. 
Information can be provided through tooltips provided on the component associated with the badge [if needed].

### Verification
Checked with Accessibility Insights app.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
