### PR TITLE
Text empty props fix

### DIFF
--- a/change/@fluentui-react-native-text-83e3f34d-001d-4153-ba98-c4800efaf372.json
+++ b/change/@fluentui-react-native-text-83e3f34d-001d-4153-ba98-c4800efaf372.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fallback when Text gets no props",
+  "packageName": "@fluentui-react-native/text",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/text/src/Text.tsx
+++ b/packages/components/text/src/Text.tsx
@@ -15,10 +15,15 @@ import { textName, TextProps, TextTokens } from './Text.types';
 import { useTextTokens } from './TextTokens';
 import React from 'react';
 
+const emptyProps = {};
 export const Text = compressible<TextProps, TextTokens>((props: TextProps, useTokens: UseTokens<TextTokens>) => {
+  if (props === undefined) {
+    props = emptyProps;
+  }
+
   // split out color and variant from props
   const {
-    align,
+    align = undefined,
     block,
     color,
     font,


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

The Text component throws an error when it doesn't receive any props because it expects `props` to be defined when destructuring it. Unfortunately it's pretty common to do something like `<Text>test</Text>` so the component should be able to handle the case where props is undefined.

Adding a fallback empty object when props is undefined. This way the destructuring works because all the props are returned as undefined.

### Verification

The Option component which doesn't have any props for its Text slot now works, whereas before it would run into a redbox error.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
