### PR TITLE
Option interactive

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Dropdown/DropdownTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Dropdown/DropdownTest.tsx
@@ -9,6 +9,7 @@ const DropdownDefault: React.FunctionComponent = () => {
   return (
     <Stack style={stackStyle}>
       <Option>Test</Option>
+      <Option disabled>Disabled Test</Option>
     </Stack>
   );
 };

--- a/change/@fluentui-react-native-dropdown-f8ae0d7b-8543-498a-9372-750df0a600d5.json
+++ b/change/@fluentui-react-native-dropdown-f8ae0d7b-8543-498a-9372-750df0a600d5.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add interactivity tokens",
+  "packageName": "@fluentui-react-native/dropdown",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-9ddb264d-f3ae-4e60-8fbc-9a93d90df7cf.json
+++ b/change/@fluentui-react-native-tester-9ddb264d-f3ae-4e60-8fbc-9a93d90df7cf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add new test case",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Dropdown/src/Option/Option.styling.ts
+++ b/packages/experimental/Dropdown/src/Option/Option.styling.ts
@@ -2,6 +2,8 @@ import { borderStyles, buildProps, fontStyles, layoutStyles, Theme, UseStylingOp
 import { optionName, OptionProps, OptionSlotProps, OptionTokens } from './Option.types';
 import { defaultOptionTokens } from './OptionTokens';
 
+export const menuItemStates: (keyof OptionTokens)[] = ['hovered', 'focused', 'pressed', 'disabled'];
+
 export const stylingSettings: UseStylingOptions<OptionProps, OptionSlotProps, OptionTokens> = {
   tokens: [defaultOptionTokens, optionName],
   slotProps: {

--- a/packages/experimental/Dropdown/src/Option/Option.styling.ts
+++ b/packages/experimental/Dropdown/src/Option/Option.styling.ts
@@ -2,23 +2,25 @@ import { borderStyles, buildProps, fontStyles, layoutStyles, Theme, UseStylingOp
 import { optionName, OptionProps, OptionSlotProps, OptionTokens } from './Option.types';
 import { defaultOptionTokens } from './OptionTokens';
 
-export const menuItemStates: (keyof OptionTokens)[] = ['hovered', 'focused', 'pressed', 'disabled'];
+export const optionStates: (keyof OptionTokens)[] = ['hovered', 'focused', 'pressed', 'disabled'];
 
 export const stylingSettings: UseStylingOptions<OptionProps, OptionSlotProps, OptionTokens> = {
   tokens: [defaultOptionTokens, optionName],
+  states: optionStates,
   slotProps: {
     root: buildProps(
       (tokens: OptionTokens, theme: Theme) => ({
         style: {
           alignItems: 'center',
           alignSelf: 'flex-start',
+          backgroundColor: tokens.backgroundColor,
           display: 'flex',
           flexDirection: 'row',
           ...borderStyles.from(tokens, theme),
           ...layoutStyles.from(tokens, theme),
         },
       }),
-      [...borderStyles.keys, ...layoutStyles.keys],
+      ['backgroundColor', ...borderStyles.keys, ...layoutStyles.keys],
     ),
     checkIcon: buildProps(
       (tokens: OptionTokens) => ({

--- a/packages/experimental/Dropdown/src/Option/Option.tsx
+++ b/packages/experimental/Dropdown/src/Option/Option.tsx
@@ -6,6 +6,7 @@ import { View } from 'react-native';
 import { Path, Svg } from 'react-native-svg';
 import { stylingSettings } from './Option.styling';
 import { optionName, OptionProps, OptionType } from './Option.types';
+import { useOption } from './useOption';
 
 export const Option = compose<OptionType>({
   displayName: optionName,
@@ -16,7 +17,8 @@ export const Option = compose<OptionType>({
     label: Text,
   },
   useRender: (userProps: OptionProps, useSlots: UseSlots<OptionType>) => {
-    const Slots = useSlots(userProps);
+    const option = useOption(userProps);
+    const Slots = useSlots(userProps, (layer): boolean => option.state[layer] || userProps[layer]);
     return (final: OptionProps, ...children: React.ReactNode[]) => {
       const mergedProps = mergeProps(userProps, final);
 

--- a/packages/experimental/Dropdown/src/Option/Option.tsx
+++ b/packages/experimental/Dropdown/src/Option/Option.tsx
@@ -20,7 +20,7 @@ export const Option = compose<OptionType>({
     const option = useOption(userProps);
     const Slots = useSlots(userProps, (layer): boolean => option.state[layer] || userProps[layer]);
     return (final: OptionProps, ...children: React.ReactNode[]) => {
-      const mergedProps = mergeProps(userProps, final);
+      const mergedProps = mergeProps(option.props, final);
 
       const checkPath = (
         <Path

--- a/packages/experimental/Dropdown/src/Option/Option.types.ts
+++ b/packages/experimental/Dropdown/src/Option/Option.types.ts
@@ -24,7 +24,13 @@ export interface OptionTokens extends FontTokens, IBorderTokens, IColorTokens, L
   spacingContentIcon?: number;
 }
 
-export type OptionProps = IWithPressableOptions<IViewProps>;
+export interface OptionProps extends IWithPressableOptions<IViewProps> {
+  /**
+   * A RefObject to access the IButton interface. Use this to access the public methods and properties of the component.
+   */
+  componentRef?: React.RefObject<IFocusable>;
+}
+
 export type OptionState = IPressableHooks<OptionProps & React.ComponentPropsWithRef<any>>;
 
 export interface OptionSlotProps {

--- a/packages/experimental/Dropdown/src/Option/Option.types.ts
+++ b/packages/experimental/Dropdown/src/Option/Option.types.ts
@@ -1,6 +1,6 @@
 import type { IViewProps } from '@fluentui-react-native/adapters';
 import { FontTokens, IBorderTokens, IColorTokens, LayoutTokens } from '@fluentui-react-native/framework';
-import { IPressableHooks, IWithPressableOptions } from '@fluentui-react-native/interactive-hooks';
+import { IFocusable, IPressableHooks, IWithPressableOptions } from '@fluentui-react-native/interactive-hooks';
 import { TextProps } from '@fluentui-react-native/text';
 import { ColorValue } from 'react-native';
 import { SvgProps } from 'react-native-svg';
@@ -22,6 +22,14 @@ export interface OptionTokens extends FontTokens, IBorderTokens, IColorTokens, L
    * Spacing, in pixels, between the label and icons
    */
   spacingContentIcon?: number;
+
+  /**
+   * States of the item control
+   */
+  disabled?: OptionTokens;
+  focused?: OptionTokens;
+  hovered?: OptionTokens;
+  pressed?: OptionTokens;
 }
 
 export interface OptionProps extends IWithPressableOptions<IViewProps> {

--- a/packages/experimental/Dropdown/src/Option/OptionTokens.ts
+++ b/packages/experimental/Dropdown/src/Option/OptionTokens.ts
@@ -14,4 +14,19 @@ export const defaultOptionTokens: TokenSettings<OptionTokens> = (t: Theme): Opti
   paddingHorizontal: globalTokens.spacing.sNudge,
   spacingContentIcon: globalTokens.spacing.xs,
   variant: 'body1',
+  hovered: {
+    backgroundColor: t.colors.neutralBackground1Hover,
+    checkmarkColor: t.colors.neutralForeground2Hover,
+    color: t.colors.neutralForeground2Hover,
+  },
+  pressed: {
+    backgroundColor: t.colors.neutralBackground1Pressed,
+    checkmarkColor: t.colors.neutralForeground2Pressed,
+    color: t.colors.neutralForeground2Pressed,
+  },
+  disabled: {
+    backgroundColor: t.colors.neutralBackground1,
+    checkmarkColor: t.colors.neutralForegroundDisabled,
+    color: t.colors.neutralForegroundDisabled,
+  },
 });

--- a/packages/experimental/Dropdown/src/Option/useOption.ts
+++ b/packages/experimental/Dropdown/src/Option/useOption.ts
@@ -1,8 +1,18 @@
+import { useAsPressable } from '@fluentui-react-native/interactive-hooks';
+import * as React from 'react';
 import { OptionProps, OptionState } from './Option.types';
 
-export const useOption = (_props: OptionProps): OptionState => {
+export const useOption = (props: OptionProps): OptionState => {
+  // attach the pressable state handlers
+  const defaultComponentRef = React.useRef(null);
+  const { onPress, componentRef = defaultComponentRef, disabled, ...rest } = props;
+
+  const pressable = useAsPressable({ ...rest, disabled, onPress });
+
   return {
-    props: {},
-    state: {},
+    props: {
+      ...pressable.props,
+    },
+    state: pressable.state,
   };
 };

--- a/packages/experimental/Dropdown/src/Option/useOption.ts
+++ b/packages/experimental/Dropdown/src/Option/useOption.ts
@@ -1,18 +1,8 @@
 import { useAsPressable } from '@fluentui-react-native/interactive-hooks';
-import * as React from 'react';
 import { OptionProps, OptionState } from './Option.types';
 
 export const useOption = (props: OptionProps): OptionState => {
-  // attach the pressable state handlers
-  const defaultComponentRef = React.useRef(null);
-  const { onPress, componentRef = defaultComponentRef, disabled, ...rest } = props;
+  const pressable = useAsPressable(props);
 
-  const pressable = useAsPressable({ ...rest, disabled, onPress });
-
-  return {
-    props: {
-      ...pressable.props,
-    },
-    state: pressable.state,
-  };
+  return pressable;
 };


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Adding interactivity state & tokens, and default styling for hovered, pressed, and disabled states.

The changes are:

- Add componentRef (which in retrospect, wasn't necessary, but it will be in the future)
- Add useAsPressable to useOption, and then return pressable props and state.
- Add interaction states and tokens, and add default tokens for those states.
- Include the new states in the lookup function for useSlots, and then merge the output of useOption into the final props

### Verification

![option_interaction](https://user-images.githubusercontent.com/4602628/189459977-8150a236-c1c6-421e-a5e2-f9526228a148.gif)
