### PR TITLE
remove usage of BUILD_LIBRARY_FOR_DISTRIBUTION

### DIFF
--- a/apps/fluent-tester/macos/Podfile.lock
+++ b/apps/fluent-tester/macos/Podfile.lock
@@ -2,26 +2,26 @@ PODS:
   - boost (1.76.0)
   - boost-for-react-native (1.63.0)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.66.64)
-  - FBReactNativeSpec (0.66.64):
+  - FBLazyVector (0.66.68)
+  - FBReactNativeSpec (0.66.68):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.66.64)
-    - RCTTypeSafety (= 0.66.64)
-    - React-Core (= 0.66.64)
-    - React-jsi (= 0.66.64)
-    - ReactCommon/turbomodule/core (= 0.66.64)
+    - RCTRequired (= 0.66.68)
+    - RCTTypeSafety (= 0.66.68)
+    - React-Core (= 0.66.68)
+    - React-jsi (= 0.66.68)
+    - ReactCommon/turbomodule/core (= 0.66.68)
   - fmt (6.2.1)
   - FRNAvatar (0.16.0):
     - MicrosoftFluentUI (= 0.5.2)
     - MicrosoftFluentUI/Avatar_ios (= 0.5.2)
     - React
-  - FRNCallout (0.21.4):
+  - FRNCallout (0.21.6):
     - React
-  - FRNCheckbox (0.12.6):
+  - FRNCheckbox (0.12.9):
     - React
-  - FRNMenuButton (0.8.11):
+  - FRNMenuButton (0.8.16):
     - React
-  - FRNRadioButton (0.15.4):
+  - FRNRadioButton (0.15.6):
     - React
   - glog (0.3.5)
   - MicrosoftFluentUI (0.5.2):
@@ -103,265 +103,265 @@ PODS:
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
-  - RCTFocusZone (0.10.4):
+  - RCTFocusZone (0.10.6):
     - React
