### PR TITLE
Add custom image ring to avatar

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Avatar/CustomizedAvatar.tsx
+++ b/apps/fluent-tester/src/TestComponents/Avatar/CustomizedAvatar.tsx
@@ -7,6 +7,7 @@ import { FontWeight } from '@fluentui-react-native/theme-types';
 import { SvgIconProps } from '@fluentui-react-native/icon';
 import TestSvg from '../../FluentTester/test-data/test.svg';
 import { ToggleButton } from '@fluentui/react-native';
+import { rainbowGradientSource } from './testImageSources';
 
 export const CustomizeUsage: React.FunctionComponent = () => {
   const [showImage, setShowImage] = useState(true);
@@ -232,6 +233,21 @@ export const CustomizeUsage: React.FunctionComponent = () => {
           ringThickness={parseInt(ringThickness)}
           size={parseInt(size) as AvatarSize}
           transparentRing={!showRing}
+        />
+      </View>
+      <View style={{ marginLeft: 20 }}>
+        <Text>Avatar with custom border</Text>
+        <CustomizedAvatar
+          active="active"
+          activeAppearance="ring"
+          avatarColor={avatarColor}
+          accessibilityLabel="Former CEO of Microsoft"
+          initials={showInitials ? initials : undefined}
+          name={showInitials ? name : undefined}
+          imageUrl={showImage ? steveBallmerPhotoUrl : undefined}
+          icon={svgIconsEnabled ? { svgSource: svgProps } : undefined}
+          transparentRing={!showRing}
+          customBorderImageSource={rainbowGradientSource}
         />
       </View>
     </View>

--- a/change/@fluentui-react-native-avatar-9059964d-59c8-43b3-89f3-efe585e7d6f7.json
+++ b/change/@fluentui-react-native-avatar-9059964d-59c8-43b3-89f3-efe585e7d6f7.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add custom image ring to avatar",
+  "packageName": "@fluentui-react-native/avatar",
+  "email": "joannaquu@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-45d5f7df-843d-4190-ae76-ed3046e89de8.json
+++ b/change/@fluentui-react-native-tester-45d5f7df-843d-4190-ae76-ed3046e89de8.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add custom image ring to avatar",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "joannaquu@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Avatar/src/Avatar.styling.ts
+++ b/packages/components/Avatar/src/Avatar.styling.ts
@@ -168,7 +168,7 @@ export const stylingSettings: UseStylingOptions<AvatarProps, AvatarSlotProps, Av
           imageStyle: { borderRadius: ringConfig.size / 2},
         };
       },
-      ['size', ...borderStyles.keys],
+      ['size'],
     ),
     badge: buildProps(
       (tokens: AvatarTokens) => {

--- a/packages/components/Avatar/src/Avatar.styling.ts
+++ b/packages/components/Avatar/src/Avatar.styling.ts
@@ -158,15 +158,14 @@ export const stylingSettings: UseStylingOptions<AvatarProps, AvatarSlotProps, Av
       ['size', 'ringColor', 'ringBackgroundColor', 'ringThickness', ...borderStyles.keys],
     ),
     imageRing: buildProps(
-      (tokens: AvatarTokens, theme: Theme) => {
+      (tokens: AvatarTokens) => {
         const ringConfig = getRingConfig(tokens);
         return {
           style: {
             minWidth: ringConfig.size,
             minHeight: ringConfig.size,
-            overflow: 'hidden',
-            ...borderStyles.from(tokens, theme),
           },
+          imageStyle: { borderRadius: ringConfig.size / 2},
         };
       },
       ['size', ...borderStyles.keys],

--- a/packages/components/Avatar/src/Avatar.styling.ts
+++ b/packages/components/Avatar/src/Avatar.styling.ts
@@ -165,7 +165,7 @@ export const stylingSettings: UseStylingOptions<AvatarProps, AvatarSlotProps, Av
             minWidth: ringConfig.size,
             minHeight: ringConfig.size,
           },
-          imageStyle: { borderRadius: ringConfig.size / 2},
+          imageStyle: { borderRadius: ringConfig.size / 2 },
         };
       },
       ['size'],

--- a/packages/components/Avatar/src/Avatar.styling.ts
+++ b/packages/components/Avatar/src/Avatar.styling.ts
@@ -157,6 +157,20 @@ export const stylingSettings: UseStylingOptions<AvatarProps, AvatarSlotProps, Av
       },
       ['size', 'ringColor', 'ringBackgroundColor', 'ringThickness', ...borderStyles.keys],
     ),
