### PR TITLE
Restore ability to create un-focusable buttons

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Button/E2EButtonTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Button/E2EButtonTest.tsx
@@ -14,6 +14,8 @@ import {
   BUTTON_ON_KEY,
   BUTTON_PRESS_TEST_COMPONENT,
   BUTTON_PRESS_TEST_COMPONENT_LABEL,
+  BUTTON_FOCUSABLE_TEST_COMPONENT,
+  BUTTON_FOCUSABLE_TEST_COMPONENT_LABEL,
 } from './consts';
 import { IViewWin32Props } from '@office-iss/react-native-win32';
 
@@ -59,6 +61,14 @@ export const E2EButtonExperimentalTest: React.FunctionComponent = () => {
           {...keyPressProps}
         >
           Press &quot;a&quot; or &quot;b&quot; after focusing this button
+        </Button>
+        <Button
+          testID={BUTTON_FOCUSABLE_TEST_COMPONENT}
+          onClick={onClick}
+          accessibilityLabel={BUTTON_FOCUSABLE_TEST_COMPONENT_LABEL}
+          focusable={false}
+        >
+          This button isn&apos;t focusable (but isn&apos;t disabled or indeterminate either)
         </Button>
         {buttonPressed ? <Text testID={BUTTON_ON_PRESS}>Button Pressed</Text> : null}
         {keyDetected ? <Text testID={BUTTON_ON_KEY}>Button Key Press detected: {keyDetected}</Text> : null}

--- a/apps/fluent-tester/src/TestComponents/Button/consts.ts
+++ b/apps/fluent-tester/src/TestComponents/Button/consts.ts
@@ -23,5 +23,9 @@ export const BUTTON_TEST_COMPONENT_LABEL = 'Test Button2 - No Accessibility Labe
 export const BUTTON_PRESS_TEST_COMPONENT = 'Button_Press_Test_Component';
 export const BUTTON_PRESS_TEST_COMPONENT_LABEL = 'Test Button3 - For Key Presses';
 
+/* Test Button 3 */
+export const BUTTON_FOCUSABLE_TEST_COMPONENT = 'Button_Focusable_Test_Component';
+export const BUTTON_FOCUSABLE_TEST_COMPONENT_LABEL = 'Test Button4 - Not focusable';
+
 export const BUTTON_ON_PRESS = 'Button_On_Press'; // For testing the press functionality on a button
 export const BUTTON_ON_KEY = 'Button_On_Key'; // For testing the key press functionality on a button

--- a/change/@fluentui-react-native-button-85797534-2360-497b-a351-ca87aa23d61c.json
+++ b/change/@fluentui-react-native-button-85797534-2360-497b-a351-ca87aa23d61c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Restore ability to create unfocusable buttons",
+  "packageName": "@fluentui-react-native/button",
+  "email": "nakambo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-7de4f1f2-5698-4ccf-9bd9-39e21aa0d318.json
+++ b/change/@fluentui-react-native-tester-7de4f1f2-5698-4ccf-9bd9-39e21aa0d318.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add test button for testing un-focusable button",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "nakambo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Button/src/useButton.ts
+++ b/packages/components/Button/src/useButton.ts
@@ -7,7 +7,7 @@ import { AccessibilityState } from 'react-native';
 export const useButton = (props: ButtonProps): ButtonState => {
   // attach the pressable state handlers
   const defaultComponentRef = React.useRef(null);
-  const { onClick, accessibilityState, componentRef = defaultComponentRef, disabled, loading, enableFocusRing, ...rest } = props;
+  const { onClick, accessibilityState, componentRef = defaultComponentRef, disabled, loading, enableFocusRing, focusable, ...rest } = props;
   const isDisabled = !!disabled || !!loading;
   // GH #1336: Set focusRef to null if button is disabled to prevent getting keyboard focus.
   const focusRef = isDisabled ? null : componentRef;
@@ -26,7 +26,7 @@ export const useButton = (props: ButtonProps): ButtonState => {
       accessibilityLabel: props.accessibilityLabel,
       accessibilityState: getAccessibilityState(isDisabled, accessibilityState),
       enableFocusRing: enableFocusRing ?? true,
-      focusable: !isDisabled,
+      focusable: focusable ?? !isDisabled,
       ref: useViewCommandFocus(componentRef),
       iconPosition: props.iconPosition || 'before',
       loading,


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [ ] android

### Description of changes

Previously (with the old deprecated buttons) it was possible to create buttons that aren't disabled but still are unfocusable. (this may sound like a bizarre use case, but is handy for creating things like split buttons where the individual component buttons are not focusable).

We seem to have lost this ability with the new Button -- which will override focusable even if passed by the component user. Let's not -- if that is specified, we respect it (and allow people to create un-focusable enabled buttons, or focusable disabled buttons as before).

### Verification

Manually tested the `focusable={false}` prop in the Win32 tester app. Existing buttons in the E2E section that don't have this property are unaffected.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [x] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
