### PR TITLE
Shadow test page minor updates

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Shadow/ShadowDepthTestSection.tsx
+++ b/apps/fluent-tester/src/TestComponents/Shadow/ShadowDepthTestSection.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { commonTestStyles } from '../Common/styles';
-import { ColorValue, View } from 'react-native';
+import { View } from 'react-native';
 import { Text } from '@fluentui/react-native';
 import { Shadow, getShadowTokenStyleSet } from '@fluentui-react-native/experimental-shadow';
 import { ShadowToken, useTheme } from '@fluentui-react-native/theme-types';

--- a/apps/fluent-tester/src/TestComponents/Shadow/ShadowDepthTestSection.tsx
+++ b/apps/fluent-tester/src/TestComponents/Shadow/ShadowDepthTestSection.tsx
@@ -10,12 +10,12 @@ import { useFluentTheme } from '@fluentui-react-native/framework';
 const getThemedStyles = themedStyleSheet(() => {
   return {
     effectBox: {
-      width: 366,
+      maxWidth: 732,
       minHeight: 64,
+      borderRadius: 8,
     },
     padding: {
       padding: 20,
-      paddingHorizontal: 24,
     },
     vmargin: {
       marginVertical: 16,
@@ -27,12 +27,14 @@ const getThemedStyles = themedStyleSheet(() => {
 interface ShadowTestBoxProps {
   shadowDepthText: string;
   shadowToken: ShadowToken;
-  backgroundColor: ColorValue;
+  isBrand?: boolean;
 }
 
 const ShadowTestBox: React.FunctionComponent<ShadowTestBoxProps> = (props: ShadowTestBoxProps) => {
   const theme = useTheme();
   const themedStyles = getThemedStyles(theme);
+  const backgroundColor = props.isBrand ? theme.colors.brandedBackground : theme.colors.background;
+  const textColor = props.isBrand ? theme.colors.primaryButtonText : theme.colors.bodyText;
 
   return (
     <Shadow shadowToken={props.shadowToken}>
@@ -42,11 +44,13 @@ const ShadowTestBox: React.FunctionComponent<ShadowTestBoxProps> = (props: Shado
           themedStyles.effectBox,
           themedStyles.vmargin,
           themedStyles.padding,
-          { backgroundColor: props.backgroundColor },
+          { backgroundColor: backgroundColor },
         ]}
       >
-        <Text variant="bodySemibold">{props.shadowDepthText}</Text>
-        <Text>{getShadowDescription(props.shadowToken)}</Text>
+        <Text variant="bodySemibold" color={textColor}>
+          {props.shadowDepthText}
+        </Text>
+        <Text color={textColor}>{getShadowDescription(props.shadowToken)}</Text>
       </View>
     </Shadow>
   );
@@ -57,42 +61,18 @@ export const ShadowDepthTestSection: React.FunctionComponent = () => {
 
   return (
     <View>
-      <ShadowTestBox shadowDepthText="Shadow 2" shadowToken={theme.shadows.shadow2} backgroundColor={theme.colors.background} />
-      <ShadowTestBox shadowDepthText="Shadow 4" shadowToken={theme.shadows.shadow4} backgroundColor={theme.colors.background} />
-      <ShadowTestBox shadowDepthText="Shadow 8" shadowToken={theme.shadows.shadow8} backgroundColor={theme.colors.background} />
-      <ShadowTestBox shadowDepthText="Shadow 16" shadowToken={theme.shadows.shadow16} backgroundColor={theme.colors.background} />
-      <ShadowTestBox shadowDepthText="Shadow 28" shadowToken={theme.shadows.shadow28} backgroundColor={theme.colors.background} />
-      <ShadowTestBox shadowDepthText="Shadow 64" shadowToken={theme.shadows.shadow64} backgroundColor={theme.colors.background} />
-      <ShadowTestBox
-        shadowDepthText="Brand Shadow 2"
-        shadowToken={theme.shadows.shadow2brand}
-        backgroundColor={theme.colors.brandBackground}
-      />
-      <ShadowTestBox
-        shadowDepthText="Brand Shadow 4"
-        shadowToken={theme.shadows.shadow4brand}
-        backgroundColor={theme.colors.brandBackground}
-      />
-      <ShadowTestBox
-        shadowDepthText="Brand Shadow 8"
-        shadowToken={theme.shadows.shadow8brand}
-        backgroundColor={theme.colors.brandBackground}
-      />
-      <ShadowTestBox
-        shadowDepthText="Brand Shadow 16"
-        shadowToken={theme.shadows.shadow16brand}
-        backgroundColor={theme.colors.brandBackground}
-      />
-      <ShadowTestBox
-        shadowDepthText="Brand Shadow 28"
-        shadowToken={theme.shadows.shadow28brand}
-        backgroundColor={theme.colors.brandBackground}
-      />
-      <ShadowTestBox
-        shadowDepthText="Brand Shadow 64"
-        shadowToken={theme.shadows.shadow64brand}
-        backgroundColor={theme.colors.brandBackground}
-      />
+      <ShadowTestBox shadowDepthText="Shadow 2" shadowToken={theme.shadows.shadow2} />
+      <ShadowTestBox shadowDepthText="Shadow 4" shadowToken={theme.shadows.shadow4} />
+      <ShadowTestBox shadowDepthText="Shadow 8" shadowToken={theme.shadows.shadow8} />
+      <ShadowTestBox shadowDepthText="Shadow 16" shadowToken={theme.shadows.shadow16} />
+      <ShadowTestBox shadowDepthText="Shadow 28" shadowToken={theme.shadows.shadow28} />
+      <ShadowTestBox shadowDepthText="Shadow 64" shadowToken={theme.shadows.shadow64} />
+      <ShadowTestBox shadowDepthText="Brand Shadow 2" shadowToken={theme.shadows.shadow2brand} isBrand={true} />
+      <ShadowTestBox shadowDepthText="Brand Shadow 4" shadowToken={theme.shadows.shadow4brand} isBrand={true} />
+      <ShadowTestBox shadowDepthText="Brand Shadow 8" shadowToken={theme.shadows.shadow8brand} isBrand={true} />
+      <ShadowTestBox shadowDepthText="Brand Shadow 16" shadowToken={theme.shadows.shadow16brand} isBrand={true} />
+      <ShadowTestBox shadowDepthText="Brand Shadow 28" shadowToken={theme.shadows.shadow28brand} isBrand={true} />
+      <ShadowTestBox shadowDepthText="Brand Shadow 64" shadowToken={theme.shadows.shadow64brand} isBrand={true} />
     </View>
   );
 };

--- a/apps/fluent-tester/src/TestComponents/Shadow/ShadowTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Shadow/ShadowTest.tsx
@@ -23,7 +23,7 @@ export const ShadowTest: React.FunctionComponent = () => {
     uwpStatus: 'Experimental',
     iosStatus: 'Experimental',
     macosStatus: 'Experimental',
-    androidStatus: 'Experimental',
+    androidStatus: 'Backlog',
   };
 
   const description = 'A Shadow component using the Fluent Design System. Shadow components can be added to other components.';

--- a/change/@fluentui-react-native-tester-34aa4483-1967-4c30-9fbf-8d885d168edd.json
+++ b/change/@fluentui-react-native-tester-34aa4483-1967-4c30-9fbf-8d885d168edd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update platform status",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

- remove width property so that test boxes fit better in iOS 
- add maxWidth property so that the test boxes don't get too big on macOS screens
- add border radius to match the [Figma](https://www.figma.com/file/KB9oUjMKen2cKnyPG7RgdS/Design-tokens-superset?node-id=4553%3A38) a bit better (although this page was never supposed to match the Figma)
- some text and background fixes - iOS doesn't have brandBackground defined but both macOS and iOS have brandedBackground so I switched to that. Also made it so that the text on a brandedBackground shows up better (white text instead of black)

### Verification

(how the change was tested, including both manual and automated tests)

#### macOS before
https://user-images.githubusercontent.com/78454019/184695913-c35cc189-2dc9-4469-bbfb-9d5220af3477.mov

#### macOS after 
https://user-images.githubusercontent.com/78454019/184695935-e8006a19-f1f0-4336-843a-cb4867928fe7.mov

#### iOS before
https://user-images.githubusercontent.com/78454019/184695996-2277f1ca-fe15-4ed1-8b4b-2c103e9d8f60.mov 

#### iOS after 
https://user-images.githubusercontent.com/78454019/184696016-a29380bf-8444-4a12-99a4-e5c88036dd62.mov

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