-  - RCTRequired (0.66.64)
-  - RCTTypeSafety (0.66.64):
-    - FBLazyVector (= 0.66.64)
+  - RCTRequired (0.66.68)
+  - RCTTypeSafety (0.66.68):
+    - FBLazyVector (= 0.66.68)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.66.64)
-    - React-Core (= 0.66.64)
-  - React (0.66.64):
-    - React-Core (= 0.66.64)
-    - React-Core/DevSupport (= 0.66.64)
-    - React-Core/RCTWebSocket (= 0.66.64)
-    - React-RCTActionSheet (= 0.66.64)
-    - React-RCTAnimation (= 0.66.64)
-    - React-RCTBlob (= 0.66.64)
-    - React-RCTImage (= 0.66.64)
-    - React-RCTLinking (= 0.66.64)
-    - React-RCTNetwork (= 0.66.64)
-    - React-RCTSettings (= 0.66.64)
-    - React-RCTText (= 0.66.64)
-    - React-RCTVibration (= 0.66.64)
-  - React-callinvoker (0.66.64)
-  - React-Core (0.66.64):
+    - RCTRequired (= 0.66.68)
+    - React-Core (= 0.66.68)
+  - React (0.66.68):
+    - React-Core (= 0.66.68)
+    - React-Core/DevSupport (= 0.66.68)
+    - React-Core/RCTWebSocket (= 0.66.68)
+    - React-RCTActionSheet (= 0.66.68)
+    - React-RCTAnimation (= 0.66.68)
+    - React-RCTBlob (= 0.66.68)
+    - React-RCTImage (= 0.66.68)
+    - React-RCTLinking (= 0.66.68)
+    - React-RCTNetwork (= 0.66.68)
+    - React-RCTSettings (= 0.66.68)
+    - React-RCTText (= 0.66.68)
+    - React-RCTVibration (= 0.66.68)
+  - React-callinvoker (0.66.68)
+  - React-Core (0.66.68):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.66.64)
-    - React-cxxreact (= 0.66.64)
-    - React-jsi (= 0.66.64)
-    - React-jsiexecutor (= 0.66.64)
-    - React-perflogger (= 0.66.64)
+    - React-Core/Default (= 0.66.68)
+    - React-cxxreact (= 0.66.68)
+    - React-jsi (= 0.66.68)
+    - React-jsiexecutor (= 0.66.68)
+    - React-perflogger (= 0.66.68)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.66.64):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default
-    - React-cxxreact (= 0.66.64)
-    - React-jsi (= 0.66.64)
-    - React-jsiexecutor (= 0.66.64)
-    - React-perflogger (= 0.66.64)
-    - Yoga
-  - React-Core/Default (0.66.64):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.66.64)
-    - React-jsi (= 0.66.64)
-    - React-jsiexecutor (= 0.66.64)
-    - React-perflogger (= 0.66.64)
-    - Yoga
-  - React-Core/DevSupport (0.66.64):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.66.64)
-    - React-Core/RCTWebSocket (= 0.66.64)
-    - React-cxxreact (= 0.66.64)
-    - React-jsi (= 0.66.64)
-    - React-jsiexecutor (= 0.66.64)
-    - React-jsinspector (= 0.66.64)
-    - React-perflogger (= 0.66.64)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.66.64):
+  - React-Core/CoreModulesHeaders (0.66.68):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.64)
-    - React-jsi (= 0.66.64)
-    - React-jsiexecutor (= 0.66.64)
-    - React-perflogger (= 0.66.64)
+    - React-cxxreact (= 0.66.68)
+    - React-jsi (= 0.66.68)
+    - React-jsiexecutor (= 0.66.68)
+    - React-perflogger (= 0.66.68)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.66.64):
+  - React-Core/Default (0.66.68):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-cxxreact (= 0.66.68)
+    - React-jsi (= 0.66.68)
+    - React-jsiexecutor (= 0.66.68)
+    - React-perflogger (= 0.66.68)
+    - Yoga
+  - React-Core/DevSupport (0.66.68):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-Core/Default (= 0.66.68)
+    - React-Core/RCTWebSocket (= 0.66.68)
+    - React-cxxreact (= 0.66.68)
+    - React-jsi (= 0.66.68)
+    - React-jsiexecutor (= 0.66.68)
+    - React-jsinspector (= 0.66.68)
+    - React-perflogger (= 0.66.68)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.66.68):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.64)
-    - React-jsi (= 0.66.64)
-    - React-jsiexecutor (= 0.66.64)
-    - React-perflogger (= 0.66.64)
+    - React-cxxreact (= 0.66.68)
+    - React-jsi (= 0.66.68)
+    - React-jsiexecutor (= 0.66.68)
+    - React-perflogger (= 0.66.68)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.66.64):
+  - React-Core/RCTAnimationHeaders (0.66.68):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.64)
-    - React-jsi (= 0.66.64)
-    - React-jsiexecutor (= 0.66.64)
-    - React-perflogger (= 0.66.64)
+    - React-cxxreact (= 0.66.68)
+    - React-jsi (= 0.66.68)
+    - React-jsiexecutor (= 0.66.68)
+    - React-perflogger (= 0.66.68)
     - Yoga
