### PR TITLE
Update react-native-svg to 12.4.0

### DIFF
--- a/apps/fluent-tester/ios/Podfile.lock
+++ b/apps/fluent-tester/ios/Podfile.lock
@@ -450,7 +450,7 @@ PODS:
   - ReactTestApp-Resources (1.0.0-dev)
   - RNCPicker (2.4.2):
     - React-Core
-  - RNSVG (12.3.0):
+  - RNSVG (12.4.3):
     - React-Core
   - SwiftLint (0.47.1)
   - Yoga (1.14.0)
@@ -621,7 +621,7 @@ SPEC CHECKSUMS:
   ReactTestApp-DevSupport: f304d297706114319929405239789b443b5c2fee
   ReactTestApp-Resources: 810cb22ae7c4e042ce930887b2665f26d8011498
   RNCPicker: 0250e95ad170569a96f5b0555cdd5e65b9084dca
-  RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8
+  RNSVG: f3b60aeeaa81960e2e0536c3a9eef50b667ef3a9
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
   Yoga: e7dc4e71caba6472ff48ad7d234389b91dadc280
 

--- a/apps/fluent-tester/package.json
+++ b/apps/fluent-tester/package.json
@@ -75,7 +75,7 @@
     "react": "17.0.2",
     "react-native": "^0.66.0",
     "react-native-macos": "^0.66.0",
-    "react-native-svg": "^12.3.0",
+    "react-native-svg": "^12.4.0",
     "react-native-windows": "^0.66.0",
     "tslib": "^2.3.1"
   },
@@ -103,7 +103,7 @@
     "react": "17.0.2",
     "react-native": "^0.66.0",
     "react-native-macos": "^0.66.0",
-    "react-native-svg": "^12.3.0",
+    "react-native-svg": "^12.4.0",
     "react-native-svg-transformer": "^1.0.0",
     "react-native-test-app": "^1.4.0",
     "react-native-windows": "^0.66.0",
@@ -118,7 +118,7 @@
     "react": "17.0.2",
     "react-native": "^0.66.0",
     "react-native-macos": "^0.66.0",
