### PR TITLE
Update Notification minHeight

### DIFF
--- a/change/@fluentui-react-native-notification-eea55bb1-b774-466c-acd1-e381c67147df.json
+++ b/change/@fluentui-react-native-notification-eea55bb1-b774-466c-acd1-e381c67147df.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "update minHeight",
+  "packageName": "@fluentui-react-native/notification",
+  "email": "joannaquu@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Notification/src/NotificationTokens.ios.ts
+++ b/packages/components/Notification/src/NotificationTokens.ios.ts
@@ -108,7 +108,7 @@ export const defaultNotificationTokens: TokenSettings<NotificationTokens, Theme>
     fontLineHeight: 20,
     fontSize: 15,
     fontWeight: '600',
-    minHeight: 64,
+    minHeight: 52,
     padding: 16,
     shadowToken: notificationShadowStyle,
     hasTitle: {
@@ -116,6 +116,7 @@ export const defaultNotificationTokens: TokenSettings<NotificationTokens, Theme>
       fontLineHeight: 18,
       fontSize: 13,
       fontWeight: '400',
+      minHeight: 62,
       paddingVertical: 12,
     },
     isBar: {

--- a/packages/components/Notification/src/NotificationTokens.ts
+++ b/packages/components/Notification/src/NotificationTokens.ts
@@ -23,13 +23,14 @@ export const defaultNotificationTokens: TokenSettings<NotificationTokens, Theme>
     fontLineHeight: 20,
     fontSize: 15,
     fontWeight: '600',
-    minHeight: 64,
+    minHeight: 52,
     padding: 16,
     shadowToken: notificationShadowStyle,
     hasTitle: {
       fontLineHeight: 18,
       fontSize: 13,
       fontWeight: '400',
+      minHeight: 62,
       paddingVertical: 12,
     },
     isBar: {

--- a/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
+++ b/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`Notification component tests Notification default 1`] = `
           "flex": 1,
           "flexDirection": "row",
           "justifyContent": "space-between",
-          "minHeight": 64,
+          "minHeight": 52,
           "padding": 16,
         }
       }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Updated Notification minHeight (52 for single line notifications, 62 for multi line notifications).

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPad Pro (12 9-inch) (5th generation) - 2022-08-12 at 14 55 54](https://user-images.githubusercontent.com/55368679/184450285-643befe0-1662-49a5-bddc-2c150dfd120a.png) | ![Simulator Screen Shot - iPad Pro (12 9-inch) (5th generation) - 2022-08-12 at 14 55 14](https://user-images.githubusercontent.com/55368679/184450248-6f9f8cf5-84cc-489d-b077-2f16d3ffa073.png) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
