### PR TITLE
Remove platform status from Fluent Tester

### DIFF
--- a/apps/component-generator/component-templates/TesterComponentTemplate/ComponentNameTest.tsx
+++ b/apps/component-generator/component-templates/TesterComponentTemplate/ComponentNameTest.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { COMPONENT_NAME_TESTPAGE } from './consts';
 import { ComponentNameDefault } from './ComponentNameDefault';
-import { Test, TestSection, PlatformStatus } from '../Test';
+import { Test, TestSection } from '../Test';
 
 const componentNameSections: TestSection[] = [
   {
@@ -12,15 +12,7 @@ const componentNameSections: TestSection[] = [
 ];
 
 export const ComponentNameTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'Beta',
-    uwpStatus: 'Experimental',
-    iosStatus: 'Experimental',
-    macosStatus: 'Beta',
-    androidStatus: 'Backlog',
-  };
-
   const description = 'component-description';
 
-  return <Test name="ComponentName Test" description={description} sections={componentNameSections} status={status}></Test>;
+  return <Test name="ComponentName Test" description={description} sections={componentNameSections} />;
 };

--- a/apps/fluent-tester/src/TestComponents/ActivityIndicator/ActivityIndicatorTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/ActivityIndicator/ActivityIndicatorTest.tsx
@@ -3,7 +3,7 @@ import { ActivityIndicator } from '@fluentui-react-native/experimental-activity-
 import { Text } from '@fluentui/react-native';
 import { Stack } from '@fluentui-react-native/stack';
 import { stackStyle, commonTestStyles as commonStyles } from '../Common/styles';
-import { Test, TestSection, PlatformStatus } from '../Test';
+import { Test, TestSection } from '../Test';
 import { ACTIVITY_INDICATOR_TESTPAGE } from './consts';
 import { View, Switch } from 'react-native';
 
@@ -85,16 +85,8 @@ const activityIndicatorSections: TestSection[] = [
 ];
 
 export const ActivityIndicatorTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'Backlog',
-    uwpStatus: 'Backlog',
-    iosStatus: 'Beta',
-    macosStatus: 'Backlog',
-    androidStatus: 'Beta',
-  };
-
   const description =
     'ActivityIndicator is a visual representation that data is being loaded. It is implemented with a View wrapping an Animated SVG. The View is to ensure that AccessibilityRole works. AccessibilityRole currently does not work on SVGs.';
 
-  return <Test name="ActivityIndicator Test" description={description} sections={activityIndicatorSections} status={status}></Test>;
+  return <Test name="ActivityIndicator Test" description={description} sections={activityIndicatorSections} />;
 };

--- a/apps/fluent-tester/src/TestComponents/Avatar/AvatarTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Avatar/AvatarTest.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { AVATAR_TESTPAGE } from './consts';
-import { Test, TestSection, PlatformStatus } from '../Test';
+import { Test, TestSection } from '../Test';
 import { StandardUsage } from './BasicAvatar';
 import { CustomizeUsage } from './CustomizedAvatar';
 import { E2EAvatarTest } from './E2EAvatarTest';
@@ -22,16 +22,8 @@ const avatarSections: TestSection[] = [
 ];
 
 export const AvatarTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'Experimental',
-    uwpStatus: 'Backlog',
-    iosStatus: 'Beta',
-    macosStatus: 'Experimental',
-    androidStatus: 'Backlog',
-  };
-
   const description =
     'AvatarView is a visual representation of a user, entity, or group. If an image is supplied, it is cropped to a circle of the requested size. If an image is not supplied, initials are extracted from the given name and email address provided and displayed on a colorful background.';
 
-  return <Test name="Avatar Test" description={description} sections={avatarSections} status={status} />;
+  return <Test name="Avatar Test" description={description} sections={avatarSections} />;
 };

--- a/apps/fluent-tester/src/TestComponents/Avatar/NativeAvatarTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Avatar/NativeAvatarTest.tsx
@@ -3,7 +3,7 @@ import { NativeAvatar, Size } from '@fluentui-react-native/experimental-avatar/'
 import { Text } from '@fluentui/react-native';
 import { Stack } from '@fluentui-react-native/stack';
 import { NATIVE_AVATAR_TESTPAGE } from './consts';
-import { Test, TestSection, PlatformStatus } from '../Test';
+import { Test, TestSection } from '../Test';
 import { testImageSource, rainbowGradientSource } from './testImageSources';
 import { commonTestStyles as commonStyles } from '../Common/styles';
 import { Switch, View } from 'react-native';
@@ -121,16 +121,8 @@ const avatarSections: TestSection[] = [
 ];
 
 export const NativeAvatarTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'Backlog',
-    uwpStatus: 'Backlog',
-    iosStatus: 'Beta',
-    macosStatus: 'Experimental',
-    androidStatus: 'Backlog',
-  };
-
   const description =
     'AvatarView is a visual representation of a user, entity, or group. If an image is supplied, it is cropped to a circle of the requested size. If an image is not supplied, initials are extracted from the given name and email address provided and displayed on a colorful background.';
 
-  return <Test name="Avatar Test" description={description} sections={avatarSections} status={status} />;
+  return <Test name="Avatar Test" description={description} sections={avatarSections} />;
 };

--- a/apps/fluent-tester/src/TestComponents/Badge/BadgeTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Badge/BadgeTest.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { BADGE_TESTPAGE } from './consts';
-import { Test, TestSection, PlatformStatus } from '../Test';
+import { Test, TestSection } from '../Test';
 import { BasicBadge } from './BasicBadgeTest';
 import { CounterBadgeTest } from './CounterBadgeTest';
 import { PresenceBadgeTest } from './PresenceBadgeTest';
@@ -22,16 +22,8 @@ const badgeSections: TestSection[] = [
 ];
 
 export const BadgeTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'Beta',
-    uwpStatus: 'Experimental',
-    iosStatus: 'Experimental',
-    macosStatus: 'Experimental',
-    androidStatus: 'Backlog',
-  };
-
   const description =
     'A badge is an additional visual descriptor for UI elements. It can be used to denote numerical value, status or general information.\n Included in this spec are base properties for usage in all badge scenarios. Reference properties for other badge types i.e. size, layout, and style variations';
 
