### PR TITLE
Made Badge in RTL to show from the left side

### DIFF
--- a/change/@fluentui-react-native-badge-7c930f94-ec71-4e88-a499-32d38bb587c3.json
+++ b/change/@fluentui-react-native-badge-7c930f94-ec71-4e88-a499-32d38bb587c3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added Badge for RTL",
+  "packageName": "@fluentui-react-native/badge",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Badge/src/Badge.styling.ts
+++ b/packages/experimental/Badge/src/Badge.styling.ts
@@ -18,7 +18,7 @@ import { defaultBadgeColorTokens } from './BadgeColorTokens';
 import { badgeFontTokens } from './BadgeFontTokens';
 
 export const coreBadgeStates: (keyof BadgeCoreTokens)[] = [...BadgeSizes, ...BadgeShapes];
-export const badgeStates: (keyof BadgeTokens)[] = [...coreBadgeStates, ...BadgeColors, ...BadgeAppearances, 'rtl', 'ltr'];
+export const badgeStates: (keyof BadgeTokens)[] = [...coreBadgeStates, ...BadgeColors, ...BadgeAppearances, 'rtl'];
 const tokensThatAreAlsoProps: (keyof BadgeConfigurableProps)[] = ['badgeColor', 'position'];
 
 export const stylingSettings: UseStylingOptions<BadgeProps, BadgeSlotProps, BadgeTokens> = {

--- a/packages/experimental/Badge/src/Badge.styling.ts
+++ b/packages/experimental/Badge/src/Badge.styling.ts
@@ -18,7 +18,7 @@ import { defaultBadgeColorTokens } from './BadgeColorTokens';
 import { badgeFontTokens } from './BadgeFontTokens';
 
 export const coreBadgeStates: (keyof BadgeCoreTokens)[] = [...BadgeSizes, ...BadgeShapes];
-export const badgeStates: (keyof BadgeTokens)[] = [...coreBadgeStates, ...BadgeColors, ...BadgeAppearances];
+export const badgeStates: (keyof BadgeTokens)[] = [...coreBadgeStates, ...BadgeColors, ...BadgeAppearances, 'rtl', 'ltr'];
 const tokensThatAreAlsoProps: (keyof BadgeConfigurableProps)[] = ['badgeColor', 'position'];
 
 export const stylingSettings: UseStylingOptions<BadgeProps, BadgeSlotProps, BadgeTokens> = {

--- a/packages/experimental/Badge/src/Badge.tsx
+++ b/packages/experimental/Badge/src/Badge.tsx
@@ -20,8 +20,7 @@ export const badgeLookup = (layer: string, userProps: BadgeProps): boolean => {
     (!userProps['shape'] && layer === 'rounded') ||
     layer === userProps['badgeColor'] ||
     (!userProps['badgeColor'] && layer === 'brand') ||
-    (I18nManager.isRTL && layer === 'rtl') ||
-    (!I18nManager.isRTL && layer === 'ltr')
+    (I18nManager.isRTL && layer === 'rtl')
   );
 };
 

--- a/packages/experimental/Badge/src/Badge.tsx
+++ b/packages/experimental/Badge/src/Badge.tsx
@@ -1,6 +1,6 @@
 /** @jsx withSlots */
 import { Children, ReactNode } from 'react';
-import { View } from 'react-native';
+import { View, I18nManager } from 'react-native';
 import { badgeName, BadgeType, BadgeProps } from './Badge.types';
 import { TextV1 as Text } from '@fluentui-react-native/text';
 import { compose, withSlots, UseSlots, mergeProps } from '@fluentui-react-native/framework';
@@ -19,7 +19,9 @@ export const badgeLookup = (layer: string, userProps: BadgeProps): boolean => {
     layer === userProps['shape'] ||
     (!userProps['shape'] && layer === 'rounded') ||
     layer === userProps['badgeColor'] ||
-    (!userProps['badgeColor'] && layer === 'brand')
+    (!userProps['badgeColor'] && layer === 'brand') ||
+    (I18nManager.isRTL && layer === 'rtl') ||
+    (!I18nManager.isRTL && layer === 'ltr')
   );
 };
 

--- a/packages/experimental/Badge/src/Badge.types.ts
+++ b/packages/experimental/Badge/src/Badge.types.ts
@@ -138,11 +138,6 @@ export interface BadgeTokens extends BadgeCoreTokens, BadgeConfigurableProps {
   rtl?: BadgeTokens;
 
   /**
-   * When isLTR - applies Badge from the right side
-   */
-  ltr?: BadgeTokens;
-
-  /**
    * Additional states that can be applied to a Badge
    */
   filled?: BadgeTokens;

--- a/packages/experimental/Badge/src/Badge.types.ts
+++ b/packages/experimental/Badge/src/Badge.types.ts
@@ -133,6 +133,16 @@ export interface BadgeTokens extends BadgeCoreTokens, BadgeConfigurableProps {
   iconWeight?: number;
 
   /**
+   * When isRTL - applies Badge from the left side
+   */
+  rtl?: BadgeTokens;
+
+  /**
+   * When isLTR - applies Badge from the right side
+   */
+  ltr?: BadgeTokens;
+
+  /**
    * Additional states that can be applied to a Badge
    */
   filled?: BadgeTokens;

--- a/packages/experimental/Badge/src/BadgeTokens.ts
+++ b/packages/experimental/Badge/src/BadgeTokens.ts
@@ -8,7 +8,6 @@ export const defaultBadgeTokens: TokenSettings<BadgeTokens, Theme> = () =>
     iconSize: 12,
     borderWidth: globalTokens.stroke.width.thin,
     bottom: globalTokens.spacing.none,
-    right: globalTokens.spacing.none,
     textPadding: globalTokens.spacing.xxs,
     position: 'absolute',
     tiny: {
@@ -69,5 +68,11 @@ export const defaultBadgeTokens: TokenSettings<BadgeTokens, Theme> = () =>
     },
     square: {
       borderRadius: globalTokens.corner.radius.none,
+    },
+    rtl: {
+      left: globalTokens.spacing.none,
+    },
+    ltr: {
+      right: globalTokens.spacing.none,
     },
   } as BadgeTokens);

--- a/packages/experimental/Badge/src/BadgeTokens.ts
+++ b/packages/experimental/Badge/src/BadgeTokens.ts
@@ -8,6 +8,7 @@ export const defaultBadgeTokens: TokenSettings<BadgeTokens, Theme> = () =>
     iconSize: 12,
     borderWidth: globalTokens.stroke.width.thin,
     bottom: globalTokens.spacing.none,
+    right: globalTokens.spacing.none,
     textPadding: globalTokens.spacing.xxs,
     position: 'absolute',
     tiny: {
@@ -71,8 +72,6 @@ export const defaultBadgeTokens: TokenSettings<BadgeTokens, Theme> = () =>
     },
     rtl: {
       left: globalTokens.spacing.none,
-    },
-    ltr: {
-      right: globalTokens.spacing.none,
+      right: undefined,
     },
   } as BadgeTokens);


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
Added tokens for RTL/LTR so Badge is displayed from the left/right side

### Verification
Checked manually

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
