### PR TITLE
Undo stripping debug symbols

### DIFF
--- a/.ado/templates/apple-xcode-build.yml
+++ b/.ado/templates/apple-xcode-build.yml
@@ -17,13 +17,3 @@ steps:
       xcWorkspacePath: ${{ parameters.xcode_workspacePath }}
       signingOption: nosign
       args: '-verbose -derivedDataPath DerivedData ${{ parameters.xcode_extraArgs }}'
-
-  - ${{ if ne(parameters.xcode_sdk, 'macosx') }}:
-      - script: |
-          strip -x -S $(Build.Repository.LocalPath)/DerivedData/${{ parameters.output_folder }}/Build/Products/${{ parameters.xcode_configuration }}-${{ parameters.xcode_sdk }}/**/*.a
-        displayName: Strip debug symbols for ios libraries
-
-  - ${{ if eq(parameters.xcode_sdk, 'macosx') }}:
-      - script: |
-          strip -x -S $(Build.Repository.LocalPath)/DerivedData/${{ parameters.output_folder }}/Build/Products/${{ parameters.xcode_configuration }}/**/*.a
-        displayName: Strip debug symbols for macos libraries


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Undo the strip debug symbols change temporarily while we work on a way to preserve debug symbols for Watson (i.e. publishing a dSYM file in the nuget). Once we find a way to do that, we'll add this change back in.