-  return <Test name="Badge Test" description={description} sections={badgeSections} status={status}></Test>;
+  return <Test name="Badge Test" description={description} sections={badgeSections} />;
 };

--- a/apps/fluent-tester/src/TestComponents/Button/ButtonTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Button/ButtonTest.tsx
@@ -3,7 +3,7 @@ import { ButtonFocusTest_deprecated } from './deprecated/ButtonFocusTest';
 import { ButtonIconTest_deprecated } from './deprecated/ButtonIconTest';
 import { BUTTON_TESTPAGE } from './consts';
 import { E2EButtonTest_deprecated } from './deprecated/E2EButtonTest';
-import { Test, TestSection, PlatformStatus } from '../Test';
+import { Test, TestSection } from '../Test';
 import { ButtonVariantTest } from './ButtonVariantTestSection';
 import { ToggleButtonTest } from './ToggleButtonTestSection';
 import { ButtonIconTest } from '../Button/ButtonIconTestSection';
@@ -57,16 +57,8 @@ const buttonSections: TestSection[] = [
 ];
 
 export const ButtonTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'Beta',
-    uwpStatus: 'Experimental',
-    iosStatus: 'Experimental',
-    macosStatus: 'Beta',
-    androidStatus: 'Backlog',
-  };
-
   const description =
     'Buttons are best used to enable a user to commit a change or complete steps in a task. They are typically found inside forms, dialogs, panels or pages. An example of their usage is confirming the deletion of a file in a confirmation dialog.\n\nWhen considering their place in a layout, contemplate the order in which a user will flow through the UI. As an example, in a form, the individual will need to read and interact with the form fields before submiting the form. Therefore, as a general rule, the button should be placed at the bottom of the UI container (a dialog, panel, or page) which holds the related UI elements.\n\nWhile buttons can technically be used to navigate a user to another part of the experience, this is not recommended unless that navigation is part of an action or their flow.';
 
-  return <Test name="Button Test" description={description} sections={buttonSections} status={status}></Test>;
+  return <Test name="Button Test" description={description} sections={buttonSections} />;
 };

--- a/apps/fluent-tester/src/TestComponents/Callout/CalloutTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Callout/CalloutTest.tsx
@@ -11,7 +11,7 @@ import {
   StealthButton,
 } from '@fluentui/react-native';
 import { CALLOUT_TESTPAGE } from './consts';
-import { Test, TestSection, PlatformStatus } from '../Test';
+import { Test, TestSection } from '../Test';
 import { E2ECalloutTest } from './CalloutE2ETest';
 import { fluentTesterStyles } from '../Common/styles';
 import { MenuPicker } from '../Common/MenuPicker';
@@ -431,15 +431,7 @@ const calloutSections: TestSection[] = [
 ];
 
 export const CalloutTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'Beta',
-    uwpStatus: 'Backlog',
-    iosStatus: 'Backlog',
-    macosStatus: 'Backlog',
-    androidStatus: 'Backlog',
-  };
-
   const description = 'A callout is an anchored tip that can be used to teach people or guide them through the app without blocking them.';
 
-  return <Test name="Callout Test" description={description} sections={calloutSections} status={status}></Test>;
+  return <Test name="Callout Test" description={description} sections={calloutSections} />;
 };

--- a/apps/fluent-tester/src/TestComponents/Checkbox/CheckboxTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Checkbox/CheckboxTest.tsx
@@ -5,7 +5,7 @@ import { View, TextInput, TextStyle } from 'react-native';
 import { commonTestStyles as commonStyles } from '../Common/styles';
 import { CHECKBOX_TESTPAGE } from './consts';
 import { E2ECheckboxTest } from './CheckboxE2ETest';
-import { Test, TestSection, PlatformStatus } from '../Test';
+import { Test, TestSection } from '../Test';
 
 function onChangeUncontrolled(isChecked: boolean) {
   console.log(isChecked);
@@ -167,16 +167,8 @@ const checkboxSections: TestSection[] = [
 ];
 
 export const CheckboxTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'Beta',
-    uwpStatus: 'Experimental',
-    iosStatus: 'N/A',
-    macosStatus: 'Experimental',
-    androidStatus: 'N/A',
-  };
-
   const description =
     'Checkboxes give people a way to select one or more items from a group, or switch between two mutually exclusive options (checked or unchecked, on or off).';
 
-  return <Test name="Checkbox Test" description={description} sections={checkboxSections} status={status} />;
+  return <Test name="Checkbox Test" description={description} sections={checkboxSections} />;
 };

--- a/apps/fluent-tester/src/TestComponents/CheckboxExperimental/CheckboxTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/CheckboxExperimental/CheckboxTest.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { EXPERIMENTAL_CHECKBOX_TESTPAGE } from './consts';
-import { Test, TestSection, PlatformStatus } from '../Test';
+import { Test, TestSection } from '../Test';
 import { Checkbox } from '@fluentui-react-native/experimental-checkbox';
 import { useTheme } from '@fluentui-react-native/theme-types';
 import { View, TextInput, TextStyle } from 'react-native';
@@ -169,16 +169,8 @@ const checkboxSections: TestSection[] = [
 ];
 
 export const ExperimentalCheckboxTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'Beta',
-    uwpStatus: 'N/A',
-    iosStatus: 'N/A',
-    macosStatus: 'Experimental',
-    androidStatus: 'N/A',
-  };
-
   const description =
     'Checkboxes give people a way to select one or more items from a group, or switch between two mutually exclusive options (checked or unchecked, on or off).';
 
-  return <Test name="Experimental Checkbox Test" description={description} sections={checkboxSections} status={status} />;
+  return <Test name="Experimental Checkbox Test" description={description} sections={checkboxSections} />;
 };

--- a/apps/fluent-tester/src/TestComponents/ContextualMenu/ContextualMenuTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/ContextualMenu/ContextualMenuTest.tsx
@@ -12,7 +12,7 @@ import {
   Checkbox,
 } from '@fluentui/react-native';
 import { CONTEXTUALMENU_TESTPAGE } from './consts';