-  - React-Core/RCTImageHeaders (0.66.64):
+  - React-Core/RCTBlobHeaders (0.66.68):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.64)
-    - React-jsi (= 0.66.64)
-    - React-jsiexecutor (= 0.66.64)
-    - React-perflogger (= 0.66.64)
+    - React-cxxreact (= 0.66.68)
+    - React-jsi (= 0.66.68)
+    - React-jsiexecutor (= 0.66.68)
+    - React-perflogger (= 0.66.68)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.66.64):
+  - React-Core/RCTImageHeaders (0.66.68):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.64)
-    - React-jsi (= 0.66.64)
-    - React-jsiexecutor (= 0.66.64)
-    - React-perflogger (= 0.66.64)
+    - React-cxxreact (= 0.66.68)
+    - React-jsi (= 0.66.68)
+    - React-jsiexecutor (= 0.66.68)
+    - React-perflogger (= 0.66.68)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.66.64):
+  - React-Core/RCTLinkingHeaders (0.66.68):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.64)
-    - React-jsi (= 0.66.64)
-    - React-jsiexecutor (= 0.66.64)
-    - React-perflogger (= 0.66.64)
+    - React-cxxreact (= 0.66.68)
+    - React-jsi (= 0.66.68)
+    - React-jsiexecutor (= 0.66.68)
+    - React-perflogger (= 0.66.68)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.66.64):
+  - React-Core/RCTNetworkHeaders (0.66.68):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.64)
-    - React-jsi (= 0.66.64)
-    - React-jsiexecutor (= 0.66.64)
-    - React-perflogger (= 0.66.64)
+    - React-cxxreact (= 0.66.68)
+    - React-jsi (= 0.66.68)
+    - React-jsiexecutor (= 0.66.68)
+    - React-perflogger (= 0.66.68)
     - Yoga
-  - React-Core/RCTTextHeaders (0.66.64):
+  - React-Core/RCTSettingsHeaders (0.66.68):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.64)
-    - React-jsi (= 0.66.64)
-    - React-jsiexecutor (= 0.66.64)
-    - React-perflogger (= 0.66.64)
+    - React-cxxreact (= 0.66.68)
+    - React-jsi (= 0.66.68)
+    - React-jsiexecutor (= 0.66.68)
+    - React-perflogger (= 0.66.68)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.66.64):
+  - React-Core/RCTTextHeaders (0.66.68):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.64)
-    - React-jsi (= 0.66.64)
-    - React-jsiexecutor (= 0.66.64)
-    - React-perflogger (= 0.66.64)
+    - React-cxxreact (= 0.66.68)
+    - React-jsi (= 0.66.68)
+    - React-jsiexecutor (= 0.66.68)
+    - React-perflogger (= 0.66.68)
     - Yoga
-  - React-Core/RCTWebSocket (0.66.64):
+  - React-Core/RCTVibrationHeaders (0.66.68):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.66.64)
-    - React-cxxreact (= 0.66.64)
-    - React-jsi (= 0.66.64)
-    - React-jsiexecutor (= 0.66.64)
-    - React-perflogger (= 0.66.64)
+    - React-Core/Default
+    - React-cxxreact (= 0.66.68)
+    - React-jsi (= 0.66.68)
+    - React-jsiexecutor (= 0.66.68)
+    - React-perflogger (= 0.66.68)
     - Yoga
-  - React-CoreModules (0.66.64):
-    - FBReactNativeSpec (= 0.66.64)
+  - React-Core/RCTWebSocket (0.66.68):
+    - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.66.64)
-    - React-Core/CoreModulesHeaders (= 0.66.64)
-    - React-jsi (= 0.66.64)
-    - React-RCTImage (= 0.66.64)
-    - ReactCommon/turbomodule/core (= 0.66.64)
-  - React-cxxreact (0.66.64):
+    - React-Core/Default (= 0.66.68)
+    - React-cxxreact (= 0.66.68)
+    - React-jsi (= 0.66.68)
+    - React-jsiexecutor (= 0.66.68)
+    - React-perflogger (= 0.66.68)
+    - Yoga
+  - React-CoreModules (0.66.68):
+    - FBReactNativeSpec (= 0.66.68)
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - RCTTypeSafety (= 0.66.68)
+    - React-Core/CoreModulesHeaders (= 0.66.68)
+    - React-jsi (= 0.66.68)
+    - React-RCTImage (= 0.66.68)
+    - ReactCommon/turbomodule/core (= 0.66.68)
+  - React-cxxreact (0.66.68):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.66.64)
-    - React-jsi (= 0.66.64)
-    - React-jsinspector (= 0.66.64)
-    - React-logger (= 0.66.64)
-    - React-perflogger (= 0.66.64)
-    - React-runtimeexecutor (= 0.66.64)
-  - React-jsi (0.66.64):
+    - React-callinvoker (= 0.66.68)
+    - React-jsi (= 0.66.68)
+    - React-jsinspector (= 0.66.68)
+    - React-logger (= 0.66.68)
+    - React-perflogger (= 0.66.68)
+    - React-runtimeexecutor (= 0.66.68)
+  - React-jsi (0.66.68):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-jsi/Default (= 0.66.64)
-  - React-jsi/Default (0.66.64):
+    - React-jsi/Default (= 0.66.68)
+  - React-jsi/Default (0.66.68):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-  - React-jsiexecutor (0.66.64):
+  - React-jsiexecutor (0.66.68):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.66.64)
-    - React-jsi (= 0.66.64)
-    - React-perflogger (= 0.66.64)
-  - React-jsinspector (0.66.64)
-  - React-logger (0.66.64):
+    - React-cxxreact (= 0.66.68)
+    - React-jsi (= 0.66.68)
+    - React-perflogger (= 0.66.68)
+  - React-jsinspector (0.66.68)
+  - React-logger (0.66.68):
     - glog
