### PR TITLE
Shadows: adjust blur value to match designs

### DIFF
--- a/change/@fluentui-react-native-button-3c05e88b-5d34-4897-956b-8ea69968abe4.json
+++ b/change/@fluentui-react-native-button-3c05e88b-5d34-4897-956b-8ea69968abe4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update shadow jest tests",
+  "packageName": "@fluentui-react-native/button",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-shadow-36218d8d-876f-4ef8-b7de-d83d77bfc659.json
+++ b/change/@fluentui-react-native-experimental-shadow-36218d8d-876f-4ef8-b7de-d83d77bfc659.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated screenshots",
+  "packageName": "@fluentui-react-native/experimental-shadow",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Button/src/FAB/__snapshots__/FAB.test.tsx.snap
+++ b/packages/components/Button/src/FAB/__snapshots__/FAB.test.tsx.snap
@@ -73,7 +73,7 @@ exports[`Default FAB (iOS) 1`] = `
         "width": 0,
       },
       "shadowOpacity": 0.12,
-      "shadowRadius": 2,
+      "shadowRadius": 1,
     }
   }
 >
@@ -119,7 +119,7 @@ exports[`Default FAB (iOS) 1`] = `
           "width": 0,
         },
         "shadowOpacity": 0.14,
-        "shadowRadius": 8,
+        "shadowRadius": 4,
       }
     }
   >

--- a/packages/experimental/Shadow/SPEC.md
+++ b/packages/experimental/Shadow/SPEC.md
@@ -12,8 +12,8 @@ These are the current `Shadow` variants:
 
 |                 | Light mode                                                                                                                                                                | Dark mode                                                                                                                                                                 |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Regular shadows | <img width="801" alt="Screen Shot 2022-08-12 at 10 46 45 AM" src="https://user-images.githubusercontent.com/78454019/184426272-fe23d23f-3c60-4811-82d8-16ae8dc501d9.png"> | <img width="788" alt="Screen Shot 2022-08-12 at 12 08 56 PM" src="https://user-images.githubusercontent.com/78454019/184427236-0b93d797-fdde-4367-9caa-751bcf335eea.png"> |
-| Brand shadows   | <img width="802" alt="Screen Shot 2022-08-12 at 12 09 15 PM" src="https://user-images.githubusercontent.com/78454019/184427300-06dacedc-5f39-4dc1-b07b-536186115d2e.png"> | <img width="789" alt="Screen Shot 2022-08-12 at 12 09 03 PM" src="https://user-images.githubusercontent.com/78454019/184427338-c322d223-4719-4593-a550-8360c45aa2e5.png"> |
+| Regular shadows | <img width="820" alt="light" src="https://user-images.githubusercontent.com/78454019/187567525-64592ead-c64c-4cc1-acd3-a21abdea2d35.png"> | <img width="820" alt="dark" src="https://user-images.githubusercontent.com/78454019/187567552-3b376f4d-eacd-482d-a395-a261c374c9f6.png"> |
+| Brand shadows   | <img width="820" alt="light-brand" src="https://user-images.githubusercontent.com/78454019/187567541-c939ceaa-35b1-4cd6-84b5-55d8a5032e0c.png"> | <img width="820" alt="dark-brand" src="https://user-images.githubusercontent.com/78454019/187567558-79783f9b-2bff-463c-b7b5-7ec692b000fd.png"> |
 
 ## Sample Code
 

--- a/packages/experimental/Shadow/src/__tests__/Shadow.test.tsx
+++ b/packages/experimental/Shadow/src/__tests__/Shadow.test.tsx
@@ -20,6 +20,13 @@ const TestShadow: React.FunctionComponent<ShadowTestProps> = (props: ShadowTestP
 };
 
 describe('Shadow component tests', () => {
+  beforeAll(() => {
+    jest.mock('react-native/Libraries/Utilities/Platform', () => ({
+      OS: 'macos',
+      select: () => null,
+    }));
+  });
+
   it('Shadow (depth=2)', () => {
     const tree = renderer.create(<TestShadow displayText="Shadow (depth=2)" depth="shadow2" />).toJSON();
     expect(tree).toMatchSnapshot();
@@ -86,5 +93,9 @@ describe('Shadow component tests', () => {
 
   it('Shadow re-renders correctly', () => {
     checkReRender(() => <TestShadow displayText="Shadow render twice test" depth="shadow2" />, 2);
+  });
+
+  afterAll(() => {
+    jest.unmock('react-native/Libraries/Utilities/Platform');
   });
 });

--- a/packages/experimental/Shadow/src/__tests__/__snapshots__/Shadow.test.tsx.snap
+++ b/packages/experimental/Shadow/src/__tests__/__snapshots__/Shadow.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`Shadow component tests Brand shadow (depth=2) 1`] = `
         "width": 0,
       },
       "shadowOpacity": 0.3,
-      "shadowRadius": 2,
+      "shadowRadius": 1,
     }
   }
 >
@@ -23,7 +23,7 @@ exports[`Shadow component tests Brand shadow (depth=2) 1`] = `
           "width": 0,
         },
         "shadowOpacity": 0.25,
-        "shadowRadius": 2,
+        "shadowRadius": 1,
       }
     }
   >