-import { Test, TestSection, PlatformStatus } from '../Test';
+import { Test, TestSection } from '../Test';
 import { svgProps, fontProps, testImage } from '../Common/iconExamples';
 import { E2EContextualMenuTest } from './E2EContextualMenuTest';
 
@@ -507,16 +507,8 @@ const contextualMenuSections: TestSection[] = [
 ];
 
 export const ContextualMenuTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'Experimental',
-    uwpStatus: 'Backlog',
-    iosStatus: 'Backlog',
-    macosStatus: 'Backlog',
-    androidStatus: 'Backlog',
-  };
-
   const description =
     'ContextualMenus are lists of commands that are based on the context of selection, mouse hover or keyboard focus. They are one of the most effective and highly used command surfaces, and can be used in a variety of places.\n\nThere are variants that originate from a command bar, or from cursor or focus. Those that come from CommandBars use a beak that is horizontally centered on the button. Ones that come from right click and menu button do not have a beak, but appear to the right and below the cursor. ContextualMenus can have submenus from commands, show selection checks, and icons.\n\nOrganize commands in groups divided by rules. This helps users remember command locations, or find less used commands based on proximity to others. One should also group sets of mutually exclusive or multiple selectable options. Use icons sparingly, for high value commands, and don’t mix icons with selection checks, as it makes parsing commands difficult. Avoid submenus of submenus as they can be difficult to invoke or remember.';
 
-  return <Test name="ContextualMenu Test" description={description} sections={contextualMenuSections} status={status}></Test>;
+  return <Test name="ContextualMenu Test" description={description} sections={contextualMenuSections} />;
 };

--- a/apps/fluent-tester/src/TestComponents/Drawer/DrawerTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Drawer/DrawerTest.tsx
@@ -7,7 +7,7 @@ import { Drawer } from '@fluentui-react-native/experimental-drawer';
 import { Stack } from '@fluentui-react-native/stack';
 import { Icon, SvgIconProps } from '@fluentui-react-native/icon';
 import { DRAWER_TESTPAGE } from './consts';
-import { Test, TestSection, PlatformStatus } from '../Test';
+import { Test, TestSection } from '../Test';
 
 import TestSvg from '../Icon/assets/test.svg';
 
@@ -45,15 +45,7 @@ const drawerSections: TestSection[] = [
 ];
 
 export const DrawerTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'N/A',
-    uwpStatus: 'N/A',
-    iosStatus: 'Backlog',
-    macosStatus: 'N/A',
-    androidStatus: 'Experimental',
-  };
-
   const description = 'A Drawer component using the Fluent Design System.  Currently only implemented on Android.';
 
-  return <Test name="Drawer Test" description={description} sections={drawerSections} status={status} />;
+  return <Test name="Drawer Test" description={description} sections={drawerSections} />;
 };

--- a/apps/fluent-tester/src/TestComponents/Expander/ExpanderTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Expander/ExpanderTest.tsx
@@ -3,7 +3,7 @@ import { Expander } from '@fluentui-react-native/experimental-expander';
 import { Text } from '@fluentui/react-native';
 import { Stack } from '@fluentui-react-native/stack';
 import { stackStyle, commonTestStyles as commonStyles } from '../Common/styles';
-import { Test, TestSection, PlatformStatus } from '../Test';
+import { Test, TestSection } from '../Test';
 import { EXPANDER_TESTPAGE } from './consts';
 import { View, Switch } from 'react-native';
 
@@ -114,16 +114,8 @@ const expanderSections: TestSection[] = [
 ];
 
 export const ExpanderTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'Backlog',
-    uwpStatus: 'Beta',
-    iosStatus: 'Backlog',
-    macosStatus: 'Backlog',
-    androidStatus: 'Backlog',
-  };
-
   const description =
     'Expander is a content control that displays components in the header and content. The control has an expanded and collapsed size. Expander is a native control implemented with WinUI 2.6 Expander.';
 
-  return <Test name="Expander Test" description={description} sections={expanderSections} status={status}></Test>;
+  return <Test name="Expander Test" description={description} sections={expanderSections} />;
 };

--- a/apps/fluent-tester/src/TestComponents/FocusTrapZone/FocusTrapZoneTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/FocusTrapZone/FocusTrapZoneTest.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { TouchableHighlight, TouchableHighlightProps, View, ViewProps } from 'react-native';
 import { stackStyle } from '../Common/styles';
 import { FOCUSTRAPZONE_TESTPAGE } from './consts';
-import { Test, TestSection, PlatformStatus } from '../Test';
+import { Test, TestSection } from '../Test';
 
 const trapZoneStyle: IFocusTrapZoneProps['style'] = {
   padding: 10,
@@ -138,16 +138,8 @@ const focusTrapZoneSections: TestSection[] = [
 ];
 
 export const FocusTrapTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'Beta',
-    uwpStatus: 'Backlog',
-    iosStatus: 'N/A',
-    macosStatus: 'N/A',
-    androidStatus: 'N/A',
-  };
-
   const description =
     'FocusTrapZone is used to trap the focus in any html element. Pressing tab will circle focus within the inner focusable elements of the FocusTrapZone.';
 
-  return <Test name="Focus Trap Zone Test" description={description} sections={focusTrapZoneSections} status={status}></Test>;
+  return <Test name="Focus Trap Zone Test" description={description} sections={focusTrapZoneSections} />;
 };

--- a/apps/fluent-tester/src/TestComponents/FocusZone/FocusZoneTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/FocusZone/FocusZoneTest.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { View, Switch } from 'react-native';
 import { FocusZone, Text, FocusZoneDirection, Checkbox } from '@fluentui/react-native';
 import { ButtonV1 as Button, ButtonProps } from '@fluentui-react-native/button';
-import { Test, TestSection, PlatformStatus } from '../Test';
+import { Test, TestSection } from '../Test';
 import { FOCUSZONE_TESTPAGE } from './consts';
 import { focusZoneTestStyles, GridButton, stackStyleFocusZone, SubheaderText } from './styles';
 import { commonTestStyles } from '../Common/styles';
@@ -285,13 +285,5 @@ const focusZoneSections: TestSection[] = [
 ];
 
 export const FocusZoneTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'Beta',
