### PR TITLE
Change order of Voiceover for Notification

### DIFF
--- a/change/@fluentui-react-native-notification-ea9c82dc-d5bf-4e9e-bf64-d7f437a28a39.json
+++ b/change/@fluentui-react-native-notification-ea9c82dc-d5bf-4e9e-bf64-d7f437a28a39.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "reorder notification voiceover",
+  "packageName": "@fluentui-react-native/notification",
+  "email": "joannaquu@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Notification/src/Notification.tsx
+++ b/packages/components/Notification/src/Notification.tsx
@@ -90,8 +90,8 @@ export const Notification = compose<NotificationType>({
       return (
         <Slots.shadow>
           <Slots.root {...mergedProps}>
-            {icon && <Slots.icon {...iconProps} />}
-            <Slots.contentContainer>
+            {icon && <Slots.icon {...iconProps} accessible={false} />}
+            <Slots.contentContainer accessible={true}>
               {title && <Slots.title>{title}</Slots.title>}
               <Slots.message style={messageStyle}>{children}</Slots.message>
             </Slots.contentContainer>

--- a/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
+++ b/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
@@ -54,6 +54,7 @@ exports[`Notification component tests Notification default 1`] = `
       }
     >
       <View
+        accessible={true}
         style={
           Object {
             "flex": 1,


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Changed order of Voiceover for Notification

### Before

https://user-images.githubusercontent.com/55368679/183992232-0db20954-7477-427b-a61e-b33cf674d16b.mp4

### After

https://user-images.githubusercontent.com/55368679/183992584-25692779-99c7-473c-bd98-0a6afbdcb05f.mp4

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