-  - React-perflogger (0.66.64)
-  - React-RCTActionSheet (0.66.64):
-    - React-Core/RCTActionSheetHeaders (= 0.66.64)
-  - React-RCTAnimation (0.66.64):
-    - FBReactNativeSpec (= 0.66.64)
+  - React-perflogger (0.66.68)
+  - React-RCTActionSheet (0.66.68):
+    - React-Core/RCTActionSheetHeaders (= 0.66.68)
+  - React-RCTAnimation (0.66.68):
+    - FBReactNativeSpec (= 0.66.68)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.66.64)
-    - React-Core/RCTAnimationHeaders (= 0.66.64)
-    - React-jsi (= 0.66.64)
-    - ReactCommon/turbomodule/core (= 0.66.64)
-  - React-RCTBlob (0.66.64):
-    - FBReactNativeSpec (= 0.66.64)
+    - RCTTypeSafety (= 0.66.68)
+    - React-Core/RCTAnimationHeaders (= 0.66.68)
+    - React-jsi (= 0.66.68)
+    - ReactCommon/turbomodule/core (= 0.66.68)
+  - React-RCTBlob (0.66.68):
+    - FBReactNativeSpec (= 0.66.68)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/RCTBlobHeaders (= 0.66.64)
-    - React-Core/RCTWebSocket (= 0.66.64)
-    - React-jsi (= 0.66.64)
-    - React-RCTNetwork (= 0.66.64)
-    - ReactCommon/turbomodule/core (= 0.66.64)
-  - React-RCTImage (0.66.64):
-    - FBReactNativeSpec (= 0.66.64)
+    - React-Core/RCTBlobHeaders (= 0.66.68)
+    - React-Core/RCTWebSocket (= 0.66.68)
+    - React-jsi (= 0.66.68)
+    - React-RCTNetwork (= 0.66.68)
+    - ReactCommon/turbomodule/core (= 0.66.68)
+  - React-RCTImage (0.66.68):
+    - FBReactNativeSpec (= 0.66.68)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.66.64)
-    - React-Core/RCTImageHeaders (= 0.66.64)
-    - React-jsi (= 0.66.64)
-    - React-RCTNetwork (= 0.66.64)
-    - ReactCommon/turbomodule/core (= 0.66.64)
-  - React-RCTLinking (0.66.64):
-    - FBReactNativeSpec (= 0.66.64)
-    - React-Core/RCTLinkingHeaders (= 0.66.64)
-    - React-jsi (= 0.66.64)
-    - ReactCommon/turbomodule/core (= 0.66.64)
-  - React-RCTNetwork (0.66.64):
-    - FBReactNativeSpec (= 0.66.64)
+    - RCTTypeSafety (= 0.66.68)
+    - React-Core/RCTImageHeaders (= 0.66.68)
+    - React-jsi (= 0.66.68)
+    - React-RCTNetwork (= 0.66.68)
+    - ReactCommon/turbomodule/core (= 0.66.68)
+  - React-RCTLinking (0.66.68):
+    - FBReactNativeSpec (= 0.66.68)
+    - React-Core/RCTLinkingHeaders (= 0.66.68)
+    - React-jsi (= 0.66.68)
+    - ReactCommon/turbomodule/core (= 0.66.68)
+  - React-RCTNetwork (0.66.68):
+    - FBReactNativeSpec (= 0.66.68)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.66.64)
-    - React-Core/RCTNetworkHeaders (= 0.66.64)
-    - React-jsi (= 0.66.64)
-    - ReactCommon/turbomodule/core (= 0.66.64)
-  - React-RCTSettings (0.66.64):
-    - FBReactNativeSpec (= 0.66.64)
+    - RCTTypeSafety (= 0.66.68)
+    - React-Core/RCTNetworkHeaders (= 0.66.68)
+    - React-jsi (= 0.66.68)
+    - ReactCommon/turbomodule/core (= 0.66.68)
+  - React-RCTSettings (0.66.68):
+    - FBReactNativeSpec (= 0.66.68)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.66.64)
-    - React-Core/RCTSettingsHeaders (= 0.66.64)
-    - React-jsi (= 0.66.64)
-    - ReactCommon/turbomodule/core (= 0.66.64)
-  - React-RCTText (0.66.64):
-    - React-Core/RCTTextHeaders (= 0.66.64)
-  - React-RCTVibration (0.66.64):
-    - FBReactNativeSpec (= 0.66.64)
+    - RCTTypeSafety (= 0.66.68)
+    - React-Core/RCTSettingsHeaders (= 0.66.68)
+    - React-jsi (= 0.66.68)
+    - ReactCommon/turbomodule/core (= 0.66.68)
+  - React-RCTText (0.66.68):
+    - React-Core/RCTTextHeaders (= 0.66.68)
+  - React-RCTVibration (0.66.68):
+    - FBReactNativeSpec (= 0.66.68)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/RCTVibrationHeaders (= 0.66.64)
-    - React-jsi (= 0.66.64)
-    - ReactCommon/turbomodule/core (= 0.66.64)
-  - React-runtimeexecutor (0.66.64):
-    - React-jsi (= 0.66.64)
-  - ReactCommon/turbomodule/core (0.66.64):
+    - React-Core/RCTVibrationHeaders (= 0.66.68)
+    - React-jsi (= 0.66.68)
+    - ReactCommon/turbomodule/core (= 0.66.68)
+  - React-runtimeexecutor (0.66.68):
+    - React-jsi (= 0.66.68)
+  - ReactCommon/turbomodule/core (0.66.68):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.66.64)
-    - React-Core (= 0.66.64)
-    - React-cxxreact (= 0.66.64)
-    - React-jsi (= 0.66.64)
-    - React-logger (= 0.66.64)
-    - React-perflogger (= 0.66.64)
+    - React-callinvoker (= 0.66.68)
+    - React-Core (= 0.66.68)
+    - React-cxxreact (= 0.66.68)
+    - React-jsi (= 0.66.68)
+    - React-logger (= 0.66.68)
+    - React-perflogger (= 0.66.68)
   - ReactTestApp-DevSupport (1.4.0):
     - React-Core
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
-  - RNCPicker (2.4.2):
+  - RNCPicker (2.4.3):
     - React-Core
   - RNSVG (12.3.0):
     - React-Core