-    uwpStatus: 'Experimental',
-    iosStatus: 'Experimental',
-    macosStatus: 'Experimental',
-    androidStatus: 'Backlog',
-  };
-
-  return <Test name="FocusZone Test" description={'No description.'} sections={focusZoneSections} status={status} />;
+  return <Test name="FocusZone Test" description={'No description.'} sections={focusZoneSections} />;
 };

--- a/apps/fluent-tester/src/TestComponents/Icon/IconTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Icon/IconTest.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { Platform, PlatformColor, View } from 'react-native';
 import { Text } from '@fluentui/react-native';
 import { Icon, RasterImageIconProps, SvgIconProps, FontIconProps } from '@fluentui-react-native/icon';
-import { Test, TestSection, PlatformStatus } from '../Test';
+import { Test, TestSection } from '../Test';
 import { ICON_TESTPAGE } from './consts';
 import { E2ETestingIcon } from './IconE2ETest';
 
@@ -107,15 +107,7 @@ const iconSections: TestSection[] = [
 ];
 
 export const IconTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'Experimental',
-    uwpStatus: 'Backlog',
-    iosStatus: 'Experimental',
-    macosStatus: 'Experimental',
-    androidStatus: 'Backlog',
-  };
-
   const description = 'Icons are styled images that can be fonts, svgs, or bitmaps';
 
-  return <Test name="Icon Test" description={description} sections={iconSections} status={status}></Test>;
+  return <Test name="Icon Test" description={description} sections={iconSections} />;
 };

--- a/apps/fluent-tester/src/TestComponents/Link/LinkTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Link/LinkTest.tsx
@@ -4,7 +4,7 @@ import { Link } from '@fluentui/react-native';
 import { Stack } from '@fluentui-react-native/stack';
 import { stackStyle } from '../Common/styles';
 import { LINK_TESTPAGE } from './consts';
-import { Test, TestSection, PlatformStatus } from '../Test';
+import { Test, TestSection } from '../Test';
 import { LinkE2ETest } from './E2ELinkTest';
 
 const Links: React.FunctionComponent = () => {
@@ -33,16 +33,8 @@ const linkSections: TestSection[] = [
 ];
 
 export const LinkTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'Beta',
-    uwpStatus: 'Experimental',
-    iosStatus: 'Experimental',
-    macosStatus: 'Beta',
-    androidStatus: 'Backlog',
-  };
-
   const description =
     'With a Link, users can navigate to another page, window, or Help topic; display a definition; initiate a command; or choose an option. A Link indicates that it can be clicked, typically by being displayed using the visited or unvisited link system colors. Traditionally, Links are underlined as well, but that approach is often unnecessary and falling out of favor to reduce visual clutter.\n\nA Link is the lightest weight clickable control, and is often used to reduce the visual complexity of a design.';
 
-  return <Test name="Link Test" description={description} sections={linkSections} status={status}></Test>;
+  return <Test name="Link Test" description={description} sections={linkSections} />;
 };

--- a/apps/fluent-tester/src/TestComponents/Menu/MenuTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Menu/MenuTest.tsx
@@ -13,7 +13,7 @@ import {
 import { Stack } from '@fluentui-react-native/stack';
 import { stackStyle } from '../Common/styles';
 import { MENU_TESTPAGE } from './consts';
-import { Test, TestSection, PlatformStatus } from '../Test';
+import { Test, TestSection } from '../Test';
 import { TextV1 as Text } from '@fluentui-react-native/text';
 import { E2EMenuTest } from './E2EMenuTest';
 
@@ -272,16 +272,8 @@ const menuSections: TestSection[] = [
 ];
 
 export const MenuTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'Experimental',
-    uwpStatus: 'Backlog',
-    iosStatus: 'Backlog',
-    macosStatus: 'Experimental',
-    androidStatus: 'Backlog',
-  };
-
   const description =
     'A Menu is an component that displays a list of options on a temporary surface. They are invoked when users interact with a button, action, or other control.';
 
-  return <Test name="Menu Test" description={description} sections={menuSections} status={status}></Test>;
+  return <Test name="Menu Test" description={description} sections={menuSections} />;
 };

--- a/apps/fluent-tester/src/TestComponents/MenuButton/MenuButtonTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/MenuButton/MenuButtonTest.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { MENU_BUTTON_TESTPAGE } from './consts';
-import { Test, TestSection, PlatformStatus } from '../Test';
+import { Test, TestSection } from '../Test';
 import { StandardMenuButton } from './StandardMenuButtonTest';
 import { NestedMenuButton } from './NestedMenuButtonTest';
 import { CustomizedMenuButton } from './CustomizedMenuButtonTest';
@@ -27,16 +27,8 @@ const menuButtonSections: TestSection[] = [
 ];
 
 export const MenuButtonTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'Experimental',
-    uwpStatus: 'Backlog',
-    iosStatus: 'Backlog',
-    macosStatus: 'Backlog',
-    androidStatus: 'Backlog',
-  };
-
   const description =
     'MenuButton is a component which contains ContextualMenu and Button components. This control combines and simplifies the API for customers.\nClicking on MenuButton opens ContextualMenu. It can have Submenu. But selection checks and a beak are not implemented.';
 
-  return <Test name="MenuButton Test" description={description} sections={menuButtonSections} status={status} />;
+  return <Test name="MenuButton Test" description={description} sections={menuButtonSections} />;
 };

--- a/apps/fluent-tester/src/TestComponents/MenuButtonExperimental/MenuButtonTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/MenuButtonExperimental/MenuButtonTest.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { MENU_BUTTON_EXPERIMENTAL_TESTPAGE } from './consts';
-import { Test, TestSection, PlatformStatus } from '../Test';
+import { Test, TestSection } from '../Test';
 import { StandardMenuButton } from './StandardMenuButtonTest';
 import { NestedMenuButton } from './NestedMenuButtonTest';
 import { E2ETestExperimentalMenuButton } from './ExperimentalMenuButtonE2ETest';
@@ -27,16 +27,8 @@ const menuButtonSections: TestSection[] = [
 ];
 
 export const ExperimentalMenuButtonTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'Experimental',
