### PR TITLE
Shadow: don't render the extra view if there isn't a shadow

### DIFF
--- a/change/@fluentui-react-native-button-93c6f519-0133-401c-b40c-fa74135217f5.json
+++ b/change/@fluentui-react-native-button-93c6f519-0133-401c-b40c-fa74135217f5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Use undefined shadowToken in NotificationTokens",
+  "packageName": "@fluentui-react-native/button",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-shadow-92c7c038-5114-415e-95f9-4a91ad4ac8f3.json
+++ b/change/@fluentui-react-native-experimental-shadow-92c7c038-5114-415e-95f9-4a91ad4ac8f3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Use undefined shadowToken in NotificationTokens",
+  "packageName": "@fluentui-react-native/experimental-shadow",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-notification-2663b576-e517-4a55-8087-c8e3b1352a76.json
+++ b/change/@fluentui-react-native-notification-2663b576-e517-4a55-8087-c8e3b1352a76.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Use undefined shadowToken in NotificationTokens",
+  "packageName": "@fluentui-react-native/notification",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Button/src/FAB/FAB.test.tsx
+++ b/packages/components/Button/src/FAB/FAB.test.tsx
@@ -15,6 +15,12 @@ it('Default FAB (iOS)', () => {
   expect(tree).toMatchSnapshot();
 });
 
