### PR TITLE
[Badge] Fixed color customization

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Badge/BasicBadgeTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Badge/BasicBadgeTest.tsx
@@ -27,10 +27,8 @@ const badgeIconPositions = ['before', 'after'];
 
 const StyledBadge = Badge.customize({
   fontWeight: 'bold',
-  fontSize: 60,
-  variant: 'heroLargeStandard',
-  textPadding: 50,
-  paddingHorizontal: 60,
+  fontSize: 12,
+  fontFamily: 'Georgia',
   backgroundColor: '#f09',
   borderColor: 'purple',
   color: 'yellow',

--- a/apps/fluent-tester/src/TestComponents/Badge/BasicBadgeTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Badge/BasicBadgeTest.tsx
@@ -26,11 +26,18 @@ const badgeAppearances: BadgeAppearance[] = [...BadgeAppearances];
 const badgeIconPositions = ['before', 'after'];
 
 const StyledBadge = Badge.customize({
-  backgroundColor: 'yellow',
-  borderColor: '#f09',
-  borderWidth: 4,
-  color: '#f07',
   fontWeight: 'bold',
+  fontSize: 60,
+  variant: 'heroLargeStandard',
+  textPadding: 50,
+  paddingHorizontal: 60,
+  backgroundColor: '#f09',
+  borderColor: 'purple',
+  color: 'yellow',
+  borderWidth: 4,
+  borderStyle: 'dashed',
+  borderRadius: 2,
+  iconColor: 'cyan',
 });
 
 export const BasicBadge: React.FunctionComponent = () => {
@@ -112,10 +119,10 @@ export const BasicBadge: React.FunctionComponent = () => {
           </Badge>
           <Badge appearance="outline" icon={iconProps} />
           <Badge icon={{ fontSource: { ...fontBuiltInProps }, color: '#fff' }}>Badge with icon</Badge>
+          <Text>Customized Badge with icon</Text>
+          <StyledBadge icon={{ svgSource: svgProps }}>Styled badge</StyledBadge>
         </>
       )}
-      <StyledBadge appearance="outline">Styled badge</StyledBadge>
-      <StyledBadge>Styled badge</StyledBadge>
     </View>
   );
 };

--- a/change/@fluentui-react-native-badge-0564d465-245e-462c-ac65-7660a7faa51c.json
+++ b/change/@fluentui-react-native-badge-0564d465-245e-462c-ac65-7660a7faa51c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed customization",
+  "packageName": "@fluentui-react-native/badge",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-730dbf6d-61c4-4430-80fb-88e860d00530.json
+++ b/change/@fluentui-react-native-tester-730dbf6d-61c4-4430-80fb-88e860d00530.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed customization",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Badge/SPEC.md
+++ b/packages/experimental/Badge/SPEC.md
@@ -119,10 +119,20 @@ export interface BadgeConfigurableProps {
   badgeColor?: BadgeColor;
 
   /**
+   * The icon color.
+   */
+  iconColor?: ColorValue;
+
+  /**
    * Badge position
    * @defaultvalue absolute
    */
   position?: FlexStyle['position'];
+
+  /**
+   * Text color.
+   */
+  textColor?: ColorValue;
 }
 ```
 
@@ -175,14 +185,12 @@ export interface BadgeCoreTokens extends LayoutTokens, FontTokens, IBorderTokens
    * The height of the Badge.
    */
   height?: number;
-  /**
-   * The icon color.
-   */
-  iconColor?: ColorValue;
+
   /**
    * The icon size.
    */
   iconSize?: number;
+
   /**
    * Set the left edge of the Badge
    */
@@ -221,11 +229,6 @@ export interface BadgeCoreTokens extends LayoutTokens, FontTokens, IBorderTokens
   square?: BadgeTokens;
 }
 export interface BadgeTokens extends BadgeCoreTokens, BadgeConfigurableProps {
-  /**
-   * The size of the icon.
-   */
-  iconSize?: number;
-
   /**
    * The weight of the lines used when drawing the icon.
    */

--- a/packages/experimental/Badge/SPEC.md
+++ b/packages/experimental/Badge/SPEC.md
@@ -128,11 +128,6 @@ export interface BadgeConfigurableProps {
    * @defaultvalue absolute
    */
   position?: FlexStyle['position'];
-
-  /**
-   * Text color.
-   */
-  textColor?: ColorValue;
 }
 ```
 

