### PR TITLE
[Avatar] Made inner gap configurable

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Avatar/CustomizedAvatar.tsx
+++ b/apps/fluent-tester/src/TestComponents/Avatar/CustomizedAvatar.tsx
@@ -25,6 +25,7 @@ export const CustomizeUsage: React.FunctionComponent = () => {
   const [ringColor, setRingColor] = useState<string>(undefined);
   const [ringBackgroundColor, setRingBackgroundColor] = useState<string>('yellow');
   const [ringThickness, setRingThickness] = useState<string>('4');
+  const [ringInnerGap, setRingInnerGap] = useState<string>('4');
   const [showRing, setShowRing] = useState<boolean>(true);
 
   const CustomizedAvatar = useMemo(() => {
@@ -40,6 +41,7 @@ export const CustomizeUsage: React.FunctionComponent = () => {
       ringColor,
       ringBackgroundColor,
       ringThickness: parseInt(ringThickness),
+      ringInnerGap: parseInt(ringInnerGap),
     };
     return Avatar.customize(tokens);
   }, [
@@ -51,6 +53,7 @@ export const CustomizeUsage: React.FunctionComponent = () => {
     size,
     ringColor,
     ringBackgroundColor,
+    ringInnerGap,
     ringThickness,
     fontWeight,
     fontFamily,
@@ -161,6 +164,15 @@ export const CustomizeUsage: React.FunctionComponent = () => {
                 setRingThickness(e.nativeEvent.text);
               }}
             />
+            <TextInput
+              accessibilityLabel="Ring inner gap"
+              style={commonStyles.textBox}
+              placeholder="Ring inner gap"
+              blurOnSubmit={true}
+              onSubmitEditing={(e) => {
+                setRingInnerGap(e.nativeEvent.text);
+              }}
+            />
           </View>
           <View style={{ paddingHorizontal: 20 }}>
             <Text style={{ fontWeight: 'bold' }}>Font tokens</Text>
@@ -232,6 +244,7 @@ export const CustomizeUsage: React.FunctionComponent = () => {
           ringThickness={parseInt(ringThickness)}
           size={parseInt(size) as AvatarSize}
           transparentRing={!showRing}
+          ringInnerGap={parseInt(ringInnerGap)}
         />
       </View>
     </View>

--- a/change/@fluentui-react-native-avatar-27c46ee8-3710-4df5-bb89-5d0c35d7b38c.json
+++ b/change/@fluentui-react-native-avatar-27c46ee8-3710-4df5-bb89-5d0c35d7b38c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added inner gap for the Avatar",
+  "packageName": "@fluentui-react-native/avatar",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-270c557e-d310-4aac-abcf-9352b36a098e.json
+++ b/change/@fluentui-react-native-tester-270c557e-d310-4aac-abcf-9352b36a098e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added inner gap for the Avatar",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Avatar/src/Avatar.styling.ts
+++ b/packages/components/Avatar/src/Avatar.styling.ts
@@ -175,6 +175,7 @@ function getRingConfig(tokens: AvatarTokens): any {
   const { size, ringThickness } = tokens;
   const SMALL_SIZE = 48;
   const MEDIUM_SIZE = 71;
+  const innerGap = tokens.ringInnerGap || ringThickness;
 
   const strokeSize = {
     small: globalTokens.stroke.width.thick,
@@ -183,29 +184,29 @@ function getRingConfig(tokens: AvatarTokens): any {
   };
   if (ringThickness) {
     return {
-      size: size + ringThickness * 4,
+      size: size + ringThickness * 2 + innerGap * 2,
       ringThickness,
-      innerStroke: ringThickness,
+      innerGap,
     };
   } else {
     if (size <= SMALL_SIZE) {
       return {
         size: size + strokeSize.small * 4,
         ringThickness: strokeSize.small,
-        innerStroke: strokeSize.small,
+        innerGap: strokeSize.small,
       };
     }
     if (size <= MEDIUM_SIZE) {
       return {
         size: size + strokeSize.medium * 4,
         ringThickness: strokeSize.medium,
-        innerStroke: strokeSize.medium,
+        innerGap: strokeSize.medium,
       };
     }
     return {
       size: size + strokeSize.large * 4,
       ringThickness: strokeSize.large,
-      innerStroke: strokeSize.large,
+      innerGap: strokeSize.large,
     };
   }
 }
@@ -222,8 +223,8 @@ function getRingSpacing(tokens: AvatarTokens) {
   const ringConfig = getRingConfig(tokens);
   return tokens.active === 'active'
     ? {
-        marginTop: ringConfig.ringThickness,
-        marginLeft: ringConfig.ringThickness,
+        marginTop: ringConfig.innerGap,
+        marginLeft: ringConfig.innerGap,
       }
     : {};
 }


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS
- [X] win32 (Office)
- [X] windows
- [ ] android

### Description of changes
Made inner gap configurable. Previously it changed according to the ring thickness. Now it's possible to set a different value for the inner gap.

### Verification
![image](https://user-images.githubusercontent.com/11574680/183957906-237fd0c0-7269-46e0-b56c-e875d93e593e.png)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
