### PR TITLE
Made count disappear when CounterBadge has content

### DIFF
--- a/change/@fluentui-react-native-badge-4ac1140e-172a-46eb-a369-6f5d120c3756.json
+++ b/change/@fluentui-react-native-badge-4ac1140e-172a-46eb-a369-6f5d120c3756.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Made content/count display of CounterBadge according to the Web",
+  "packageName": "@fluentui-react-native/badge",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Badge/src/CounterBadge/CounterBadge.tsx
+++ b/packages/experimental/Badge/src/CounterBadge/CounterBadge.tsx
@@ -28,13 +28,14 @@ export const CounterBadge = compose<CounterBadgeType>({
       const { count, icon, iconPosition = 'before', overflowCount, dot, ...mergedProps } = mergeProps(badge.props, final);
       const { showBadge } = badge.state;
       const displayCount = count && count > overflowCount ? `${overflowCount}+` : `${count}`;
+      const hasChildren = Children.toArray(children)[0];
 
       return showBadge ? (
         <Slots.root {...mergedProps}>
           {!dot && (
             <React.Fragment>
               {icon && iconPosition === 'before' && <Slots.icon {...iconProps} />}
-              {!Children.toArray(children)[0] && <Slots.text>{displayCount}</Slots.text>}
+              {!hasChildren && <Slots.text>{displayCount}</Slots.text>}
               {Children.map(children, (child, i) =>
                 typeof child === 'string' ? <Slots.text key={`text-${i}`}>{child}</Slots.text> : child,
               )}

--- a/packages/experimental/Badge/src/CounterBadge/CounterBadge.tsx
+++ b/packages/experimental/Badge/src/CounterBadge/CounterBadge.tsx
@@ -28,12 +28,14 @@ export const CounterBadge = compose<CounterBadgeType>({
       const { count, icon, iconPosition = 'before', overflowCount, dot, ...mergedProps } = mergeProps(badge.props, final);
       const { showBadge } = badge.state;
       const displayCount = count && count > overflowCount ? `${overflowCount}+` : `${count}`;
+      const hasChildren = children[0] && children[0][0];
+
       return showBadge ? (
         <Slots.root {...mergedProps}>
           {!dot && (
             <React.Fragment>
               {icon && iconPosition === 'before' && <Slots.icon {...iconProps} />}
-              <Slots.text>{displayCount}</Slots.text>
+              {!hasChildren && <Slots.text>{displayCount}</Slots.text>}
               {Children.map(children, (child, i) =>
                 typeof child === 'string' ? <Slots.text key={`text-${i}`}>{child}</Slots.text> : child,
               )}

--- a/packages/experimental/Badge/src/CounterBadge/CounterBadge.tsx
+++ b/packages/experimental/Badge/src/CounterBadge/CounterBadge.tsx
@@ -28,14 +28,13 @@ export const CounterBadge = compose<CounterBadgeType>({
       const { count, icon, iconPosition = 'before', overflowCount, dot, ...mergedProps } = mergeProps(badge.props, final);
       const { showBadge } = badge.state;
       const displayCount = count && count > overflowCount ? `${overflowCount}+` : `${count}`;
-      const hasChildren = children[0] && children[0][0];
 
       return showBadge ? (
         <Slots.root {...mergedProps}>
           {!dot && (
             <React.Fragment>
               {icon && iconPosition === 'before' && <Slots.icon {...iconProps} />}
-              {!hasChildren && <Slots.text>{displayCount}</Slots.text>}
+              {!Children.toArray(children)[0] && <Slots.text>{displayCount}</Slots.text>}
               {Children.map(children, (child, i) =>
                 typeof child === 'string' ? <Slots.text key={`text-${i}`}>{child}</Slots.text> : child,
               )}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
When CounterBadge has content, count prop shouldn't be displayed.

### Verification
**Before**
![image](https://user-images.githubusercontent.com/11574680/184385079-6e7194be-6164-4fac-b024-e1f3ca2dd085.png)

**After**
![image](https://user-images.githubusercontent.com/11574680/184384361-065fc898-07f5-4733-9ecf-4dda094c17ae.png)


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
