### PR TITLE
[No Merge] Test path for the Badge component

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Badge/BasicBadgeTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Badge/BasicBadgeTest.tsx
@@ -63,7 +63,6 @@ export const BasicBadge: React.FunctionComponent = () => {
   const badgeConfig = {
     appearance: badgeAppearance,
     badgeColor,
-    position: 'absolute',
     size,
     shape,
   };
@@ -87,11 +86,13 @@ export const BasicBadge: React.FunctionComponent = () => {
       <View style={{ position: 'relative', backgroundColor: 'yellow', padding: 20, width: 200 }}>
         <Text>Parent component for the Badge</Text>
         {svgIconsEnabled && showIcon ? (
-          <Badge {...badgeConfig} icon={{ svgSource: svgProps }} iconPosition={iconPosition}>
+          <Badge {...badgeConfig} position="absolute" icon={{ svgSource: svgProps }} iconPosition={iconPosition}>
             {badgeContent}
           </Badge>
         ) : (
-          <Badge {...badgeConfig}>{badgeContent}</Badge>
+          <Badge position="absolute" {...badgeConfig}>
+            {badgeContent}
+          </Badge>
         )}
       </View>
 

--- a/apps/fluent-tester/src/TestComponents/Badge/BasicBadgeTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Badge/BasicBadgeTest.tsx
@@ -31,7 +31,6 @@ const StyledBadge = Badge.customize({
   borderWidth: 4,
   color: '#f07',
   fontWeight: 'bold',
-  position: 'relative',
 });
 
 export const BasicBadge: React.FunctionComponent = () => {
@@ -64,6 +63,7 @@ export const BasicBadge: React.FunctionComponent = () => {
   const badgeConfig = {
     appearance: badgeAppearance,
     badgeColor,
+    position: 'absolute',
     size,
     shape,
   };
@@ -96,32 +96,22 @@ export const BasicBadge: React.FunctionComponent = () => {
       </View>
 
       <Text>Size</Text>
-      <Badge position="relative" size="tiny" shape="circular" />
-      <Badge position="relative" size="extraSmall" shape="circular" badgeColor="red" />
-      <Badge position="relative" size="small">
-        Small
-      </Badge>
-      <Badge position="relative" size="medium">
-        Medium
-      </Badge>
-      <Badge position="relative" size="large">
-        Large
-      </Badge>
-      <Badge position="relative" size="extraLarge">
-        Extra Large
-      </Badge>
+      <Badge size="tiny" shape="circular" />
+      <Badge size="extraSmall" shape="circular" badgeColor="red" />
+      <Badge size="small">Small</Badge>
+      <Badge size="medium">Medium</Badge>
+      <Badge size="large">Large</Badge>
+      <Badge size="extraLarge">Extra Large</Badge>
       {svgIconsEnabled && (
         <>
           <Text>Badge with icon</Text>
-          <Badge position="relative" icon={{ svgSource: svgProps }} iconPosition="after">
+          <Badge icon={{ svgSource: svgProps }} iconPosition="after">
             Badge with
             <Image source={{ uri: satyaPhotoUrl }} style={{ width: 20, height: 20 }} />
             <Text style={{ backgroundColor: 'yellow' }}>optional content</Text>
           </Badge>
-          <Badge position="relative" appearance="outline" icon={iconProps} />
-          <Badge position="relative" icon={{ fontSource: { ...fontBuiltInProps }, color: '#fff' }}>
-            Badge with icon
-          </Badge>
+          <Badge appearance="outline" icon={iconProps} />
+          <Badge icon={{ fontSource: { ...fontBuiltInProps }, color: '#fff' }}>Badge with icon</Badge>
         </>
       )}
       <StyledBadge appearance="outline">Styled badge</StyledBadge>

--- a/apps/fluent-tester/src/theme/applyTheme.ts
+++ b/apps/fluent-tester/src/theme/applyTheme.ts
@@ -55,7 +55,7 @@ const themingModule = getThemingModule()[0];
 export function applyTheme(parent: Theme, name: ThemeNames, appearance: ThemeOptions['appearance']): PartialTheme {
   switch (name) {
     case 'Office':
-      return themingModule ? createOfficeTheme({ appearance, paletteName: 'WhiteColors' }).theme : {};
+      return themingModule ? createOfficeTheme({ appearance, paletteName: 'LowerRibbon_FluentSV' }).theme : {};
     case 'Caterpillar':
       return applyCaterpillarTheme(parent);
     default:

--- a/change/@fluentui-react-native-badge-06471718-8251-4070-a12c-bf98643d18d3.json
+++ b/change/@fluentui-react-native-badge-06471718-8251-4070-a12c-bf98643d18d3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[Badge] Set relative position as the default one",
+  "packageName": "@fluentui-react-native/badge",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-badge-7c930f94-ec71-4e88-a499-32d38bb587c3.json
+++ b/change/@fluentui-react-native-badge-7c930f94-ec71-4e88-a499-32d38bb587c3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added Badge for RTL",
+  "packageName": "@fluentui-react-native/badge",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-56d2b25e-0ca2-44a3-80fe-6aa05b722f8f.json
+++ b/change/@fluentui-react-native-tester-56d2b25e-0ca2-44a3-80fe-6aa05b722f8f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[Badge] Set relative position as the default one",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Badge/src/Badge.styling.ts
+++ b/packages/experimental/Badge/src/Badge.styling.ts
@@ -18,7 +18,7 @@ import { defaultBadgeColorTokens } from './BadgeColorTokens';
 import { badgeFontTokens } from './BadgeFontTokens';
 
 export const coreBadgeStates: (keyof BadgeCoreTokens)[] = [...BadgeSizes, ...BadgeShapes];
-export const badgeStates: (keyof BadgeTokens)[] = [...coreBadgeStates, ...BadgeColors, ...BadgeAppearances];
+export const badgeStates: (keyof BadgeTokens)[] = [...coreBadgeStates, ...BadgeColors, ...BadgeAppearances, 'rtl'];
 const tokensThatAreAlsoProps: (keyof BadgeConfigurableProps)[] = ['badgeColor', 'position'];
 
 export const stylingSettings: UseStylingOptions<BadgeProps, BadgeSlotProps, BadgeTokens> = {

--- a/packages/experimental/Badge/src/Badge.tsx
+++ b/packages/experimental/Badge/src/Badge.tsx
@@ -1,6 +1,6 @@
 /** @jsx withSlots */
 import { Children, ReactNode } from 'react';
-import { View } from 'react-native';
+import { View, I18nManager } from 'react-native';
 import { badgeName, BadgeType, BadgeProps } from './Badge.types';
 import { TextV1 as Text } from '@fluentui-react-native/text';
 import { compose, withSlots, UseSlots, mergeProps } from '@fluentui-react-native/framework';
@@ -19,7 +19,8 @@ export const badgeLookup = (layer: string, userProps: BadgeProps): boolean => {
     layer === userProps['shape'] ||
     (!userProps['shape'] && layer === 'rounded') ||
     layer === userProps['badgeColor'] ||
-    (!userProps['badgeColor'] && layer === 'brand')
+    (!userProps['badgeColor'] && layer === 'brand') ||
+    (I18nManager.isRTL && layer === 'rtl')
   );
 };
 

--- a/packages/experimental/Badge/src/Badge.types.ts
+++ b/packages/experimental/Badge/src/Badge.types.ts
@@ -133,6 +133,11 @@ export interface BadgeTokens extends BadgeCoreTokens, BadgeConfigurableProps {
   iconWeight?: number;
 
   /**
+   * When isRTL - applies Badge from the left side
+   */
+  rtl?: BadgeTokens;
+
+  /**
    * Additional states that can be applied to a Badge
    */
   filled?: BadgeTokens;

--- a/packages/experimental/Badge/src/BadgeColorTokens.ts
+++ b/packages/experimental/Badge/src/BadgeColorTokens.ts
@@ -5,6 +5,8 @@ import { getFilledColorProps, getOutlineColorProps, getTintColorProps, getGhostC
 
 export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
   ({
+    color: t.colors.neutralForegroundOnBrand,
+    backgroundColor: t.colors.brandBackgroundStatic,
     filled: {
       borderColor: 'transparent',
     },

--- a/packages/experimental/Badge/src/BadgeColorTokens.win32.ts
+++ b/packages/experimental/Badge/src/BadgeColorTokens.win32.ts
@@ -5,6 +5,8 @@ import { getFilledColorProps, getOutlineColorProps, getTintColorProps, getGhostC
 
 export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
   ({
+    color: t.colors.neutralForegroundOnBrand,
+    backgroundColor: t.colors.brandBackgroundStatic,
     filled: {
       borderColor: 'transparent',
     },

--- a/packages/experimental/Badge/src/BadgeTokens.ts
+++ b/packages/experimental/Badge/src/BadgeTokens.ts
@@ -10,7 +10,7 @@ export const defaultBadgeTokens: TokenSettings<BadgeTokens, Theme> = () =>
     bottom: globalTokens.spacing.none,
     right: globalTokens.spacing.none,
     textPadding: globalTokens.spacing.xxs,
-    position: 'absolute',
+    position: 'relative',
     tiny: {
       minWidth: 6,
       minHeight: 6,

--- a/packages/experimental/Badge/src/BadgeTokens.ts
+++ b/packages/experimental/Badge/src/BadgeTokens.ts
@@ -70,4 +70,8 @@ export const defaultBadgeTokens: TokenSettings<BadgeTokens, Theme> = () =>
     square: {
       borderRadius: globalTokens.corner.radius.none,
     },
+    rtl: {
+      left: globalTokens.spacing.none,
+      right: undefined,
+    },
   } as BadgeTokens);

--- a/packages/experimental/Badge/src/__tests__/__snapshots__/Badge.test.tsx.snap
+++ b/packages/experimental/Badge/src/__tests__/__snapshots__/Badge.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`Badge component tests Badge all props 1`] = `
       "minHeight": 24,
       "minWidth": 24,
       "paddingHorizontal": 4,
-      "position": "absolute",
+      "position": "relative",
       "right": 0,
       "width": undefined,
     }
@@ -82,7 +82,7 @@ exports[`Badge component tests Badge tokens 1`] = `
       "minHeight": 24,
       "minWidth": 24,
       "paddingHorizontal": 4,
-      "position": "absolute",
+      "position": "relative",
       "right": 0,
       "width": undefined,
     }
@@ -131,7 +131,7 @@ exports[`Badge component tests Empty Badge 1`] = `
       "minHeight": 24,
       "minWidth": 24,
       "paddingHorizontal": 4,
-      "position": "absolute",
+      "position": "relative",
       "right": 0,
       "width": undefined,
     }


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This is final test path for the Avatar component. The only thing was changed here is paletteName from "WhiteColors" to "LowerRibbon_FluentSV".

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