--- a/packages/experimental/Badge/src/Badge.styling.ts
+++ b/packages/experimental/Badge/src/Badge.styling.ts
@@ -19,7 +19,7 @@ import { badgeFontTokens } from './BadgeFontTokens';
 
 export const coreBadgeStates: (keyof BadgeCoreTokens)[] = [...BadgeSizes, ...BadgeShapes];
 export const badgeStates: (keyof BadgeTokens)[] = [...coreBadgeStates, ...BadgeColors, ...BadgeAppearances, 'rtl'];
-const tokensThatAreAlsoProps: (keyof BadgeConfigurableProps)[] = ['badgeColor', 'icon', 'iconColor', 'iconPosition', 'position'];
+const tokensThatAreAlsoProps: (keyof BadgeConfigurableProps)[] = ['badgeColor', 'color', 'icon', 'iconColor', 'iconPosition', 'position'];
 
 export const stylingSettings: UseStylingOptions<BadgeProps, BadgeSlotProps, BadgeTokens> = {
   tokens: [defaultBadgeTokens, defaultBadgeColorTokens, badgeFontTokens, badgeName],
@@ -74,7 +74,7 @@ export const stylingSettings: UseStylingOptions<BadgeProps, BadgeSlotProps, Badg
           style: {
             ...fontStyles.from(tokens, theme),
             color: tokens.color,
-            ...getIconMargin(tokens),
+            ...getTextMargin(tokens),
           },
         };
       },
@@ -111,7 +111,7 @@ export function getBadgePosition(tokens: BadgeCoreTokens) {
   };
 }
 
