### PR TITLE
Changing Location of Appium Driver Dependency Installs

### DIFF
--- a/.ado/templates/e2e-testing-ios.yml
+++ b/.ado/templates/e2e-testing-ios.yml
@@ -1,9 +1,4 @@
 steps:
-  - script: |
-      yarn appium driver install xcuitest
-    workingDirectory: apps/fluent-tester
-    displayName: 'Installing appium xcuitest driver'
-
   # Creates a variable that determines whether the previous build tasks succeeded.
   # Usage: We want the tasks that generate reports to run for both passing/failing E2E testing tasks. In order to do so, we need to make
   # those reporting tasks run even on when certain previous tasks fail. This variable allows us to differentiate build failures from

--- a/.ado/templates/e2e-testing-macos.yml
+++ b/.ado/templates/e2e-testing-macos.yml
@@ -1,9 +1,4 @@
 steps:
-  - script: |
-      yarn appium driver install mac2
-    workingDirectory: apps/fluent-tester
-    displayName: 'Installing appium mac2 driver'
-
   # Creates a variable that determines whether the previous build tasks succeeded.
   # Usage: We want the tasks that generate reports to run for both passing/failing E2E testing tasks. In order to do so, we need to make
   # those reporting tasks run even on when certain previous tasks fail. This variable allows us to differentiate build failures from

--- a/.ado/templates/e2e-testing-uwp.yml
+++ b/.ado/templates/e2e-testing-uwp.yml
@@ -4,11 +4,6 @@ steps:
     workingDirectory: apps/fluent-tester
     displayName: 'yarn bundle'
 
-  - script: |
-      yarn appium driver install windows
-    workingDirectory: apps/fluent-tester
-    displayName: 'Installing appium windows driver'
-
   # WinAppDriver 1.2 is being deployed across MS hosted agents. appium-windows-driver is tied to a specific version of WinAppDriver,
   # failing if a hash is mismatched. The latest current available package supports 1.2rc.
   # Uninstall WinAppDriver 1.2.1 if installed and instead install WinAppDriver 1.1 for now

--- a/.ado/templates/e2e-testing-win32.yml
+++ b/.ado/templates/e2e-testing-win32.yml
@@ -4,11 +4,6 @@ steps:
     workingDirectory: apps/win32
     displayName: 'yarn bundle'
 
-  - script: |
-      yarn appium driver install windows
-    workingDirectory: apps/win32
-    displayName: 'Installing appium windows driver'
-
   # WinAppDriver 1.2 is being deployed across MS hosted agents. appium-windows-driver is tied to a specific version of WinAppDriver,
   # failing if a hash is mismatched. The latest current available package supports 1.2rc.
   # Uninstall WinAppDriver 1.2.1 if installed and instead install WinAppDriver 1.1 for now

--- a/apps/fluent-tester/package.json
+++ b/apps/fluent-tester/package.json
@@ -100,6 +100,8 @@
     "@wdio/spec-reporter": "7.23.0",
     "appium": "2.0.0-beta.41",
     "appium-mac2-driver": "1.4.0",
+    "appium-xcuitest-driver": "4.11.1",
+    "appium-windows-driver": "2.0.7",
     "flow-bin": "^0.113.0",
     "metro-config": "^0.66.2",
     "metro-react-native-babel-preset": "^0.66.2",

--- a/change/@fluentui-react-native-tester-1dc09ce0-d3b6-4c06-9bfa-6202a5472d8e.json
+++ b/change/@fluentui-react-native-tester-1dc09ce0-d3b6-4c06-9bfa-6202a5472d8e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Adding Appium driver dependencies",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "safreibe@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -51,6 +51,12 @@
       "apps/*",
       "packages/**",
       "scripts"
+    ],
+    "nohoist": [
+      "@fluentui-react-native/tester-win32/appium-windows-driver",
+      "@fluentui-react-native/tester/appium-mac2-driver",
+      "@fluentui-react-native/tester/appium-xcuitest-driver",
+      "@fluentui-react-native/tester/appium-windows-driver"
     ]
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -76,7 +76,7 @@
     json-schema "0.4.0"
     source-map-support "0.5.21"
 
