### PR TITLE
[Badge] Set relative position by default

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Badge/BasicBadgeTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Badge/BasicBadgeTest.tsx
@@ -31,7 +31,6 @@ const StyledBadge = Badge.customize({
   borderWidth: 4,
   color: '#f07',
   fontWeight: 'bold',
-  position: 'relative',
 });
 
 export const BasicBadge: React.FunctionComponent = () => {
@@ -64,6 +63,7 @@ export const BasicBadge: React.FunctionComponent = () => {
   const badgeConfig = {
     appearance: badgeAppearance,
     badgeColor,
+    position: 'absolute',
     size,
     shape,
   };
@@ -96,32 +96,22 @@ export const BasicBadge: React.FunctionComponent = () => {
       </View>
 
       <Text>Size</Text>
-      <Badge position="relative" size="tiny" shape="circular" />
-      <Badge position="relative" size="extraSmall" shape="circular" badgeColor="red" />
-      <Badge position="relative" size="small">
-        Small
-      </Badge>
-      <Badge position="relative" size="medium">
-        Medium
-      </Badge>
-      <Badge position="relative" size="large">
-        Large
-      </Badge>
-      <Badge position="relative" size="extraLarge">
-        Extra Large
-      </Badge>
+      <Badge size="tiny" shape="circular" />
+      <Badge size="extraSmall" shape="circular" badgeColor="red" />
+      <Badge size="small">Small</Badge>
+      <Badge size="medium">Medium</Badge>
+      <Badge size="large">Large</Badge>
+      <Badge size="extraLarge">Extra Large</Badge>
       {svgIconsEnabled && (
         <>
           <Text>Badge with icon</Text>
-          <Badge position="relative" icon={{ svgSource: svgProps }} iconPosition="after">
+          <Badge icon={{ svgSource: svgProps }} iconPosition="after">
             Badge with
             <Image source={{ uri: satyaPhotoUrl }} style={{ width: 20, height: 20 }} />
             <Text style={{ backgroundColor: 'yellow' }}>optional content</Text>
           </Badge>
-          <Badge position="relative" appearance="outline" icon={iconProps} />
-          <Badge position="relative" icon={{ fontSource: { ...fontBuiltInProps }, color: '#fff' }}>
-            Badge with icon
-          </Badge>
+          <Badge appearance="outline" icon={iconProps} />
+          <Badge icon={{ fontSource: { ...fontBuiltInProps }, color: '#fff' }}>Badge with icon</Badge>
         </>
       )}
       <StyledBadge appearance="outline">Styled badge</StyledBadge>

--- a/apps/fluent-tester/src/TestComponents/Badge/BasicBadgeTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Badge/BasicBadgeTest.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import React, { useState, useCallback } from 'react';
-import { View, Platform, Text, Image } from 'react-native';
+import { View, Platform, Text, Image, FlexStyle } from 'react-native';
 import {
   Badge,
   BadgeAppearance,
@@ -63,7 +63,7 @@ export const BasicBadge: React.FunctionComponent = () => {
   const badgeConfig = {
     appearance: badgeAppearance,
     badgeColor,
-    position: 'absolute',
+    position: 'absolute' as FlexStyle['position'],
     size,
     shape,
   };

--- a/change/@fluentui-react-native-badge-06471718-8251-4070-a12c-bf98643d18d3.json
+++ b/change/@fluentui-react-native-badge-06471718-8251-4070-a12c-bf98643d18d3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[Badge] Set relative position as the default one",
+  "packageName": "@fluentui-react-native/badge",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-56d2b25e-0ca2-44a3-80fe-6aa05b722f8f.json
+++ b/change/@fluentui-react-native-tester-56d2b25e-0ca2-44a3-80fe-6aa05b722f8f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[Badge] Set relative position as the default one",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Badge/src/BadgeTokens.ts
+++ b/packages/experimental/Badge/src/BadgeTokens.ts
@@ -10,6 +10,7 @@ export const defaultBadgeTokens: TokenSettings<BadgeTokens, Theme> = () =>
     bottom: globalTokens.spacing.none,
     right: globalTokens.spacing.none,
     textPadding: globalTokens.spacing.xxs,
+    position: 'relative',
     tiny: {
       minWidth: 6,
       minHeight: 6,

--- a/packages/experimental/Badge/src/BadgeTokens.ts
+++ b/packages/experimental/Badge/src/BadgeTokens.ts
@@ -10,7 +10,6 @@ export const defaultBadgeTokens: TokenSettings<BadgeTokens, Theme> = () =>
     bottom: globalTokens.spacing.none,
     right: globalTokens.spacing.none,
     textPadding: globalTokens.spacing.xxs,
-    position: 'absolute',
     tiny: {
       minWidth: 6,
       minHeight: 6,

--- a/packages/experimental/Badge/src/__tests__/__snapshots__/Badge.test.tsx.snap
+++ b/packages/experimental/Badge/src/__tests__/__snapshots__/Badge.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`Badge component tests Badge all props 1`] = `
       "minHeight": 24,
       "minWidth": 24,
       "paddingHorizontal": 4,
-      "position": "absolute",
+      "position": "relative",
       "right": 0,
       "width": undefined,
     }
@@ -82,7 +82,7 @@ exports[`Badge component tests Badge tokens 1`] = `
       "minHeight": 24,
       "minWidth": 24,
       "paddingHorizontal": 4,
-      "position": "absolute",
+      "position": "relative",
       "right": 0,
       "width": undefined,
     }
@@ -131,7 +131,7 @@ exports[`Badge component tests Empty Badge 1`] = `
       "minHeight": 24,
       "minWidth": 24,
       "paddingHorizontal": 4,
-      "position": "absolute",
+      "position": "relative",
       "right": 0,
       "width": undefined,
     }


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
Talked to Web folks abut default positioning. Relative should be default. But it's still possible to customize positioning using prop or token

### Verification
Checked manually

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