-export function getIconMargin(tokens: BadgeTokens) {
+export function getTextMargin(tokens: BadgeTokens) {
   if (tokens.icon) {
     return tokens.iconPosition === 'before'
       ? {

--- a/packages/experimental/Badge/src/Badge.styling.ts
+++ b/packages/experimental/Badge/src/Badge.styling.ts
@@ -17,9 +17,9 @@ import { defaultBadgeTokens } from './BadgeTokens';
 import { defaultBadgeColorTokens } from './BadgeColorTokens';
 import { badgeFontTokens } from './BadgeFontTokens';
 
-export const coreBadgeStates: (keyof BadgeCoreTokens)[] = [...BadgeSizes, ...BadgeShapes];
+export const coreBadgeStates: (keyof BadgeCoreTokens)[] = [...BadgeSizes, ...BadgeShapes, 'textPadding'];
 export const badgeStates: (keyof BadgeTokens)[] = [...coreBadgeStates, ...BadgeColors, ...BadgeAppearances, 'rtl'];
-const tokensThatAreAlsoProps: (keyof BadgeConfigurableProps)[] = ['badgeColor', 'position'];
+const tokensThatAreAlsoProps: (keyof BadgeConfigurableProps)[] = ['badgeColor', 'iconColor', 'position', 'textColor'];
 
 export const stylingSettings: UseStylingOptions<BadgeProps, BadgeSlotProps, BadgeTokens> = {
   tokens: [defaultBadgeTokens, defaultBadgeColorTokens, badgeFontTokens, badgeName],
@@ -47,7 +47,19 @@ export const stylingSettings: UseStylingOptions<BadgeProps, BadgeSlotProps, Badg
           },
         };
       },
-      ['backgroundColor', 'width', 'minHeight', 'bottom', 'right', 'top', 'left', ...borderStyles.keys, ...layoutStyles.keys],
+      [
+        'backgroundColor',
+        'badgeColor',
+        'width',
+        'minHeight',
+        'bottom',
+        'right',
+        'top',
+        'left',
+        'position',
+        ...borderStyles.keys,
+        ...layoutStyles.keys,
+      ],
     ),
     icon: buildProps(
       (tokens: BadgeTokens) => ({
@@ -60,10 +72,10 @@ export const stylingSettings: UseStylingOptions<BadgeProps, BadgeSlotProps, Badg
     text: buildProps(
       (tokens: BadgeTokens, theme: Theme) => ({
         ...fontStyles.from(tokens, theme),
-        color: tokens.color,
+        color: tokens.textColor || tokens.color,
         paddingHorizontal: tokens.textPadding,
       }),
-      ['color', 'textPadding', ...fontStyles.keys],
+      ['color', 'textColor', 'textPadding', ...fontStyles.keys],
     ),
   },
 };

--- a/packages/experimental/Badge/src/Badge.styling.ts
+++ b/packages/experimental/Badge/src/Badge.styling.ts
@@ -17,9 +17,9 @@ import { defaultBadgeTokens } from './BadgeTokens';
 import { defaultBadgeColorTokens } from './BadgeColorTokens';
 import { badgeFontTokens } from './BadgeFontTokens';
 
-export const coreBadgeStates: (keyof BadgeCoreTokens)[] = [...BadgeSizes, ...BadgeShapes, 'textPadding'];
+export const coreBadgeStates: (keyof BadgeCoreTokens)[] = [...BadgeSizes, ...BadgeShapes];
 export const badgeStates: (keyof BadgeTokens)[] = [...coreBadgeStates, ...BadgeColors, ...BadgeAppearances, 'rtl'];
-const tokensThatAreAlsoProps: (keyof BadgeConfigurableProps)[] = ['badgeColor', 'iconColor', 'position', 'textColor'];
+const tokensThatAreAlsoProps: (keyof BadgeConfigurableProps)[] = ['badgeColor', 'icon', 'iconColor', 'iconPosition', 'position'];
 
 export const stylingSettings: UseStylingOptions<BadgeProps, BadgeSlotProps, BadgeTokens> = {
   tokens: [defaultBadgeTokens, defaultBadgeColorTokens, badgeFontTokens, badgeName],
@@ -38,7 +38,6 @@ export const stylingSettings: UseStylingOptions<BadgeProps, BadgeSlotProps, Badg
             flexDirection: 'row',
             alignSelf: 'flex-start',
             justifyContent: 'center',
-            minHeight: tokens.minHeight,
             width: tokens.width,
             backgroundColor: _badgeColor,
             position,
@@ -70,12 +69,16 @@ export const stylingSettings: UseStylingOptions<BadgeProps, BadgeSlotProps, Badg
       ['iconSize', 'iconColor', 'color'],
     ),
     text: buildProps(
-      (tokens: BadgeTokens, theme: Theme) => ({
-        ...fontStyles.from(tokens, theme),
-        color: tokens.textColor || tokens.color,
-        paddingHorizontal: tokens.textPadding,
-      }),
-      ['color', 'textColor', 'textPadding', ...fontStyles.keys],
+      (tokens: BadgeTokens, theme: Theme) => {
+        return {
+          style: {
+            ...fontStyles.from(tokens, theme),
+            color: tokens.color,
+            ...getIconMargin(tokens),
+          },
+        };
+      },
+      ['color', 'textMargin', ...fontStyles.keys],
     ),
   },
 };
@@ -106,4 +109,17 @@ export function getBadgePosition(tokens: BadgeCoreTokens) {
     ...verticalPosition,
     ...horizontalPosition,
   };
+}
+
+export function getIconMargin(tokens: BadgeTokens) {
+  if (tokens.icon) {
+    return tokens.iconPosition === 'before'
+      ? {
+          marginStart: tokens.textMargin,
+        }
+      : {
+          marginEnd: tokens.textMargin,
+        };
+  }
+  return {};
 }

