### PR TITLE
Switch High Contrast

### DIFF
--- a/change/@fluentui-react-native-switch-20cf9c74-1254-4db1-bbf9-485deef899fb.json
+++ b/change/@fluentui-react-native-switch-20cf9c74-1254-4db1-bbf9-485deef899fb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added better HC token mapping for win32",
+  "packageName": "@fluentui-react-native/switch",
+  "email": "nkhalil942@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Switch/src/SwitchTokens.win32.ts
+++ b/packages/experimental/Switch/src/SwitchTokens.win32.ts
@@ -1,0 +1,140 @@
+import { Theme } from '@fluentui-react-native/framework';
+import { TokenSettings } from '@fluentui-react-native/use-styling';
+import { SwitchTokens } from './Switch.types';
+
+// toggleOn: {
+//   trackColor: t.colors.compoundBrandBackground1,
+//   thumbColor: t.colors.neutralForegroundOnBrandHover,
+//   borderColor: t.colors.compoundBrandBackground1,
+//   hovered: {
+//     trackColor: t.colors.neutralForegroundOnBrandHover,
+//     thumbColor: t.colors.compoundBrandBackground1Hover,
+//     borderColor: t.colors.compoundBrandBackground1Hover,
+//   },
+//   pressed: {
+//     trackColor: t.colors.compoundBrandBackground1Pressed,
+//     thumbColor: t.colors.neutralForegroundOnBrandHoverPressed,
+//     borderColor: t.colors.compoundBrandBackground1Pressed,
+//   },
+//   disabled: {
+//     trackColor: t.colors.neutralForegroundDisabled,
+//     thumbColor: t.colors.brandBackground,
+//     borderColor: t.colors.neutralForegroundDisabled,
+//   },
+// },
+// toggleOff: {
+//   trackColor: t.colors.brandBackground,
+//   thumbColor: t.colors.neutralForegroundOnBrand,
+//   borderColor: t.colors.neutralForegroundOnBrand,
+//   hovered: {
+//     trackColor: t.colors.brandBackgroundHover,
+//     thumbColor: t.colors.neutralForegroundOnBrandHover,
+//     borderColor: t.colors.neutralForegroundOnBrandHover,
+//   },
+//   pressed: {
+//     trackColor: t.colors.neutralForegroundOnBrandPressed,
+//     thumbColor: t.colors.neutralStrokeAccessiblePressed,
+//     borderColor: t.colors.neutralStrokeAccessiblePressed,
+//   },
+//   disabled: {
+//     trackColor: t.colors.brandBackground,
+//     thumbColor: t.colors.neutralStrokeDisabled,
+//     borderColor: t.colors.neutralStrokeDisabled,
+//   },
+// }
+
+export const defaultSwitchTokens: TokenSettings<SwitchTokens, Theme> = (t: Theme) => ({
+  borderWidth: 1,
+  borderRadius: 10,
+  minHeight: 28,
+  minWidth: 40,
+  thumbSize: 14,
+  thumbRadius: 17,
+  trackHeight: 20,
+  trackWidth: 40,
+  focusBorderRadius: 4,
+  focusBorderWidth: 2,
+  focusStrokeColor: t.colors.transparentBackground,
+  padding: 2,
+  color: t.colors.neutralForeground2,
+  trackMarginTop: 2,
+  trackMarginBottom: 2,
+  trackMarginLeft: 2,
+  trackMarginRight: 2,
+  thumbMargin: 2,
+
+  beforeContent: {
+    trackMarginLeft: 8,
+  },
+
+  afterContent: {
+    trackMarginRight: 8,
+  },
+
+  before: {
+    flexDirection: 'row',
+    toggleContainerFlexDirection: 'row',
+  },
+
+  above: {
+    flexDirection: 'column',
+    toggleContainerFlexDirection: 'row',
+  },
+
+  after: {
+    flexDirection: 'row-reverse',
+    toggleContainerFlexDirection: 'row-reverse',
+  },
+
+  toggleOn: {
+    trackColor: t.colors.compoundBrandBackground1,
+    thumbColor: isHighContrast(t) ? t.colors.neutralForegroundOnBrandHover : t.colors.neutralForegroundInverted,
+    borderColor: t.colors.compoundBrandBackground1,
+    justifyContent: 'flex-end',
+    hovered: {
+      trackColor: isHighContrast(t) ? t.colors.neutralForegroundOnBrandHover : t.colors.compoundBrandBackground1Hover,
+      thumbColor: isHighContrast(t) ? t.colors.compoundBrandBackground1Hover : t.colors.neutralForegroundInvertedLink,
+      borderColor: t.colors.compoundBrandBackground1Hover,
+    },
+    pressed: {
+      trackColor: t.colors.compoundBrandBackground1Pressed,
+      thumbColor: isHighContrast(t) ? t.colors.neutralForegroundOnBrandHoverPressed : t.colors.neutralForegroundInvertedLink,
+      borderColor: t.colors.compoundBrandBackground1Pressed,
+    },
+    disabled: {
+      trackColor: isHighContrast ? t.colors.neutralForegroundDisabled : t.colors.neutralBackgroundDisabled,
+      thumbColor: isHighContrast ? t.colors.brandBackground : t.colors.neutralStrokeDisabled,
+      borderColor: t.colors.neutralForegroundDisabled,
+    },
+  },
+
+  toggleOff: {
+    trackColor: isHighContrast(t) ? t.colors.brandBackground : t.colors.neutralForegroundInvertedLink,
+    thumbColor: isHighContrast(t) ? t.colors.neutralForegroundOnBrand : t.colors.neutralStrokeAccessible,
+    borderColor: isHighContrast(t) ? t.colors.neutralForegroundOnBrand : t.colors.neutralStrokeAccessible,
+    justifyContent: 'flex-start',
+    hovered: {
+      trackColor: isHighContrast(t) ? t.colors.brandBackgroundHover : t.colors.neutralForegroundInvertedLinkHover,
+      thumbColor: isHighContrast(t) ? t.colors.neutralForegroundOnBrandHover : t.colors.neutralStrokeAccessibleHover,
+      borderColor: isHighContrast(t) ? t.colors.neutralForegroundOnBrandHover : t.colors.neutralStrokeAccessibleHover,
+    },
+    pressed: {
+      trackColor: isHighContrast(t) ? t.colors.neutralForegroundOnBrandPressed : t.colors.neutralForegroundInvertedLinkPressed,
+      thumbColor: t.colors.neutralStrokeAccessiblePressed,
+      borderColor: t.colors.neutralStrokeAccessiblePressed,
+    },
+    disabled: {
+      trackColor: isHighContrast(t) ? t.colors.brandBackground : t.colors.neutralBackgroundDisabled,
+      thumbColor: t.colors.neutralStrokeDisabled,
+      borderColor: t.colors.neutralStrokeDisabled,
+    },
+  },
+
+  focused: {
+    focusStrokeColor: t.colors.strokeFocus2,
+  },
+});
+
+function isHighContrast(t: Theme) {
+  return t.name === 'HighContrast';
+}