-    uwpStatus: 'Backlog',
-    iosStatus: 'Backlog',
-    macosStatus: 'Backlog',
-    androidStatus: 'Backlog',
-  };
-
   const description =
     'MenuButton is a component which contains ContextualMenu and Button components. This control combines and simplifies the API for customers.\nClicking on MenuButton opens ContextualMenu. It can have Submenu. But selection checks and a beak are not implemented.';
 
-  return <Test name="Experimental MenuButton Test" description={description} sections={menuButtonSections} status={status} />;
+  return <Test name="Experimental MenuButton Test" description={description} sections={menuButtonSections} />;
 };

--- a/apps/fluent-tester/src/TestComponents/NativeDatePicker/NativeDatePickerTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/NativeDatePicker/NativeDatePickerTest.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@fluentui-react-native/button';
 import { NativeDatePicker } from '@fluentui-react-native/experimental-native-date-picker';
 import { NATIVEDATEPICKER_TESTPAGE } from './consts';
-import { PlatformStatus, Test, TestSection } from '../Test';
+import { Test, TestSection } from '../Test';
 import * as React from 'react';
 import { Stack } from '@fluentui-react-native/stack';
 import { stackStyle, commonTestStyles as commonStyles } from '../Common/styles';
@@ -235,15 +235,7 @@ const nativeDatePickerSections: TestSection[] = [
 ];
 
 export const NativeDatePickerTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'N/A',
-    uwpStatus: 'N/A',
-    iosStatus: 'Experimental',
-    macosStatus: 'N/A',
-    androidStatus: 'N/A',
-  };
-
   const description = 'A Native date picker component using the Fluent Design System.  Currently only implemented on iOS.';
 
-  return <Test name="Native Date Picker Test" description={description} sections={nativeDatePickerSections} status={status}></Test>;
+  return <Test name="Native Date Picker Test" description={description} sections={nativeDatePickerSections} />;
 };

--- a/apps/fluent-tester/src/TestComponents/Notification/NotificationTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Notification/NotificationTest.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Notification, NotificationVariant, NotificationVariants } from '@fluentui-react-native/notification';
-import { Test, TestSection, PlatformStatus } from '../Test';
+import { Test, TestSection } from '../Test';
 import { Animated, StyleSheet, Switch, TextInput, View } from 'react-native';
 import { Text } from '@fluentui-react-native/experimental-text';
 import { ButtonV1 as Button } from '@fluentui-react-native/button';
@@ -272,15 +272,7 @@ const notificationSections: TestSection[] = [
 ];
 
 export const NotificationTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'Backlog',
-    uwpStatus: 'Backlog',
-    iosStatus: 'Experimental',
-    macosStatus: 'Backlog',
-    androidStatus: 'Backlog',
-  };
-
   const description = 'Testing notification component';
 
-  return <Test name="Notification Test" description={description} sections={notificationSections} status={status}></Test>;
+  return <Test name="Notification Test" description={description} sections={notificationSections} />;
 };

--- a/apps/fluent-tester/src/TestComponents/Persona/PersonaTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Persona/PersonaTest.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { StandardUsage } from './StandardUsage';
 import { CustomizeUsage } from './CustomizeUsage';
 import { PERSONA_TESTPAGE } from './consts';
-import { Test, TestSection, PlatformStatus } from '../Test';
+import { Test, TestSection } from '../Test';
 
 const personaSections: TestSection[] = [
   {
@@ -17,16 +17,8 @@ const personaSections: TestSection[] = [
 ];
 
 export const PersonaTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'Beta',
-    uwpStatus: 'Experimental',
-    iosStatus: 'Experimental',
-    macosStatus: 'Experimental',
-    androidStatus: 'Backlog',
-  };
-
   const description =
     "Personas are used for rendering an individual's avatar and presence. Persona renders a PersonaCoin along with descriptive text components.";
 
-  return <Test name="Persona Test" description={description} sections={personaSections} status={status} />;
+  return <Test name="Persona Test" description={description} sections={personaSections} />;
 };

--- a/apps/fluent-tester/src/TestComponents/PersonaCoin/PersonaCoinTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/PersonaCoin/PersonaCoinTest.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { StandardUsage } from './StandardUsage';
 import { CustomizeUsage } from './CustomizeUsage';
 import { PERSONACOIN_TESTPAGE } from './consts';
-import { Test, TestSection, PlatformStatus } from '../Test';
+import { Test, TestSection } from '../Test';
 
 const personaCoinSections: TestSection[] = [
   {
@@ -17,15 +17,7 @@ const personaCoinSections: TestSection[] = [
 ];
 
 export const PersonaCoinTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'Beta',
-    uwpStatus: 'Experimental',
-    iosStatus: 'Experimental',
-    macosStatus: 'Experimental',
-    androidStatus: 'Backlog',
-  };
-
   const description = "PersonaCoins are used for rendering an individual's avatar. PersonaCoin renders the circular image component.";
 
-  return <Test name="PersonaCoin Test" description={description} sections={personaCoinSections} status={status} />;
+  return <Test name="PersonaCoin Test" description={description} sections={personaCoinSections} />;
 };

--- a/apps/fluent-tester/src/TestComponents/Pressable/PressableTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Pressable/PressableTest.tsx
@@ -5,7 +5,7 @@ import { Stack } from '@fluentui-react-native/stack';
 import { Square } from '../Common/Square';
 import { Alert, GestureResponderEvent, StyleSheet, View, ViewProps, ViewStyle, Text } from 'react-native';
 import { PRESSABLE_TESTPAGE } from './consts';