+it('Custom FAB with no shadow(iOS)', () => {
+  const CustomFABNoShadow = FAB.customize({ shadowToken: undefined });
+  const tree = renderer.create(<CustomFABNoShadow>Custom FAB with no shadow(iOS)</CustomFABNoShadow>).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
 it('Button simple rendering does not invalidate styling', () => {
   checkRenderConsistency(() => <FAB>Default FAB</FAB>, 2);
 });

--- a/packages/components/Button/src/FAB/__snapshots__/FAB.test.tsx.snap
+++ b/packages/components/Button/src/FAB/__snapshots__/FAB.test.tsx.snap
@@ -2,84 +2,64 @@
 
 exports[`Custom FAB with no shadow(iOS) 1`] = `
 <View
+  accessibilityLabel="Custom FAB with no shadow(iOS)"
+  accessibilityRole="button"
+  accessibilityState={
+    Object {
+      "disabled": false,
+    }
+  }
+  accessible={true}
+  disabled={false}
+  enableFocusRing={true}
+  focusable={true}
+  iconPosition="before"
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onPress={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
   style={
     Object {
-      "shadowColor": "000000",
-      "shadowOffset": Object {
-        "height": 0,
-        "width": 0,
-      },
-      "shadowOpacity": 0,
-      "shadowRadius": 0,
+      "alignItems": "center",
+      "alignSelf": "flex-start",
+      "backgroundColor": "#0078d4",
+      "borderColor": "#005a9e",
+      "borderRadius": 9999,
+      "display": "flex",
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "minHeight": 56,
+      "minWidth": 56,
+      "padding": 16,
+      "width": undefined,
     }
   }
 >
-  <View
-    accessibilityLabel="Custom FAB with no shadow(iOS)"
-    accessibilityRole="button"
-    accessibilityState={
-      Object {
-        "disabled": false,
-      }
-    }
-    accessible={true}
-    disabled={false}
-    enableFocusRing={true}
-    focusable={true}
-    iconPosition="before"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onPress={[Function]}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
+  <Text
+    ellipsizeMode="tail"
+    numberOfLines={0}
     style={
       Object {
-        "alignItems": "center",
-        "alignSelf": "flex-start",
-        "backgroundColor": "#0078d4",
-        "borderColor": "#005a9e",
-        "borderRadius": 9999,
-        "display": "flex",
-        "flexDirection": "row",
-        "justifyContent": "center",
-        "minHeight": 56,
-        "minWidth": 56,
-        "padding": 16,
-        "shadowColor": "000000",
-        "shadowOffset": Object {
-          "height": 0,
-          "width": 0,
-        },
-        "shadowOpacity": 0,
-        "shadowRadius": 0,
+        "color": "#ffffff",
+        "fontFamily": "Segoe UI",
+        "fontSize": 12,
+        "fontWeight": "400",
+        "margin": 0,
+        "marginBottom": 0,
+        "marginEnd": 0,
+        "marginStart": 0,
+        "marginTop": 0,
       }
     }
   >
-    <Text
-      ellipsizeMode="tail"
-      numberOfLines={0}
-      style={
-        Object {
-          "color": "#ffffff",
-          "fontFamily": "Segoe UI",
-          "fontSize": 12,
-          "fontWeight": "400",
-          "margin": 0,
-          "marginBottom": 0,
-          "marginEnd": 0,
-          "marginStart": 0,
-          "marginTop": 0,
-        }
-      }
-    >
-      Custom FAB with no shadow(iOS)
-    </Text>
-  </View>
+    Custom FAB with no shadow(iOS)
+  </Text>
 </View>
 `;
 

--- a/packages/components/Button/src/FAB/__snapshots__/FAB.test.tsx.snap
+++ b/packages/components/Button/src/FAB/__snapshots__/FAB.test.tsx.snap
@@ -1,5 +1,88 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Custom FAB with no shadow(iOS) 1`] = `
+<View
+  style={
+    Object {
+      "shadowColor": "000000",
+      "shadowOffset": Object {
+        "height": 0,
+        "width": 0,
+      },
+      "shadowOpacity": 0,
+      "shadowRadius": 0,
+    }
+  }
+>
+  <View
+    accessibilityLabel="Custom FAB with no shadow(iOS)"
+    accessibilityRole="button"
+    accessibilityState={
+      Object {
+        "disabled": false,
+      }
+    }
+    accessible={true}
+    disabled={false}
+    enableFocusRing={true}
+    focusable={true}
+    iconPosition="before"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onPress={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Object {
+        "alignItems": "center",
+        "alignSelf": "flex-start",
+        "backgroundColor": "#0078d4",
+        "borderColor": "#005a9e",
+        "borderRadius": 9999,
+        "display": "flex",
+        "flexDirection": "row",
+        "justifyContent": "center",
+        "minHeight": 56,
+        "minWidth": 56,
+        "padding": 16,
+        "shadowColor": "000000",
+        "shadowOffset": Object {
+          "height": 0,
+          "width": 0,
+        },
+        "shadowOpacity": 0,
+        "shadowRadius": 0,
+      }
+    }
+  >
+    <Text
+      ellipsizeMode="tail"
+      numberOfLines={0}
+      style={
+        Object {
+          "color": "#ffffff",
+          "fontFamily": "Segoe UI",
+          "fontSize": 12,
+          "fontWeight": "400",
+          "margin": 0,
+          "marginBottom": 0,
+          "marginEnd": 0,
+          "marginStart": 0,
+          "marginTop": 0,
+        }
+      }
+    >
+      Custom FAB with no shadow(iOS)
+    </Text>
+  </View>
+</View>
+`;
+
 exports[`Default FAB (iOS) 1`] = `
 <View
   style={

--- a/packages/components/Notification/src/NotificationTokens.ios.ts
+++ b/packages/components/Notification/src/NotificationTokens.ios.ts
@@ -3,11 +3,6 @@ import { TokenSettings } from '@fluentui-react-native/use-styling';
 import { NotificationTokens } from './Notification.types';
 import { DynamicColorIOS } from 'react-native';
 
-const emptyShadowStyle = {
-  ambient: { x: 0, y: 0, blur: 0, color: '#00000000' },
-  key: { x: 0, y: 0, blur: 0, color: '#00000000' },
-};
-
 const notificationShadowStyle = {
   ambient: { x: 0, y: 8, blur: 8, color: '#00000024' },
   key: { x: 0, y: 0, blur: 1, color: '#0000001f' },
@@ -121,7 +116,7 @@ export const defaultNotificationTokens: TokenSettings<NotificationTokens, Theme>
     isBar: {
       borderRadius: 0,
       fontWeight: '400',
-      shadowToken: emptyShadowStyle,
+      shadowToken: undefined,
     },
     primary: {
       backgroundColor: notificationColors.brandBackground4,

--- a/packages/components/Notification/src/NotificationTokens.ts
+++ b/packages/components/Notification/src/NotificationTokens.ts
@@ -2,11 +2,6 @@ import { Theme } from '@fluentui-react-native/framework';
 import { TokenSettings } from '@fluentui-react-native/use-styling';
 import { NotificationTokens } from './Notification.types';
 
-const emptyShadowStyle = {
-  ambient: { x: 0, y: 0, blur: 0, color: '#00000000' },
-  key: { x: 0, y: 0, blur: 0, color: '#00000000' },
-};
-
 const notificationShadowStyle = {
   ambient: { x: 0, y: 8, blur: 8, color: '#00000024' },
   key: { x: 0, y: 0, blur: 1, color: '#0000001f' },
@@ -35,7 +30,7 @@ export const defaultNotificationTokens: TokenSettings<NotificationTokens, Theme>
     isBar: {
       borderRadius: 0,
       fontWeight: '400',
-      shadowToken: emptyShadowStyle,
+      shadowToken: undefined,
     },
     primary: {
       backgroundColor: '#EBF3FC', // brandBackground4

--- a/packages/experimental/Shadow/src/Shadow.tsx
+++ b/packages/experimental/Shadow/src/Shadow.tsx
@@ -8,23 +8,23 @@ export const Shadow = stagedComponent((props: ShadowProps) => {
   return (final: ShadowProps, children: React.ReactNode) => {
     if (!props.shadowToken) {
       return <>{children}</>;
-    } else {
-      const shadowTokenStyleSet = getShadowTokenStyleSet(props.shadowToken);
-      const mergedProps = mergeProps(final, { style: shadowTokenStyleSet.ambient });
-
-      const childrenArray = React.Children.toArray(children) as React.ReactElement[];
-      const child = childrenArray[0];
-
-      if (__DEV__) {
-        if (childrenArray.length !== 1) {
-          console.warn('Shadow must only have one child');
-        }
-      }
-
-      const childWithKeyShadow = React.cloneElement(child, mergeProps(child.props, { style: shadowTokenStyleSet.key }));
-
-      return <View {...mergedProps}>{childWithKeyShadow}</View>;
     }
+
+    const shadowTokenStyleSet = getShadowTokenStyleSet(props.shadowToken);
+    const mergedProps = mergeProps(final, { style: shadowTokenStyleSet.ambient });
+
+    const childrenArray = React.Children.toArray(children) as React.ReactElement[];
+    const child = childrenArray[0];
+
+    if (__DEV__) {
+      if (childrenArray.length !== 1) {
+        console.warn('Shadow must only have one child');
+      }
+    }
+
+    const childWithKeyShadow = React.cloneElement(child, mergeProps(child.props, { style: shadowTokenStyleSet.key }));
+
+    return <View {...mergedProps}>{childWithKeyShadow}</View>;
   };
 });
 

--- a/packages/experimental/Shadow/src/Shadow.tsx
+++ b/packages/experimental/Shadow/src/Shadow.tsx
@@ -6,21 +6,25 @@ import { getShadowTokenStyleSet } from './shadowStyle';
 
 export const Shadow = stagedComponent((props: ShadowProps) => {
   return (final: ShadowProps, children: React.ReactNode) => {
-    const shadowTokenStyleSet = getShadowTokenStyleSet(props.shadowToken);
-    const mergedProps = mergeProps(final, { style: shadowTokenStyleSet.ambient });
+    if (!props.shadowToken) {
+      return <>{children}</>;
+    } else {
+      const shadowTokenStyleSet = getShadowTokenStyleSet(props.shadowToken);
+      const mergedProps = mergeProps(final, { style: shadowTokenStyleSet.ambient });
 
-    const childrenArray = React.Children.toArray(children) as React.ReactElement[];
-    const child = childrenArray[0];
+      const childrenArray = React.Children.toArray(children) as React.ReactElement[];
+      const child = childrenArray[0];
 
-    if (__DEV__) {
-      if (childrenArray.length !== 1) {
-        console.warn('Shadow must only have one child');
+      if (__DEV__) {
+        if (childrenArray.length !== 1) {
+          console.warn('Shadow must only have one child');
+        }
       }
+
+      const childWithKeyShadow = React.cloneElement(child, mergeProps(child.props, { style: shadowTokenStyleSet.key }));
+
+      return <View {...mergedProps}>{childWithKeyShadow}</View>;
     }
-
-    const childWithKeyShadow = React.cloneElement(child, mergeProps(child.props, { style: shadowTokenStyleSet.key }));
-
-    return <View {...mergedProps}>{childWithKeyShadow}</View>;
   };
 });
 

--- a/packages/experimental/Shadow/src/shadowStyle.ts
+++ b/packages/experimental/Shadow/src/shadowStyle.ts
@@ -5,13 +5,6 @@ import { ColorValue } from 'react-native';
 export const getShadowTokenStyleSet = memoize(getShadowTokenStyleSetWorker);
 
 function getShadowTokenStyleSetWorker(shadowToken: ShadowToken) {
-  if (!shadowToken) {
-    return {
-      key: emptyShadowStyle,
-      ambient: emptyShadowStyle,
-    };
-  }
-
   const keyShadow = shadowToken.key;
   const ambientShadow = shadowToken.ambient;
 
@@ -47,14 +40,4 @@ const shadowOpacityFromRGBAColor = (rgbaColor: ColorValue) => {
 
   // Round to two decimal places
   return Math.round(opacityAsDecimal * 100) / 100;
-};
-
-const emptyShadowStyle = {
-  shadowColor: '000000',
-  shadowOpacity: 0,
-  shadowRadius: 0,
-  shadowOffset: {
-    width: 0,
-    height: 0,
-  },
 };


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Follow up to a conversation in #1897 

Just return the child if there is no shadow (i.e. if ShadowToken is undefined) - don't add an extra view, or add unnecessary shadow props. Also updated Notification to pass in undefined as well.

Passing in undefined to not render is a Shadow isn't ideal, but not sure what a better solution would be. The other idea we had was to add a shadow0 token to the token pipeline, which would work too, it just seems a little strange because I don't think we'd ever actually use any of the values. Still though, if passing in undefined is confusing we could add support so that if either undefined or shadow0 are passed in, we just return the child.

### Verification

No visible changes, just verified with the snapshot tests. Added a test for a FAB that doesn't have a shadow, first commit contains snapshot of what this snapshot used to be before the change, second commit contains the change + what the snapshot looks like after the change - no longer has the extra view or the extra shadow props.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
