### PR TITLE
add additional script in ado build to strip symbols.

### DIFF
--- a/.ado/templates/apple-xcode-build.yml
+++ b/.ado/templates/apple-xcode-build.yml
@@ -17,3 +17,7 @@ steps:
       xcWorkspacePath: ${{ parameters.xcode_workspacePath }}
       signingOption: nosign
       args: '-verbose -derivedDataPath DerivedData ${{ parameters.xcode_extraArgs }}'
+
+    - script: |
+        strip -x -S $(Build.Repository.LocalPath)/DerivedData/${{ parameters.output_folder }}/Build/Products/${{ parameters.xcode_configuration }}/*.a
+      displayName: Strip debug symbols


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

FURN Apple nuget only contains release config. However, it doesn't seem to strip symbols which is more concerning how our cocoapod is setup.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