@@ -42,7 +42,7 @@ exports[`Shadow component tests Brand shadow (depth=4) 1`] = `
         "width": 0,
       },
       "shadowOpacity": 0.3,
-      "shadowRadius": 2,
+      "shadowRadius": 1,
     }
   }
 >
@@ -55,7 +55,7 @@ exports[`Shadow component tests Brand shadow (depth=4) 1`] = `
           "width": 0,
         },
         "shadowOpacity": 0.25,
-        "shadowRadius": 4,
+        "shadowRadius": 2,
       }
     }
   >
@@ -74,7 +74,7 @@ exports[`Shadow component tests Brand shadow (depth=8) 1`] = `
         "width": 0,
       },
       "shadowOpacity": 0.3,
-      "shadowRadius": 2,
+      "shadowRadius": 1,
     }
   }
 >
@@ -87,7 +87,7 @@ exports[`Shadow component tests Brand shadow (depth=8) 1`] = `
           "width": 0,
         },
         "shadowOpacity": 0.25,
-        "shadowRadius": 8,
+        "shadowRadius": 4,
       }
     }
   >
@@ -106,7 +106,7 @@ exports[`Shadow component tests Brand shadow (depth=16) 1`] = `
         "width": 0,
       },
       "shadowOpacity": 0.3,
-      "shadowRadius": 2,
+      "shadowRadius": 1,
     }
   }
 >
@@ -119,7 +119,7 @@ exports[`Shadow component tests Brand shadow (depth=16) 1`] = `
           "width": 0,
         },
         "shadowOpacity": 0.25,
-        "shadowRadius": 16,
+        "shadowRadius": 8,
       }
     }
   >
@@ -138,7 +138,7 @@ exports[`Shadow component tests Brand shadow (depth=28) 1`] = `
         "width": 0,
       },
       "shadowOpacity": 0.3,
-      "shadowRadius": 8,
+      "shadowRadius": 4,
     }
   }
 >
@@ -151,7 +151,7 @@ exports[`Shadow component tests Brand shadow (depth=28) 1`] = `
           "width": 0,
         },
         "shadowOpacity": 0.25,
-        "shadowRadius": 28,
+        "shadowRadius": 14,
       }
     }
   >
@@ -170,7 +170,7 @@ exports[`Shadow component tests Brand shadow (depth=64) 1`] = `
         "width": 0,
       },
       "shadowOpacity": 0.3,
-      "shadowRadius": 8,
+      "shadowRadius": 4,
     }
   }
 >
@@ -183,7 +183,7 @@ exports[`Shadow component tests Brand shadow (depth=64) 1`] = `
           "width": 0,
         },
         "shadowOpacity": 0.25,
-        "shadowRadius": 64,
+        "shadowRadius": 32,
       }
     }
   >
@@ -202,7 +202,7 @@ exports[`Shadow component tests Shadow (depth=2) 1`] = `
         "width": 0,
       },
       "shadowOpacity": 0.12,
-      "shadowRadius": 2,
+      "shadowRadius": 1,
     }
   }
 >
@@ -215,7 +215,7 @@ exports[`Shadow component tests Shadow (depth=2) 1`] = `
           "width": 0,
         },
         "shadowOpacity": 0.14,
-        "shadowRadius": 2,
+        "shadowRadius": 1,
       }
     }
   >
@@ -234,7 +234,7 @@ exports[`Shadow component tests Shadow (depth=4) 1`] = `
         "width": 0,
       },
       "shadowOpacity": 0.12,
-      "shadowRadius": 2,
+      "shadowRadius": 1,
     }
   }
 >
@@ -247,7 +247,7 @@ exports[`Shadow component tests Shadow (depth=4) 1`] = `
           "width": 0,
         },
         "shadowOpacity": 0.14,
-        "shadowRadius": 4,
+        "shadowRadius": 2,
       }
     }
   >
