### PR TITLE
Picker color

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Common/MenuPicker.desktop.tsx
+++ b/apps/fluent-tester/src/TestComponents/Common/MenuPicker.desktop.tsx
@@ -20,19 +20,13 @@ export const MenuPicker: React.FunctionComponent<MenuPickerProps> = (props: Menu
     }
   });
 
-  const MenuText = Text.customize({
-    tokens: {
-      color: 'neutralForeground2',
-    },
-  });
-
   return (
     <View style={menuPickerStyles.container}>
       <Text style={menuPickerStyles.prompt}>{prompt}</Text>
       <Menu>
         <MenuTrigger>
           <Button>
-            <MenuText>{label}</MenuText>
+            <Text>{label}</Text>
             <View style={menuPickerStyles.chevronContainer}>
               <SvgXml xml={chevronXml} />
             </View>

--- a/apps/fluent-tester/src/TestComponents/Common/MenuPicker.desktop.tsx
+++ b/apps/fluent-tester/src/TestComponents/Common/MenuPicker.desktop.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { Text, View, StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import { Menu, MenuItem, MenuTrigger, MenuPopover, MenuList } from '@fluentui-react-native/menu';
 import { MenuPickerProps, collectionItem } from './MenuPicker';
-import { ButtonV1 as Button } from '@fluentui/react-native';
+import { ButtonV1 as Button, Text } from '@fluentui/react-native';
 import { SvgXml } from 'react-native-svg';
 
 const chevronXml = `
@@ -20,13 +20,19 @@ export const MenuPicker: React.FunctionComponent<MenuPickerProps> = (props: Menu
     }
   });
 
+  const MenuText = Text.customize({
+    tokens: {
+      color: 'neutralForeground2',
+    },
+  });
+
   return (
     <View style={menuPickerStyles.container}>
       <Text style={menuPickerStyles.prompt}>{prompt}</Text>
       <Menu>
         <MenuTrigger>
           <Button>
-            <Text>{label}</Text>
+            <MenuText>{label}</MenuText>
             <View style={menuPickerStyles.chevronContainer}>
               <SvgXml xml={chevronXml} />
             </View>

--- a/change/@fluentui-react-native-tester-4063e84c-3aae-49bf-9387-ef8453b498fe.json
+++ b/change/@fluentui-react-native-tester-4063e84c-3aae-49bf-9387-ef8453b498fe.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Menu Picker for desktop is now using a FURN text  element",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "nkhalil942@gmail.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Increased visibility of Picker in dark mode by using the Fluent UI Text instead of the React Native Text.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/20259210/185261770-501f8aac-7ece-4b89-8652-20c2ff70259a.png) | ![image](https://user-images.githubusercontent.com/20259210/185263812-1148d0f6-7349-4242-859c-6422e0960b2f.png) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