-    "react-native-svg": "^12.3.0",
+    "react-native-svg": "^12.4.0",
     "react-native-windows": "^0.66.0"
   },
   "jest": {

--- a/apps/win32/package.json
+++ b/apps/win32/package.json
@@ -34,7 +34,7 @@
     "@fluentui-react-native/tester": "^0.82.3",
     "react": "17.0.2",
     "react-native": "^0.66.0",
-    "react-native-svg": "^12.3.0",
+    "react-native-svg": "^12.4.0",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/change/@fluentui-react-native-avatar-9ed04add-5f2b-48ce-83d0-abc378b1b9e5.json
+++ b/change/@fluentui-react-native-avatar-9ed04add-5f2b-48ce-83d0-abc378b1b9e5.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "update react-native-svg to 12.4.0",
+  "packageName": "@fluentui-react-native/avatar",
+  "email": "joannaquu@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-badge-ade8bddd-e644-4e79-903f-157e21185464.json
+++ b/change/@fluentui-react-native-badge-ade8bddd-e644-4e79-903f-157e21185464.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "update react-native-svg to 12.4.0",
+  "packageName": "@fluentui-react-native/badge",
+  "email": "joannaquu@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-checkbox-c5941ddf-3db8-4848-9a34-2fe8048dc18a.json
+++ b/change/@fluentui-react-native-checkbox-c5941ddf-3db8-4848-9a34-2fe8048dc18a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "update react-native-svg to 12.4.0",
+  "packageName": "@fluentui-react-native/checkbox",
+  "email": "joannaquu@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-contextual-menu-9de4f1ef-7ffa-4f0f-b993-df448f8fbcda.json
+++ b/change/@fluentui-react-native-contextual-menu-9de4f1ef-7ffa-4f0f-b993-df448f8fbcda.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "update react-native-svg to 12.4.0",
+  "packageName": "@fluentui-react-native/contextual-menu",
+  "email": "joannaquu@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-activity-indicator-472ae168-d99c-47d7-97c1-23bdb1df8190.json
+++ b/change/@fluentui-react-native-experimental-activity-indicator-472ae168-d99c-47d7-97c1-23bdb1df8190.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "update react-native-svg to 12.4.0",
+  "packageName": "@fluentui-react-native/experimental-activity-indicator",
+  "email": "joannaquu@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-menu-button-da8fa901-a050-4d3c-9fa7-e006a77e45cf.json
+++ b/change/@fluentui-react-native-experimental-menu-button-da8fa901-a050-4d3c-9fa7-e006a77e45cf.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "update react-native-svg to 12.4.0",
+  "packageName": "@fluentui-react-native/experimental-menu-button",
+  "email": "joannaquu@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-shimmer-eff04e41-7831-4237-87e7-bc50e6620473.json
+++ b/change/@fluentui-react-native-experimental-shimmer-eff04e41-7831-4237-87e7-bc50e6620473.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "update react-native-svg to 12.4.0",
+  "packageName": "@fluentui-react-native/experimental-shimmer",
+  "email": "joannaquu@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-icon-42fc5f2a-0480-45f1-8e70-e431c16cae79.json
+++ b/change/@fluentui-react-native-icon-42fc5f2a-0480-45f1-8e70-e431c16cae79.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "update react-native-svg to 12.4.0",
+  "packageName": "@fluentui-react-native/icon",
+  "email": "joannaquu@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-menu-button-ddf7dcc8-b467-45c2-8dac-d0b9d1696d79.json
+++ b/change/@fluentui-react-native-menu-button-ddf7dcc8-b467-45c2-8dac-d0b9d1696d79.json
@@ -1,0 +1,6 @@
+{
+  "type": "minor",
+  "packageName": "@fluentui-react-native/menu-button",
+  "email": "joannaquu@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-menu-c17d36cf-995b-4dfe-ae2e-3711126eaec0.json
+++ b/change/@fluentui-react-native-menu-c17d36cf-995b-4dfe-ae2e-3711126eaec0.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "update react-native-svg to 12.4.0",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "joannaquu@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-notification-4acb029a-7867-437e-88b4-dbb58284aca6.json
+++ b/change/@fluentui-react-native-notification-4acb029a-7867-437e-88b4-dbb58284aca6.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "update react-native-svg to 12.4.0",
+  "packageName": "@fluentui-react-native/notification",
+  "email": "joannaquu@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-0b8c96ab-bb86-4bea-b4de-7342e64d838d.json
+++ b/change/@fluentui-react-native-tester-0b8c96ab-bb86-4bea-b4de-7342e64d838d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "update react-native-svg to 12.4.0",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "joannaquu@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-win32-69ba6d29-e3d2-4884-824a-00da47d63b45.json
+++ b/change/@fluentui-react-native-tester-win32-69ba6d29-e3d2-4884-824a-00da47d63b45.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "update react-native-svg to 12.4.0",
+  "packageName": "@fluentui-react-native/tester-win32",
+  "email": "joannaquu@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Avatar/package.json
+++ b/packages/components/Avatar/package.json
@@ -37,7 +37,7 @@
     "@fluentui-react-native/theme-tokens": "^0.19.0",
     "@fluentui-react-native/tokens": "^0.16.0",
     "@fluentui-react-native/use-styling": "^0.9.0",
-    "react-native-svg": "^12.3.0"
+    "react-native-svg": "^12.4.0"
   },
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",

--- a/packages/components/Checkbox/package.json
+++ b/packages/components/Checkbox/package.json
@@ -38,7 +38,7 @@
     "@uifabricshared/foundation-compose": "^1.12.1",
     "@uifabricshared/foundation-composable": ">=0.11.0 <1.0.0",
     "@uifabricshared/foundation-settings": ">=0.12.0 <1.0.0",
-    "react-native-svg": "^12.3.0",
+    "react-native-svg": "^12.4.0",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/packages/components/ContextualMenu/package.json
+++ b/packages/components/ContextualMenu/package.json
@@ -51,6 +51,6 @@
   "peerDependencies": {
     "react": ">=17.0.2",
     "react-native": ">=0.66.0",
-    "react-native-svg": "^12.3.0"
+    "react-native-svg": "^12.4.0"
   }
 }

--- a/packages/components/Menu/package.json
+++ b/packages/components/Menu/package.json
@@ -34,7 +34,7 @@
     "@fluentui-react-native/theme-tokens": ">=0.19.0 <1.0.0",
     "@fluentui-react-native/tokens": ">=0.16.0 <1.0.0",
     "@fluentui-react-native/use-styling": ">=0.9.0 <1.0.0",
