### PR TITLE
MenuItem styling fixes

### DIFF
--- a/change/@fluentui-react-native-menu-d49a11dc-f623-409b-b0ff-b439cccc7fcb.json
+++ b/change/@fluentui-react-native-menu-d49a11dc-f623-409b-b0ff-b439cccc7fcb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Minor fixes for caching and adding new tokens",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/SPEC.md
+++ b/packages/components/Menu/SPEC.md
@@ -252,6 +252,16 @@ export interface MenuItemTokens extends LayoutTokens, FontTokens, IBorderTokens,
   checkmarkSize?: number;
 
   /**
+   * Space between parts of the item control in pixels
+   */
+  gap?: number;
+
+  /**
+   * Color of the indicator that shows that an item has a submenu
+   */
+  submenuIndicatorColor?: ColorValue;
+
+  /**
    * Amount of space in pixels around the indicator that shows that an item has a submenu
    */
   submenuIndicatorPadding?: number;
@@ -260,11 +270,6 @@ export interface MenuItemTokens extends LayoutTokens, FontTokens, IBorderTokens,
    * Height and width in pixels of the indicator that shows that an item has a submenu
    */
   submenuIndicatorSize?: number;
-
-  /**
-   * Space between parts of the item control in pixels
-   */
-  gap?: number;
 
   /**
    * States of the item control

--- a/packages/components/Menu/src/MenuItem/MenuItem.styling.ts
+++ b/packages/components/Menu/src/MenuItem/MenuItem.styling.ts
@@ -20,7 +20,7 @@ export const stylingSettings: UseStylingOptions<MenuItemProps, MenuItemSlotProps
           ...borderStyles.from(tokens, theme),
         },
       }),
-      ['backgroundColor', ...layoutStyles.keys],
+      ['backgroundColor', ...borderStyles.keys, ...layoutStyles.keys],
     ),
     checkmark: buildProps(
       (tokens: MenuItemTokens) => ({
@@ -35,9 +35,9 @@ export const stylingSettings: UseStylingOptions<MenuItemProps, MenuItemSlotProps
     content: buildProps(
       (tokens: MenuItemTokens, theme: Theme) => {
         return {
+          color: tokens.color,
           style: {
             flexGrow: 1,
-            color: tokens.color,
             ...fontStyles.from(tokens, theme),
           },
         };
@@ -47,7 +47,7 @@ export const stylingSettings: UseStylingOptions<MenuItemProps, MenuItemSlotProps
     submenuIndicator: buildProps(
       (tokens: MenuItemTokens) => {
         return {
-          color: tokens.color,
+          color: tokens.submenuIndicatorColor,
           height: tokens.submenuIndicatorSize,
           width: tokens.submenuIndicatorSize,
           viewBox:
@@ -57,7 +57,7 @@ export const stylingSettings: UseStylingOptions<MenuItemProps, MenuItemSlotProps
             (tokens.submenuIndicatorSize - tokens.submenuIndicatorPadding * 2),
         };
       },
-      ['color'],
+      ['submenuIndicatorColor', 'submenuIndicatorPadding', 'submenuIndicatorSize'],
     ),
   },
 };

--- a/packages/components/Menu/src/MenuItem/MenuItem.types.ts
+++ b/packages/components/Menu/src/MenuItem/MenuItem.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ViewProps } from 'react-native';
+import { ColorValue, ViewProps } from 'react-native';
 import { XmlProps } from 'react-native-svg';
 import type { IViewProps } from '@fluentui-react-native/adapters';
 import { TextProps } from '@fluentui-react-native/text';
@@ -15,6 +15,16 @@ export interface MenuItemTokens extends LayoutTokens, FontTokens, IBorderTokens,
   checkmarkSize?: number;
 
   /**
+   * Space between parts of the item control in pixels
+   */
+  gap?: number;
+
+  /**
+   * Color of the indicator that shows that an item has a submenu
+   */
+  submenuIndicatorColor?: ColorValue;
+
+  /**
    * Amount of space in pixels around the indicator that shows that an item has a submenu
    */
   submenuIndicatorPadding?: number;
@@ -23,11 +33,6 @@ export interface MenuItemTokens extends LayoutTokens, FontTokens, IBorderTokens,
    * Height and width in pixels of the indicator that shows that an item has a submenu
    */
   submenuIndicatorSize?: number;
