### PR TITLE
RadioButton: Fix truncation in RTL mode

### DIFF
--- a/change/@fluentui-react-native-radio-group-a0ef3223-4154-47dc-83e8-04cf8da7154f.json
+++ b/change/@fluentui-react-native-radio-group-a0ef3223-4154-47dc-83e8-04cf8da7154f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "RadioButton: Fix truncation in RTL mode",
+  "packageName": "@fluentui-react-native/radio-group",
+  "email": "67026167+chiuam@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/RadioGroup/src/RadioButton.macos.tsx
+++ b/packages/components/RadioGroup/src/RadioButton.macos.tsx
@@ -45,9 +45,6 @@ export const RadioButton = compose<IRadioButtonType>({
         onPress: onPressRerouted,
         selected: isSelected,
         style: {
-          // Fluent controls are designed to snap to a 4 px grid
-          marginLeft: 4,
-          marginTop: 4,
           minWidth: '100%',
           minHeight: 20,
         },

--- a/packages/components/RadioGroup/src/RadioButton.macos.tsx
+++ b/packages/components/RadioGroup/src/RadioButton.macos.tsx
@@ -48,7 +48,7 @@ export const RadioButton = compose<IRadioButtonType>({
           // Fluent controls are designed to snap to a 4 px grid
           marginLeft: 4,
           marginTop: 4,
-          minWidth: 20,
+          minWidth: '100%',
           minHeight: 20,
         },
       },


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
Two RTL issues on macOS:
  1. RadioButton label gets truncated
  2. Some native controls(RadioButton and Checkbox) are left-aligned

This PR fixes issue 1 by setting the width to fill 100% to its parent view. (Note: Since RadioButton doesn't support multiline, truncation can still happen if the string is wider than its parent view.)
For issue 2, I couldn't figure out the root cause but seems like there's limitation around text alignment as mentioned [here](https://reactnative.dev/blog/2016/08/19/right-to-left-support-for-react-native-apps#limitations-and-future-plan) and [RNTester](https://github.com/microsoft/react-native-macos/blob/main/packages/rn-tester/js/examples/RTL/RTLExample.js#L671).

Edit: created #2025 as followup


### Verification

(how the change was tested, including both manual and automated tests)

| |  Before                                       | After                                      |
|-----------------------| -----------------------|--------------------------------------------|
|RTL|![image](https://user-images.githubusercontent.com/67026167/186249169-18247dc8-cfd8-439e-87a9-d9b3ff1bc9d2.png) | ![image](https://user-images.githubusercontent.com/67026167/186248318-645d08d7-2be3-499e-a3de-76840977436b.png) |
|LTR|![image](https://user-images.githubusercontent.com/67026167/186248820-6dd74236-ae00-4b38-b998-20e0bcee21f8.png) | ![image](https://user-images.githubusercontent.com/67026167/186248461-49c404f3-3401-4534-94cd-fb5ca9badf47.png) |
### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [X] Internationalization and Right-to-left Layouts