-"@appium/support@^2.57.0", "@appium/support@^2.59.3", "@appium/support@^2.59.5":
+"@appium/support@^2.55.3", "@appium/support@^2.57.0", "@appium/support@^2.59.3", "@appium/support@^2.59.5":
   version "2.60.0"
   resolved "https://registry.yarnpkg.com/@appium/support/-/support-2.60.0.tgz#3ab7cbc94a219d61aabe269d1336b078dabdeffb"
   integrity sha512-hrCeBqeQ0xxAEGLxF/8CfwXTQMgD9z5Jd5Bz5JCFbmgSSRUd8u0MaeiRQJDfCB9q6m3Gw2KXFliFhe+M9Hf/WA==
@@ -3929,6 +3929,11 @@
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.1.tgz#70c239275fc6d6a84e41b9a8d623a93c0d59b6b4"
   integrity sha512-4wOae+5N2RZ+CZXd9ZKwkaDi55IxrSTOjHpxTvQQ4fomtOJmqVxbmICA9jE1jvnqNhpfgz8cnfFagG86wV/xLQ==
 
+"@xmldom/xmldom@^0.x":
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.2.tgz#b695ff674e8216efa632a3d36ad51ae9843380c0"
+  integrity sha512-+R0juSseERyoPvnBQ/cZih6bpF7IpCXlWbHRoCRzYzqpz6gWHOgf8o4MOEf6KBVuOyqU+gCNLkCWVIJAro8XyQ==
+
 "@yarnpkg/lockfile@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
@@ -4134,6 +4139,53 @@ appdirsjs@^1.2.4:
   resolved "https://registry.yarnpkg.com/appdirsjs/-/appdirsjs-1.2.6.tgz#fccf9ee543315492867cacfcfd4a2b32257d30ac"
   integrity sha512-D8wJNkqMCeQs3kLasatELsddox/Xqkhp+J07iXGyL54fVN7oc+nmNfYzGuCs1IEP6uBw+TfpuO3JKwc+lECy4w==
 
+appium-idb@^1.0.0:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/appium-idb/-/appium-idb-1.6.2.tgz#b5a672e2f07c7a792c277335865dcdab1dd3b32a"
+  integrity sha512-wdF1ksH1WIqh7UTT/KmFUDCmku5agRyCivGUvIudIYv6SLvYE95mMR79ySO0DhznkUAjhIVC9pLw7iVShhXhjQ==
+  dependencies:
+    "@appium/support" "^2.55.3"
+    "@babel/runtime" "^7.0.0"
+    asyncbox "^2.5.2"
+    bluebird "^3.1.1"
+    lodash "^4.0.0"
+    source-map-support "^0.x"
+    teen_process "^2.0.1"
+
+appium-ios-device@^2.0.0, appium-ios-device@^2.4.0:
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/appium-ios-device/-/appium-ios-device-2.4.5.tgz#038b26ca6e96cee159c841175b8cec8fe885c3a0"
+  integrity sha512-yJeuyNWqu4cdTEm48OYChzSbd155lzP0jD1uplNmV9+hBGorLeTGhmQq8DSPh3mnD8aqb40zcojSch/gIVWkfA==
+  dependencies:
+    "@appium/support" "^2.55.3"
+    "@babel/runtime" "^7.0.0"
+    asyncbox "^2.9.2"
+    bluebird "^3.1.1"
+    bplist-creator "^0.x"
+    bplist-parser "^0.x"
+    lodash "^4.17.15"
+    semver "^7.0.0"
+    source-map-support "^0.x"
+    uuid "^9.0.0"
+
+appium-ios-simulator@^4.0.0:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/appium-ios-simulator/-/appium-ios-simulator-4.1.4.tgz#78e2cdd010b8d3143a97dd4d048b9e7cf91a99fe"
+  integrity sha512-Pl5mFCjyVHXHItFPk2ajas/UUEhFmMTP/OVg1Jpzps6fQVEfOqIMvEptl6ZR0PMg5ol9HnIPtICIvUh585JUfg==
+  dependencies:
+    "@appium/support" "^2.55.3"
+    "@babel/runtime" "^7.0.0"
+    "@xmldom/xmldom" "^0.x"
+    appium-xcode "^4.0.0"
+    async-lock "^1.0.0"
+    asyncbox "^2.3.1"
+    bluebird "^3.5.1"
+    lodash "^4.2.1"
+    node-simctl "^7.1.0"
+    semver "^7.0.0"
+    source-map-support "^0.x"
+    teen_process "^2.0.0"
+
 appium-mac2-driver@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/appium-mac2-driver/-/appium-mac2-driver-1.4.0.tgz#6059bcaada3608505c2b2f2535d33b7cc43c2584"