@@ -266,7 +266,7 @@ exports[`Shadow component tests Shadow (depth=8) 1`] = `
         "width": 0,
       },
       "shadowOpacity": 0.12,
-      "shadowRadius": 2,
+      "shadowRadius": 1,
     }
   }
 >
@@ -279,7 +279,7 @@ exports[`Shadow component tests Shadow (depth=8) 1`] = `
           "width": 0,
         },
         "shadowOpacity": 0.14,
-        "shadowRadius": 8,
+        "shadowRadius": 4,
       }
     }
   >
@@ -298,7 +298,7 @@ exports[`Shadow component tests Shadow (depth=16) 1`] = `
         "width": 0,
       },
       "shadowOpacity": 0.12,
-      "shadowRadius": 2,
+      "shadowRadius": 1,
     }
   }
 >
@@ -311,7 +311,7 @@ exports[`Shadow component tests Shadow (depth=16) 1`] = `
           "width": 0,
         },
         "shadowOpacity": 0.14,
-        "shadowRadius": 16,
+        "shadowRadius": 8,
       }
     }
   >
@@ -330,7 +330,7 @@ exports[`Shadow component tests Shadow (depth=28) 1`] = `
         "width": 0,
       },
       "shadowOpacity": 0.2,
-      "shadowRadius": 8,
+      "shadowRadius": 4,
     }
   }
 >
@@ -343,7 +343,7 @@ exports[`Shadow component tests Shadow (depth=28) 1`] = `
           "width": 0,
         },
         "shadowOpacity": 0.24,
-        "shadowRadius": 28,
+        "shadowRadius": 14,
       }
     }
   >
@@ -362,7 +362,7 @@ exports[`Shadow component tests Shadow (depth=64) 1`] = `
         "width": 0,
       },
       "shadowOpacity": 0.2,
-      "shadowRadius": 8,
+      "shadowRadius": 4,
     }
   }
 >
@@ -375,7 +375,7 @@ exports[`Shadow component tests Shadow (depth=64) 1`] = `
           "width": 0,
         },
         "shadowOpacity": 0.24,
-        "shadowRadius": 64,
+        "shadowRadius": 32,
       }
     }
   >

--- a/packages/experimental/Shadow/src/shadowStyle.ts
+++ b/packages/experimental/Shadow/src/shadowStyle.ts
@@ -2,6 +2,10 @@ import { memoize } from '@fluentui-react-native/framework';
 import { ShadowToken } from '@fluentui-react-native/theme-types';
 import { ColorValue } from 'react-native';
 