--- a/packages/experimental/Switch/src/SwitchTokens.win32.ts
+++ b/packages/experimental/Switch/src/SwitchTokens.win32.ts
@@ -2,47 +2,6 @@ import { Theme } from '@fluentui-react-native/framework';
 import { TokenSettings } from '@fluentui-react-native/use-styling';
 import { SwitchTokens } from './Switch.types';
 
-// toggleOn: {
-//   trackColor: t.colors.compoundBrandBackground1,
-//   thumbColor: t.colors.neutralForegroundOnBrandHover,
-//   borderColor: t.colors.compoundBrandBackground1,
-//   hovered: {
-//     trackColor: t.colors.neutralForegroundOnBrandHover,
-//     thumbColor: t.colors.compoundBrandBackground1Hover,
-//     borderColor: t.colors.compoundBrandBackground1Hover,
-//   },
-//   pressed: {
-//     trackColor: t.colors.compoundBrandBackground1Pressed,
-//     thumbColor: t.colors.neutralForegroundOnBrandHoverPressed,
-//     borderColor: t.colors.compoundBrandBackground1Pressed,
-//   },
-//   disabled: {
-//     trackColor: t.colors.neutralForegroundDisabled,
-//     thumbColor: t.colors.brandBackground,
-//     borderColor: t.colors.neutralForegroundDisabled,
-//   },
-// },
-// toggleOff: {
-//   trackColor: t.colors.brandBackground,
-//   thumbColor: t.colors.neutralForegroundOnBrand,
-//   borderColor: t.colors.neutralForegroundOnBrand,
-//   hovered: {
-//     trackColor: t.colors.brandBackgroundHover,
-//     thumbColor: t.colors.neutralForegroundOnBrandHover,
-//     borderColor: t.colors.neutralForegroundOnBrandHover,
-//   },
-//   pressed: {
-//     trackColor: t.colors.neutralForegroundOnBrandPressed,
-//     thumbColor: t.colors.neutralStrokeAccessiblePressed,
-//     borderColor: t.colors.neutralStrokeAccessiblePressed,
-//   },
-//   disabled: {
-//     trackColor: t.colors.brandBackground,
-//     thumbColor: t.colors.neutralStrokeDisabled,
-//     borderColor: t.colors.neutralStrokeDisabled,
-//   },
-// }
-
 export const defaultSwitchTokens: TokenSettings<SwitchTokens, Theme> = (t: Theme) => ({
   borderWidth: 1,
   borderRadius: 10,

--- a/packages/experimental/Switch/src/SwitchTokens.win32.ts
+++ b/packages/experimental/Switch/src/SwitchTokens.win32.ts
@@ -57,7 +57,7 @@ export const defaultSwitchTokens: TokenSettings<SwitchTokens, Theme> = (t: Theme
     },
     pressed: {
       trackColor: t.colors.compoundBrandBackground1Pressed,
-      thumbColor: isHighContrast(t) ? t.colors.neutralForegroundOnBrandHoverPressed : t.colors.neutralForegroundInvertedLink,
+      thumbColor: isHighContrast(t) ? t.colors.neutralForegroundOnBrandHover : t.colors.neutralForegroundInvertedLink,
       borderColor: t.colors.compoundBrandBackground1Pressed,
     },
     disabled: {

--- a/packages/experimental/Switch/src/SwitchTokens.win32.ts
+++ b/packages/experimental/Switch/src/SwitchTokens.win32.ts
@@ -61,8 +61,8 @@ export const defaultSwitchTokens: TokenSettings<SwitchTokens, Theme> = (t: Theme
       borderColor: t.colors.compoundBrandBackground1Pressed,
     },
     disabled: {
-      trackColor: isHighContrast ? t.colors.neutralForegroundDisabled : t.colors.neutralBackgroundDisabled,
-      thumbColor: isHighContrast ? t.colors.brandBackground : t.colors.neutralStrokeDisabled,
+      trackColor: isHighContrast(t) ? t.colors.neutralForegroundDisabled : t.colors.neutralBackgroundDisabled,
+      thumbColor: isHighContrast(t) ? t.colors.brandBackground : t.colors.neutralStrokeDisabled,
       borderColor: t.colors.neutralForegroundDisabled,
     },
   },


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

No longer depending on the values of the tokens in the redlines to provide the colors for high contrast. Instead now we are checking to see if we're in high contrast mode and map tokens we picked ourselves to provide the colors for high contrast.

This makes the Switch's high contrast look closer to what we expected a high contrast Switch to look like. It also resolves the issue of the thumb not being visible when using high contrast on windows 11.

### Verification

Windows 10 High Contrast
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/20259210/185985809-90b0fe75-d5ab-4933-acbb-8e104521d963.png) | ![image](https://user-images.githubusercontent.com/20259210/185984738-0b1806b2-7471-438c-8f88-64f5632a2138.png) |

Windows 11 Aquatic High Contract
Note: The first switch in these before/after screen shots has a mouse hovered over them.
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/20259210/185986064-96b3461b-b1fb-4e29-97ec-d4103cccec3e.png) | ![image](https://user-images.githubusercontent.com/20259210/185985257-18721286-a42e-404b-9d59-05c4fcb99b24.png) |


### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