-
-  /**
-   * Space between parts of the item control in pixels
-   */
-  gap?: number;
 
   /**
    * States of the item control

--- a/packages/components/Menu/src/MenuItem/MenuItemTokens.ts
+++ b/packages/components/Menu/src/MenuItem/MenuItemTokens.ts
@@ -7,8 +7,6 @@ export const defaultMenuItemTokens: TokenSettings<MenuItemTokens, Theme> = (t: T
   backgroundColor: t.colors.neutralBackground1,
   borderRadius: globalTokens.corner.radius.medium,
   checkmarkSize: 16,
-  submenuIndicatorPadding: globalTokens.spacing.none,
-  submenuIndicatorSize: 16,
   color: t.colors.neutralForeground2,
   fontFamily: t.typography.families.primary,
   fontSize: globalTokens.font.size[300],
@@ -18,16 +16,22 @@ export const defaultMenuItemTokens: TokenSettings<MenuItemTokens, Theme> = (t: T
   minWidth: 160,
   maxWidth: 300,
   padding: globalTokens.spacing.sNudge,
+  submenuIndicatorColor: t.colors.neutralForeground2,
+  submenuIndicatorPadding: globalTokens.spacing.none,
+  submenuIndicatorSize: 16,
   hovered: {
     backgroundColor: t.colors.neutralBackground1Hover,
     color: t.colors.neutralForeground2Hover,
+    submenuIndicatorColor: t.colors.neutralForeground2Hover,
   },
   pressed: {
     backgroundColor: t.colors.neutralBackground1Pressed,
     color: t.colors.neutralForeground2Pressed,
+    submenuIndicatorColor: t.colors.neutralForeground2Pressed,
   },
   disabled: {
     backgroundColor: t.colors.neutralBackground1,
     color: t.colors.neutralForegroundDisabled,
+    submenuIndicatorColor: t.colors.neutralForegroundDisabled,
   },
 });

--- a/packages/components/Menu/src/MenuItem/MenuItemTokens.win32.ts
+++ b/packages/components/Menu/src/MenuItem/MenuItemTokens.win32.ts
@@ -7,8 +7,6 @@ export const defaultMenuItemTokens: TokenSettings<MenuItemTokens, Theme> = (t: T
   backgroundColor: t.colors.neutralBackground1,
   borderRadius: globalTokens.corner.radius.none,
   checkmarkSize: 16,
-  submenuIndicatorPadding: globalTokens.spacing.xxs,
-  submenuIndicatorSize: 16,
   color: t.colors.neutralForeground1,
   fontFamily: t.typography.families.primary,
   fontSize: globalTokens.font.size[200],
@@ -19,20 +17,27 @@ export const defaultMenuItemTokens: TokenSettings<MenuItemTokens, Theme> = (t: T
   maxWidth: 300,
   padding: globalTokens.spacing.xs,
   paddingHorizontal: globalTokens.spacing.s,
+  submenuIndicatorColor: t.colors.neutralForeground1,
+  submenuIndicatorPadding: globalTokens.spacing.xxs,
+  submenuIndicatorSize: 16,
   hovered: {
     backgroundColor: t.colors.neutralBackground1Hover,
     color: t.colors.neutralForeground1Hover,
+    submenuIndicatorColor: t.colors.neutralForeground1Hover,
   },
   pressed: {
     backgroundColor: t.colors.neutralBackground1Pressed,
     color: t.colors.neutralForeground1Pressed,
+    submenuIndicatorColor: t.colors.neutralForeground1Pressed,
   },
   disabled: {
     backgroundColor: t.colors.neutralBackground1,
     color: t.colors.neutralForegroundDisabled,
+    submenuIndicatorColor: t.colors.neutralForegroundDisabled,
   },
   focused: {
     backgroundColor: t.colors.neutralBackground1Hover,
     color: t.colors.neutralForeground1Hover,
+    submenuIndicatorColor: t.colors.neutralForeground1Hover,
   },
 });

--- a/packages/components/Menu/src/MenuItemCheckbox/MenuItemCheckbox.styling.ts
+++ b/packages/components/Menu/src/MenuItemCheckbox/MenuItemCheckbox.styling.ts
@@ -20,7 +20,7 @@ export const stylingSettings: UseStylingOptions<MenuItemCheckboxProps, MenuItemC
           ...borderStyles.from(tokens, theme),
         },
       }),
-      ['backgroundColor', ...layoutStyles.keys],
+      ['backgroundColor', ...borderStyles.keys, ...layoutStyles.keys],
     ),
     checkmark: buildProps(
       (tokens: MenuItemCheckboxTokens) => ({
@@ -31,7 +31,7 @@ export const stylingSettings: UseStylingOptions<MenuItemCheckboxProps, MenuItemC
         viewBox: '0 0 ' + (tokens.checkmarkSize - tokens.checkmarkPadding * 2) + ' ' + (tokens.checkmarkSize - tokens.checkmarkPadding * 2),
         style: { marginEnd: tokens.gap },
       }),
-      ['checkmarkSize', 'gap', 'color'],
+      ['checkmarkPadding', 'checkmarkSize', 'checkmarkVisibility', 'color', 'gap'],
     ),
     content: buildProps(
       (tokens: MenuItemCheckboxTokens, theme: Theme) => ({


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Fixed a few styling issues I noticed for the Menu Item(s):

1. Added missing caching entries
2. Added some color tokens for the icons to allow for customization separate from the text color. These include checkmarkColor and submenuIndicatorColor.
3. Some alphabetizing

### Verification

Still need to verify. Snapshot tests pass so presumably there are no UI changes at rest.