### PR TITLE
Implement useSizeClassIOS hook

### DIFF
--- a/apps/fluent-tester/src/FluentTesterApp.tsx
+++ b/apps/fluent-tester/src/FluentTesterApp.tsx
@@ -6,13 +6,18 @@ import { Platform } from 'react-native';
 import { FluentTester, FluentTesterProps } from './FluentTester';
 import { tests } from './testPages';
 import { testerTheme } from './theme/index';
-
-const isMobile = Platform.OS == 'android' || (Platform.OS === 'ios' && Platform.isPad === false);
+import { useSizeClassIOS } from '@fluentui-react-native/interactive-hooks';
 
 export const FluentTesterApp: React.FunctionComponent<FluentTesterProps> = (props) => {
+  const sizeClass = useSizeClassIOS();
+  const isMobile = Platform.OS == 'android' || (Platform.OS === 'ios' && Platform.isPad === false);
+
+  // If on iPad we are presented in a Split View or Slide Over context, show the single pane view.
+  const shouldShowSinglePane = isMobile || (!isMobile && sizeClass === 'compact');
+
   return (
     <ThemeProvider theme={testerTheme}>
-      <FluentTester enabledTests={tests} enableSinglePaneView={isMobile} {...props} />
+      <FluentTester enabledTests={tests} enableSinglePaneView={shouldShowSinglePane} {...props} />
     </ThemeProvider>
   );
 };

--- a/change/@fluentui-react-native-interactive-hooks-90e4632d-1fe0-4e7e-9e44-bb1b69eeac1f.json
+++ b/change/@fluentui-react-native-interactive-hooks-90e4632d-1fe0-4e7e-9e44-bb1b69eeac1f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Implement useSizeClass hook",
+  "packageName": "@fluentui-react-native/interactive-hooks",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-001f54f3-5460-413d-9c6c-1d51ddd915e0.json
+++ b/change/@fluentui-react-native-tester-001f54f3-5460-413d-9c6c-1d51ddd915e0.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Implement useSizeClass hook",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/utils/interactive-hooks/src/index.ts
+++ b/packages/utils/interactive-hooks/src/index.ts
@@ -60,3 +60,5 @@ export { preferKeyDownForKeyEvents, useKeyCallback, useKeyDownProps, useKeyProps
 export type { KeyCallback, KeyPressProps } from './useKeyProps';
 export { useOnPressWithFocus } from './useOnPressWithFocus';
 export type { OnPressCallback, OnPressWithFocusCallback } from './useOnPressWithFocus';
+export type { SizeClassIOS } from './useSizeClassIOS';
+export { useSizeClassIOS } from './useSizeClassIOS';

--- a/packages/utils/interactive-hooks/src/useSizeClassIOS.ts
+++ b/packages/utils/interactive-hooks/src/useSizeClassIOS.ts
@@ -1,0 +1,23 @@
+import { Platform, useWindowDimensions } from 'react-native';
+
+export type SizeClassIOS = 'regular' | 'compact' | undefined;
+
+/**
+ * Hook that "guesses" our Size Class on iOS based on our window width
+ * For more information about Size Classes, see teh following:
+ * https://developer.apple.com/documentation/uikit/uitraitcollection
+ * https://developer.apple.com/design/human-interface-guidelines/foundations/layout/#platform-considerations
+ * @returns SizeClassIOS: enum determining our size class
+ */
+export const useSizeClassIOS: () => SizeClassIOS = () => {
+  const width = useWindowDimensions().width;
+  if (Platform.OS === 'ios' && Platform.isPad === true) {
+    if (width > 375) {
+      return 'regular';
+    } else {
+      return 'compact';
+    }
+  } else {
+    return undefined;
+  }
+};

--- a/packages/utils/interactive-hooks/src/useSizeClassIOS.ts
+++ b/packages/utils/interactive-hooks/src/useSizeClassIOS.ts
@@ -11,7 +11,7 @@ export type SizeClassIOS = 'regular' | 'compact' | undefined;
  */
 export const useSizeClassIOS: () => SizeClassIOS = () => {
   const width = useWindowDimensions().width;
-  if (Platform.OS === 'ios' && Platform.isPad === true) {
+  if (Platform.OS === 'ios') {
     if (width > 375) {
       return 'regular';
     } else {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Note, this depends on #1952 landing. This should resolve some issues with #1934 

Implement a hook to "guess" the app's size class (if we're running on iOS, undefined on other platforms). We don't have access to this information without a native module / changes in RN Core, so the guess will have to do for now :/ 

### Verification

Updated FluentTester to change to the mobile layout if we're in compact mode.

https://user-images.githubusercontent.com/6722175/182713864-7ed693cd-1cc6-48f4-8eaf-9a33bda69979.mp4

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
