### PR TITLE
ContextualMenu: Fix layout issue in SubmenuItem

### DIFF
--- a/change/@fluentui-react-native-contextual-menu-5f6a54cb-0a42-409c-80b6-788744536666.json
+++ b/change/@fluentui-react-native-contextual-menu-5f6a54cb-0a42-409c-80b6-788744536666.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix layout issue in SubmenuItem",
+  "packageName": "@fluentui-react-native/contextual-menu",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/ContextualMenu/src/SubmenuItem.settings.macos.ts
+++ b/packages/components/ContextualMenu/src/SubmenuItem.settings.macos.ts
@@ -14,7 +14,7 @@ export const settings: IComposeSettings<SubmenuItemType> = [
       enableFocusRing: false,
       style: {
         display: 'flex',
-        alignItems: 'flex-start',
+        // alignItems: 'flex-start',
         flexDirection: 'row',
         alignSelf: 'flex-start',
         width: '100%',

--- a/packages/components/ContextualMenu/src/SubmenuItem.settings.macos.ts
+++ b/packages/components/ContextualMenu/src/SubmenuItem.settings.macos.ts
@@ -14,7 +14,6 @@ export const settings: IComposeSettings<SubmenuItemType> = [
       enableFocusRing: false,
       style: {
         display: 'flex',
-        // alignItems: 'flex-start',
         flexDirection: 'row',
         alignSelf: 'flex-start',
         width: '100%',

--- a/packages/components/ContextualMenu/src/SubmenuItem.settings.macos.ts
+++ b/packages/components/ContextualMenu/src/SubmenuItem.settings.macos.ts
@@ -14,10 +14,10 @@ export const settings: IComposeSettings<SubmenuItemType> = [
       enableFocusRing: false,
       style: {
         display: 'flex',
-        flex: 1,
+        alignItems: 'flex-start',
         flexDirection: 'row',
         alignSelf: 'flex-start',
-        justifyContent: 'space-between',
+        width: '100%',
         borderRadius: 5,
       },
     },
@@ -30,7 +30,7 @@ export const settings: IComposeSettings<SubmenuItemType> = [
     startstack: {
       style: {
         display: 'flex',
-        flex: 1,
+        flexGrow: 1,
         paddingStart: 5,
         alignItems: 'center',
         flexDirection: 'row',
@@ -41,7 +41,6 @@ export const settings: IComposeSettings<SubmenuItemType> = [
     endstack: {
       style: {
         display: 'flex',
-        flex: 1,
         paddingEnd: 5,
         alignItems: 'center',
         flexDirection: 'row',

--- a/packages/components/ContextualMenu/src/SubmenuItem.settings.ts
+++ b/packages/components/ContextualMenu/src/SubmenuItem.settings.ts
@@ -28,7 +28,7 @@ export const settings: IComposeSettings<SubmenuItemType> = [
     startstack: {
       style: {
         display: 'flex',
-        flex: 1,
+        flexGrow: 1,
         paddingStart: 5,
         alignItems: 'center',
         flexDirection: 'row',
@@ -40,7 +40,6 @@ export const settings: IComposeSettings<SubmenuItemType> = [
     endstack: {
       style: {
         display: 'flex',
-        flex: 1,
         paddingEnd: 5,
         alignItems: 'center',
         flexDirection: 'row',


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

SubmenuItem was not laying out properly.

SubmenuItem has a startStack (for startIcon, text) and an endStack (endIcon, chevron). The endStack should take minimum space, while startStack should take all the rest of available space. However, both were `flex : 1` so they took equal space. See this Xcode view debugger screenshot, and how those 2 frames are of equal size.

<img width="1792" alt="Screen Shot 2022-08-04 at 10 17 18 PM" src="https://user-images.githubusercontent.com/6722175/183007822-2eb196f3-37ed-4bf9-804b-ea0ff3f15622.png">


Changing `flex : 1` to `flexGrow: 1` In startStack should fix this.

### Verification

Before:
<img width="210" alt="Screen Shot 2022-08-04 at 10 21 37 PM" src="https://user-images.githubusercontent.com/6722175/183007900-5f344774-171a-4df1-bb3b-d8e952f7d8ca.png">
After:
<img width="204" alt="Screen Shot 2022-08-04 at 10 21 50 PM" src="https://user-images.githubusercontent.com/6722175/183007919-f518d87d-82ff-4417-b544-d8c739b4c391.png">


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