@@ -4148,6 +4200,38 @@ appium-mac2-driver@1.4.0:
     source-map-support "^0.x"
     teen_process "^1.15.0"
 
+appium-remote-debugger@^9.1.1:
+  version "9.1.3"
+  resolved "https://registry.yarnpkg.com/appium-remote-debugger/-/appium-remote-debugger-9.1.3.tgz#f91ab7886d9f374b04d3df75cd464fdf56bb8979"
+  integrity sha512-0p99CNU+LXgmgjbX3BOOBYSdpKD+P+yRwzeoRyF1YkXvuBCYh1WfMXiydi6HWVN8mATN2GjUMFX6pu6bHLwMaA==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    appium-ios-device "^2.0.0"
+    async-lock "^1.2.2"
+    asyncbox "^2.6.0"
+    bluebird "^3.4.7"
+    fancy-log "^2.0.0"
+    glob "^8.0.3"
+    lodash "^4.17.11"
+    source-map-support "^0.x"
+    teen_process "^2.0.0"
+
+appium-webdriveragent@^4.8.4:
+  version "4.8.5"
+  resolved "https://registry.yarnpkg.com/appium-webdriveragent/-/appium-webdriveragent-4.8.5.tgz#fd2c1745b40deabe3dd74ad81b89b6707e9d7827"
+  integrity sha512-+9lig9AK6kXoWf5W9/qzS9mdL1aFaBUchbSoGyiLfnMhk3D2bmxHVqUGeKvR1TCP2f0m/fkWMQbXPgTsrtWxEQ==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    appium-ios-simulator "^4.0.0"
+    async-lock "^1.0.0"
+    asyncbox "^2.5.3"
+    axios "^0.x"
+    bluebird "^3.5.5"
+    lodash "^4.17.11"
+    node-simctl "^7.0.1"
+    source-map-support "^0.x"
+    teen_process "^2.0.0"
+
 appium-windows-driver@2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/appium-windows-driver/-/appium-windows-driver-2.0.7.tgz#2a9a29bf2a7b752b087eefc37ca1a0a7928ff58f"
@@ -4161,6 +4245,49 @@ appium-windows-driver@2.0.7:
     portscanner "2.2.0"
     source-map-support "^0.5.5"
     teen_process "^2.0.1"
