### PR TITLE
Switch's labelPosition set to 'after' and On/Off Text props are Exclusive 

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Switch/Switch.tsx
+++ b/apps/fluent-tester/src/TestComponents/Switch/Switch.tsx
@@ -77,7 +77,6 @@ const OnOffText: React.FunctionComponent = () => {
   return (
     <View style={commonTestStyles.settingsPicker}>
       <Switch defaultChecked={true} labelPosition={'before'} label={'Autosave'} onText={'On'} offText={'Off'} />
-      <Switch defaultChecked={true} labelPosition={'after'} label={'Autosave'} onText={'On'} offText={'Off'} />
       <Switch defaultChecked={true} labelPosition={'above'} label={'Autosave'} onText={'On'} offText={'Off'} />
     </View>
   );

--- a/change/@fluentui-react-native-switch-35658877-67f4-444a-b055-6d571f48d5e6.json
+++ b/change/@fluentui-react-native-switch-35658877-67f4-444a-b055-6d571f48d5e6.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": " Label position set to 'after' will prevent onText and offText from rendering",
+  "packageName": "@fluentui-react-native/switch",
+  "email": "nkhalil942@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-57c8117b-07fb-4fb5-b791-1b37539fc31e.json
+++ b/change/@fluentui-react-native-tester-57c8117b-07fb-4fb5-b791-1b37539fc31e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Updated Switch onText/offText example",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "nkhalil942@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Switch/SPEC.md
+++ b/packages/experimental/Switch/SPEC.md
@@ -88,7 +88,7 @@ export interface SwitchProps extends Omit<IWithPressableOptions<ViewProps>, 'onP
   onText?: string;
 
   /**
-   * Sets the position of the Switch's label. The position value 'after' is mutually exclusive with the onText and offText props.
+   * Sets the position of the Switch's label. The position value 'after' is mutually exclusive with the onText and offText props. This is due to variable width of the text props causing the Switch's position to change when it shouldn't.
    */
   labelPosition?: 'before' | 'above' | 'after';
 }

--- a/packages/experimental/Switch/SPEC.md
+++ b/packages/experimental/Switch/SPEC.md
@@ -88,7 +88,7 @@ export interface SwitchProps extends Omit<IWithPressableOptions<ViewProps>, 'onP
   onText?: string;
 
   /**
-   * Sets the position of the Switch's label
+   * Sets the position of the Switch's label. The position value 'after' is mutually exclusive with the onText and offText props.
    */
   labelPosition?: 'before' | 'above' | 'after';
 }

--- a/packages/experimental/Switch/SPEC.md
+++ b/packages/experimental/Switch/SPEC.md
@@ -88,7 +88,9 @@ export interface SwitchProps extends Omit<IWithPressableOptions<ViewProps>, 'onP
   onText?: string;
 
   /**
-   * Sets the position of the Switch's label. The position value 'after' is mutually exclusive with the onText and offText props. This is due to variable width of the text props causing the Switch's position to change when it shouldn't.
+   * Sets the position of the Switch's label. The position value 'after' is mutually
+   * exclusive with the onText and offText props. This is due to variable width
+   * of the text props causing the Switch's position to change when it shouldn't.
    */
   labelPosition?: 'before' | 'above' | 'after';
 }

--- a/packages/experimental/Switch/src/Switch.types.ts
+++ b/packages/experimental/Switch/src/Switch.types.ts
@@ -161,7 +161,9 @@ export interface SwitchProps extends Omit<IWithPressableOptions<ViewProps>, 'onP
   onText?: string;
 
   /**
-   * Sets the position of the Switch's label. The position value 'after' is mutually exclusive with the onText and offText props. This is due to variable width of the text props causing the Switch's position to change when it shouldn't.
+   * Sets the position of the Switch's label. The position value 'after' is mutually
+   * exclusive with the onText and offText props. This is due to variable width
+   * of the text props causing the Switch's position to change when it shouldn't.
    */
   labelPosition?: 'before' | 'above' | 'after';
 }

--- a/packages/experimental/Switch/src/Switch.types.ts
+++ b/packages/experimental/Switch/src/Switch.types.ts
@@ -161,7 +161,7 @@ export interface SwitchProps extends Omit<IWithPressableOptions<ViewProps>, 'onP
   onText?: string;
 
   /**
-   * Sets the position of the Switch's label
+   * Sets the position of the Switch's label. The position value 'after' is mutually exclusive with the onText and offText props.
    */
   labelPosition?: 'before' | 'above' | 'after';
 }

