### PR TITLE
couple more fixing to find folder path to strip debug symbols

### DIFF
--- a/.ado/templates/apple-xcode-build.yml
+++ b/.ado/templates/apple-xcode-build.yml
@@ -18,6 +18,12 @@ steps:
       signingOption: nosign
       args: '-verbose -derivedDataPath DerivedData ${{ parameters.xcode_extraArgs }}'
 
-  - script: |
-      strip -x -S $(Build.Repository.LocalPath)/DerivedData/${{ parameters.output_folder }}/Build/Products/${{ parameters.xcode_configuration }}/*.a
-    displayName: Strip debug symbols
+  - ${{ if and(ne(parameters.xcode_sdk, 'macosx'), eq(parameters.xcode_configuration, 'Debug')) }}:
+      - script: |
+          strip -x -S $(Build.Repository.LocalPath)/DerivedData/${{ parameters.output_folder }}/Build/Products/${{ parameters.xcode_configuration }}-${{ parameters.xcode_sdk }}/**/*.a
+        displayName: Strip debug symbols for ios libraries
+
+  - ${{ if and(eq(parameters.xcode_sdk, 'macosx'), eq(parameters.xcode_configuration, 'Debug')) }}:
+      - script: |
+          strip -x -S $(Build.Repository.LocalPath)/DerivedData/${{ parameters.output_folder }}/Build/Products/${{ parameters.xcode_configuration }}/**/*.a
+        displayName: Strip debug symbols for macos libraries

--- a/.ado/templates/apple-xcode-build.yml
+++ b/.ado/templates/apple-xcode-build.yml
@@ -18,12 +18,12 @@ steps:
       signingOption: nosign
       args: '-verbose -derivedDataPath DerivedData ${{ parameters.xcode_extraArgs }}'
 
-  - ${{ if and(ne(parameters.xcode_sdk, 'macosx'), eq(parameters.xcode_configuration, 'Debug')) }}:
+  - ${{ if ne(parameters.xcode_sdk, 'macosx') }}:
       - script: |
           strip -x -S $(Build.Repository.LocalPath)/DerivedData/${{ parameters.output_folder }}/Build/Products/${{ parameters.xcode_configuration }}-${{ parameters.xcode_sdk }}/**/*.a
         displayName: Strip debug symbols for ios libraries
 
-  - ${{ if and(eq(parameters.xcode_sdk, 'macosx'), eq(parameters.xcode_configuration, 'Debug')) }}:
+  - ${{ if eq(parameters.xcode_sdk, 'macosx') }}:
       - script: |
           strip -x -S $(Build.Repository.LocalPath)/DerivedData/${{ parameters.output_folder }}/Build/Products/${{ parameters.xcode_configuration }}/**/*.a
         displayName: Strip debug symbols for macos libraries


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
- make sure iOS folder path is Release-iphoneos  or Release-iphonesimulator
- add wildcard for folder path to find the .a libraries to strip

### Verification
n/a

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