-    "react-native-svg": "^12.3.0",
+    "react-native-svg": "^12.4.0",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/packages/components/MenuButton/package.json
+++ b/packages/components/MenuButton/package.json
@@ -38,7 +38,7 @@
     "@uifabricshared/foundation-composable": ">=0.11.0 <1.0.0",
     "@uifabricshared/foundation-compose": "^1.12.1",
     "@uifabricshared/foundation-settings": ">=0.12.0 <1.0.0",
-    "react-native-svg": "^12.3.0"
+    "react-native-svg": "^12.4.0"
   },
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",

--- a/packages/components/Notification/package.json
+++ b/packages/components/Notification/package.json
@@ -46,7 +46,7 @@
     "@types/react-native": "^0.66.0",
     "react": "17.0.2",
     "react-native": "^0.66.0",
-    "react-native-svg": "^12.3.0"
+    "react-native-svg": "^12.4.0"
   },
   "peerDependencies": {
     "react": ">=17.0.2",

--- a/packages/experimental/ActivityIndicator/package.json
+++ b/packages/experimental/ActivityIndicator/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@fluentui-react-native/framework": "0.8.0",
     "assert-never": "^1.2.1",
-    "react-native-svg": "^12.3.0"
+    "react-native-svg": "^12.4.0"
   },
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",

--- a/packages/experimental/Badge/package.json
+++ b/packages/experimental/Badge/package.json
@@ -32,7 +32,7 @@
     "@fluentui-react-native/theme-tokens": "^0.19.0",
     "@fluentui-react-native/tokens": "^0.16.0",
     "@fluentui-react-native/use-styling": "^0.9.0",
-    "react-native-svg": "^12.3.0"
+    "react-native-svg": "^12.4.0"
   },
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",

--- a/packages/experimental/Icon/package.json
+++ b/packages/experimental/Icon/package.json
@@ -24,7 +24,7 @@
     "@fluentui-react-native/theme-types": ">=0.18.0 <1.0.0",
     "@fluentui-react-native/theming-utils": ">=0.14.0 <1.0.0",
     "@fluentui-react-native/tokens": ">=0.16.0 <1.0.0",
-    "react-native-svg": "^12.3.0"
+    "react-native-svg": "^12.4.0"
   },
   "repository": {
     "type": "git",

--- a/packages/experimental/MenuButton/package.json
+++ b/packages/experimental/MenuButton/package.json
@@ -30,7 +30,7 @@
     "@fluentui-react-native/experimental-button": "^0.16.11",
     "@fluentui-react-native/framework": "0.8.0",
     "@fluentui-react-native/tokens": ">=0.16.0 <1.0.0",
-    "react-native-svg": "^12.3.0"
+    "react-native-svg": "^12.4.0"
   },
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",

--- a/packages/experimental/Shimmer/package.json
+++ b/packages/experimental/Shimmer/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@fluentui-react-native/framework": "0.8.0",
     "@fluentui-react-native/tokens": ">=0.16.0 <1.0.0",
-    "react-native-svg": "^12.3.0"
+    "react-native-svg": "^12.4.0"
   },
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5637,7 +5637,7 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-css-select@^4.1.3, css-select@^4.2.1, css-select@^4.3.0:
+css-select@^4.1.3, css-select@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-4.3.0.tgz#db7129b2846662fd8628cfc496abb2b59e41529b"
   integrity sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==
@@ -5648,12 +5648,23 @@ css-select@^4.1.3, css-select@^4.2.1, css-select@^4.3.0:
     domutils "^2.8.0"
     nth-check "^2.0.1"
 
+css-select@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-5.1.0.tgz#b8ebd6554c3637ccc76688804ad3f6a6fdaea8a6"
+  integrity sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==
+  dependencies:
+    boolbase "^1.0.0"
+    css-what "^6.1.0"
+    domhandler "^5.0.2"
+    domutils "^3.0.1"
+    nth-check "^2.0.1"
+
 css-shorthand-properties@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/css-shorthand-properties/-/css-shorthand-properties-1.1.1.tgz#1c808e63553c283f289f2dd56fcee8f3337bd935"
   integrity sha512-Md+Juc7M3uOdbAFwOYlTrccIZ7oCFuzrhKYQjdeUEW/sE1hv17Jp/Bws+ReOPpGVBTYCBoYo+G17V5Qo8QQ75A==
 