+
+appium-xcode@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/appium-xcode/-/appium-xcode-4.0.2.tgz#be44ccff6ce0982c2f5de6d9883881cb5877fc60"
+  integrity sha512-UxD9nnDP1K7yl6iwlN87jjvmtiXufn3QLz0Y2EDRK8seKA+Zzyg9GSr5o2eETlvr7jZnibnDFBgtbz1P6/cUYA==
+  dependencies:
+    "@appium/support" "^2.55.3"
+    "@babel/runtime" "^7.0.0"
+    asyncbox "^2.3.0"
+    lodash "^4.17.4"
+    plist "^3.0.1"
+    semver "^7.0.0"
+    source-map-support "^0.x"
+    teen_process "^2.0.0"
+
+appium-xcuitest-driver@4.11.1:
+  version "4.11.1"
+  resolved "https://registry.yarnpkg.com/appium-xcuitest-driver/-/appium-xcuitest-driver-4.11.1.tgz#b88e9ec06a5d644a905759930471464cd4f83bfd"
+  integrity sha512-CJvrrsNxAghl76f8EQXBL2NhKsIo2O9b5BfXgwVwxUtRH8H3mYoxzz0zzZ+s8R/2V5koPA1efaU2it/HZHtfWg==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    "@xmldom/xmldom" "^0.x"
+    appium-idb "^1.0.0"
+    appium-ios-device "^2.4.0"
+    appium-ios-simulator "^4.0.0"
+    appium-remote-debugger "^9.1.1"
+    appium-webdriveragent "^4.8.4"
+    appium-xcode "^4.0.0"
+    async-lock "^1.0.0"
+    asyncbox "^2.3.1"
+    bluebird "^3.5.1"
+    css-selector-parser "^1.4.1"
+    js2xmlparser2 "^0.x"
+    lodash "^4.17.10"
+    lru-cache "^7.0.1"
+    moment "^2.24.0"
+    moment-timezone "^0.x"
+    node-simctl "^7.0.0"
+    portscanner "2.2.0"
+    semver "^7.0.0"
+    source-map-support "^0.x"
+    teen_process "^2.0.0"
+    ws "^8.0.0"
 
 appium@2.0.0-beta.41:
   version "2.0.0-beta.41"
@@ -4525,7 +4652,7 @@ async-listener@^0.6.0:
     semver "^5.3.0"
     shimmer "^1.1.0"
 
-async-lock@1.3.2:
+async-lock@1.3.2, async-lock@^1.0.0, async-lock@^1.2.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/async-lock/-/async-lock-1.3.2.tgz#56668613f91c1c55432b4db73e65c9ced664e789"
   integrity sha512-phnXdS3RP7PPcmP6NWWzWMU0sLTeyvtZCxBPpZdkYE3seGLKSQZs9FrmVO/qwypq98FUtWWUEYxziLkdGk5nnA==
@@ -4549,7 +4676,7 @@ async@^3.2.0, async@^3.2.3:
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.3.tgz#ac53dafd3f4720ee9e8a160628f18ea91df196c9"
   integrity sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==
 
-asyncbox@2.9.2, asyncbox@^2.0.2, asyncbox@^2.3.1:
+asyncbox@2.9.2, asyncbox@^2.0.2, asyncbox@^2.3.0, asyncbox@^2.3.1, asyncbox@^2.5.2, asyncbox@^2.5.3, asyncbox@^2.6.0, asyncbox@^2.9.2:
   version "2.9.2"
   resolved "https://registry.yarnpkg.com/asyncbox/-/asyncbox-2.9.2.tgz#6af359a9667ff3d0e7ddfbd500e097d7346a2d9b"
   integrity sha512-VSon1vGccTPcseugq0hl1ImUReW2+Z0GrDpeNHrxuZIKIUf5+gaeXtEFqESFJzSlF3y1UHC8Pkc6AhX/mTiBLA==
@@ -4944,7 +5071,7 @@ bl@^4.0.3, bl@^4.1.0:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-bluebird@3.7.2, bluebird@^3.5.1, bluebird@^3.7.2:
+bluebird@3.7.2, bluebird@^3.1.1, bluebird@^3.4.7, bluebird@^3.5.1, bluebird@^3.5.5, bluebird@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -4984,7 +5111,7 @@ bplist-creator@0.1.0:
   dependencies:
     stream-buffers "2.2.x"
 
-bplist-creator@0.1.1:
+bplist-creator@0.1.1, bplist-creator@^0.x:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/bplist-creator/-/bplist-creator-0.1.1.tgz#ef638af058a7021e10ebfd557ffd73d95e6799fc"
   integrity sha512-Ese7052fdWrxp/vqSJkydgx/1MdBnNOCV2XVfbmdGWD2H6EYza+Q4pyYSuVSnCUD22hfI/BFI4jHaC3NLXLlJQ==
@@ -4998,7 +5125,7 @@ bplist-parser@0.3.1:
   dependencies:
     big-integer "1.6.x"
 
