### PR TITLE
Remove minHeight:62 from Notification

### DIFF
--- a/change/@fluentui-react-native-notification-38b825df-9389-442f-a901-2b6325a63241.json
+++ b/change/@fluentui-react-native-notification-38b825df-9389-442f-a901-2b6325a63241.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "remove minHeight: 62",
+  "packageName": "@fluentui-react-native/notification",
+  "email": "joannaquu@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Notification/src/NotificationTokens.ios.ts
+++ b/packages/components/Notification/src/NotificationTokens.ios.ts
@@ -116,7 +116,6 @@ export const defaultNotificationTokens: TokenSettings<NotificationTokens, Theme>
       fontLineHeight: 18,
       fontSize: 13,
       fontWeight: '400',
-      minHeight: 62,
       paddingVertical: 12,
     },
     isBar: {

--- a/packages/components/Notification/src/NotificationTokens.ts
+++ b/packages/components/Notification/src/NotificationTokens.ts
@@ -30,7 +30,6 @@ export const defaultNotificationTokens: TokenSettings<NotificationTokens, Theme>
       fontLineHeight: 18,
       fontSize: 13,
       fontWeight: '400',
-      minHeight: 62,
       paddingVertical: 12,
     },
     isBar: {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Removed incorrect addition minHeight:62 from Notification. The screenshots below look the same because the height of a toast notification with a title ends up being 62.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 13 Pro - 2022-08-15 at 09 40 04](https://user-images.githubusercontent.com/55368679/184677653-ff64555f-ec4e-4b53-9304-11c91557f0da.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-08-15 at 09 40 13](https://user-images.githubusercontent.com/55368679/184677683-8ec6ab4b-cf22-45e2-a007-4a4ae28a0bf5.png) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