@@ -508,47 +508,47 @@ SPEC CHECKSUMS:
   boost: 613e39eac4239cc72b15421247b5ab05361266a2
   boost-for-react-native: 8f7c9ecfe357664c072ffbe2432569667cbf1f1b
   DoubleConversion: ed15e075aa758ac0e4c1f8b830bd4e4d40d669e8
-  FBLazyVector: 269032fe4980555b1a6675ed556dcf9d78353a78
-  FBReactNativeSpec: 8ea3aaffceb4bd261cf9c5df534d74714f6e485e
+  FBLazyVector: 57bd8804c56ae0bde502ee5aef26281d7103f9fe
+  FBReactNativeSpec: dc797dc1d82fed388267756b6d7a0d0b7e917379
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   FRNAvatar: 827ebe75e839ce442c88cc6a23940aa614ca7946
-  FRNCallout: 249365dd056e7a1c8f5edaa1b70f1ac8329021c7
-  FRNCheckbox: b45089f6c385c2107a7e548415ccc770eae8748d
-  FRNMenuButton: adbaefda7450616d4875529e921b8e9640212bcc
-  FRNRadioButton: aeb75d9242cd3f0c1ad5982439d38a8cf1162ff9
+  FRNCallout: e1c0ce7f3eb95e180544480e96c82d36c87a9d0e
+  FRNCheckbox: 23597f9a9ab476ed83d6459e271f66a093da3c48
+  FRNMenuButton: 07f7e7207f573fa49e6fcd03a7d54ed933c35e15
+  FRNRadioButton: b8415575f94fbd75d448575b1d443cf1122d1fc1
   glog: 42c4bf47024808486e90b25ea9e5ac3959047641
   MicrosoftFluentUI: 2f4c624fd4606aa2392c09be69a45e297a41f593
   RCT-Folly: 43adc9ce880eb76792f88c011773cb5c664c1419
