### PR TITLE
Aligned a11y for badge according to Web

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Avatar/BasicAvatar.tsx
+++ b/apps/fluent-tester/src/TestComponents/Avatar/BasicAvatar.tsx
@@ -46,6 +46,7 @@ export const StandardUsage: FunctionComponent = () => {
   };
 
   const svgIconsEnabled = ['ios', 'macos', 'win32', 'android'].includes(Platform.OS as string);
+  const badgeStatus = presence === undefinedText ? undefined : presence;
 
   return (
     <View style={commonStyles.root}>
@@ -79,7 +80,7 @@ export const StandardUsage: FunctionComponent = () => {
           name="Satya Nadella"
           shape={isSquare ? 'square' : 'circular'}
           accessibilityLabel="Photo of Satya Nadella"
-          badge={{ status: presence === undefinedText ? undefined : presence, outOfOffice }}
+          badge={{ status: badgeStatus, outOfOffice, accessibilityLabel: badgeStatus }}
           imageUrl={showImage ? satyaPhotoUrl : undefined}
           avatarColor={avatarColor}
         />

--- a/change/@fluentui-react-native-badge-98e29f6e-5e0e-4149-9bef-e7295db772e6.json
+++ b/change/@fluentui-react-native-badge-98e29f6e-5e0e-4149-9bef-e7295db772e6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Aligned Badge accessibility with Web implementation",
+  "packageName": "@fluentui-react-native/badge",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-d0aab44c-9203-470a-aa67-74cbfab98130.json
+++ b/change/@fluentui-react-native-tester-d0aab44c-9203-470a-aa67-74cbfab98130.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "PR change",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Badge/src/Badge.tsx
+++ b/packages/components/Badge/src/Badge.tsx
@@ -45,15 +45,7 @@ export const Badge = compose<BadgeType>({
         <Slots.root {...mergedProps}>
           {icon && showIcon && iconPosition === 'before' && <Slots.icon accessible={false} {...iconProps} />}
           {showContent &&
-            Children.map(children, (child, i) =>
-              typeof child === 'string' ? (
-                <Slots.text accessible={false} key={`text-${i}`}>
-                  {child}
-                </Slots.text>
-              ) : (
-                child
-              ),
-            )}
+            Children.map(children, (child, i) => (typeof child === 'string' ? <Slots.text key={`text-${i}`}>{child}</Slots.text> : child))}
           {icon && showIcon && iconPosition === 'after' && <Slots.icon accessible={false} {...iconProps} />}
         </Slots.root>
       );

--- a/packages/components/Badge/src/CounterBadge/CounterBadge.tsx
+++ b/packages/components/Badge/src/CounterBadge/CounterBadge.tsx
@@ -34,12 +34,12 @@ export const CounterBadge = compose<CounterBadgeType>({
         <Slots.root {...mergedProps}>
           {!dot && (
             <React.Fragment>
-              {icon && iconPosition === 'before' && <Slots.icon {...iconProps} />}
+              {icon && iconPosition === 'before' && <Slots.icon accessible={false} {...iconProps} />}
               {!hasChildren && <Slots.text>{displayCount}</Slots.text>}
               {Children.map(children, (child, i) =>
                 typeof child === 'string' ? <Slots.text key={`text-${i}`}>{child}</Slots.text> : child,
               )}
-              {icon && iconPosition === 'after' && <Slots.icon {...iconProps} />}
+              {icon && iconPosition === 'after' && <Slots.icon accessible={false} {...iconProps} />}
             </React.Fragment>
           )}
         </Slots.root>

--- a/packages/components/Badge/src/PresenceBadge/PresenceBadge.tsx
+++ b/packages/components/Badge/src/PresenceBadge/PresenceBadge.tsx
@@ -57,7 +57,7 @@ export const PresenceBadge = compose<PresenceBadgeType>({
       const path = getIconPath(status, isOutOfOffice);
 
       return (
-        <Slots.root {...mergedProps} accessibilityLabel={status} accessible={true}>
+        <Slots.root {...mergedProps} accessible={true}>
           <Slots.svg viewBox="0 0 16 16" fill="none">
             <Path fill="currentColor" d={path} />
           </Slots.svg>

--- a/packages/components/Badge/src/PresenceBadge/PresenceBadge.tsx
+++ b/packages/components/Badge/src/PresenceBadge/PresenceBadge.tsx
@@ -57,7 +57,7 @@ export const PresenceBadge = compose<PresenceBadgeType>({
       const path = getIconPath(status, isOutOfOffice);
 
       return (
-        <Slots.root {...mergedProps}>
+        <Slots.root {...mergedProps} accessibilityLabel={status} accessible={true}>
           <Slots.svg viewBox="0 0 16 16" fill="none">
             <Path fill="currentColor" d={path} />
           </Slots.svg>

--- a/packages/components/Badge/src/__tests__/__snapshots__/Badge.test.tsx.snap
+++ b/packages/components/Badge/src/__tests__/__snapshots__/Badge.test.tsx.snap
@@ -348,7 +348,6 @@ exports[`CounterBadge component tests Empty Badge 1`] = `null`;
 
 exports[`PresenceBadge component tests PresenceBadge props 1`] = `
 <View
-  accessibilityLabel="available"
   accessible={true}
   iconPosition="before"
   style={

--- a/packages/components/Badge/src/__tests__/__snapshots__/Badge.test.tsx.snap
+++ b/packages/components/Badge/src/__tests__/__snapshots__/Badge.test.tsx.snap
@@ -39,7 +39,6 @@ exports[`Badge component tests Badge all props 1`] = `
     ♣
   </Text>
   <Text
-    accessible={false}
     ellipsizeMode="tail"
     numberOfLines={0}
     style={
@@ -81,7 +80,6 @@ exports[`Badge component tests Badge tokens 1`] = `
   }
 >
   <Text
-    accessible={false}
     ellipsizeMode="tail"
     numberOfLines={0}
     style={
@@ -147,7 +145,7 @@ exports[`CounterBadge component tests CounterBadge all props 1`] = `
   }
 >
   <Text
-    accessible={true}
+    accessible={false}
     style={
       Object {
         "color": "#fff",
@@ -350,6 +348,8 @@ exports[`CounterBadge component tests Empty Badge 1`] = `null`;
 
 exports[`PresenceBadge component tests PresenceBadge props 1`] = `
 <View
+  accessibilityLabel="available"
+  accessible={true}
   iconPosition="before"
   style={
     Object {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
I got an answer from Web team, they added aria-attributes to their badges. As we align our implementation with Web, I did the same for our component. Currently text, badge status and number are accessible. Icons are not.

### Verification
Checked with Accessibility Insights for Windows

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