+// The blur property from the token is not the same as the shadow radius value,
+// it needs to be divided by 2 to achieve the same effect.
+const shadowBlurAdjustment = 0.5;
+
 export const getShadowTokenStyleSet = memoize(getShadowTokenStyleSetWorker);
 
 function getShadowTokenStyleSetWorker(shadowToken: ShadowToken) {
@@ -12,7 +16,7 @@ function getShadowTokenStyleSetWorker(shadowToken: ShadowToken) {
     key: {
       shadowColor: shadowColorFromRGBAColor(keyShadow.color),
       shadowOpacity: shadowOpacityFromRGBAColor(keyShadow.color),
-      shadowRadius: keyShadow.blur,
+      shadowRadius: keyShadow.blur * shadowBlurAdjustment,
       shadowOffset: {
         width: keyShadow.x,
         height: keyShadow.y,
@@ -21,7 +25,7 @@ function getShadowTokenStyleSetWorker(shadowToken: ShadowToken) {
     ambient: {
       shadowColor: shadowColorFromRGBAColor(ambientShadow.color),
       shadowOpacity: shadowOpacityFromRGBAColor(ambientShadow.color),
-      shadowRadius: ambientShadow.blur,
+      shadowRadius: ambientShadow.blur * shadowBlurAdjustment,
       shadowOffset: {
         width: ambientShadow.x,
         height: ambientShadow.y,

--- a/packages/experimental/Shadow/src/shadowStyle.ts
+++ b/packages/experimental/Shadow/src/shadowStyle.ts
@@ -3,7 +3,7 @@ import { ShadowToken } from '@fluentui-react-native/theme-types';
 import { ColorValue, Platform } from 'react-native';
 
 // For iOS/macOS, the blur property from the token is not the same as the shadow radius value,
-// it needs to be divided by 2 to achieve the same effect.
+// it needs to be divided by 2 to achieve the same effect. See https://github.com/microsoft/apple-ux-guide/blob/gh-pages/Shadows.md
 const appleShadowBlurAdjustment = 0.5;
 const defaultShadowBlurAdjustment = 1;
 

--- a/packages/experimental/Shadow/src/shadowStyle.ts
+++ b/packages/experimental/Shadow/src/shadowStyle.ts
@@ -4,13 +4,15 @@ import { ColorValue, Platform } from 'react-native';
 
 // For iOS/macOS, the blur property from the token is not the same as the shadow radius value,
 // it needs to be divided by 2 to achieve the same effect.
-const shadowBlurAdjustment = Platform.OS === 'macos' || Platform.OS === 'ios' ? 0.5 : 1;
+const appleShadowBlurAdjustment = 0.5;
+const defaultShadowBlurAdjustment = 1;
 
 export const getShadowTokenStyleSet = memoize(getShadowTokenStyleSetWorker);
 
 function getShadowTokenStyleSetWorker(shadowToken: ShadowToken) {
   const keyShadow = shadowToken.key;
   const ambientShadow = shadowToken.ambient;
+  const shadowBlurAdjustment = Platform.OS === 'macos' || Platform.OS === 'ios' ? appleShadowBlurAdjustment : defaultShadowBlurAdjustment;
 
   return {
     key: {

--- a/packages/experimental/Shadow/src/shadowStyle.ts
+++ b/packages/experimental/Shadow/src/shadowStyle.ts
@@ -1,10 +1,10 @@
 import { memoize } from '@fluentui-react-native/framework';
 import { ShadowToken } from '@fluentui-react-native/theme-types';
-import { ColorValue } from 'react-native';
+import { ColorValue, Platform } from 'react-native';
 
-// The blur property from the token is not the same as the shadow radius value,
+// For iOS/macOS, the blur property from the token is not the same as the shadow radius value,
 // it needs to be divided by 2 to achieve the same effect.
-const shadowBlurAdjustment = 0.5;
+const shadowBlurAdjustment = Platform.OS === 'macos' || Platform.OS === 'ios' ? 0.5 : 1;
 
 export const getShadowTokenStyleSet = memoize(getShadowTokenStyleSetWorker);
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

In Fluent UI Apple the blur had to be divided by 2 in order to match the [Figma](https://www.figma.com/file/KB9oUjMKen2cKnyPG7RgdS/Design-tokens-superset?node-id=4553%3A38) ([see note here](https://www.figma.com/file/KB9oUjMKen2cKnyPG7RgdS/Design-tokens-superset?node-id=5887%3A0)), and after checking in FURN dividing the blur by 2 also matches the Figma better. Screenshots from Figma:

| Light | Light Brand |
| - | - |
| <img width="518" alt="Screen Shot 2022-08-30 at 5 26 56 PM" src="https://user-images.githubusercontent.com/78454019/187567127-f755c116-bab4-423f-8438-b28cbf21ee96.png"> | <img width="463" alt="Screen Shot 2022-08-30 at 5 27 07 PM" src="https://user-images.githubusercontent.com/78454019/187567130-8485fbc0-4751-4ffb-9d20-25975ad3d5b1.png"> |


### Verification



| | Before                                       | After                                      |
| - |----------------------------------------------|--------------------------------------------|
| Light | <img width="820" alt="before-light" src="https://user-images.githubusercontent.com/78454019/187566278-f509fa4b-66a1-4715-a87e-7bf93660ce60.png"> |  <img width="820" alt="after-light" src="https://user-images.githubusercontent.com/78454019/187566306-7fed97a9-1f11-4c8d-97c5-4c6b6123ce43.png"> |
| Light Brand |  <img width="820" alt="before-light-brand" src="https://user-images.githubusercontent.com/78454019/187566357-bc190162-d757-4122-93ac-209ce6a18f61.png"> | <img width="820" alt="after-light-brand" src="https://user-images.githubusercontent.com/78454019/187566340-373629de-0650-48e8-8ddc-45ccd11c4b07.png"> |
| Dark | <img width="820" alt="before-dark" src="https://user-images.githubusercontent.com/78454019/187566398-d78deb8e-50b2-40e4-9a51-03234b38a923.png"> | <img width="820" alt="after-dark" src="https://user-images.githubusercontent.com/78454019/187566427-81615a75-4f74-41fa-8cf5-67e9f6e19593.png"> |
| Dark Brand | <img width="820" alt="before-dark-brand" src="https://user-images.githubusercontent.com/78454019/187566412-4f3c6ca8-0885-4f1b-9497-403572462a95.png"> | <img width="820" alt="after-dark-brand" src="https://user-images.githubusercontent.com/78454019/187566477-e251b6ea-e65f-41e2-bf10-c47c6cf2e30b.png">

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
