### PR TITLE
[Button] Prefer user key events over those handled by Fluent

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Button/E2EButtonTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Button/E2EButtonTest.tsx
@@ -11,14 +11,37 @@ import {
   BUTTON_NO_A11Y_LABEL_COMPONENT,
   BUTTON_ACCESSIBILITY_LABEL,
   BUTTON_TEST_COMPONENT_LABEL,
+  BUTTON_ON_KEY,
+  BUTTON_PRESS_TEST_COMPONENT,
+  BUTTON_PRESS_TEST_COMPONENT_LABEL,
 } from './consts';
+import { IViewWin32Props } from '@office-iss/react-native-win32';
 
 export const E2EButtonExperimentalTest: React.FunctionComponent = () => {
   const [buttonPressed, setButtonPressed] = React.useState(false);
+  const [keyDetected, setKeyDetected] = React.useState('');
 
   const onClick = React.useCallback(() => {
     setButtonPressed(!buttonPressed);
+    setKeyDetected('');
   }, [buttonPressed]);
+
+  const keyPressProps: Omit<IViewWin32Props, 'accessibilityRole' | 'onBlur' | 'onFocus'> = {
+    keyDownEvents: [{ key: 'a' }],
+    onKeyDown: (args) => {
+      if (args.nativeEvent.key === 'a') {
+        setKeyDetected('a (down)');
+        args.stopPropagation();
+      }
+    },
+    keyUpEvents: [{ key: 'b' }],
+    onKeyUp: (args) => {
+      if (args.nativeEvent.key === 'b') {
+        setKeyDetected('b (up)');
+        args.stopPropagation();
+      }
+    },
+  };
 
   return (
     <View>
@@ -29,7 +52,16 @@ export const E2EButtonExperimentalTest: React.FunctionComponent = () => {
         <Button testID={BUTTON_NO_A11Y_LABEL_COMPONENT} onClick={onClick}>
           {BUTTON_TEST_COMPONENT_LABEL}
         </Button>
+        <Button
+          testID={BUTTON_PRESS_TEST_COMPONENT}
+          onClick={onClick}
+          accessibilityLabel={BUTTON_PRESS_TEST_COMPONENT_LABEL}
+          {...keyPressProps}
+        >
+          Press &quot;a&quot; or &quot;b&quot; after focusing this button
+        </Button>
         {buttonPressed ? <Text testID={BUTTON_ON_PRESS}>Button Pressed</Text> : null}
+        {keyDetected ? <Text testID={BUTTON_ON_KEY}>Button Key Press detected: {keyDetected}</Text> : null}
       </Stack>
     </View>
   );

--- a/apps/fluent-tester/src/TestComponents/Button/consts.ts
+++ b/apps/fluent-tester/src/TestComponents/Button/consts.ts
@@ -19,4 +19,9 @@ export const BUTTON_ACCESSIBILITY_LABEL = 'E2E testing Button accessibility labe
 export const BUTTON_NO_A11Y_LABEL_COMPONENT = 'Button_No_A11y_label_Component';
 export const BUTTON_TEST_COMPONENT_LABEL = 'Test Button2 - No Accessibility Label'; // A component on each specific test page
 
+/* Test Button 3 */
+export const BUTTON_PRESS_TEST_COMPONENT = 'Button_Press_Test_Component';
+export const BUTTON_PRESS_TEST_COMPONENT_LABEL = 'Test Button3 - For Key Presses';
+
 export const BUTTON_ON_PRESS = 'Button_On_Press'; // For testing the press functionality on a button
+export const BUTTON_ON_KEY = 'Button_On_Key'; // For testing the key press functionality on a button

--- a/change/@fluentui-react-native-4221b05c-1ae5-4e53-9245-bae22887f579.json
+++ b/change/@fluentui-react-native-4221b05c-1ae5-4e53-9245-bae22887f579.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Adding flag to determine platform preference for keyUp vs. keyDown",
+  "packageName": "@fluentui/react-native",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-button-77eecae8-b0be-4785-b955-ed88ca1ff044.json
+++ b/change/@fluentui-react-native-button-77eecae8-b0be-4785-b955-ed88ca1ff044.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Allow user props to override default button key handling",
+  "packageName": "@fluentui-react-native/button",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-interactive-hooks-52aba033-698f-4d0e-a2c7-421956f9eb94.json
+++ b/change/@fluentui-react-native-interactive-hooks-52aba033-698f-4d0e-a2c7-421956f9eb94.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Adding flag to determine platform preference for keyUp vs. keyDown",
+  "packageName": "@fluentui-react-native/interactive-hooks",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-a9cb20ea-b513-4fba-8547-c8aa2ad663ec.json
+++ b/change/@fluentui-react-native-tester-a9cb20ea-b513-4fba-8547-c8aa2ad663ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adding button to test buttons that also handle key presses",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Button/SPEC.md
+++ b/packages/components/Button/SPEC.md
@@ -267,6 +267,8 @@ The following is a set of keys that interact with the `Button` component:
 | `Enter` | Executes the function passed into the `onClick` prop. |
 | `Space` | Executes the function passed into the `onClick` prop. |
 
+It is possible to override key behaviors by specifying `onKeyUp` or `onKeyDown`, depending on what `preferKeyDownForKeyEvents` from the `@fluentui-react-native/interactive-hooks` package indicates. Providing the callback this way will prevent the default behaviors noted above -- you will need to handle `Enter` and `Space` in the provided callback if the default behavior is desired.
+
 #### Cursor interaction
 
 - Cursor moves onto botton: Should immediately change the styling of the `Button` so that it appears to be hovered.

--- a/packages/components/Button/src/useButton.ts
+++ b/packages/components/Button/src/useButton.ts
@@ -18,7 +18,8 @@ export const useButton = (props: ButtonProps): ButtonState => {
 
   return {
     props: {
-      ...pressable.props,
+      ...onKeyUpProps,
+      ...pressable.props, // allow user key events to override those set by us
       accessible: true,
       accessibilityRole: 'button',
       onAccessibilityTap: props.onAccessibilityTap || (!hasTogglePattern ? props.onClick : undefined),
@@ -27,7 +28,6 @@ export const useButton = (props: ButtonProps): ButtonState => {
       enableFocusRing: enableFocusRing ?? true,
       focusable: !isDisabled,
       ref: useViewCommandFocus(componentRef),
-      ...onKeyUpProps,
       iconPosition: props.iconPosition || 'before',
       loading,
     },

--- a/packages/libraries/core/src/index.ts
+++ b/packages/libraries/core/src/index.ts
@@ -184,6 +184,7 @@ export type { ITextProps, ITextType } from '@fluentui-react-native/text';
 export {
   createIconProps,
   normalizeRect,
+  preferKeyDownForKeyEvents,
   useAsPressable,
   useAsToggle,
   useFocusState,

--- a/packages/utils/interactive-hooks/src/index.ts
+++ b/packages/utils/interactive-hooks/src/index.ts
@@ -56,7 +56,7 @@ export type {
   TextLayout,
   TextLayoutEvent,
 } from './Pressability/CoreEventTypes';
-export { useKeyCallback, useKeyDownProps, useKeyProps, useKeyUpProps } from './useKeyProps';
+export { preferKeyDownForKeyEvents, useKeyCallback, useKeyDownProps, useKeyProps, useKeyUpProps } from './useKeyProps';
 export type { KeyCallback, KeyPressProps } from './useKeyProps';
 export { useOnPressWithFocus } from './useOnPressWithFocus';
 export type { OnPressCallback, OnPressWithFocusCallback } from './useOnPressWithFocus';

--- a/packages/utils/interactive-hooks/src/useKeyProps.macos.ts
+++ b/packages/utils/interactive-hooks/src/useKeyProps.macos.ts
@@ -73,3 +73,6 @@ export const useKeyDownProps = memoize(getKeyDownPropsWorker);
  * @returns KeyPressProps: An object containing the correct platform specific props to  handle key press
  */
 export const useKeyProps = memoize(getKeyDownPropsWorker);
+
+/** Exposes the behavior of useKeyProps for the current platform as a boolean */
+export const preferKeyDownForKeyEvents = true;

--- a/packages/utils/interactive-hooks/src/useKeyProps.ts
+++ b/packages/utils/interactive-hooks/src/useKeyProps.ts
@@ -55,3 +55,6 @@ export const useKeyDownProps = noOp2;
  * @returns KeyPressProps: An object containing the correct platform specific props to  handle key press
  */
 export const useKeyProps = noOp2;
+
+/** Exposes the behavior of useKeyProps for the current platform as a boolean */
+export const preferKeyDownForKeyEvents = false;

--- a/packages/utils/interactive-hooks/src/useKeyProps.win32.ts
+++ b/packages/utils/interactive-hooks/src/useKeyProps.win32.ts
@@ -77,3 +77,6 @@ export const useKeyDownProps = memoize(getKeyDownPropsWorker);
  * @returns KeyPressProps: An object containing the correct platform specific props to handle key press
  */
 export const useKeyProps = memoize(getKeyUpPropsWorker);
+
+/** Exposes the behavior of useKeyProps for the current platform as a boolean */
+export const preferKeyDownForKeyEvents = false;

--- a/packages/utils/interactive-hooks/src/useKeyProps.windows.ts
+++ b/packages/utils/interactive-hooks/src/useKeyProps.windows.ts
@@ -69,3 +69,6 @@ export const useKeyDownProps = memoize(getKeyDownPropsWorker);
  * @returns KeyPressProps: An object containing the correct platform specific props to  handle key press
  */
 export const useKeyProps = memoize(getKeyUpPropsWorker);
+
+/** Exposes the behavior of useKeyProps for the current platform as a boolean */
+export const preferKeyDownForKeyEvents = false;


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [ ] android

### Description of changes

Currently, on Windows, the `Button` component handles keyUp events (keyDown for macOS). What that means is someone can't have a keyUp (or keyDown) handler of their own to do "special" things on keypresses on buttons (e.g. perhaps implement a split button).

Previously (prior to PR https://github.com/microsoft/fluentui-react-native/pull/1373), `Button` always used keyUp, so button users could at least use keyDown to do things, but now depending on the target platform, a button user would have to handle the slot NOT used by Fluent.

I investigated the possibility of creating a composite handler (such that for user requested keys we always pass back to the user, and if not specified, then we pass back the handling to Fluent). It looks like it will need substantial refactoring because the event types for key handlers in useKeyProps does not match that exposed by Win32. Further, the approach to specifying valid keys (the name of the prop, as well the specifics like modifiers) is different for the Mac.

Therefore, in this change, I am instead suggesting the *other* approach I previously discussed with Saad -- if a button user tries to override a particular key handler, the user is also responsible for providing the default behaviors (like Enter\Space to invoke the button event).

For client usage correctness (and convenience), also expose a flag to indicate platform behavior with respect to keyUp or keyDown.

### Verification

Manually, using Fluent tester.

* Regular button use case (no key handler): Enter\Space works as expected
* New button added to handle key events: ONLY handled key events pass through; since Enter\Space isn't one of them, this lets us prevent default action (of course, handling those two keys manually in the custom handler would restore that behavior).

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [x] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