-bplist-parser@0.3.2:
+bplist-parser@0.3.2, bplist-parser@^0.x:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/bplist-parser/-/bplist-parser-0.3.2.tgz#3ac79d67ec52c4c107893e0237eb787cbacbced7"
   integrity sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ==
@@ -5826,6 +5953,11 @@ css-select@^4.1.3, css-select@^4.2.1, css-select@^4.3.0:
     domhandler "^4.3.1"
     domutils "^2.8.0"
     nth-check "^2.0.1"
+
+css-selector-parser@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/css-selector-parser/-/css-selector-parser-1.4.1.tgz#03f9cb8a81c3e5ab2c51684557d5aaf6d2569759"
+  integrity sha512-HYPSb7y/Z7BNDCOrakL4raGO2zltZkbeXyAd6Tg9obzix6QhzxCotdBl6VT0Dv4vZfJGVz3WL/xaEI9Ly3ul0g==
 
 css-shorthand-properties@^1.1.1:
   version "1.1.1"
@@ -7045,6 +7177,13 @@ extract-zip@2.0.1:
     yauzl "^2.10.0"
   optionalDependencies:
     "@types/yauzl" "^2.9.1"
+
+fancy-log@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fancy-log/-/fancy-log-2.0.0.tgz#cad207b8396d69ae4796d74d17dff5f68b2f7343"
+  integrity sha512-9CzxZbACXMUXW13tS0tI8XsGGmxWzO2DmYrGuBJOJ8k8q2K7hwfJA5qHjuPPe8wtsco33YR9wc+Rlr5wYFvhSA==
+  dependencies:
+    color-support "^1.1.3"
 
 fast-deep-equal@^2.0.1:
   version "2.0.1"
@@ -9203,6 +9342,11 @@ js-yaml@^4.0.0, js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
+js2xmlparser2@^0.x:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/js2xmlparser2/-/js2xmlparser2-0.2.0.tgz#a7ca2089b83d02331d631892dd6743864125033f"
+  integrity sha512-SzFGc1hQqzpDcalKmrM5gobSMGRSRg2lgaZrHGIfowrmd8+uaI+PWW62jcCGIqI+b4wdyYK0VKMhvVtJfkD0cg==
+
 js2xmlparser@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/js2xmlparser/-/js2xmlparser-3.0.0.tgz#3fb60eaa089c5440f9319f51760ccd07e2499733"
@@ -9789,7 +9933,7 @@ lodash.zip@^4.2.0:
   resolved "https://registry.yarnpkg.com/lodash.zip/-/lodash.zip-4.2.0.tgz#ec6662e4896408ed4ab6c542a3990b72cc080020"
   integrity sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=
 
-lodash@4.17.21, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.6.1, lodash@^4.7.0, lodash@~4.17.10:
+lodash@4.17.21, lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.6.1, lodash@^4.7.0, lodash@~4.17.10:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -9899,6 +10043,11 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+lru-cache@^7.0.1:
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.14.0.tgz#21be64954a4680e303a09e9468f880b98a0b3c7f"
+  integrity sha512-EIRtP1GrSJny0dqb50QXRUNBxHJhcpxHC++M5tD7RYbvLLn5KVWKsbyswSSqDuU15UFi3bgTQIY8nhDMeF6aDQ==
 
 magic-string@^0.25.7:
   version "0.25.9"
@@ -10504,7 +10653,14 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-moment@2.29.4, moment@^2.29.4:
+moment-timezone@^0.x:
+  version "0.5.37"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.37.tgz#adf97f719c4e458fdb12e2b4e87b8bec9f4eef1e"
+  integrity sha512-uEDzDNFhfaywRl+vwXxffjjq1q0Vzr+fcQpQ1bU0kbzorfS7zVtZnCnGc8mhWmF39d4g4YriF6kwA75mJKE/Zg==
+  dependencies:
+    moment ">= 2.9.0"
+
+moment@2.29.4, "moment@>= 2.9.0", moment@^2.24.0, moment@^2.29.4:
   version "2.29.4"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
   integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
@@ -10711,6 +10867,23 @@ node-releases@^2.0.3:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.4.tgz#f38252370c43854dc48aa431c766c6c398f40476"
   integrity sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ==
 
