### PR TITLE
[Badge] Changed some global tokens to alias tokens

### DIFF
--- a/change/@fluentui-react-native-badge-b9a6151b-6f5b-4509-80c7-8aa70af0b838.json
+++ b/change/@fluentui-react-native-badge-b9a6151b-6f5b-4509-80c7-8aa70af0b838.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated some color to alias tokens",
+  "packageName": "@fluentui-react-native/badge",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Badge/src/BadgeColorTokens.ts
+++ b/packages/experimental/Badge/src/BadgeColorTokens.ts
@@ -15,18 +15,15 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
       borderColor: 'transparent',
     },
     outline: {
-      ...getOutlineColorProps({ color: t.colors.brandForeground1, colorDark: t.colors.brandForeground1 }, t),
+      ...getOutlineColorProps({ color: t.colors.brandForeground1 }, t),
       backgroundColor: t.colors.transparentBackground,
     },
     tint: {
       ...getTintColorProps(
         {
-          backgroundColor: globalTokens.color.brand.tint60,
-          color: t.colors.brandForeground1,
+          backgroundColor: t.colors.brandBackground2,
+          color: t.colors.brandForeground2,
           borderColor: t.colors.brandStroke2,
-          backgroundColorDark: globalTokens.color.outlook.shade40,
-          colorDark: globalTokens.color.brand.tint30,
-          borderColorDark: globalTokens.color.outlook.shade40,
         },
         t,
       ),
@@ -37,7 +34,6 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
       ...getGhostColorProps(
         {
           color: t.colors.brandForeground1,
-          colorDark: t.colors.brandForeground1,
         },
         t,
       ),
@@ -52,17 +48,14 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
         ),
       },
       outline: {
-        ...getOutlineColorProps({ color: t.colors.brandForeground1, colorDark: t.colors.brandForeground1 }, t),
+        ...getOutlineColorProps({ color: t.colors.brandForeground1 }, t),
       },
       tint: {
         ...getTintColorProps(
           {
-            backgroundColor: globalTokens.color.brand.tint60,
-            color: t.colors.brandForeground1,
+            backgroundColor: t.colors.brandBackground2,
+            color: t.colors.brandForeground2,
             borderColor: t.colors.brandStroke2,
-            backgroundColorDark: globalTokens.color.outlook.shade40,
-            colorDark: globalTokens.color.brand.tint30,
-            borderColorDark: globalTokens.color.outlook.shade40,
           },
           t,
         ),
@@ -71,7 +64,6 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
         ...getGhostColorProps(
           {
             color: t.colors.brandForeground1,
-            colorDark: t.colors.brandForeground1,
           },
           t,
         ),
@@ -152,7 +144,7 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
         ...getFilledColorProps(
           {
             backgroundColor: globalTokens.color.yellow.primary,
-            color: globalTokens.color.grey[14],
+            color: t.colors.neutralForeground1,
           },
           t,
         ),
@@ -224,13 +216,13 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
           {
             backgroundColor: globalTokens.color.grey[14],
             backgroundColorDark: globalTokens.color.white,
-            colorDark: globalTokens.color.grey[14],
+            colorDark: t.colors.neutralForeground1,
           },
           t,
         ),
       },
       outline: {
-        ...getOutlineColorProps({ color: globalTokens.color.grey[14], colorDark: globalTokens.color.white }, t),
+        ...getOutlineColorProps({ color: t.colors.neutralForeground1, colorDark: globalTokens.color.white }, t),
       },
       tint: {
         ...getTintColorProps(
@@ -248,8 +240,7 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
       ghost: {
         ...getGhostColorProps(
           {
-            color: globalTokens.color.grey[14],
-            colorDark: globalTokens.color.white,
+            color: t.colors.neutralForeground1,
           },
           t,
         ),
@@ -259,10 +250,8 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
       filled: {
         ...getFilledColorProps(
           {
-            backgroundColor: globalTokens.color.grey[92],
-            color: globalTokens.color.grey[38],
-            backgroundColorDark: t.colors.black,
-            colorDark: globalTokens.color.grey[68],
+            backgroundColor: t.colors.neutralBackground5,
+            color: t.colors.neutralForeground3,
             hcBackground: t.colors.neutralBackground3,
             hcColor: t.colors.brandForeground1,
             hcBorderColor: t.colors.brandForeground1,
@@ -271,20 +260,14 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
         ),
       },
       outline: {
-        ...getOutlineColorProps(
-          { color: globalTokens.color.grey[92], colorDark: globalTokens.color.grey[68], borderColorDark: globalTokens.color.grey[32] },
-          t,
-        ),
+        ...getOutlineColorProps({ color: t.colors.neutralForeground3, borderColorDark: t.colors.neutralStroke2 }, t),
       },
       tint: {
         ...getTintColorProps(
           {
-            backgroundColor: globalTokens.color.grey[94],
-            color: globalTokens.color.grey[38],
-            borderColor: globalTokens.color.grey[92],
-            backgroundColorDark: globalTokens.color.grey[8],
-            colorDark: globalTokens.color.grey[68],
-            borderColorDark: globalTokens.color.grey[32],
+            backgroundColor: t.colors.neutralBackground4,
+            color: t.colors.neutralForeground3,
+            borderColor: t.colors.neutralStroke2,
           },
           t,
         ),
@@ -292,8 +275,7 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
       ghost: {
         ...getGhostColorProps(
           {
-            color: globalTokens.color.grey[92],
-            colorDark: globalTokens.color.grey[68],
+            color: t.colors.neutralForeground3,
           },
           t,
         ),
@@ -303,10 +285,8 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
       filled: {
         ...getFilledColorProps(
           {
-            backgroundColor: t.colors.white,
-            color: globalTokens.color.grey[14],
-            backgroundColorDark: globalTokens.color.grey[16],
-            colorDark: t.colors.neutralForegroundOnBrand,
+            backgroundColor: t.colors.neutralBackground1,
+            color: t.colors.neutralForeground1,
             hcBackground: t.colors.neutralBackground3,
             hcColor: t.colors.brandForeground1,
             hcBorderColor: t.colors.brandForeground1,
@@ -315,17 +295,14 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
         ),
       },
       outline: {
-        ...getOutlineColorProps({ color: globalTokens.color.white, colorDark: globalTokens.color.white }, t),
+        ...getOutlineColorProps({ color: t.colors.neutralForegroundOnBrand }, t),
       },
       tint: {
         ...getTintColorProps(
           {
-            backgroundColor: globalTokens.color.white,
-            color: globalTokens.color.grey[38],
-            borderColor: globalTokens.color.grey[88],
-            backgroundColorDark: globalTokens.color.grey[29],
-            colorDark: globalTokens.color.grey[68],
-            borderColorDark: globalTokens.color.grey[32],
+            backgroundColor: t.colors.neutralBackground1,
+            color: t.colors.neutralForeground3,
+            borderColor: t.colors.neutralStroke2,
           },
           t,
         ),
@@ -333,8 +310,7 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
       ghost: {
         ...getGhostColorProps(
           {
-            color: globalTokens.color.white,
-            colorDark: globalTokens.color.white,
+            color: t.colors.neutralForegroundOnBrand,
           },
           t,
         ),

--- a/packages/experimental/Badge/src/BadgeColorTokens.ts
+++ b/packages/experimental/Badge/src/BadgeColorTokens.ts
@@ -121,7 +121,7 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
         ...getFilledColorProps(
           {
             backgroundColor: globalTokens.color.yellow.primary,
-            color: globalTokens.color.grey[14],
+            color: globalTokens.color.grey[14], // It should be neutralForegroundStatic1. It's hardcoded because the token doesn't exist right now
           },
           t,
         ),

--- a/packages/experimental/Badge/src/BadgeColorTokens.ts
+++ b/packages/experimental/Badge/src/BadgeColorTokens.ts
@@ -6,37 +6,14 @@ import { getFilledColorProps, getOutlineColorProps, getTintColorProps, getGhostC
 export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
   ({
     filled: {
-      ...getFilledColorProps(
-        {
-          backgroundColor: t.colors.brandBackgroundStatic,
-        },
-        t,
-      ),
       borderColor: 'transparent',
     },
     outline: {
-      ...getOutlineColorProps({ color: t.colors.brandForeground1 }, t),
       backgroundColor: t.colors.transparentBackground,
-    },
-    tint: {
-      ...getTintColorProps(
-        {
-          backgroundColor: t.colors.brandBackground2,
-          color: t.colors.brandForeground2,
-          borderColor: t.colors.brandStroke2,
-        },
-        t,
-      ),
     },
     ghost: {
       backgroundColor: t.colors.transparentBackground,
       borderColor: t.colors.transparentStroke,
-      ...getGhostColorProps(
-        {
-          color: t.colors.brandForeground1,
-        },
-        t,
-      ),
     },
     brand: {
       filled: {
@@ -144,7 +121,7 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
         ...getFilledColorProps(
           {
             backgroundColor: globalTokens.color.yellow.primary,
-            color: t.colors.neutralForeground1,
+            color: globalTokens.color.grey[14],
           },
           t,
         ),
@@ -214,22 +191,21 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
       filled: {
         ...getFilledColorProps(
           {
-            backgroundColor: globalTokens.color.grey[14],
-            backgroundColorDark: globalTokens.color.white,
-            colorDark: t.colors.neutralForeground1,
+            backgroundColor: t.colors.neutralForeground1,
+            color: t.colors.neutralBackground1,
           },
           t,
         ),
       },
       outline: {
-        ...getOutlineColorProps({ color: t.colors.neutralForeground1, colorDark: globalTokens.color.white }, t),
+        ...getOutlineColorProps({ color: t.colors.neutralForeground3, borderColor: t.colors.neutralStrokeAccessible }, t),
       },
       tint: {
         ...getTintColorProps(
           {
-            backgroundColor: globalTokens.color.grey[38],
-            color: t.colors.neutralForegroundOnBrand,
-            borderColor: t.colors.transparentBackground,
+            backgroundColor: t.colors.neutralBackground3,
+            color: t.colors.neutralForeground3,
+            borderColor: t.colors.neutralStrokeAccessible,
             backgroundColorDark: globalTokens.color.grey[68],
             colorDark: globalTokens.color.grey[16],
             borderColorDark: globalTokens.color.grey[68],
@@ -254,13 +230,12 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
             color: t.colors.neutralForeground3,
             hcBackground: t.colors.neutralBackground3,
             hcColor: t.colors.brandForeground1,
-            hcBorderColor: t.colors.brandForeground1,
           },
           t,
         ),
       },
       outline: {
-        ...getOutlineColorProps({ color: t.colors.neutralForeground3, borderColorDark: t.colors.neutralStroke2 }, t),
+        ...getOutlineColorProps({ color: t.colors.neutralForeground3, borderColor: t.colors.neutralStroke2 }, t),
       },
       tint: {
         ...getTintColorProps(
@@ -289,7 +264,6 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
             color: t.colors.neutralForeground1,
             hcBackground: t.colors.neutralBackground3,
             hcColor: t.colors.brandForeground1,
-            hcBorderColor: t.colors.brandForeground1,
           },
           t,
         ),

--- a/packages/experimental/Badge/src/BadgeColorTokens.ts
+++ b/packages/experimental/Badge/src/BadgeColorTokens.ts
@@ -203,8 +203,8 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
       tint: {
         ...getTintColorProps(
           {
-            backgroundColor: t.colors.neutralBackground3,
-            color: t.colors.neutralForeground3,
+            backgroundColor: t.colors.neutralForeground3,
+            color: t.colors.neutralBackground1,
             borderColor: t.colors.neutralStrokeAccessible,
             backgroundColorDark: globalTokens.color.grey[68],
             colorDark: globalTokens.color.grey[16],

--- a/packages/experimental/Badge/src/BadgeColorTokens.win32.ts
+++ b/packages/experimental/Badge/src/BadgeColorTokens.win32.ts
@@ -16,18 +16,15 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
       borderColor: 'transparent',
     },
     outline: {
-      ...getOutlineColorProps({ color: t.colors.brandForeground1, colorDark: t.colors.brandForeground1 }, t, getWin32Props),
+      ...getOutlineColorProps({ color: t.colors.brandForeground1 }, t, getWin32Props),
       backgroundColor: t.colors.transparentBackground,
     },
     tint: {
       ...getTintColorProps(
         {
           backgroundColor: t.colors.brandBackground2,
-          color: t.colors.brandForeground1,
+          color: t.colors.brandForeground2,
           borderColor: t.colors.brandStroke2,
-          backgroundColorDark: globalTokens.color.outlook.shade40,
-          colorDark: globalTokens.color.brand.tint30,
-          borderColorDark: globalTokens.color.outlook.shade40,
         },
         t,
         getWin32Props,
@@ -39,7 +36,6 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
       ...getGhostColorProps(
         {
           color: t.colors.brandForeground1,
-          colorDark: t.colors.brandForeground1,
         },
         t,
         getWin32Props,
@@ -56,17 +52,14 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
         ),
       },
       outline: {
-        ...getOutlineColorProps({ color: t.colors.brandForeground1, colorDark: t.colors.brandForeground1 }, t, getWin32Props),
+        ...getOutlineColorProps({ color: t.colors.brandForeground1 }, t, getWin32Props),
       },
       tint: {
         ...getTintColorProps(
           {
             backgroundColor: t.colors.brandBackground2,
-            color: t.colors.brandForeground1,
+            color: t.colors.brandForeground2,
             borderColor: t.colors.brandStroke2,
-            backgroundColorDark: globalTokens.color.outlook.shade40,
-            colorDark: globalTokens.color.brand.tint30,
-            borderColorDark: globalTokens.color.outlook.shade40,
           },
           t,
           getWin32Props,
@@ -76,7 +69,6 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
         ...getGhostColorProps(
           {
             color: t.colors.brandForeground1,
-            colorDark: t.colors.brandForeground1,
           },
           t,
           getWin32Props,
@@ -277,7 +269,6 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
         ...getGhostColorProps(
           {
             color: t.colors.neutralForeground1,
-            colorDark: globalTokens.color.white,
           },
           t,
           getWin32Props,
@@ -288,10 +279,8 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
       filled: {
         ...getFilledColorProps(
           {
-            backgroundColor: t.colors.neutralBackground1Selected,
+            backgroundColor: t.colors.neutralBackground5,
             color: t.colors.neutralForeground3,
-            backgroundColorDark: t.colors.black,
-            colorDark: globalTokens.color.grey[68],
             hcBackground: t.colors.neutralBackground3,
             hcColor: t.colors.brandForeground1,
             hcBorderColor: t.colors.brandForeground1,
@@ -301,21 +290,14 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
         ),
       },
       outline: {
-        ...getOutlineColorProps(
-          { color: globalTokens.color.grey[92], colorDark: globalTokens.color.grey[68], borderColorDark: globalTokens.color.grey[32] },
-          t,
-          getWin32Props,
-        ),
+        ...getOutlineColorProps({ color: t.colors.neutralForeground3, borderColorDark: t.colors.neutralStroke2 }, t, getWin32Props),
       },
       tint: {
         ...getTintColorProps(
           {
-            backgroundColor: t.colors.neutralBackground1Selected,
+            backgroundColor: t.colors.neutralBackground4,
             color: t.colors.neutralForeground3,
-            borderColor: globalTokens.color.grey[92],
-            backgroundColorDark: globalTokens.color.grey[8],
-            colorDark: globalTokens.color.grey[68],
-            borderColorDark: globalTokens.color.grey[32],
+            borderColor: t.colors.neutralStroke2,
           },
           t,
           getWin32Props,
@@ -324,8 +306,7 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
       ghost: {
         ...getGhostColorProps(
           {
-            color: globalTokens.color.grey[92],
-            colorDark: globalTokens.color.grey[68],
+            color: t.colors.neutralForeground3,
           },
           t,
           getWin32Props,
@@ -336,10 +317,8 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
       filled: {
         ...getFilledColorProps(
           {
-            backgroundColor: t.colors.white,
+            backgroundColor: t.colors.neutralBackground1,
             color: t.colors.neutralForeground1,
-            backgroundColorDark: globalTokens.color.grey[16],
-            colorDark: t.colors.neutralForegroundOnBrand,
             hcBackground: t.colors.neutralBackground3,
             hcColor: t.colors.brandForeground1,
             hcBorderColor: t.colors.brandForeground1,
@@ -349,17 +328,14 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
         ),
       },
       outline: {
-        ...getOutlineColorProps({ color: globalTokens.color.white, colorDark: globalTokens.color.white }, t, getWin32Props),
+        ...getOutlineColorProps({ color: t.colors.neutralForegroundOnBrand }, t, getWin32Props),
       },
       tint: {
         ...getTintColorProps(
           {
-            backgroundColor: globalTokens.color.white,
+            backgroundColor: t.colors.neutralBackground1,
             color: t.colors.neutralForeground3,
-            borderColor: globalTokens.color.grey[88],
-            backgroundColorDark: globalTokens.color.grey[29],
-            colorDark: globalTokens.color.grey[68],
-            borderColorDark: globalTokens.color.grey[32],
+            borderColor: t.colors.neutralStroke2,
           },
           t,
           getWin32Props,
@@ -368,8 +344,7 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
       ghost: {
         ...getGhostColorProps(
           {
-            color: globalTokens.color.white,
-            colorDark: globalTokens.color.white,
+            color: t.colors.neutralForegroundOnBrand,
           },
           t,
           getWin32Props,

--- a/packages/experimental/Badge/src/BadgeColorTokens.win32.ts
+++ b/packages/experimental/Badge/src/BadgeColorTokens.win32.ts
@@ -227,8 +227,8 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
       tint: {
         ...getTintColorProps(
           {
-            backgroundColor: t.colors.neutralBackground3,
-            color: t.colors.neutralForeground3,
+            backgroundColor: t.colors.neutralForeground3,
+            color: t.colors.neutralBackground1,
             borderColor: t.colors.neutralStrokeAccessible,
             backgroundColorDark: globalTokens.color.grey[68],
             colorDark: globalTokens.color.grey[16],

--- a/packages/experimental/Badge/src/BadgeColorTokens.win32.ts
+++ b/packages/experimental/Badge/src/BadgeColorTokens.win32.ts
@@ -6,40 +6,14 @@ import { getFilledColorProps, getOutlineColorProps, getTintColorProps, getGhostC
 export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
   ({
     filled: {
-      ...getFilledColorProps(
-        {
-          backgroundColor: t.colors.brandBackgroundStatic,
-        },
-        t,
-        getWin32Props,
-      ),
       borderColor: 'transparent',
     },
     outline: {
-      ...getOutlineColorProps({ color: t.colors.brandForeground1 }, t, getWin32Props),
       backgroundColor: t.colors.transparentBackground,
-    },
-    tint: {
-      ...getTintColorProps(
-        {
-          backgroundColor: t.colors.brandBackground2,
-          color: t.colors.brandForeground2,
-          borderColor: t.colors.brandStroke2,
-        },
-        t,
-        getWin32Props,
-      ),
     },
     ghost: {
       backgroundColor: t.colors.transparentBackground,
       borderColor: t.colors.transparentStroke,
-      ...getGhostColorProps(
-        {
-          color: t.colors.brandForeground1,
-        },
-        t,
-        getWin32Props,
-      ),
     },
     brand: {
       filled: {
@@ -160,7 +134,7 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
         ...getFilledColorProps(
           {
             backgroundColor: globalTokens.color.yellow.primary,
-            color: t.colors.neutralForeground1,
+            color: globalTokens.color.grey[14],
           },
           t,
           getWin32Props,
@@ -240,23 +214,22 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
       filled: {
         ...getFilledColorProps(
           {
-            backgroundColor: globalTokens.color.grey[14],
-            backgroundColorDark: globalTokens.color.white,
-            colorDark: t.colors.neutralForeground1,
+            backgroundColor: t.colors.neutralForeground1,
+            color: t.colors.neutralBackground1,
           },
           t,
           getWin32Props,
         ),
       },
       outline: {
-        ...getOutlineColorProps({ color: t.colors.neutralForeground1, colorDark: globalTokens.color.white }, t, getWin32Props),
+        ...getOutlineColorProps({ color: t.colors.neutralForeground3, borderColor: t.colors.neutralStrokeAccessible }, t, getWin32Props),
       },
       tint: {
         ...getTintColorProps(
           {
-            backgroundColor: globalTokens.color.grey[38],
-            color: t.colors.neutralForegroundOnBrand,
-            borderColor: t.colors.transparentBackground,
+            backgroundColor: t.colors.neutralBackground3,
+            color: t.colors.neutralForeground3,
+            borderColor: t.colors.neutralStrokeAccessible,
             backgroundColorDark: globalTokens.color.grey[68],
             colorDark: globalTokens.color.grey[16],
             borderColorDark: globalTokens.color.grey[68],
@@ -283,14 +256,13 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
             color: t.colors.neutralForeground3,
             hcBackground: t.colors.neutralBackground3,
             hcColor: t.colors.brandForeground1,
-            hcBorderColor: t.colors.brandForeground1,
           },
           t,
           getWin32Props,
         ),
       },
       outline: {
-        ...getOutlineColorProps({ color: t.colors.neutralForeground3, borderColorDark: t.colors.neutralStroke2 }, t, getWin32Props),
+        ...getOutlineColorProps({ color: t.colors.neutralForeground3, borderColor: t.colors.neutralStroke2 }, t, getWin32Props),
       },
       tint: {
         ...getTintColorProps(
@@ -321,7 +293,6 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
             color: t.colors.neutralForeground1,
             hcBackground: t.colors.neutralBackground3,
             hcColor: t.colors.brandForeground1,
-            hcBorderColor: t.colors.brandForeground1,
           },
           t,
           getWin32Props,

--- a/packages/experimental/Badge/src/BadgeColorTokens.win32.ts
+++ b/packages/experimental/Badge/src/BadgeColorTokens.win32.ts
@@ -134,7 +134,7 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
         ...getFilledColorProps(
           {
             backgroundColor: globalTokens.color.yellow.primary,
-            color: globalTokens.color.grey[14],
+            color: globalTokens.color.grey[14], // It should be neutralForegroundStatic1. It's hardcoded because the token doesn't exist right now
           },
           t,
           getWin32Props,

--- a/packages/experimental/Badge/src/colorHelper.ts
+++ b/packages/experimental/Badge/src/colorHelper.ts
@@ -47,7 +47,6 @@ export function getFilledColorProps(
   const colorDark = restColors.colorDark || color;
   const hcBackground = restColors.hcBackground || theme.colors.neutralBackgroundInverted;
   const hcColor = restColors.hcColor || theme.colors.neutralForegroundInverted;
-  const hcBorderColor = restColors.hcBorderColor || theme.colors.transparentStroke;
   const getThemeProps = getProps || getDefaultProps;
 
   return getThemeProps(theme, {
@@ -65,7 +64,7 @@ export function getFilledColorProps(
       backgroundColor: hcBackground,
       color: hcColor,
       iconColor: hcColor,
-      borderColor: hcBorderColor,
+      borderColor: theme.colors.transparentStroke,
     },
   });
 }
@@ -82,14 +81,15 @@ export function getOutlineColorProps(
   getProps?: (theme: Theme, themeProps: ThemeProps) => Record<string, unknown>,
 ) {
   const { color } = colors;
+  const borderColor = colors.borderColor || color;
   const colorDark = colors.colorDark || color;
-  const borderColorDark = colors.borderColorDark || colorDark;
+  const borderColorDark = colors.borderColorDark || borderColor || colorDark;
   const getThemeProps = getProps || getDefaultProps;
   return getThemeProps(theme, {
     light: {
       color: color,
       iconColor: color,
-      borderColor: color,
+      borderColor: borderColor,
     },
     dark: {
       color: colorDark,

--- a/packages/experimental/Badge/src/colorHelper.ts
+++ b/packages/experimental/Badge/src/colorHelper.ts
@@ -81,7 +81,8 @@ export function getOutlineColorProps(
   theme: Theme,
   getProps?: (theme: Theme, themeProps: ThemeProps) => Record<string, unknown>,
 ) {
-  const { color, colorDark } = colors;
+  const { color } = colors;
+  const colorDark = colors.colorDark || color;
   const borderColorDark = colors.borderColorDark || colorDark;
   const getThemeProps = getProps || getDefaultProps;
   return getThemeProps(theme, {
@@ -114,7 +115,10 @@ export function getTintColorProps(
   theme: Theme,
   getProps?: (theme: Theme, themeProps: ThemeProps) => Record<string, unknown>,
 ) {
-  const { backgroundColor, color, borderColor, backgroundColorDark, colorDark, borderColorDark } = colors;
+  const { backgroundColor, color, borderColor } = colors;
+  const backgroundColorDark = colors.backgroundColorDark || backgroundColor;
+  const colorDark = colors.colorDark || color;
+  const borderColorDark = colors.borderColorDark || borderColor;
   const getThemeProps = getProps || getDefaultProps;
   return getThemeProps(theme, {
     light: {
@@ -149,7 +153,8 @@ export function getGhostColorProps(
   theme: Theme,
   getProps?: (theme: Theme, themeProps: ThemeProps) => Record<string, unknown>,
 ) {
-  const { color, colorDark } = colors;
+  const { color } = colors;
+  const colorDark = colors.colorDark || color;
   const getThemeProps = getProps || getDefaultProps;
   return getThemeProps(theme, {
     light: {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
Changed some global tokens to alias tokens.
Colorful and Important color changes will be in the following PR

**Notes:**
1. Didn't change the colorful tokens. There were only red in shared colors and the color was too different from the design:
![image](https://user-images.githubusercontent.com/11574680/185188898-283ef4d2-4240-4406-b157-8eae35bc7994.png)

2. I didn't update grey tokens for 'important' color. I asked a designer about correct tokens. Waiting for the answer

### Verification
![image](https://user-images.githubusercontent.com/11574680/185189155-80b12085-1ad1-4a89-979d-e4e5de7d5443.png)
![image](https://user-images.githubusercontent.com/11574680/185189175-a2e7239c-25f3-4d27-ac14-3d70a882acbc.png)
![image](https://user-images.githubusercontent.com/11574680/185189189-aac55900-de80-4f25-852e-82117d68137c.png)
![image](https://user-images.githubusercontent.com/11574680/185189205-3b739341-c364-48ef-8ea9-bb22688e6c5d.png)


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
