### PR TITLE
Fixed content for tiny and extraSmall Badge

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Badge/BasicBadgeTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Badge/BasicBadgeTest.tsx
@@ -67,7 +67,6 @@ export const BasicBadge: React.FunctionComponent = () => {
     size,
     shape,
   };
-  const badgeContent = size === 'tiny' || size === 'extraSmall' ? '' : 'Basic badge';
 
   return (
     <View>
@@ -88,10 +87,10 @@ export const BasicBadge: React.FunctionComponent = () => {
         <Text>Parent component for the Badge</Text>
         {svgIconsEnabled && showIcon ? (
           <Badge {...badgeConfig} icon={{ svgSource: svgProps }} iconPosition={iconPosition}>
-            {badgeContent}
+            Basic badge
           </Badge>
         ) : (
-          <Badge {...badgeConfig}>{badgeContent}</Badge>
+          <Badge {...badgeConfig}>Basic badge</Badge>
         )}
       </View>
 

--- a/change/@fluentui-react-native-badge-87835827-4645-4918-a2a5-03e041c8ccd2.json
+++ b/change/@fluentui-react-native-badge-87835827-4645-4918-a2a5-03e041c8ccd2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed showing content for tiny and extraSmall badge",
+  "packageName": "@fluentui-react-native/badge",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-430d0b43-95d3-40d7-97af-23025f0c3212.json
+++ b/change/@fluentui-react-native-tester-430d0b43-95d3-40d7-97af-23025f0c3212.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed showing content for tiny and extraSmall badge",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Badge/src/Badge.tsx
+++ b/packages/experimental/Badge/src/Badge.tsx
@@ -39,20 +39,24 @@ export const Badge = compose<BadgeType>({
     const Slots = useSlots(userProps, (layer) => badgeLookup(layer, userProps));
 
     return (final: BadgeProps, ...children: ReactNode[]) => {
-      const { icon, iconPosition = 'before', ...mergedProps } = mergeProps(badge, final);
+      const { icon, iconPosition = 'before', size, ...mergedProps } = mergeProps(badge, final);
+      const showContent = size !== 'tiny' && size !== 'extraSmall';
+      const showIcon = size !== 'tiny';
+
       return (
         <Slots.root {...mergedProps}>
-          {icon && iconPosition === 'before' && <Slots.icon accessible={false} {...iconProps} />}
-          {Children.map(children, (child, i) =>
-            typeof child === 'string' ? (
-              <Slots.text accessible={false} key={`text-${i}`}>
-                {child}
-              </Slots.text>
-            ) : (
-              child
-            ),
-          )}
-          {icon && iconPosition === 'after' && <Slots.icon accessible={false} {...iconProps} />}
+          {icon && showIcon && iconPosition === 'before' && <Slots.icon accessible={false} {...iconProps} />}
+          {showContent &&
+            Children.map(children, (child, i) =>
+              typeof child === 'string' ? (
+                <Slots.text accessible={false} key={`text-${i}`}>
+                  {child}
+                </Slots.text>
+              ) : (
+                child
+              ),
+            )}
+          {icon && showIcon && iconPosition === 'after' && <Slots.icon accessible={false} {...iconProps} />}
         </Slots.root>
       );
     };

--- a/packages/experimental/Badge/src/Badge.tsx
+++ b/packages/experimental/Badge/src/Badge.tsx
@@ -39,7 +39,7 @@ export const Badge = compose<BadgeType>({
     const Slots = useSlots(userProps, (layer) => badgeLookup(layer, userProps));
 
     return (final: BadgeProps, ...children: ReactNode[]) => {
-      const { icon, iconPosition = 'before', size, ...mergedProps } = mergeProps(badge, final);
+      const { icon, iconPosition, size, ...mergedProps } = mergeProps(badge, final);
       const showContent = size !== 'tiny' && size !== 'extraSmall';
       const showIcon = size !== 'tiny';
 

--- a/packages/experimental/Badge/src/__tests__/__snapshots__/Badge.test.tsx.snap
+++ b/packages/experimental/Badge/src/__tests__/__snapshots__/Badge.test.tsx.snap
@@ -4,7 +4,6 @@ exports[`Badge component tests Badge all props 1`] = `
 <View
   appearance="outline"
   shape="rounded"
-  size="large"
   style={
     Object {
       "alignItems": "center",
@@ -67,7 +66,6 @@ exports[`Badge component tests Badge all props 1`] = `
 
 exports[`Badge component tests Badge tokens 1`] = `
 <View
-  size="medium"
   style={
     Object {
       "alignItems": "center",
@@ -116,7 +114,6 @@ exports[`Badge component tests Badge tokens 1`] = `
 
 exports[`Badge component tests Empty Badge 1`] = `
 <View
-  size="medium"
   style={
     Object {
       "alignItems": "center",


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
- Fixed showing content for tiny and extra-small badges
- Fixed showing icon for tiny Badges

When Badge is tiny, no content or icons should be shown. For extraSmall no content should be shown.

That's how it looks in Web:
tiny:
<img width="22" alt="image" src="https://user-images.githubusercontent.com/11574680/186641109-07b61444-30e2-47c8-a9ad-e9adbad157dd.png">
extraSmall:
<img width="41" alt="image" src="https://user-images.githubusercontent.com/11574680/186641197-f46b1b63-c8e2-4ab4-9f45-18f0d71e9e0c.png">
In the spec there's no font tokens for tiny. For extraSmall Badge only icon is expected.

### Verification
Checked manually.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