-  RCTFocusZone: fdeb094b06648e757aedf8828e93bc028cd43cc3
-  RCTRequired: 829ebe304e405e9d32b8e56eae62dedcaeba1b4c
-  RCTTypeSafety: 84a70a5f88d881fc8fcd1d8c3b641bfa0e9e1541
-  React: a445d40e3867d024a274784fb343891528960c54
-  React-callinvoker: b619135420297f76afe530a75b8fd271970d2cd6
-  React-Core: ac0d91b4a36c6960c3d7c3cb2183fec11d1f164a
-  React-CoreModules: 6d247f4a846ee268422c978781cf140ec7b9a805
-  React-cxxreact: f8f9a8991bb4a9a47785eb8ae233bd77e016bbc7
-  React-jsi: dfababc3beb0456a08e70be5c1593b33c98d6865
-  React-jsiexecutor: ccdc7580d3b7fec2a1c331439c024670947086d6
-  React-jsinspector: cacb63c18d235c41741ad80fa4c4bdfb7f1bef46
-  React-logger: 50315eae86186d952430ac9dd63a4ad2045bc633
-  React-perflogger: 1bae9dbc45505fd246a7d3ce673623b4a97cc1fe
-  React-RCTActionSheet: e315f9ecd1c411da44a277538343ab35afc15946
-  React-RCTAnimation: 04d14fc95f124f9f1c3d1feab406e72e58d493f3
-  React-RCTBlob: 7b0fa4ea6711628d8328986daf15919020a50f36
-  React-RCTImage: ddebef50d5370b8b1cbaed611e3e68a5cf16acc4
-  React-RCTLinking: b41354f49b8507dfadc4cd1687b270fdb8696950
-  React-RCTNetwork: b2ebc29698640abf674008f460ed7ef5cd7ecce1
-  React-RCTSettings: 77ac7c9777ab17260a116e359ac38a4ae7d1762b
-  React-RCTText: e540a98b779e8c1e7bffa2651b807aad2f9cb1c8
-  React-RCTVibration: 5a5061c8d53b0cdb0fdd6dd8e2a83a5e0e20a607
-  React-runtimeexecutor: 5316ac41f54c44581bb49b3ed4c4229ab1bd4b32
-  ReactCommon: ffb18b20873edd7c6c2702a9238fadf9a535dd8a
+  RCTFocusZone: 200ae955445d25b6c7174d8a8b7bbc9605932be4
+  RCTRequired: c72379189b8ec7d5e3b09f06d424d52e9c965a71
+  RCTTypeSafety: d87f671b8c0d64a4d3d63ce4f7e493099f1715fc
+  React: 02b2fc537a7800f918dfc7179419c6c4b72be34c
+  React-callinvoker: f05289c3f50aeae19d621274143266e35cbdfdb0
+  React-Core: 680190e05ff29f84bfff56a575f8a1a829056356
+  React-CoreModules: 3f191a390df28d3d0e93d0eca86e19e0424daf7d
+  React-cxxreact: 06539145522d2f2966a098ca43445e985fb44ba5
+  React-jsi: b4c9c12869b86c3b55e5d49c7398840ceb5db015
+  React-jsiexecutor: 5c4ff7c2e11b6d14fd854eedc153361e566e51a3
+  React-jsinspector: 674c632c09e71f6261c281a016a9dbcc64e51520
+  React-logger: 11ca3fed098b79f82707c54fcef4cab3e5dffcf2
+  React-perflogger: 01e20a5e68d2bd95d0750d2d3de3df4011d19575
+  React-RCTActionSheet: 4686d942572c9435a32cc17b0f26ed31454a5fe9
+  React-RCTAnimation: 7a9f7f105aa6ef632a54e74cc52a77932911e8e4
+  React-RCTBlob: e6f3ac4bd044497bd8f95cd59f9ef2043972874a
+  React-RCTImage: c02953fbd4cc2ccef5dc18c5ec3532021355558b
+  React-RCTLinking: f1e1d113db2912f1bcaaa59173666875e2a73e5a
+  React-RCTNetwork: be43a9529ef2cfea4d596cac386c50bb5838a8af
+  React-RCTSettings: a21201ba54cc72e4e554876fcca4877e7aa702ac
+  React-RCTText: c72828842f18b855944f69daa9a158e6d1a02257
+  React-RCTVibration: 9ed93c2eb04e9dc459f08d3229884e83b707dbe3
+  React-runtimeexecutor: f2e02da86b0d42d698b0c1a34ecb068029e0a338
+  ReactCommon: ba87dae95d6364cdce4d6abb758ad1862b645e6f
   ReactTestApp-DevSupport: f304d297706114319929405239789b443b5c2fee
   ReactTestApp-Resources: 320923a3635f7bf90caa1a28fd29765b577888d9