-import { Test, TestSection, PlatformStatus } from '../Test';
+import { Test, TestSection } from '../Test';
 
 const styles = StyleSheet.create({
   dottedBorder: {
@@ -131,15 +131,7 @@ const pressableSections: TestSection[] = [
 ];
 
 export const PressableTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'Beta',
-    uwpStatus: 'Experimental',
-    iosStatus: 'Experimental',
-    macosStatus: 'Experimental',
-    androidStatus: 'Backlog',
-  };
-
   const description = 'No description.';
 
-  return <Test name="Pressable Test" description={description} sections={pressableSections} status={status} />;
+  return <Test name="Pressable Test" description={description} sections={pressableSections} />;
 };

--- a/apps/fluent-tester/src/TestComponents/RadioGroup/RadioGroupTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/RadioGroup/RadioGroupTest.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { View } from 'react-native';
 import { RadioButton, RadioGroup, Separator } from '@fluentui/react-native';
 import { RADIOGROUP_TESTPAGE } from './consts';
-import { Test, TestSection, PlatformStatus } from '../Test';
+import { Test, TestSection } from '../Test';
 import { E2ERadioGroupTest } from './RadioGroupE2ETest';
 
 const BasicRadioGroup: React.FunctionComponent = () => {
@@ -65,15 +65,7 @@ const radioGroupSections: TestSection[] = [
 ];
 
 export const RadioGroupTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'Beta',
-    uwpStatus: 'Experimental',
-    iosStatus: 'Experimental',
-    macosStatus: 'Beta',
-    androidStatus: 'Backlog',
-  };
-
   const description = 'No description.';
 
-  return <Test name="RadioGroup Test" description={description} sections={radioGroupSections} status={status} />;
+  return <Test name="RadioGroup Test" description={description} sections={radioGroupSections} />;
 };

--- a/apps/fluent-tester/src/TestComponents/Separator/SeparatorTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Separator/SeparatorTest.tsx
@@ -4,7 +4,7 @@ import { Button, Separator } from '@fluentui/react-native';
 import { stackStyle, separatorStackStyle } from '../Common/styles';
 import { Stack } from '@fluentui-react-native/stack';
 import { SEPARATOR_TESTPAGE } from './consts';
-import { Test, TestSection, PlatformStatus } from '../Test';
+import { Test, TestSection } from '../Test';
 
 const BlueSeparator = Separator.customize({ color: 'blue' });
 const RedSeparator = Separator.customize({ color: 'red' });
@@ -36,16 +36,8 @@ const separatorSections: TestSection[] = [
 ];
 
 export const SeparatorTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'Beta',
-    uwpStatus: 'Experimental',
-    iosStatus: 'Experimental',
-    macosStatus: 'Beta',
-    androidStatus: 'Backlog',
-  };
-
   const description =
     "A separator visually separates content into groups.\n\nYou can render content in the separator by specifying the component's children. The component's children can be plain text or a component like Icon. The content is center-aligned by default.";
 
-  return <Test name="Separator Test" description={description} sections={separatorSections} status={status} />;
+  return <Test name="Separator Test" description={description} sections={separatorSections} />;
 };

--- a/apps/fluent-tester/src/TestComponents/Shadow/ShadowTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Shadow/ShadowTest.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Test, TestSection, PlatformStatus } from '../Test';
+import { Test, TestSection } from '../Test';
 import { SHADOW_TESTPAGE } from './consts';
 import { ShadowDepthTestSection } from './ShadowDepthTestSection';
 import { ShadowButtonTestSection } from './ShadowButtonTestSection';
@@ -18,15 +18,7 @@ const shadowSections: TestSection[] = [
 ];
 
 export const ShadowTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'Experimental',
-    uwpStatus: 'Experimental',
-    iosStatus: 'Experimental',
-    macosStatus: 'Experimental',
-    androidStatus: 'Experimental',
-  };
-
   const description = 'A Shadow component using the Fluent Design System. Shadow components can be added to other components.';
 
-  return <Test name="Shadow Test" description={description} sections={shadowSections} status={status} />;
+  return <Test name="Shadow Test" description={description} sections={shadowSections} />;
 };

--- a/apps/fluent-tester/src/TestComponents/Shimmer/ShimmerTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Shimmer/ShimmerTest.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Shimmer } from '@fluentui-react-native/experimental-shimmer';
 import { SHIMMER_TESTPAGE } from './consts';
-import { Test, TestSection, PlatformStatus } from '../Test';
+import { Test, TestSection } from '../Test';
 import { Stack } from '@fluentui-react-native/stack';
 import { stackStyle } from '../Common/styles';
 import { shimmerBorderRadiusTests, shimmerRectsAndRect, shimmerRectsAndCircle } from './ShimmerTestElementSets';
@@ -111,16 +111,8 @@ const shimmerSections: TestSection[] = [
 ];
 
 export const ShimmerTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'Beta',
-    uwpStatus: 'Backlog',
-    iosStatus: 'Beta',
-    macosStatus: 'Backlog',
-    androidStatus: 'Backlog',
-  };
-
   const description =
     'Shimmer is a temporary animation placeholder for when a service call takes time to return data but the rest of the UI should continue rendering.';
 
-  return <Test name="Shimmer Test" description={description} sections={shimmerSections} status={status} />;
+  return <Test name="Shimmer Test" description={description} sections={shimmerSections} />;
 };

--- a/apps/fluent-tester/src/TestComponents/Svg/SvgTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Svg/SvgTest.tsx
@@ -4,7 +4,7 @@ import { Separator } from '@fluentui/react-native';
 import { Circle, Defs, G, Line, Path, Polygon, LinearGradient, RadialGradient, Rect, Stop, Svg, SvgUri, Use } from 'react-native-svg';
 import TestSvg from './Assets/accessible-icon-brands.svg';
 import { SVG_TESTPAGE } from './consts';
-import { Test, TestSection, PlatformStatus } from '../Test';
+import { Test, TestSection } from '../Test';
 
 const styles = StyleSheet.create({
   svg: {
@@ -191,15 +191,7 @@ const svgSections: TestSection[] = [
 ];
 
 export const SvgTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'Beta',
-    uwpStatus: 'Backlog',
-    iosStatus: 'Backlog',
-    macosStatus: 'Backlog',
-    androidStatus: 'Backlog',
-  };
-
   const description = 'No description.';
 
-  return <Test name="Svg Test" description={description} sections={svgSections} status={status} />;
+  return <Test name="Svg Test" description={description} sections={svgSections} />;
 };

--- a/apps/fluent-tester/src/TestComponents/Switch/Switch.tsx
+++ b/apps/fluent-tester/src/TestComponents/Switch/Switch.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Test, TestSection, PlatformStatus } from '../Test';
+import { Test, TestSection } from '../Test';
 import { SWITCH_TESTPAGE } from './consts';
 import { View, StyleSheet } from 'react-native';
 import { Switch } from '@fluentui-react-native/switch';