-css-tree@^1.0.0-alpha.39, css-tree@^1.1.2, css-tree@^1.1.3:
+css-tree@^1.1.2, css-tree@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.1.3.tgz#eb4870fb6fd7707327ec95c2ff2ab09b5e8db91d"
   integrity sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==
@@ -5670,6 +5681,11 @@ css-what@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.0.1.tgz#3be33be55b9f302f710ba3a9c3abc1e2a63fc7eb"
   integrity sha512-z93ZGFLNc6yaoXAmVhqoSIb+BduplteCt1fepvwhBUQK6MNE4g6fgjpuZKJKp0esUe+vXWlIkwZZjNWoOKw0ZA==
+
+css-what@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz#fb5effcf76f1ddea2c81bdfaa4de44e79bac70f4"
+  integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
 
 csso@^4.2.0:
   version "4.2.0"
@@ -6035,6 +6051,15 @@ dom-serializer@^1.0.1, dom-serializer@^1.3.2:
     domhandler "^4.2.0"
     entities "^2.0.0"
 
+dom-serializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
+  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    entities "^4.2.0"
+
 dom-walk@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.2.tgz#0c548bef048f4d1f2a97249002236060daa3fd84"
@@ -6044,6 +6069,11 @@ domelementtype@^2.0.1, domelementtype@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.2.0.tgz#9a0b6c2782ed6a1c7323d42267183df9bd8b1d57"
   integrity sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==
+
+domelementtype@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
+  integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
 
 domexception@^2.0.1:
   version "2.0.1"
@@ -6059,6 +6089,13 @@ domhandler@^4.0.0, domhandler@^4.2.0, domhandler@^4.3.1:
   dependencies:
     domelementtype "^2.2.0"
 
+domhandler@^5.0.1, domhandler@^5.0.2:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
+  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
+  dependencies:
+    domelementtype "^2.3.0"
+
 domutils@^2.5.2, domutils@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135"
@@ -6067,6 +6104,15 @@ domutils@^2.5.2, domutils@^2.8.0:
     dom-serializer "^1.0.1"
     domelementtype "^2.2.0"
     domhandler "^4.2.0"
+
+domutils@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.0.1.tgz#696b3875238338cb186b6c0612bd4901c89a4f1c"
+  integrity sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==
+  dependencies:
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.1"
 
 dot-case@^3.0.4:
   version "3.0.4"
@@ -6171,6 +6217,11 @@ entities@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-3.0.1.tgz#2b887ca62585e96db3903482d336c1006c3001d4"
   integrity sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==
+
+entities@^4.2.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.3.1.tgz#c34062a94c865c322f9d67b4384e4169bcede6a4"
+  integrity sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg==
 
 entities@~2.1.0:
   version "2.1.0"
@@ -11711,13 +11762,13 @@ react-native-svg-transformer@^1.0.0:
     "@svgr/plugin-svgo" "^6.1.2"
     path-dirname "^1.0.2"
 
-react-native-svg@^12.3.0:
-  version "12.3.0"
-  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-12.3.0.tgz#40f657c5d1ee366df23f3ec8dae76fd276b86248"
-  integrity sha512-ESG1g1j7/WLD7X3XRFTQHVv0r6DpbHNNcdusngAODIxG88wpTWUZkhcM3A2HJTb+BbXTFDamHv7FwtRKWQ/ALg==
+react-native-svg@^12.4.0:
+  version "12.4.3"
+  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-12.4.3.tgz#d383c6f587f6f3f3664413ae0e73134e91d11317"
+  integrity sha512-8OF+vvXsI854YlHBOQkanNcyio+7oQO0nQsS/Noji2VmPoMnLiJiMaxmOD9RHxGkbbo7lzbYWdxVdNibjN/8IA==
   dependencies:
-    css-select "^4.2.1"
-    css-tree "^1.0.0-alpha.39"
+    css-select "^5.1.0"
+    css-tree "^1.1.3"
 
 react-native-test-app@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

Updated react-native-svg to from 12.3.0 to 12.4.0. This unblocks Notification.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
