### PR TITLE
Change Platform Status to be collapsible

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Test.tsx
+++ b/apps/fluent-tester/src/TestComponents/Test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StyleSheet, View, Platform } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { Text, ToggleButton, Separator } from '@fluentui/react-native';
 import { Stack } from '@fluentui-react-native/stack';
 import { stackStyle } from './Common/styles';
@@ -27,6 +27,14 @@ export interface TestProps {
   sections: TestSection[];
 }
 
+const definitions = {
+  Production: 'Control is ready for broad partner use and to be used in production-ready scenarios.',
+  Beta: 'Control is ready for partner consumption, but not ready for production release (e.g. fixing bugs).',
+  Experimental: 'Control code checked into repo, but not ready for partner use.',
+  Backlog: 'Control is in plan and on our backlog to deliver.',
+  'N/A': 'Control is not in current plan.',
+};
+
 const styles = StyleSheet.create({
   name: {
     marginTop: 4,
@@ -44,11 +52,8 @@ const styles = StyleSheet.create({
   },
   statusView: {
     flexDirection: 'row',
-    alignItems: 'flex-start',
+    alignItems: 'center',
     justifyContent: 'space-between',
-  },
-  statusHeader: {
-    marginBottom: 6,
   },
   statusLabel: {
     marginTop: 2,
@@ -58,9 +63,6 @@ const styles = StyleSheet.create({
     fontWeight: 'normal',
   },
 });
-
-// mobile platform check to not render status components.
-const isMobile = Platform.OS == 'android' || (Platform.OS == 'ios' && !Platform.isPad);
 
 export const Test = (props: TestProps): React.ReactElement<Record<string, never>> => {
   const [showStatus, setShowStatus] = React.useState(false);
@@ -84,63 +86,42 @@ export const Test = (props: TestProps): React.ReactElement<Record<string, never>
       <Stack style={stackStyle}>
         <Text style={styles.description}>{props.description}</Text>
       </Stack>
-      {!isMobile && (
-        <Stack style={stackStyle}>
-          <View style={styles.statusView}>
-            <Text style={[styles.statusHeader]} variant="headerStandard">
-              Platform Status
+      <Stack style={stackStyle}>
+        <View style={styles.statusView}>
+          <Text variant="headerStandard">Platform Status</Text>
+          <ToggleButton iconOnly={true} icon={{ fontSource: fontIconProps }} onClick={() => setShowStatus(!showStatus)} />
+        </View>
+        {showStatus && (
+          <View>
+            <Text style={[styles.statusLabel]} variant="bodySemibold">
+              Win32: <Text style={styles.status}>{props.status.win32Status}</Text>
             </Text>
-            <ToggleButton
-              iconOnly={true}
-              icon={{ fontSource: fontIconProps }}
-              onClick={() => setShowStatus(!showStatus)}
-              style={[styles.statusLabel]}
-            />
-          </View>
-          {showStatus && (
-            <View>
-              <Text style={[styles.statusLabel]} variant="bodySemibold">
-                Win32: <Text style={styles.status}>{props.status.win32Status}</Text>
-              </Text>
-              <Text style={[styles.statusLabel]} variant="bodySemibold">
-                UWP: <Text style={styles.status}>{props.status.uwpStatus}</Text>
-              </Text>
-              <Text style={[styles.statusLabel]} variant="bodySemibold">
-                iOS: <Text style={styles.status}>{props.status.iosStatus}</Text>
-              </Text>
-              <Text style={[styles.statusLabel]} variant="bodySemibold">
-                macOS: <Text style={styles.status}>{props.status.macosStatus}</Text>
-              </Text>
-              <Text style={[styles.statusLabel]} variant="bodySemibold">
-                Android: <Text style={styles.status}>{props.status.androidStatus}</Text>
-              </Text>
+            <Text style={[styles.statusLabel]} variant="bodySemibold">
+              UWP: <Text style={styles.status}>{props.status.uwpStatus}</Text>
+            </Text>
+            <Text style={[styles.statusLabel]} variant="bodySemibold">
+              iOS: <Text style={styles.status}>{props.status.iosStatus}</Text>
+            </Text>
+            <Text style={[styles.statusLabel]} variant="bodySemibold">
+              macOS: <Text style={styles.status}>{props.status.macosStatus}</Text>
+            </Text>
+            <Text style={[styles.statusLabel]} variant="bodySemibold">
+              Android: <Text style={styles.status}>{props.status.androidStatus}</Text>
+            </Text>
 
-              <Text style={[styles.definitionHeader]} variant="headerStandard">
-                Status Definitions
-              </Text>
-              <Text style={[styles.statusLabel]} variant="bodySemibold">
-                Production:{' '}
-                <Text style={styles.status}>Control is ready for broad partner use and to be used in production-ready scenarios.</Text>
-              </Text>
-              <Text style={[styles.statusLabel]} variant="bodySemibold">
-                Beta:{' '}
-                <Text style={styles.status}>
-                  Control is ready for partner consumption, but not ready for production release (e.g. fixing bugs).
+            <Text style={[styles.definitionHeader]} variant="headerStandard">
+              Status Definitions
+            </Text>
+            {Object.entries(definitions).map(([key, value]) => {
+              return (
+                <Text style={[styles.statusLabel]} variant="bodySemibold" key={key}>
+                  {key}: <Text style={styles.status}>{value}</Text>
                 </Text>
-              </Text>
-              <Text style={[styles.statusLabel]} variant="bodySemibold">
-                Experimental: <Text style={styles.status}>Control code checked into repo, but not ready for partner use.</Text>
-              </Text>
-              <Text style={[styles.statusLabel]} variant="bodySemibold">
-                Backlog: <Text style={styles.status}>Control is in plan and on our backlog to deliver.</Text>
-              </Text>
-              <Text style={[styles.statusLabel]} variant="bodySemibold">
-                N/A: <Text style={styles.status}>Control is not in current plan.</Text>
-              </Text>
-            </View>
-          )}
-        </Stack>
-      )}
+              );
+            })}
+          </View>
+        )}
+      </Stack>
       {props.sections.map((section, index) => {
         const TestComponent = section.component;
         return (

--- a/apps/fluent-tester/src/TestComponents/Test.tsx
+++ b/apps/fluent-tester/src/TestComponents/Test.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, View, Platform } from 'react-native';
 import { Text, ToggleButton, Separator } from '@fluentui/react-native';
 import { Stack } from '@fluentui-react-native/stack';
 import { stackStyle } from './Common/styles';
+import { Icon } from '@fluentui-react-native/icon';
 
 export type TestSection = {
   name: string;
@@ -63,6 +64,11 @@ const isMobile = Platform.OS == 'android' || (Platform.OS == 'ios' && !Platform.
 
 export const Test = (props: TestProps): React.ReactElement<Record<string, never>> => {
   const [showStatus, setShowStatus] = React.useState(false);
+  const fontBuiltInProps = {
+    fontFamily: 'Arial',
+    codepoint: showStatus ? 0x2796 : 0x2795,
+    fontSize: 10,
+  };
 
   return (
     <View testID="ScrollViewAreaForComponents">
@@ -73,8 +79,8 @@ export const Test = (props: TestProps): React.ReactElement<Record<string, never>
       <Stack style={stackStyle}>
         <Text style={styles.description}>{props.description}</Text>
       </Stack>
-      <ToggleButton onClick={() => setShowStatus(!showStatus)} style={[styles.statusLabel]}>
-        Platform Status {showStatus ? '-' : '+'}
+      <ToggleButton iconOnly={true} onClick={() => setShowStatus(!showStatus)} style={[styles.statusLabel]}>
+        <Icon fontSource={fontBuiltInProps} />
       </ToggleButton>
       {!isMobile && showStatus && (
         <Stack style={stackStyle}>

--- a/apps/fluent-tester/src/TestComponents/Test.tsx
+++ b/apps/fluent-tester/src/TestComponents/Test.tsx
@@ -4,6 +4,7 @@ import { Text, ToggleButton, Separator } from '@fluentui/react-native';
 import { Stack } from '@fluentui-react-native/stack';
 import { stackStyle } from './Common/styles';
 import { Icon } from '@fluentui-react-native/icon';
+import { useTheme } from '@fluentui-react-native/theme-types';
 
 export type TestSection = {
   name: string;
@@ -64,9 +65,14 @@ const isMobile = Platform.OS == 'android' || (Platform.OS == 'ios' && !Platform.
 
 export const Test = (props: TestProps): React.ReactElement<Record<string, never>> => {
   const [showStatus, setShowStatus] = React.useState(false);
+  const theme = useTheme();
+  const fontFamily = theme.typography.families.primary;
+
+  const plusCodepoint = 0x2795;
+  const minusCodepoint = 0x2796;
   const fontIconProps = {
-    fontFamily: 'Arial',
-    codepoint: showStatus ? 0x2796 : 0x2795,
+    fontFamily: fontFamily,
+    codepoint: showStatus ? minusCodepoint : plusCodepoint,
     fontSize: 10,
   };
 

--- a/apps/fluent-tester/src/TestComponents/Test.tsx
+++ b/apps/fluent-tester/src/TestComponents/Test.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 import { Text, ToggleButton, Separator } from '@fluentui/react-native';
 import { Stack } from '@fluentui-react-native/stack';
 import { stackStyle } from './Common/styles';
 import { useTheme } from '@fluentui-react-native/theme-types';
+import Svg, { G, Path, SvgProps } from 'react-native-svg';
+import { SvgIconProps } from '@fluentui-react-native/icon';
 
 export type TestSection = {
   name: string;
@@ -66,6 +68,25 @@ const styles = StyleSheet.create({
 
 export const Test = (props: TestProps): React.ReactElement<Record<string, never>> => {
   const [showStatus, setShowStatus] = React.useState(false);
+
+  const toggleSvg: React.FunctionComponent<SvgProps> = () => {
+    const plusPath =
+      'M6.5 1.75C6.5 1.33579 6.16421 1 5.75 1C5.33579 1 5 1.33579 5 1.75V5H1.75C1.33579 5 1 5.33579 1 5.75C1 6.16421 1.33579 6.5 1.75 6.5H5V9.75C5 10.1642 5.33579 10.5 5.75 10.5C6.16421 10.5 6.5 10.1642 6.5 9.75V6.5H9.75C10.1642 6.5 10.5 6.16421 10.5 5.75C10.5 5.33579 10.1642 5 9.75 5H6.5V1.75Z';
+    const minusPath = 'M2.75 5.25h6.5s0.75 0 0.75 0.75v0s0 0.75 -0.75 0.75h-6.5s-0.75 0 -0.75 -0.75v0s0 -0.75 0.75 -0.75';
+
+    const path = showStatus ? minusPath : plusPath;
+    return (
+      <Svg>
+        <G>
+          <Path d={path} fill="black" />
+        </G>
+      </Svg>
+    );
+  };
+  const svgProps: SvgIconProps = {
+    src: toggleSvg,
+  };
+
   const theme = useTheme();
   const fontFamily = theme.typography.families.primary;
 
@@ -76,6 +97,8 @@ export const Test = (props: TestProps): React.ReactElement<Record<string, never>
     codepoint: showStatus ? minusCodepoint : plusCodepoint,
     fontSize: 10,
   };
+
+  const toggleIconProps = Platform.OS === 'windows' ? { fontSource: fontIconProps } : { svgSource: svgProps, width: 12, height: 12 };
 
   return (
     <View testID="ScrollViewAreaForComponents">
@@ -89,10 +112,10 @@ export const Test = (props: TestProps): React.ReactElement<Record<string, never>
       <Stack style={stackStyle}>
         <View style={styles.statusView}>
           <Text variant="headerStandard">Platform Status</Text>
-          <ToggleButton iconOnly={true} icon={{ fontSource: fontIconProps }} onClick={() => setShowStatus(!showStatus)} />
+          <ToggleButton iconOnly={true} icon={toggleIconProps} onClick={() => setShowStatus(!showStatus)} />
         </View>
         {showStatus && (
-          <View>
+          <>
             <Text style={[styles.statusLabel]} variant="bodySemibold">
               Win32: <Text style={styles.status}>{props.status.win32Status}</Text>
             </Text>
@@ -119,7 +142,7 @@ export const Test = (props: TestProps): React.ReactElement<Record<string, never>
                 </Text>
               );
             })}
-          </View>
+          </>
         )}
       </Stack>
       {props.sections.map((section, index) => {

--- a/apps/fluent-tester/src/TestComponents/Test.tsx
+++ b/apps/fluent-tester/src/TestComponents/Test.tsx
@@ -69,53 +69,51 @@ export const Test = (props: TestProps): React.ReactElement<Record<string, never>
       </Stack>
       {!isMobile && (
         <Stack style={stackStyle}>
-          <View style={styles.statusView}>
-            <Stack>
-              <Text style={[styles.statusHeader]} variant="headerStandard">
-                Platform Status
-              </Text>
-              <Text style={[styles.statusLabel]} variant="bodySemibold">
-                Win32: <Text style={styles.status}>{props.status.win32Status}</Text>
-              </Text>
-              <Text style={[styles.statusLabel]} variant="bodySemibold">
-                UWP: <Text style={styles.status}>{props.status.uwpStatus}</Text>
-              </Text>
-              <Text style={[styles.statusLabel]} variant="bodySemibold">
-                iOS: <Text style={styles.status}>{props.status.iosStatus}</Text>
-              </Text>
-              <Text style={[styles.statusLabel]} variant="bodySemibold">
-                macOS: <Text style={styles.status}>{props.status.macosStatus}</Text>
-              </Text>
-              <Text style={[styles.statusLabel]} variant="bodySemibold">
-                Android: <Text style={styles.status}>{props.status.androidStatus}</Text>
-              </Text>
-            </Stack>
+          <Stack>
+            <Text style={[styles.statusHeader]} variant="headerStandard">
+              Platform Status
+            </Text>
+            <Text style={[styles.statusLabel]} variant="bodySemibold">
+              Win32: <Text style={styles.status}>{props.status.win32Status}</Text>
+            </Text>
+            <Text style={[styles.statusLabel]} variant="bodySemibold">
+              UWP: <Text style={styles.status}>{props.status.uwpStatus}</Text>
+            </Text>
+            <Text style={[styles.statusLabel]} variant="bodySemibold">
+              iOS: <Text style={styles.status}>{props.status.iosStatus}</Text>
+            </Text>
+            <Text style={[styles.statusLabel]} variant="bodySemibold">
+              macOS: <Text style={styles.status}>{props.status.macosStatus}</Text>
+            </Text>
+            <Text style={[styles.statusLabel]} variant="bodySemibold">
+              Android: <Text style={styles.status}>{props.status.androidStatus}</Text>
+            </Text>
+          </Stack>
 
-            <Stack style={stackStyle}>
-              <Text style={[styles.statusHeader]} variant="headerStandard">
-                Status Definitions
+          <Stack style={stackStyle}>
+            <Text style={[styles.statusHeader]} variant="headerStandard">
+              Status Definitions
+            </Text>
+            <Text style={[styles.statusLabel]} variant="bodySemibold">
+              Production:{' '}
+              <Text style={styles.status}>Control is ready for broad partner use and to be used in production-ready scenarios.</Text>
+            </Text>
+            <Text style={[styles.statusLabel]} variant="bodySemibold">
+              Beta:{' '}
+              <Text style={styles.status}>
+                Control is ready for partner consumption, but not ready for production release (e.g. fixing bugs).
               </Text>
-              <Text style={[styles.statusLabel]} variant="bodySemibold">
-                Production:{' '}
-                <Text style={styles.status}>Control is ready for broad partner use and to be used in production-ready scenarios.</Text>
-              </Text>
-              <Text style={[styles.statusLabel]} variant="bodySemibold">
-                Beta:{' '}
-                <Text style={styles.status}>
-                  Control is ready for partner consumption, but not ready for production release (e.g. fixing bugs).
-                </Text>
-              </Text>
-              <Text style={[styles.statusLabel]} variant="bodySemibold">
-                Experimental: <Text style={styles.status}>Control code checked into repo, but not ready for partner use.</Text>
-              </Text>
-              <Text style={[styles.statusLabel]} variant="bodySemibold">
-                Backlog: <Text style={styles.status}>Control is in plan and on our backlog to deliver.</Text>
-              </Text>
-              <Text style={[styles.statusLabel]} variant="bodySemibold">
-                N/A: <Text style={styles.status}>Control is not in current plan.</Text>
-              </Text>
-            </Stack>
-          </View>
+            </Text>
+            <Text style={[styles.statusLabel]} variant="bodySemibold">
+              Experimental: <Text style={styles.status}>Control code checked into repo, but not ready for partner use.</Text>
+            </Text>
+            <Text style={[styles.statusLabel]} variant="bodySemibold">
+              Backlog: <Text style={styles.status}>Control is in plan and on our backlog to deliver.</Text>
+            </Text>
+            <Text style={[styles.statusLabel]} variant="bodySemibold">
+              N/A: <Text style={styles.status}>Control is not in current plan.</Text>
+            </Text>
+          </Stack>
         </Stack>
       )}
       {props.sections.map((section, index) => {

--- a/apps/fluent-tester/src/TestComponents/Test.tsx
+++ b/apps/fluent-tester/src/TestComponents/Test.tsx
@@ -30,6 +30,10 @@ const styles = StyleSheet.create({
   name: {
     marginTop: 4,
   },
+  definitionHeader: {
+    marginTop: 12,
+    marginBottom: 6,
+  },
   description: {
     alignItems: 'flex-start',
     flexWrap: 'wrap',
@@ -69,51 +73,47 @@ export const Test = (props: TestProps): React.ReactElement<Record<string, never>
       </Stack>
       {!isMobile && (
         <Stack style={stackStyle}>
-          <Stack>
-            <Text style={[styles.statusHeader]} variant="headerStandard">
-              Platform Status
-            </Text>
-            <Text style={[styles.statusLabel]} variant="bodySemibold">
-              Win32: <Text style={styles.status}>{props.status.win32Status}</Text>
-            </Text>
-            <Text style={[styles.statusLabel]} variant="bodySemibold">
-              UWP: <Text style={styles.status}>{props.status.uwpStatus}</Text>
-            </Text>
-            <Text style={[styles.statusLabel]} variant="bodySemibold">
-              iOS: <Text style={styles.status}>{props.status.iosStatus}</Text>
-            </Text>
-            <Text style={[styles.statusLabel]} variant="bodySemibold">
-              macOS: <Text style={styles.status}>{props.status.macosStatus}</Text>
-            </Text>
-            <Text style={[styles.statusLabel]} variant="bodySemibold">
-              Android: <Text style={styles.status}>{props.status.androidStatus}</Text>
-            </Text>
-          </Stack>
+          <Text style={[styles.statusHeader]} variant="headerStandard">
+            Platform Status
+          </Text>
+          <Text style={[styles.statusLabel]} variant="bodySemibold">
+            Win32: <Text style={styles.status}>{props.status.win32Status}</Text>
+          </Text>
+          <Text style={[styles.statusLabel]} variant="bodySemibold">
+            UWP: <Text style={styles.status}>{props.status.uwpStatus}</Text>
+          </Text>
+          <Text style={[styles.statusLabel]} variant="bodySemibold">
+            iOS: <Text style={styles.status}>{props.status.iosStatus}</Text>
+          </Text>
+          <Text style={[styles.statusLabel]} variant="bodySemibold">
+            macOS: <Text style={styles.status}>{props.status.macosStatus}</Text>
+          </Text>
+          <Text style={[styles.statusLabel]} variant="bodySemibold">
+            Android: <Text style={styles.status}>{props.status.androidStatus}</Text>
+          </Text>
 
-          <Stack style={stackStyle}>
-            <Text style={[styles.statusHeader]} variant="headerStandard">
-              Status Definitions
+          <Text style={[styles.definitionHeader]} variant="headerStandard">
+            Status Definitions
+          </Text>
+          <Text style={[styles.statusLabel]} variant="bodySemibold">
+            Production:{' '}
+            <Text style={styles.status}>Control is ready for broad partner use and to be used in production-ready scenarios.</Text>
+          </Text>
+          <Text style={[styles.statusLabel]} variant="bodySemibold">
+            Beta:{' '}
+            <Text style={styles.status}>
+              Control is ready for partner consumption, but not ready for production release (e.g. fixing bugs).
             </Text>
-            <Text style={[styles.statusLabel]} variant="bodySemibold">
-              Production:{' '}
-              <Text style={styles.status}>Control is ready for broad partner use and to be used in production-ready scenarios.</Text>
-            </Text>
-            <Text style={[styles.statusLabel]} variant="bodySemibold">
-              Beta:{' '}
-              <Text style={styles.status}>
-                Control is ready for partner consumption, but not ready for production release (e.g. fixing bugs).
-              </Text>
-            </Text>
-            <Text style={[styles.statusLabel]} variant="bodySemibold">
-              Experimental: <Text style={styles.status}>Control code checked into repo, but not ready for partner use.</Text>
-            </Text>
-            <Text style={[styles.statusLabel]} variant="bodySemibold">
-              Backlog: <Text style={styles.status}>Control is in plan and on our backlog to deliver.</Text>
-            </Text>
-            <Text style={[styles.statusLabel]} variant="bodySemibold">
-              N/A: <Text style={styles.status}>Control is not in current plan.</Text>
-            </Text>
-          </Stack>
+          </Text>
+          <Text style={[styles.statusLabel]} variant="bodySemibold">
+            Experimental: <Text style={styles.status}>Control code checked into repo, but not ready for partner use.</Text>
+          </Text>
+          <Text style={[styles.statusLabel]} variant="bodySemibold">
+            Backlog: <Text style={styles.status}>Control is in plan and on our backlog to deliver.</Text>
+          </Text>
+          <Text style={[styles.statusLabel]} variant="bodySemibold">
+            N/A: <Text style={styles.status}>Control is not in current plan.</Text>
+          </Text>
         </Stack>
       )}
       {props.sections.map((section, index) => {

--- a/apps/fluent-tester/src/TestComponents/Test.tsx
+++ b/apps/fluent-tester/src/TestComponents/Test.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
 import { StyleSheet, View, Platform } from 'react-native';
-import { Text, Separator } from '@fluentui/react-native';
+import { Text, ToggleButton, Separator, createIconProps } from '@fluentui/react-native';
 import { Stack } from '@fluentui-react-native/stack';
 import { stackStyle } from './Common/styles';
+import Svg, { G, Path, SvgProps } from 'react-native-svg';
+import { Icon, SvgIconProps } from '@fluentui-react-native/icon';
 
 export type TestSection = {
   name: string;
@@ -62,6 +64,24 @@ const styles = StyleSheet.create({
 const isMobile = Platform.OS == 'android' || (Platform.OS == 'ios' && !Platform.isPad);
 
 export const Test = (props: TestProps): React.ReactElement<Record<string, never>> => {
+  const [showStatus, setShowStatus] = React.useState(false);
+  const toggleSvg: React.FunctionComponent<SvgProps> = () => {
+    const path = showStatus
+      ? 'M2.75 5.25h6.5s0.75 0 0.75 0.75v0s0 0.75 -0.75 0.75h-6.5s-0.75 0 -0.75 -0.75v0s0 -0.75 0.75 -0.75'
+      : 'M6.5 1.75C6.5 1.33579 6.16421 1 5.75 1C5.33579 1 5 1.33579 5 1.75V5H1.75C1.33579 5 1 5.33579 1 5.75C1 6.16421 1.33579 6.5 1.75 6.5H5V9.75C5 10.1642 5.33579 10.5 5.75 10.5C6.16421 10.5 6.5 10.1642 6.5 9.75V6.5H9.75C10.1642 6.5 10.5 6.16421 10.5 5.75C10.5 5.33579 10.1642 5 9.75 5H6.5V1.75Z';
+    return (
+      <Svg>
+        <G>
+          <Path d={path} fill="black" />
+        </G>
+      </Svg>
+    );
+  };
+  const svgProps: SvgIconProps = {
+    src: toggleSvg,
+  };
+  const toggleIconProps = createIconProps({ svgSource: svgProps, width: 12, height: 12 });
+
   return (
     <View testID="ScrollViewAreaForComponents">
       <Text style={[styles.name]} variant="heroSemibold">
@@ -71,7 +91,10 @@ export const Test = (props: TestProps): React.ReactElement<Record<string, never>
       <Stack style={stackStyle}>
         <Text style={styles.description}>{props.description}</Text>
       </Stack>
-      {!isMobile && (
+      <ToggleButton onClick={() => setShowStatus(!showStatus)} style={[styles.statusLabel]}>
+        Platform Status <Icon {...toggleIconProps} />
+      </ToggleButton>
+      {!isMobile && showStatus && (
         <Stack style={stackStyle}>
           <Text style={[styles.statusHeader]} variant="headerStandard">
             Platform Status

--- a/apps/fluent-tester/src/TestComponents/Test.tsx
+++ b/apps/fluent-tester/src/TestComponents/Test.tsx
@@ -64,7 +64,7 @@ const isMobile = Platform.OS == 'android' || (Platform.OS == 'ios' && !Platform.
 
 export const Test = (props: TestProps): React.ReactElement<Record<string, never>> => {
   const [showStatus, setShowStatus] = React.useState(false);
-  const fontBuiltInProps = {
+  const fontIconProps = {
     fontFamily: 'Arial',
     codepoint: showStatus ? 0x2796 : 0x2795,
     fontSize: 10,
@@ -80,7 +80,7 @@ export const Test = (props: TestProps): React.ReactElement<Record<string, never>
         <Text style={styles.description}>{props.description}</Text>
       </Stack>
       <ToggleButton iconOnly={true} onClick={() => setShowStatus(!showStatus)} style={[styles.statusLabel]}>
-        <Icon fontSource={fontBuiltInProps} />
+        <Icon fontSource={fontIconProps} />
       </ToggleButton>
       {!isMobile && showStatus && (
         <Stack style={stackStyle}>

--- a/apps/fluent-tester/src/TestComponents/Test.tsx
+++ b/apps/fluent-tester/src/TestComponents/Test.tsx
@@ -84,55 +84,61 @@ export const Test = (props: TestProps): React.ReactElement<Record<string, never>
       <Stack style={stackStyle}>
         <Text style={styles.description}>{props.description}</Text>
       </Stack>
-      <ToggleButton
-        iconOnly={true}
-        icon={{ fontSource: fontIconProps }}
-        onClick={() => setShowStatus(!showStatus)}
-        style={[styles.statusLabel]}
-      />
-      {!isMobile && showStatus && (
+      {!isMobile && (
         <Stack style={stackStyle}>
-          <Text style={[styles.statusHeader]} variant="headerStandard">
-            Platform Status
-          </Text>
-          <Text style={[styles.statusLabel]} variant="bodySemibold">
-            Win32: <Text style={styles.status}>{props.status.win32Status}</Text>
-          </Text>
-          <Text style={[styles.statusLabel]} variant="bodySemibold">
-            UWP: <Text style={styles.status}>{props.status.uwpStatus}</Text>
-          </Text>
-          <Text style={[styles.statusLabel]} variant="bodySemibold">
-            iOS: <Text style={styles.status}>{props.status.iosStatus}</Text>
-          </Text>
-          <Text style={[styles.statusLabel]} variant="bodySemibold">
-            macOS: <Text style={styles.status}>{props.status.macosStatus}</Text>
-          </Text>
-          <Text style={[styles.statusLabel]} variant="bodySemibold">
-            Android: <Text style={styles.status}>{props.status.androidStatus}</Text>
-          </Text>
-
-          <Text style={[styles.definitionHeader]} variant="headerStandard">
-            Status Definitions
-          </Text>
-          <Text style={[styles.statusLabel]} variant="bodySemibold">
-            Production:{' '}
-            <Text style={styles.status}>Control is ready for broad partner use and to be used in production-ready scenarios.</Text>
-          </Text>
-          <Text style={[styles.statusLabel]} variant="bodySemibold">
-            Beta:{' '}
-            <Text style={styles.status}>
-              Control is ready for partner consumption, but not ready for production release (e.g. fixing bugs).
+          <View style={styles.statusView}>
+            <Text style={[styles.statusHeader]} variant="headerStandard">
+              Platform Status
             </Text>
-          </Text>
-          <Text style={[styles.statusLabel]} variant="bodySemibold">
-            Experimental: <Text style={styles.status}>Control code checked into repo, but not ready for partner use.</Text>
-          </Text>
-          <Text style={[styles.statusLabel]} variant="bodySemibold">
-            Backlog: <Text style={styles.status}>Control is in plan and on our backlog to deliver.</Text>
-          </Text>
-          <Text style={[styles.statusLabel]} variant="bodySemibold">
-            N/A: <Text style={styles.status}>Control is not in current plan.</Text>
-          </Text>
+            <ToggleButton
+              iconOnly={true}
+              icon={{ fontSource: fontIconProps }}
+              onClick={() => setShowStatus(!showStatus)}
+              style={[styles.statusLabel]}
+            />
+          </View>
+          {showStatus && (
+            <View>
+              <Text style={[styles.statusLabel]} variant="bodySemibold">
+                Win32: <Text style={styles.status}>{props.status.win32Status}</Text>
+              </Text>
+              <Text style={[styles.statusLabel]} variant="bodySemibold">
+                UWP: <Text style={styles.status}>{props.status.uwpStatus}</Text>
+              </Text>
+              <Text style={[styles.statusLabel]} variant="bodySemibold">
+                iOS: <Text style={styles.status}>{props.status.iosStatus}</Text>
+              </Text>
+              <Text style={[styles.statusLabel]} variant="bodySemibold">
+                macOS: <Text style={styles.status}>{props.status.macosStatus}</Text>
+              </Text>
+              <Text style={[styles.statusLabel]} variant="bodySemibold">
+                Android: <Text style={styles.status}>{props.status.androidStatus}</Text>
+              </Text>
+
+              <Text style={[styles.definitionHeader]} variant="headerStandard">
+                Status Definitions
+              </Text>
+              <Text style={[styles.statusLabel]} variant="bodySemibold">
+                Production:{' '}
+                <Text style={styles.status}>Control is ready for broad partner use and to be used in production-ready scenarios.</Text>
+              </Text>
+              <Text style={[styles.statusLabel]} variant="bodySemibold">
+                Beta:{' '}
+                <Text style={styles.status}>
+                  Control is ready for partner consumption, but not ready for production release (e.g. fixing bugs).
+                </Text>
+              </Text>
+              <Text style={[styles.statusLabel]} variant="bodySemibold">
+                Experimental: <Text style={styles.status}>Control code checked into repo, but not ready for partner use.</Text>
+              </Text>
+              <Text style={[styles.statusLabel]} variant="bodySemibold">
+                Backlog: <Text style={styles.status}>Control is in plan and on our backlog to deliver.</Text>
+              </Text>
+              <Text style={[styles.statusLabel]} variant="bodySemibold">
+                N/A: <Text style={styles.status}>Control is not in current plan.</Text>
+              </Text>
+            </View>
+          )}
         </Stack>
       )}
       {props.sections.map((section, index) => {

--- a/apps/fluent-tester/src/TestComponents/Test.tsx
+++ b/apps/fluent-tester/src/TestComponents/Test.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import { StyleSheet, View, Platform } from 'react-native';
-import { Text, ToggleButton, Separator, createIconProps } from '@fluentui/react-native';
+import { Text, ToggleButton, Separator } from '@fluentui/react-native';
 import { Stack } from '@fluentui-react-native/stack';
 import { stackStyle } from './Common/styles';
-import Svg, { G, Path, SvgProps } from 'react-native-svg';
-import { Icon, SvgIconProps } from '@fluentui-react-native/icon';
 
 export type TestSection = {
   name: string;
@@ -65,22 +63,6 @@ const isMobile = Platform.OS == 'android' || (Platform.OS == 'ios' && !Platform.
 
 export const Test = (props: TestProps): React.ReactElement<Record<string, never>> => {
   const [showStatus, setShowStatus] = React.useState(false);
-  const toggleSvg: React.FunctionComponent<SvgProps> = () => {
-    const path = showStatus
-      ? 'M2.75 5.25h6.5s0.75 0 0.75 0.75v0s0 0.75 -0.75 0.75h-6.5s-0.75 0 -0.75 -0.75v0s0 -0.75 0.75 -0.75'
-      : 'M6.5 1.75C6.5 1.33579 6.16421 1 5.75 1C5.33579 1 5 1.33579 5 1.75V5H1.75C1.33579 5 1 5.33579 1 5.75C1 6.16421 1.33579 6.5 1.75 6.5H5V9.75C5 10.1642 5.33579 10.5 5.75 10.5C6.16421 10.5 6.5 10.1642 6.5 9.75V6.5H9.75C10.1642 6.5 10.5 6.16421 10.5 5.75C10.5 5.33579 10.1642 5 9.75 5H6.5V1.75Z';
-    return (
-      <Svg>
-        <G>
-          <Path d={path} fill="black" />
-        </G>
-      </Svg>
-    );
-  };
-  const svgProps: SvgIconProps = {
-    src: toggleSvg,
-  };
-  const toggleIconProps = createIconProps({ svgSource: svgProps, width: 12, height: 12 });
 
   return (
     <View testID="ScrollViewAreaForComponents">
@@ -92,7 +74,7 @@ export const Test = (props: TestProps): React.ReactElement<Record<string, never>
         <Text style={styles.description}>{props.description}</Text>
       </Stack>
       <ToggleButton onClick={() => setShowStatus(!showStatus)} style={[styles.statusLabel]}>
-        Platform Status <Icon {...toggleIconProps} />
+        Platform Status {showStatus ? '-' : '+'}
       </ToggleButton>
       {!isMobile && showStatus && (
         <Stack style={stackStyle}>

--- a/apps/fluent-tester/src/TestComponents/Test.tsx
+++ b/apps/fluent-tester/src/TestComponents/Test.tsx
@@ -85,9 +85,12 @@ export const Test = (props: TestProps): React.ReactElement<Record<string, never>
       <Stack style={stackStyle}>
         <Text style={styles.description}>{props.description}</Text>
       </Stack>
-      <ToggleButton iconOnly={true} onClick={() => setShowStatus(!showStatus)} style={[styles.statusLabel]}>
-        <Icon fontSource={fontIconProps} />
-      </ToggleButton>
+      <ToggleButton
+        iconOnly={true}
+        icon={{ fontSource: fontIconProps }}
+        onClick={() => setShowStatus(!showStatus)}
+        style={[styles.statusLabel]}
+      />
       {!isMobile && showStatus && (
         <Stack style={stackStyle}>
           <Text style={[styles.statusHeader]} variant="headerStandard">

--- a/apps/fluent-tester/src/TestComponents/Test.tsx
+++ b/apps/fluent-tester/src/TestComponents/Test.tsx
@@ -3,7 +3,6 @@ import { StyleSheet, View, Platform } from 'react-native';
 import { Text, ToggleButton, Separator } from '@fluentui/react-native';
 import { Stack } from '@fluentui-react-native/stack';
 import { stackStyle } from './Common/styles';
-import { Icon } from '@fluentui-react-native/icon';
 import { useTheme } from '@fluentui-react-native/theme-types';
 
 export type TestSection = {

--- a/change/@fluentui-react-native-tester-d51309c0-9c64-4fcb-af74-3ffb809303cd.json
+++ b/change/@fluentui-react-native-tester-d51309c0-9c64-4fcb-af74-3ffb809303cd.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix issue where status definitions don't wrap",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "joannaquu@gmail.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [ ] android

### Description of changes

Changed Platform Status to be collapsible on macOS/win32. Also added Platform Status to mobile and fixed issue where Status Definitions don't wrap when resized horizontally on macOS/win32 test app. Previously, resizing the FluentTester window smaller caused the status definitions to extend beyond the page and be cut off. This change moves the status definitions below the platform status, allowing for correct wrapping.

### Verification

Before

https://user-images.githubusercontent.com/55368679/186288207-8c2d92c3-6f15-416c-86d0-871c8ffdcca0.mov

After

https://user-images.githubusercontent.com/55368679/186747691-ef79bda8-62d5-4724-a4ab-a0bff42dc164.mov

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 13 Pro - 2022-08-25 at 10 20 03](https://user-images.githubusercontent.com/55368679/186729613-6b598599-9931-4da6-9055-d8d3f52faba3.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-08-25 at 12 01 42](https://user-images.githubusercontent.com/55368679/186747210-fc2d27ee-d003-46c8-a559-44838b6cf591.png) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