-  RNCPicker: 0250e95ad170569a96f5b0555cdd5e65b9084dca
+  RNCPicker: a99807a74d9cd65c394f6e2a6c843a377b355b4d
   RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
-  Yoga: d030f4c37fae1eff9cfecaa9fa5d10f836b63143
+  Yoga: 07d970de63dd0abbf7d59cf7dbd86436a1133e9c
 
 PODFILE CHECKSUM: 553ec4eec9578ceafbc92e27e0789d7ddcd88c74
 

--- a/change/@fluentui-react-native-menu-button-bd655716-06f9-4b34-b6fc-6383c7ac5ec5.json
+++ b/change/@fluentui-react-native-menu-button-bd655716-06f9-4b34-b6fc-6383c7ac5ec5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "pod update",
+  "packageName": "@fluentui-react-native/menu-button",
+  "email": "hyshin@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-215f5a78-286e-4405-bbff-9eb9ebb1be03.json
+++ b/change/@fluentui-react-native-tester-215f5a78-286e-4405-bbff-9eb9ebb1be03.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "BUILD_LIBRARY_FOR_DISTRIBUTION no clear benefit. remove.",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "hyshin@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/MenuButton/FRNMenuButton.podspec
+++ b/packages/components/MenuButton/FRNMenuButton.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/microsoft/fluentui-react-native.git", :tag => "#{s.version}" }
   s.swift_version    = "5.0"
 
-  s.pod_target_xcconfig = { 'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES', 'OTHER_SWIFT_FLAGS' => '-gline-tables-only' }
+  s.pod_target_xcconfig = { 'OTHER_SWIFT_FLAGS' => '-gline-tables-only' }
 
   s.osx.deployment_target = "10.15"
   s.osx.source_files      = "macos/*.{swift,h,m,mm}"


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

No clear benefit of this BUILD_LIBRARY_FOR_DISTRIBUTION build flag and Fluent UI apple native library doesn't use it either.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