--- a/packages/experimental/Switch/src/Switch.types.ts
+++ b/packages/experimental/Switch/src/Switch.types.ts
@@ -161,7 +161,7 @@ export interface SwitchProps extends Omit<IWithPressableOptions<ViewProps>, 'onP
   onText?: string;
 
   /**
-   * Sets the position of the Switch's label. The position value 'after' is mutually exclusive with the onText and offText props.
+   * Sets the position of the Switch's label. The position value 'after' is mutually exclusive with the onText and offText props. This is due to variable width of the text props causing the Switch's position to change when it shouldn't.
    */
   labelPosition?: 'before' | 'above' | 'after';
 }

--- a/packages/experimental/Switch/src/useSwitch.ts
+++ b/packages/experimental/Switch/src/useSwitch.ts
@@ -34,7 +34,7 @@ export const useSwitch = (props: SwitchProps): SwitchInfo => {
     console.warn("The props 'defaultChecked' and 'checked' are mutually exclusive. Use only one of the props, do not use both.");
   }
 
-  if (labelPosition === 'after') {
+  if (labelPosition === 'after' || labelPosition === undefined) {
     if (__DEV__ && (!!props.onText || !!props.offText)) {
       console.warn(
         "The prop labelPosition's value of \"after\" and the props 'onText' or 'offText' are mutually exclusive. Try setting 'labelPosition' value to \"before\" or \"above\" instead.",

--- a/packages/experimental/Switch/src/useSwitch.ts
+++ b/packages/experimental/Switch/src/useSwitch.ts
@@ -31,7 +31,15 @@ export const useSwitch = (props: SwitchProps): SwitchInfo => {
   const focusRef = isDisabled ? null : componentRef;
 
   if (__DEV__ && defaultChecked !== undefined && checked !== undefined) {
-    console.warn('The props defaultChecked and checked are mutually exclusive. Use only one of the props, do not use both.');
+    console.warn("The props 'defaultChecked' and 'checked' are mutually exclusive. Use only one of the props, do not use both.");
+  }
+
+  if (__DEV__ && labelPosition === 'after' && (!!props.onText || !!props.offText)) {
+    props.onText = null;
+    props.offText = null;
+    console.warn(
+      "The prop labelPosition's value of \"after\" and the props 'onText' or 'offText' are mutually exclusive. Try setting 'labelPosition' value to \"before\" or \"above\" instead.",
+    );
   }
 
   const onClickWithFocus = useOnPressWithFocus(focusRef, toggleCallback);

--- a/packages/experimental/Switch/src/useSwitch.ts
+++ b/packages/experimental/Switch/src/useSwitch.ts
@@ -34,12 +34,14 @@ export const useSwitch = (props: SwitchProps): SwitchInfo => {
     console.warn("The props 'defaultChecked' and 'checked' are mutually exclusive. Use only one of the props, do not use both.");
   }
 
-  if (__DEV__ && labelPosition === 'after' && (!!props.onText || !!props.offText)) {
+  if (labelPosition === 'after') {
+    if (__DEV__ && (!!props.onText || !!props.offText)) {
+      console.warn(
+        "The prop labelPosition's value of \"after\" and the props 'onText' or 'offText' are mutually exclusive. Try setting 'labelPosition' value to \"before\" or \"above\" instead.",
+      );
+    }
     props.onText = null;
     props.offText = null;
-    console.warn(
-      "The prop labelPosition's value of \"after\" and the props 'onText' or 'offText' are mutually exclusive. Try setting 'labelPosition' value to \"before\" or \"above\" instead.",
-    );
   }
 
   const onClickWithFocus = useOnPressWithFocus(focusRef, toggleCallback);


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

If the labelPosition prop is set to 'after' the onText and offText will not render and the user will be given a warning. This change is needed to prevent the variable width of the onText and offText from changing the position of the Switch as the control is toggled.

Before this change, when the labelPosition was set to 'after', the Switch's On/Off Text would be placed _before_ the Switch. On/Off Text would then move the Switch around as the Switch's toggle state would change due to the variable length of the onText and offText props.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