+node-simctl@^7.0.0, node-simctl@^7.0.1, node-simctl@^7.1.0:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/node-simctl/-/node-simctl-7.1.4.tgz#57c70c642b0a0a3aeb73d99466a6c1031345b886"
+  integrity sha512-nVRdOBGU6PFfLjYhwlmPx7OVsJOQoekiCijSFS/im2tsmHac1/rtPjsCBedGeztrF/zfcG7FYGF8jVM5vWDPHg==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    asyncbox "^2.3.1"
+    bluebird "^3.5.1"
+    lodash "^4.2.1"
+    npmlog "^6.0.0"
+    rimraf "^3.0.0"
+    semver "^7.0.0"
+    source-map-support "^0.x"
+    teen_process "^2.0.0"
+    uuid "^8.0.0"
+    which "^2.0.0"
+
 node-stream-zip@^1.9.1:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/node-stream-zip/-/node-stream-zip-1.15.0.tgz#158adb88ed8004c6c49a396b50a6a5de3bca33ea"
@@ -10764,7 +10937,7 @@ npm-run-path@^4.0.0, npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
-npmlog@6.0.2:
+npmlog@6.0.2, npmlog@^6.0.0:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-6.0.2.tgz#c8166017a42f2dea92d6453168dd865186a70830"
   integrity sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==
@@ -11451,7 +11624,7 @@ please-upgrade-node@^3.2.0:
   dependencies:
     semver-compare "^1.0.0"
 
-plist@3.0.6:
+plist@3.0.6, plist@^3.0.1:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/plist/-/plist-3.0.6.tgz#7cfb68a856a7834bca6dbfe3218eb9c7740145d3"
   integrity sha512-WiIVYyrp8TD4w8yCvyeIr+lkmrGRd5u0VbRnU+tP/aRLxP/YadJUYOMZJ/6hIa3oUyVCsycXvtNRgd5XBJIbiA==
@@ -13187,7 +13360,7 @@ teen_process@1.16.0, teen_process@^1.15.0:
     source-map-support "^0.5.3"
     which "^2.0.2"
 
-teen_process@^2.0.1:
+teen_process@^2.0.0, teen_process@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/teen_process/-/teen_process-2.0.1.tgz#3e23d4b980bcdb7f7d0d064868943c6d8ec09894"
   integrity sha512-1YI3e/leIKqkEliocmT2rqpRAJQS9/cgTWqoILdcSTT4aomSGamNXS0uevHwX1O34lVOidWQWDlMiZ+jaSI/5A==
@@ -13726,6 +13899,11 @@ uuid@^3.0.0, uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
+
 v8-to-istanbul@^8.1.0:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-8.1.1.tgz#77b752fd3975e31bbcef938f85e9bd1c7a8d60ed"
@@ -13912,7 +14090,7 @@ which-module@^2.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which@2.0.2, which@^2.0.1, which@^2.0.2:
+which@2.0.2, which@^2.0.0, which@^2.0.1, which@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
@@ -14064,6 +14242,11 @@ ws@^7, ws@^7.4.6:
   version "7.5.7"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.7.tgz#9e0ac77ee50af70d58326ecff7e85eb3fa375e67"
   integrity sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==
+
+ws@^8.0.0:
+  version "8.8.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.8.1.tgz#5dbad0feb7ade8ecc99b830c1d77c913d4955ff0"
+  integrity sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==
 
 xcode@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [X] macOS
- [X] win32 (Office)
- [X] windows
- [ ] android

### Description of changes

Appium v2, requires an extra dependency for each platform's specific driver. When the Appium server starts, it looks in the current folders' _node_modules_ for the driver package. However, in FURN, all packages are downloaded in the roots' _node_modules_ rather than each individual folder. This is causing issues when trying to run E2E tests locally.

The fix is to add the `nohoist` property in the roots' package.json for these specific packages. This makes it so the package gets installed in the _node_modules_ folder where that package.json lives, thereby fixing this issue.

### Verification

Local _ CI

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
