### PR TITLE
[Button] Remoed unused styles

### DIFF
--- a/change/@fluentui-react-native-button-124d53a8-de9b-4579-82d3-45802ff27f3e.json
+++ b/change/@fluentui-react-native-button-124d53a8-de9b-4579-82d3-45802ff27f3e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Removed unused styles",
+  "packageName": "@fluentui-react-native/button",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Button/src/Button.styling.ts
+++ b/packages/components/Button/src/Button.styling.ts
@@ -1,6 +1,6 @@
 import { buttonName, ButtonCoreTokens, ButtonTokens, ButtonSlotProps, ButtonProps, ButtonSize } from './Button.types';
 import { Theme, UseStylingOptions, buildProps } from '@fluentui-react-native/framework';
-import { borderStyles, layoutStyles, fontStyles, shadowStyles, FontTokens } from '@fluentui-react-native/tokens';
+import { borderStyles, layoutStyles, fontStyles, FontTokens } from '@fluentui-react-native/tokens';
 import { defaultButtonTokens } from './ButtonTokens';
 import { defaultButtonColorTokens } from './ButtonColorTokens';
 import { Platform, ColorValue } from 'react-native';
@@ -44,10 +44,9 @@ export const stylingSettings: UseStylingOptions<ButtonProps, ButtonSlotProps, Bu
           backgroundColor: tokens.backgroundColor,
           ...borderStyles.from(tokens, theme),
           ...layoutStyles.from(tokens, theme),
-          ...shadowStyles.from(tokens, theme),
         },
       }),
-      ['backgroundColor', 'width', ...borderStyles.keys, ...layoutStyles.keys, ...shadowStyles.keys],
+      ['backgroundColor', 'width', ...borderStyles.keys, ...layoutStyles.keys],
     ),
     content: buildProps(
       (tokens: ButtonTokens, theme: Theme) => {

--- a/packages/components/Button/src/Button.tsx
+++ b/packages/components/Button/src/Button.tsx
@@ -9,7 +9,6 @@ import { compose, mergeProps, withSlots, UseSlots } from '@fluentui-react-native
 import { useButton } from './useButton';
 import { Icon } from '@fluentui-react-native/icon';
 import { createIconProps, IPressableState } from '@fluentui-react-native/interactive-hooks';
-import { Shadow } from '@fluentui-react-native/experimental-shadow';
 
 /**
  * A function which determines if a set of styles should be applied to the compoent given the current state and props of the button.
@@ -42,7 +41,6 @@ export const Button = compose<ButtonType>({
     root: View,
     icon: Icon,
     content: Text,
-    shadow: Shadow,
   },
   useRender: (userProps: ButtonProps, useSlots: UseSlots<ButtonType>) => {
     const button = useButton(userProps);

--- a/packages/components/Button/src/Button.types.ts
+++ b/packages/components/Button/src/Button.types.ts
@@ -5,7 +5,6 @@ import { FontTokens, IBorderTokens, IColorTokens, IShadowTokens, LayoutTokens } 
 import { IFocusable, IPressableHooks, IWithPressableOptions, InteractionEvent } from '@fluentui-react-native/interactive-hooks';
 import { IconProps, IconSourcesType } from '@fluentui-react-native/icon';
 import { IViewProps } from '@fluentui-react-native/adapters';
-import { ShadowProps } from '@fluentui-react-native/experimental-shadow';
 import { ShadowToken } from '@fluentui-react-native/theme-types';
 
 export const buttonName = 'Button';
@@ -155,7 +154,6 @@ export interface ButtonSlotProps {
   root: React.PropsWithRef<IViewProps>;
   icon: IconProps;
   content: TextProps;
-  shadow?: ShadowProps;
 }
 
 export interface ButtonType {

--- a/packages/components/Button/src/FAB/FAB.styling.ts
+++ b/packages/components/Button/src/FAB/FAB.styling.ts
@@ -1,4 +1,5 @@
-import { ButtonCoreTokens, ButtonSlotProps, ButtonCoreProps } from '../Button.types';
+import { ButtonCoreTokens, ButtonCoreProps } from '../Button.types';
+import { FABSlotProps } from './FAB.types';
 import { Theme, UseStylingOptions, buildProps } from '@fluentui-react-native/framework';
 import { borderStyles, layoutStyles, fontStyles, shadowStyles } from '@fluentui-react-native/tokens';
 import { buttonCoreStates } from '../Button.styling';
@@ -6,7 +7,7 @@ import { getTextMarginAdjustment } from '@fluentui-react-native/styling-utils';
 import { defaultFABTokens } from './FABTokens';
 import { defaultFABColorTokens } from './FABColorTokens';
 
-export const stylingSettings: UseStylingOptions<ButtonCoreProps, ButtonSlotProps, ButtonCoreTokens> = {
+export const stylingSettings: UseStylingOptions<ButtonCoreProps, FABSlotProps, ButtonCoreTokens> = {
   tokens: [defaultFABTokens, defaultFABColorTokens],
   states: [...buttonCoreStates],
   slotProps: {

--- a/packages/components/Button/src/FAB/FAB.types.ts
+++ b/packages/components/Button/src/FAB/FAB.types.ts
@@ -1,9 +1,13 @@
 import { ButtonSlotProps, ButtonCoreTokens, ButtonCoreProps } from '../Button.types';
+import { ShadowProps } from '@fluentui-react-native/experimental-shadow';
 
 export const fabName = 'FAB';
 
+export interface FABSlotProps extends ButtonSlotProps {
+  shadow?: ShadowProps;
+}
 export interface FABType {
   props: ButtonCoreProps;
   tokens: ButtonCoreTokens;
-  slotProps: ButtonSlotProps;
+  slotProps: FABSlotProps;
 }


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS
- [X] win32 (Office)
- [X] windows
- [ ] android

### Description of changes
Removed unused Shadow styles from the Button component

### Verification
Ran tests and checked manually

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