+    imageRing: buildProps(
+      (tokens: AvatarTokens, theme: Theme) => {
+        const ringConfig = getRingConfig(tokens);
+        return {
+          style: {
+            minWidth: ringConfig.size,
+            minHeight: ringConfig.size,
+            overflow: 'hidden',
+            ...borderStyles.from(tokens, theme),
+          },
+        };
+      },
+      ['size', ...borderStyles.keys],
+    ),
     badge: buildProps(
       (tokens: AvatarTokens) => {
         return {

--- a/packages/components/Avatar/src/Avatar.tsx
+++ b/packages/components/Avatar/src/Avatar.tsx
@@ -1,5 +1,5 @@
 /** @jsx withSlots */
-import { Image, View, Text, Platform } from 'react-native';
+import { Image, View, Text, Platform, ImageBackground } from 'react-native';
 import { Fragment } from 'react';
 import { AvatarProps, AvatarType, AvatarName, AvatarState, AvatarSlotProps } from './Avatar.types';
 import { stylingSettings } from './Avatar.styling';
@@ -41,6 +41,7 @@ export const Avatar = compose<AvatarType>({
     initialsBackground: View,
     icon: Icon,
     ring: View,
+    imageRing: ImageBackground,
     badge: PresenceBadge,
     fallbackIcon: Svg,
   },
@@ -50,13 +51,14 @@ export const Avatar = compose<AvatarType>({
 
     return (final: AvatarProps) => {
       const { showRing, transparentRing, showBadge } = avatar.state;
-      const { badge, ...mergedProps } = avatar.props;
+      const { badge, customBorderImageSource, ...mergedProps } = avatar.props;
       const svgIconsEnabled = ['ios', 'macos', 'win32', 'android'].includes(Platform.OS as string);
-      const RingComponent = showRing && !transparentRing ? Slots.ring : Fragment;
+      const RingComponent = showRing && !transparentRing ? (customBorderImageSource ? Slots.imageRing : Slots.ring) : Fragment;
+      const ringProps = createRingComponentProps(userProps);
 
       return (
         <Slots.root {...mergedProps}>
-          <RingComponent>{renderAvatar(final, avatar.props, Slots, svgIconsEnabled)}</RingComponent>
+          <RingComponent {...ringProps}>{renderAvatar(final, avatar.props, Slots, svgIconsEnabled)}</RingComponent>
           {svgIconsEnabled && showBadge && <Slots.badge {...badge} />}
         </Slots.root>
       );
@@ -85,4 +87,13 @@ function getFallbackIconPath() {
   const path =
     'M7 0C4.79086 0 3 1.79086 3 4C3 6.20914 4.79086 8 7 8C9.20914 8 11 6.20914 11 4C11 1.79086 9.20914 0 7 0ZM4 4C4 2.34315 5.34315 1 7 1C8.65685 1 10 2.34315 10 4C10 5.65685 8.65685 7 7 7C5.34315 7 4 5.65685 4 4ZM2.00873 9C0.903151 9 0 9.88687 0 11C0 12.6912 0.83281 13.9663 2.13499 14.7966C3.41697 15.614 5.14526 16 7 16C8.85474 16 10.583 15.614 11.865 14.7966C13.1672 13.9663 14 12.6912 14 11C14 9.89557 13.1045 9.00001 12 9.00001L2.00873 9ZM1 11C1 10.4467 1.44786 10 2.00873 10L12 10C12.5522 10 13 10.4478 13 11C13 12.3088 12.3777 13.2837 11.3274 13.9534C10.2568 14.636 8.73511 15 7 15C5.26489 15 3.74318 14.636 2.67262 13.9534C1.62226 13.2837 1 12.3088 1 11Z';
   return <Path fill="currentColor" d={path}></Path>;
+}
+
+function createRingComponentProps(userProps: AvatarProps) {
+  if (userProps.customBorderImageSource) {
+    return {
+      source: userProps.customBorderImageSource,
+    };
+  }
+  return null;
 }

--- a/packages/components/Avatar/src/Avatar.types.ts
+++ b/packages/components/Avatar/src/Avatar.types.ts
@@ -1,5 +1,5 @@
 import type { IViewProps } from '@fluentui-react-native/adapters';
-import { ImageProps, ViewProps, TextProps, ColorValue } from 'react-native';
+import { ImageProps, ViewProps, TextProps, ColorValue, ImageURISource, ImageBackgroundProps } from 'react-native';
 import { IBackgroundColorTokens, IForegroundColorTokens, IBorderTokens, FontTokens } from '@fluentui-react-native/tokens';
 import { PresenceBadgeProps, BadgeSize, PresenceBadgeStatus } from '@fluentui-react-native/badge';
 import { IconProps, IconSourcesType } from '@fluentui-react-native/icon';
@@ -108,6 +108,7 @@ export interface AvatarConfigurableProps {
   ringColor?: ColorValue;
   ringThickness?: number;
   transparentRing?: boolean;
+  customBorderImageSource?: ImageURISource;
 
   /**
    * Size of the avatar in pixels.
@@ -278,6 +279,7 @@ export interface AvatarSlotProps {
   icon: IconProps;
   fallbackIcon: SvgProps;
   ring: ViewProps;
+  imageRing: ImageBackgroundProps;
   badge: PresenceBadgeProps;
 }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Added option to add custom image ring to avatar

### Verification

![Simulator Screen Shot - iPad Pro (12 9-inch) (5th generation) - 2022-08-01 at 11 33 42](https://user-images.githubusercontent.com/55368679/182220048-c25cd423-1ab3-41be-b632-f72e7e9d7348.png)

This has been tested in iOS, macOS, and win32

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