@@ -116,15 +116,7 @@ const toggleSections: TestSection[] = [
 ];
 
 export const SwitchTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'Experimental',
-    uwpStatus: 'Backlog',
-    iosStatus: 'Backlog',
-    macosStatus: 'Backlog',
-    androidStatus: 'Backlog',
-  };
-
   const description = 'Switch is a control that has two mutually exclusive states.';
 
-  return <Test name="Switch Test" description={description} sections={toggleSections} status={status}></Test>;
+  return <Test name="Switch Test" description={description} sections={toggleSections} />;
 };

--- a/apps/fluent-tester/src/TestComponents/Tabs/TabsTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Tabs/TabsTest.tsx
@@ -3,7 +3,7 @@ import { Platform, View } from 'react-native';
 import { Tabs, TabsItem, Text, Button } from '@fluentui/react-native';
 import { stackStyle } from '../Common/styles';
 import { TABS_TESTPAGE } from './consts';
-import { Test, TestSection, PlatformStatus } from '../Test';
+import { Test, TestSection } from '../Test';
 import { E2ETabsTest } from './TabsE2ETest';
 import TestSvg from './test.svg';
 
@@ -285,15 +285,7 @@ if (Platform.OS !== 'windows') {
 }
 
 export const TabsTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'Experimental',
-    uwpStatus: 'Experimental',
-    iosStatus: 'Backlog',
-    macosStatus: 'Experimental',
-    androidStatus: 'Backlog',
-  };
-
   const description = 'With Tabs, users can navigate to another view.';
 
-  return <Test name="Tabs Test" description={description} sections={tabsSections} status={status} />;
+  return <Test name="Tabs Test" description={description} sections={tabsSections} />;
 };

--- a/apps/fluent-tester/src/TestComponents/TabsExperimental/TabsTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/TabsExperimental/TabsTest.tsx
@@ -5,7 +5,7 @@ import { Button } from '@fluentui-react-native/experimental-button';
 import { Tabs, TabsItem } from '@fluentui-react-native/experimental-tabs';
 import { stackStyle } from '../Common/styles';
 import { EXPERIMENTAL_TABS_TESTPAGE } from './consts';
-import { Test, TestSection, PlatformStatus } from '../Test';
+import { Test, TestSection } from '../Test';
 import { SvgIconProps } from '@fluentui-react-native/icon';
 import TestSvg from './test.svg';
 import { E2ETestExperimentalTabs } from './TabsExperimentalE2ETest';
@@ -265,15 +265,7 @@ if (Platform.OS !== 'windows') {
 }
 
 export const ExperimentalTabsTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'Experimental',
-    uwpStatus: 'Experimental',
-    iosStatus: 'Backlog',
-    macosStatus: 'Experimental',
-    androidStatus: 'Backlog',
-  };
-
   const description = 'With Tabs, users can navigate to another view.';
 
-  return <Test name="Experimental Tabs Test" description={description} sections={tabsSections} status={status} />;
+  return <Test name="Experimental Tabs Test" description={description} sections={tabsSections} />;
 };

--- a/apps/fluent-tester/src/TestComponents/Test.tsx
+++ b/apps/fluent-tester/src/TestComponents/Test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StyleSheet, View, Platform } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { Text, Separator } from '@fluentui/react-native';
 import { Stack } from '@fluentui-react-native/stack';
 import { stackStyle } from './Common/styles';
@@ -10,19 +10,9 @@ export type TestSection = {
   component: React.FunctionComponent;
 };
 
-export type Status = 'Production' | 'Beta' | 'Experimental' | 'Backlog' | 'N/A';
-export type PlatformStatus = {
-  win32Status: Status;
-  uwpStatus: Status;
-  iosStatus: Status;
-  macosStatus: Status;
-  androidStatus: Status;
-};
-
 export interface TestProps {
   name: string;
   description: string;
-  status: PlatformStatus;
   sections: TestSection[];
 }
 
@@ -54,9 +44,6 @@ const styles = StyleSheet.create({
   },
 });
 