--- a/packages/experimental/Badge/src/Badge.tsx
+++ b/packages/experimental/Badge/src/Badge.tsx
@@ -13,13 +13,11 @@ export const badgeLookup = (layer: string, userProps: BadgeProps): boolean => {
   return (
     userProps[layer] ||
     layer === userProps['appearance'] ||
-    (!userProps['appearance'] && layer === 'filled') ||
     layer === userProps['size'] ||
     (!userProps['size'] && layer === 'large') ||
     layer === userProps['shape'] ||
     (!userProps['shape'] && layer === 'circular') ||
     layer === userProps['badgeColor'] ||
-    (!userProps['badgeColor'] && layer === 'brand') ||
     (I18nManager.isRTL && layer === 'rtl')
   );
 };

--- a/packages/experimental/Badge/src/Badge.types.ts
+++ b/packages/experimental/Badge/src/Badge.types.ts
@@ -24,10 +24,20 @@ export interface BadgeConfigurableProps {
   badgeColor?: BadgeColor;
 
   /**
+   * The icon color.
+   */
+  iconColor?: ColorValue;
+
+  /**
    * Badge position
    * @defaultvalue absolute
    */
   position?: FlexStyle['position'];
+
+  /**
+   * Text color.
+   */
+  textColor?: ColorValue;
 }
 
 export interface BadgeCoreProps extends IViewProps {
@@ -71,14 +81,12 @@ export interface BadgeCoreTokens extends LayoutTokens, FontTokens, IBorderTokens
    * The height of the Badge.
    */
   height?: number;
-  /**
-   * The icon color.
-   */
-  iconColor?: ColorValue;
+
   /**
    * The icon size.
    */
   iconSize?: number;
+
   /**
    * Set the left edge of the Badge
    */
@@ -94,6 +102,7 @@ export interface BadgeCoreTokens extends LayoutTokens, FontTokens, IBorderTokens
    * icons or images
    */
   textPadding?: number;
+
   /**
    * Set the top edge of the Badge
    */
@@ -122,12 +131,7 @@ export interface BadgeCoreTokens extends LayoutTokens, FontTokens, IBorderTokens
   square?: BadgeTokens;
 }
 export interface BadgeTokens extends BadgeCoreTokens, BadgeConfigurableProps {
-  /**
-   * The size of the icon.
-   */
-  iconSize?: number;
-
-  /**
+  /*
    * The weight of the lines used when drawing the icon.
    */
   iconWeight?: number;

--- a/packages/experimental/Badge/src/Badge.types.ts
+++ b/packages/experimental/Badge/src/Badge.types.ts
@@ -24,20 +24,31 @@ export interface BadgeConfigurableProps {
   badgeColor?: BadgeColor;
 
   /**
+   * Set the text color
+   */
+  color?: ColorValue;
+
+  /*
+   * Source URL or name of the icon to show on the Badge.
+   */
+  icon?: IconSourcesType;
+
+  /**
    * The icon color.
    */
   iconColor?: ColorValue;
+
+  /**
+   * Icon can be placed before or after Badge's content.
+   * @default before
+   */
+  iconPosition?: BadgeIconPosition;
 
   /**
    * Badge position
    * @defaultvalue absolute
    */
   position?: FlexStyle['position'];
-
-  /**
-   * Text color.
-   */
-  textColor?: ColorValue;
 }
 
 export interface BadgeCoreProps extends IViewProps {
@@ -59,19 +70,8 @@ export interface BadgeProps extends BadgeCoreProps, BadgeConfigurableProps {
    * @defaultvalue filled
    */
   appearance?: BadgeAppearance;
-
-  /*
-   * Source URL or name of the icon to show on the Badge.
-   */
-  icon?: IconSourcesType;
-
-  /**
-   * Icon can be placed before or after Badge's content.
-   * @default before
-   */
-  iconPosition?: BadgeIconPosition;
 }
-export interface BadgeCoreTokens extends LayoutTokens, FontTokens, IBorderTokens, IShadowTokens, IColorTokens {
+export interface BadgeCoreTokens extends LayoutTokens, FontTokens, IBorderTokens, IShadowTokens, Omit<IColorTokens, 'color'> {
   /**
    * Set the bottom edge of the Badge
    */
@@ -101,7 +101,7 @@ export interface BadgeCoreTokens extends LayoutTokens, FontTokens, IBorderTokens
    * Set padding for text container when Badge contains
    * icons or images
    */
-  textPadding?: number;
+  textMargin?: number;
 
   /**
    * Set the top edge of the Badge
@@ -164,7 +164,7 @@ export interface BadgeTokens extends BadgeCoreTokens, BadgeConfigurableProps {
 
 export interface BadgeSlotProps {
   root: IViewProps;
-  icon: IconProps;
+  icon?: IconProps;
   text: TextProps;
 }
 

--- a/packages/experimental/Badge/src/BadgeColorTokens.ts
+++ b/packages/experimental/Badge/src/BadgeColorTokens.ts
@@ -5,8 +5,11 @@ import { getFilledColorProps, getOutlineColorProps, getTintColorProps, getGhostC
 
 export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
   ({
+    color: t.colors.neutralForegroundOnBrand,
+    backgroundColor: t.colors.brandBackgroundStatic,
+    borderColor: t.colors.transparentStroke,
     filled: {
-      borderColor: 'transparent',
+      borderColor: t.colors.transparentStroke,
     },
     outline: {
       backgroundColor: t.colors.transparentBackground,

--- a/packages/experimental/Badge/src/BadgeColorTokens.win32.ts
+++ b/packages/experimental/Badge/src/BadgeColorTokens.win32.ts
@@ -5,8 +5,11 @@ import { getFilledColorProps, getOutlineColorProps, getTintColorProps, getGhostC
 
 export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
   ({
+    color: t.colors.neutralForegroundOnBrand,
+    backgroundColor: t.colors.brandBackgroundStatic,
+    borderColor: t.colors.transparentStroke,
     filled: {
-      borderColor: 'transparent',
+      borderColor: t.colors.transparentStroke,
     },
     outline: {
       backgroundColor: t.colors.transparentBackground,

--- a/packages/experimental/Badge/src/BadgeTokens.ts
+++ b/packages/experimental/Badge/src/BadgeTokens.ts
@@ -9,7 +9,7 @@ export const defaultBadgeTokens: TokenSettings<BadgeTokens, Theme> = () =>
     borderWidth: globalTokens.stroke.width.thin,
     bottom: globalTokens.spacing.none,
     right: globalTokens.spacing.none,
-    textPadding: globalTokens.spacing.xxs,
+    textMargin: globalTokens.spacing.xxs,
     position: 'relative',
     tiny: {
       minWidth: 6,
@@ -31,7 +31,7 @@ export const defaultBadgeTokens: TokenSettings<BadgeTokens, Theme> = () =>
       minHeight: 16,
       iconSize: 12,
       paddingHorizontal: globalTokens.spacing.xxs,
-      textPadding: globalTokens.spacing.xxs,
+      textMargin: globalTokens.spacing.xxs,
       flexGap: globalTokens.spacing.xxs,
       rounded: {
         borderRadius: globalTokens.corner.radius.small,
@@ -42,7 +42,7 @@ export const defaultBadgeTokens: TokenSettings<BadgeTokens, Theme> = () =>
       minHeight: 20,
       iconSize: 12,
       paddingHorizontal: globalTokens.spacing.xs,
-      textPadding: globalTokens.spacing.xxs,
+      textMargin: globalTokens.spacing.xxs,
       flexGap: globalTokens.spacing.xxs,
     },
     large: {
@@ -50,7 +50,7 @@ export const defaultBadgeTokens: TokenSettings<BadgeTokens, Theme> = () =>
       minHeight: 24,
       iconSize: 16,
       paddingHorizontal: globalTokens.spacing.xs,
-      textPadding: globalTokens.spacing.xxs,
+      textMargin: globalTokens.spacing.xxs,
       flexGap: globalTokens.spacing.xxs,
     },
     extraLarge: {
@@ -58,7 +58,7 @@ export const defaultBadgeTokens: TokenSettings<BadgeTokens, Theme> = () =>
       minHeight: 32,
       iconSize: 20,
       paddingHorizontal: globalTokens.spacing.sNudge,
-      textPadding: globalTokens.spacing.xxs,
+      textMargin: globalTokens.spacing.xxs,
       flexGap: globalTokens.spacing.xs,
     },
     rounded: {

--- a/packages/experimental/Badge/src/__tests__/__snapshots__/Badge.test.tsx.snap
+++ b/packages/experimental/Badge/src/__tests__/__snapshots__/Badge.test.tsx.snap
@@ -42,21 +42,15 @@ exports[`Badge component tests Badge all props 1`] = `
   <Text
     accessible={false}
     ellipsizeMode="tail"
-    fontFamily="Segoe UI"
-    fontSize={12}
-    fontWeight="400"
     numberOfLines={0}
-    paddingHorizontal={2}
     style={
       Object {
         "color": "#ffffff",
         "fontFamily": "Segoe UI",
         "fontSize": 12,
-        "fontStyle": undefined,
         "fontWeight": "400",
         "margin": 0,
-        "textAlign": undefined,
-        "textDecorationLine": undefined,
+        "marginEnd": 2,
       }
     }
   >
@@ -91,21 +85,14 @@ exports[`Badge component tests Badge tokens 1`] = `
   <Text
     accessible={false}
     ellipsizeMode="tail"
-    fontFamily="Segoe UI"
-    fontSize={12}
-    fontWeight="400"
     numberOfLines={0}
-    paddingHorizontal={2}
     style={
       Object {
         "color": "#ffffff",
         "fontFamily": "Segoe UI",
         "fontSize": 12,
-        "fontStyle": undefined,
         "fontWeight": "400",
         "margin": 0,
-        "textAlign": undefined,
-        "textDecorationLine": undefined,
       }
     }
   >

--- a/packages/experimental/Badge/src/__tests__/__snapshots__/Badge.test.tsx.snap
+++ b/packages/experimental/Badge/src/__tests__/__snapshots__/Badge.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`Badge component tests Badge all props 1`] = `
       "alignItems": "center",
       "alignSelf": "flex-start",
       "backgroundColor": "transparent",
-      "borderColor": "#0078d4",
+      "borderColor": "transparent",
       "borderRadius": 4,
       "borderWidth": 1,
       "bottom": 0,
@@ -49,7 +49,7 @@ exports[`Badge component tests Badge all props 1`] = `
     paddingHorizontal={2}
     style={
       Object {
-        "color": "#0078d4",
+        "color": "#ffffff",
         "fontFamily": "Segoe UI",
         "fontSize": 12,
         "fontStyle": undefined,
@@ -72,8 +72,8 @@ exports[`Badge component tests Badge tokens 1`] = `
     Object {
       "alignItems": "center",
       "alignSelf": "flex-start",
-      "backgroundColor": "#0078d4",
-      "borderColor": "transparent",
+      "backgroundColor": "yellow",
+      "borderColor": "#f09",
       "borderRadius": 9999,
       "borderWidth": 4,
       "bottom": 0,
@@ -181,7 +181,7 @@ exports[`CounterBadge component tests CounterBadge all props 1`] = `
     numberOfLines={0}
     style={
       Object {
-        "color": "#0078d4",
+        "color": "#ffffff",
         "fontFamily": "Segoe UI",
         "fontSize": 12,
         "fontStyle": undefined,
@@ -327,8 +327,8 @@ exports[`CounterBadge component tests CounterBadge tokens 1`] = `
     Object {
       "alignItems": "center",
       "alignSelf": "flex-start",
-      "backgroundColor": "#0078d4",
-      "borderColor": "transparent",
+      "backgroundColor": "yellow",
+      "borderColor": "#f09",
       "borderRadius": 9999,
       "borderWidth": 4,
       "bottom": 0,


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
- Background, color and borderColor wasn't possible to customize using tokens. Only by overriding e.g. `tokens: { brand: {filled: { ...styles }} }`
- Exposed iconColor and textColor as a prop

### Verification
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Colors didn't change  ![image](https://user-images.githubusercontent.com/11574680/186717227-5611cbe5-ede6-4fa8-8d9e-e9966f4fa92b.png) |  ![image](https://user-images.githubusercontent.com/11574680/186716634-3e5a36ca-be49-45bb-8ec0-c037be4644d7.png) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