-// mobile platform check to not render status components.
-const isMobile = Platform.OS == 'android' || (Platform.OS == 'ios' && !Platform.isPad);
-
 export const Test = (props: TestProps): React.ReactElement<Record<string, never>> => {
   return (
     <View testID="ScrollViewAreaForComponents">
@@ -67,57 +54,6 @@ export const Test = (props: TestProps): React.ReactElement<Record<string, never>
       <Stack style={stackStyle}>
         <Text style={styles.description}>{props.description}</Text>
       </Stack>
-      {!isMobile && (
-        <Stack style={stackStyle}>
-          <View style={styles.statusView}>
-            <Stack>
-              <Text style={[styles.statusHeader]} variant="headerStandard">
-                Platform Status
-              </Text>
-              <Text style={[styles.statusLabel]} variant="bodySemibold">
-                Win32: <Text style={styles.status}>{props.status.win32Status}</Text>
-              </Text>
-              <Text style={[styles.statusLabel]} variant="bodySemibold">
-                UWP: <Text style={styles.status}>{props.status.uwpStatus}</Text>
-              </Text>
-              <Text style={[styles.statusLabel]} variant="bodySemibold">
-                iOS: <Text style={styles.status}>{props.status.iosStatus}</Text>
-              </Text>
-              <Text style={[styles.statusLabel]} variant="bodySemibold">
-                macOS: <Text style={styles.status}>{props.status.macosStatus}</Text>
-              </Text>
-              <Text style={[styles.statusLabel]} variant="bodySemibold">
-                Android: <Text style={styles.status}>{props.status.androidStatus}</Text>
-              </Text>
-            </Stack>
-
-            <Stack style={stackStyle}>
-              <Text style={[styles.statusHeader]} variant="headerStandard">
-                Status Definitions
-              </Text>
-              <Text style={[styles.statusLabel]} variant="bodySemibold">
-                Production:{' '}
-                <Text style={styles.status}>Control is ready for broad partner use and to be used in production-ready scenarios.</Text>
-              </Text>
-              <Text style={[styles.statusLabel]} variant="bodySemibold">
-                Beta:{' '}
-                <Text style={styles.status}>
-                  Control is ready for partner consumption, but not ready for production release (e.g. fixing bugs).
-                </Text>
-              </Text>
-              <Text style={[styles.statusLabel]} variant="bodySemibold">
-                Experimental: <Text style={styles.status}>Control code checked into repo, but not ready for partner use.</Text>
-              </Text>
-              <Text style={[styles.statusLabel]} variant="bodySemibold">
-                Backlog: <Text style={styles.status}>Control is in plan and on our backlog to deliver.</Text>
-              </Text>
-              <Text style={[styles.statusLabel]} variant="bodySemibold">
-                N/A: <Text style={styles.status}>Control is not in current plan.</Text>
-              </Text>
-            </Stack>
-          </View>
-        </Stack>
-      )}
       {props.sections.map((section, index) => {
         const TestComponent = section.component;
         return (

--- a/apps/fluent-tester/src/TestComponents/Text/TextTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Text/TextTest.tsx
@@ -3,7 +3,7 @@ import { StandardUsage } from './StandardUsage';
 import { CustomizeUsage } from './CustomizeUsage';
 import { PressableUsage } from './PressableUsage';
 import { E2ETextTest } from './TextE2ETest';
-import { Test, TestSection, PlatformStatus } from '../Test';
+import { Test, TestSection } from '../Test';
 
 const textSections: TestSection[] = [
   {
@@ -25,15 +25,7 @@ const textSections: TestSection[] = [
 ];
 
 export const TextTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'Experimental',
-    uwpStatus: 'Experimental',
-    iosStatus: 'Experimental',
-    macosStatus: 'Experimental',
-    androidStatus: 'Beta',
-  };
-
   const description = 'Text is a component for displaying text. You can use Text to standardize text across your app.';
 
-  return <Test name="Text Test" description={description} sections={textSections} status={status} />;
+  return <Test name="Text Test" description={description} sections={textSections} />;
 };

--- a/apps/fluent-tester/src/TestComponents/TextExperimental/TextExperimentalTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/TextExperimental/TextExperimentalTest.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { StandardUsage } from './StandardUsage';
 import { CustomizeUsage } from './CustomizeUsage';
 import { PressableUsage } from './PressableUsage';
-import { Test, TestSection, PlatformStatus } from '../Test';
+import { Test, TestSection } from '../Test';
 import { E2EExperimentalTextTest } from './ExperimentalTextE2ETest';
 import { EXPERIMENTAL_TEXT_TESTPAGE } from './consts';
 
@@ -27,15 +27,7 @@ const textSections: TestSection[] = [
 ];
 
 export const TextExperimentalTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'Experimental',
-    uwpStatus: 'Experimental',
-    iosStatus: 'Experimental',
-    macosStatus: 'Experimental',
-    androidStatus: 'Beta',
-  };
-
   const description = 'Text is a component for displaying text. You can use Text to standardize text across your app.';
 
-  return <Test name="Experimental Text Test" description={description} sections={textSections} status={status} />;
+  return <Test name="Experimental Text Test" description={description} sections={textSections} />;
 };

--- a/apps/fluent-tester/src/TestComponents/Theme/ThemeTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Theme/ThemeTest.tsx
@@ -5,7 +5,7 @@ import { themedStyleSheet } from '@fluentui-react-native/themed-stylesheet';
 import { commonTestStyles } from '../Common/styles';
 import { Button, PrimaryButton, Text, StealthButton } from '@fluentui/react-native';
 import { THEME_TESTPAGE } from './consts';
-import { Test, TestSection, PlatformStatus } from '../Test';
+import { Test, TestSection } from '../Test';
 
 const getThemedStyles = themedStyleSheet((theme: Theme) => {
   return {
@@ -108,16 +108,8 @@ const themeSections: TestSection[] = [
 ];
 
 export const ThemeTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'Beta',
-    uwpStatus: 'Experimental',
-    iosStatus: 'Experimental',
-    macosStatus: 'Experimental',
-    androidStatus: 'Backlog',
-  };
-
   const description =
     'The entire color palette of the controls is themeable. We provide a set of sensible defaults, but you can override all colors individually.';
 
-  return <Test name="Theme Test" description={description} sections={themeSections} status={status} />;
+  return <Test name="Theme Test" description={description} sections={themeSections} />;
 };

--- a/apps/fluent-tester/src/TestComponents/Tokens/TokenTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Tokens/TokenTest.tsx
@@ -7,7 +7,7 @@ import { createOfficeAliasTokens } from '@fluentui-react-native/win32-theme';
 import { createAliasTokens } from '@fluentui-react-native/default-theme';
 import { commonTestStyles } from '../Common/styles';
 import { Text } from '@fluentui/react-native';
-import { Test, TestSection, PlatformStatus } from '../Test';
+import { Test, TestSection } from '../Test';
 import { TOKENS_TEST_COMPONENT, TOKEN_TESTPAGE } from './consts';
 
 const getThemedStyles = themedStyleSheet((theme: Theme) => {
@@ -101,15 +101,7 @@ const themeSections: TestSection[] = [
 ];
 
 export const TokenTest: React.FunctionComponent = () => {
-  const status: PlatformStatus = {
-    win32Status: 'Experimental',
-    uwpStatus: 'Backlog',
-    iosStatus: 'Backlog',
-    macosStatus: 'Backlog',
-    androidStatus: 'Backlog',
-  };
-
   const description = 'Alias tokens given from token pipeline. Currently values are pulled from web. Will be used to style components.';
 
-  return <Test name="Token Test" description={description} sections={themeSections} status={status} />;
+  return <Test name="Token Test" description={description} sections={themeSections} />;
 };

--- a/change/@fluentui-react-native-tester-b9949f19-a062-4326-b159-4b5bb4fb4f8a.json
+++ b/change/@fluentui-react-native-tester-b9949f19-a062-4326-b159-4b5bb4fb4f8a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "remove platform status",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "joannaquu@gmail.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [ ] android

### Description of changes

Remove platform status from each test

### Verification




| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img alt="image" src="https://user-images.githubusercontent.com/55368679/184024644-2eeb2421-b3a5-436d-b700-1d3df6a91831.png"> | <img alt="image" src="https://user-images.githubusercontent.com/55368679/184024016-6dbe268e-7292-4884-b575-1e0123770e60.png"> |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
