### PR TITLE
Expose `accessibilityAccessKey` prop to MenuItem

### DIFF
--- a/apps/fluent-tester/package.json
+++ b/apps/fluent-tester/package.json
@@ -119,7 +119,7 @@
     "webdriverio": "7.23.0"
   },
   "peerDependencies": {
-    "@office-iss/react-native-win32": "^0.66.0",
+    "@office-iss/react-native-win32": "^0.66.6",
     "react": "17.0.2",
     "react-native": "^0.66.0",
     "react-native-macos": "^0.66.0",

--- a/apps/win32/package.json
+++ b/apps/win32/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/scripts": "^0.1.1",
-    "@office-iss/react-native-win32": "^0.66.0",
+    "@office-iss/react-native-win32": "^0.66.6",
     "@office-iss/rex-win32": "0.66.17-devmain.15229.10000",
     "@rnx-kit/cli": "^0.9.57",
     "@rnx-kit/metro-config": "^1.2.26",

--- a/change/@fluentui-react-native-adapters-42383a61-72b8-4715-ac99-9bd2d8dd5c59.json
+++ b/change/@fluentui-react-native-adapters-42383a61-72b8-4715-ac99-9bd2d8dd5c59.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "\"Add accessibilityAccessKey as a prop to adapter\"",
+  "packageName": "@fluentui-react-native/adapters",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-button-ffb7ea97-9dcb-461b-bdf0-26bd912738c8.json
+++ b/change/@fluentui-react-native-button-ffb7ea97-9dcb-461b-bdf0-26bd912738c8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove rn win32 dep",
+  "packageName": "@fluentui-react-native/button",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-checkbox-0dc457d9-ba23-4f12-b112-653abea3f8fe.json
+++ b/change/@fluentui-react-native-checkbox-0dc457d9-ba23-4f12-b112-653abea3f8fe.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove rn win32 dep",
+  "packageName": "@fluentui-react-native/checkbox",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-checkbox-cea85eb1-114f-4371-b254-139901eeb188.json
+++ b/change/@fluentui-react-native-experimental-checkbox-cea85eb1-114f-4371-b254-139901eeb188.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove rn win32 dep",
+  "packageName": "@fluentui-react-native/experimental-checkbox",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-tabs-77f8a16c-59d1-47fd-8c88-9a09836ecdf3.json
+++ b/change/@fluentui-react-native-experimental-tabs-77f8a16c-59d1-47fd-8c88-9a09836ecdf3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove rn win32 dep",
+  "packageName": "@fluentui-react-native/experimental-tabs",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-focus-zone-192d5c35-efa3-4f93-ba55-01b7414f565b.json
+++ b/change/@fluentui-react-native-focus-zone-192d5c35-efa3-4f93-ba55-01b7414f565b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove rn win32 dep",
+  "packageName": "@fluentui-react-native/focus-zone",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-focus-zone-192d5c35-efa3-4f93-ba55-01b7414f565b.json
+++ b/change/@fluentui-react-native-focus-zone-192d5c35-efa3-4f93-ba55-01b7414f565b.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Remove rn win32 dep",
-  "packageName": "@fluentui-react-native/focus-zone",
-  "email": "ruaraki@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-react-native-focus-zone-3744b194-3648-403b-993f-14f7ec8ef5f9.json
+++ b/change/@fluentui-react-native-focus-zone-3744b194-3648-403b-993f-14f7ec8ef5f9.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "No changes",
+  "packageName": "@fluentui-react-native/focus-zone",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-icon-def6fae0-4658-4360-bb63-9525d83864bf.json
+++ b/change/@fluentui-react-native-icon-def6fae0-4658-4360-bb63-9525d83864bf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove rn win32 dep",
+  "packageName": "@fluentui-react-native/icon",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-interactive-hooks-3b8859fd-5153-48e8-8780-f75d8294252c.json
+++ b/change/@fluentui-react-native-interactive-hooks-3b8859fd-5153-48e8-8780-f75d8294252c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update RN Win32",
+  "packageName": "@fluentui-react-native/interactive-hooks",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-menu-36dabdd9-9b8f-43ba-87fa-d56273e1a266.json
+++ b/change/@fluentui-react-native-menu-36dabdd9-9b8f-43ba-87fa-d56273e1a266.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "\"MenuItems and MenuTrigger should be based off of IViewProps\"",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-notification-56b16d58-49ee-4a07-8e91-c632df6c0146.json
+++ b/change/@fluentui-react-native-notification-56b16d58-49ee-4a07-8e91-c632df6c0146.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove rn win32 dep",
+  "packageName": "@fluentui-react-native/notification",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-persona-coin-b4fca9ed-c69d-4393-b9d0-506c4fbe7973.json
+++ b/change/@fluentui-react-native-persona-coin-b4fca9ed-c69d-4393-b9d0-506c4fbe7973.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove rn win32 dep",
+  "packageName": "@fluentui-react-native/persona-coin",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-radio-group-cce8d77b-a7af-4eb7-b223-811c19cf220d.json
+++ b/change/@fluentui-react-native-radio-group-cce8d77b-a7af-4eb7-b223-811c19cf220d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove rn win32 dep",
+  "packageName": "@fluentui-react-native/radio-group",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-separator-761b5aa3-f5d6-44c6-a781-84ad65c73b88.json
+++ b/change/@fluentui-react-native-separator-761b5aa3-f5d6-44c6-a781-84ad65c73b88.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove rn win32 dep",
+  "packageName": "@fluentui-react-native/separator",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-switch-36c302ca-0b5a-49b6-8f63-5012675c2d72.json
+++ b/change/@fluentui-react-native-switch-36c302ca-0b5a-49b6-8f63-5012675c2d72.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove rn win32 dep",
+  "packageName": "@fluentui-react-native/switch",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tabs-f87a6b38-e4d0-4343-8358-c2eff12a24f6.json
+++ b/change/@fluentui-react-native-tabs-f87a6b38-e4d0-4343-8358-c2eff12a24f6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove rn win32 dep",
+  "packageName": "@fluentui-react-native/tabs",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tabs-f87a6b38-e4d0-4343-8358-c2eff12a24f6.json
+++ b/change/@fluentui-react-native-tabs-f87a6b38-e4d0-4343-8358-c2eff12a24f6.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Remove rn win32 dep",
+  "comment": "Update RN Win32",
   "packageName": "@fluentui-react-native/tabs",
   "email": "ruaraki@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-native-tester-b9191753-b160-42a5-965f-36b9ab50464c.json
+++ b/change/@fluentui-react-native-tester-b9191753-b160-42a5-965f-36b9ab50464c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update RN Win32",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-win32-0141bc2a-ec0a-479d-accb-40f57bf9657b.json
+++ b/change/@fluentui-react-native-tester-win32-0141bc2a-ec0a-479d-accb-40f57bf9657b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update RN Win32",
+  "packageName": "@fluentui-react-native/tester-win32",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Button/package.json
+++ b/packages/components/Button/package.json
@@ -47,7 +47,6 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/test-tools": ">=0.1.1 <1.0.0",
-    "@office-iss/react-native-win32": "^0.66.0",
     "@types/react-native": "^0.66.0",
     "@fluentui-react-native/scripts": "^0.1.1",
     "react": "17.0.2",

--- a/packages/components/Checkbox/package.json
+++ b/packages/components/Checkbox/package.json
@@ -45,7 +45,6 @@
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/scripts": "^0.1.1",
     "@fluentui-react-native/test-tools": ">=0.1.1 <1.0.0",
-    "@office-iss/react-native-win32": "^0.66.0",
     "@types/react-native": "^0.66.0",
     "react-native": "^0.66.0"
   },

--- a/packages/components/FocusZone/package.json
+++ b/packages/components/FocusZone/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
+    "@office-iss/react-native-win32": "^0.66.6",
     "@types/react-native": "^0.66.0",
     "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.66.0"

--- a/packages/components/FocusZone/package.json
+++ b/packages/components/FocusZone/package.json
@@ -33,7 +33,6 @@
   },
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
-    "@office-iss/react-native-win32": "^0.66.0",
     "@types/react-native": "^0.66.0",
     "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.66.0"

--- a/packages/components/Menu/src/MenuItem/MenuItem.types.ts
+++ b/packages/components/Menu/src/MenuItem/MenuItem.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ColorValue, ViewProps } from 'react-native';
+import { ColorValue } from 'react-native';
 import { XmlProps } from 'react-native-svg';
 import type { IViewProps } from '@fluentui-react-native/adapters';
 import { TextProps } from '@fluentui-react-native/text';
@@ -43,7 +43,7 @@ export interface MenuItemTokens extends LayoutTokens, FontTokens, IBorderTokens,
   pressed?: MenuItemTokens;
 }
 
-export interface MenuItemProps extends Omit<IWithPressableOptions<ViewProps>, 'onPress'> {
+export interface MenuItemProps extends Omit<IWithPressableOptions<IViewProps>, 'onPress'> {
   /**
    * A RefObject to access the IButton interface. Use this to access the public methods and properties of the component.
    */

--- a/packages/components/Menu/src/MenuTrigger/MenuTrigger.types.ts
+++ b/packages/components/Menu/src/MenuTrigger/MenuTrigger.types.ts
@@ -1,9 +1,9 @@
+import { IViewProps } from '@fluentui-react-native/adapters';
 import { InteractionEvent, IWithPressableOptions } from '@fluentui-react-native/interactive-hooks';
-import { ViewProps } from 'react-native';
 
 export const menuTriggerName = 'MenuTrigger';
 
-export interface MenuTriggerChildProps extends Omit<IWithPressableOptions<ViewProps>, 'onPress'> {
+export interface MenuTriggerChildProps extends Omit<IWithPressableOptions<IViewProps>, 'onPress'> {
   /**
    * A RefObject to refer to the trigger component.
    */

--- a/packages/components/Notification/package.json
+++ b/packages/components/Notification/package.json
@@ -42,7 +42,6 @@
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/scripts": "^0.1.1",
     "@fluentui-react-native/test-tools": ">=0.1.1 <1.0.0",
-    "@office-iss/react-native-win32": "^0.66.0",
     "@types/react-native": "^0.66.0",
     "react": "17.0.2",
     "react-native": "^0.66.0",

--- a/packages/components/PersonaCoin/package.json
+++ b/packages/components/PersonaCoin/package.json
@@ -37,7 +37,6 @@
   },
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
-    "@office-iss/react-native-win32": "^0.66.0",
     "@types/react-native": "^0.66.0",
     "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.66.0"

--- a/packages/components/RadioGroup/package.json
+++ b/packages/components/RadioGroup/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/test-tools": ">=0.1.1 <1.0.0",
-    "@office-iss/react-native-win32": "^0.66.0",
+    "@office-iss/react-native-win32": "^0.66.6",
     "@types/react-native": "^0.66.0",
     "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.66.0"

--- a/packages/components/Separator/package.json
+++ b/packages/components/Separator/package.json
@@ -30,7 +30,6 @@
   },
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
-    "@office-iss/react-native-win32": "^0.66.0",
     "@types/react-native": "^0.66.0",
     "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.66.0"

--- a/packages/components/Tabs/package.json
+++ b/packages/components/Tabs/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/test-tools": ">=0.1.1 <1.0.0",
-    "@office-iss/react-native-win32": "^0.66.0",
+    "@office-iss/react-native-win32": "^0.66.6",
     "@types/react-native": "^0.66.0",
     "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.66.0"

--- a/packages/experimental/Checkbox/package.json
+++ b/packages/experimental/Checkbox/package.json
@@ -35,7 +35,6 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/scripts": "^0.1.1",
-    "@office-iss/react-native-win32": "^0.66.0",
     "@types/react-native": "^0.66.0",
     "react": "17.0.2",
     "react-native": "^0.66.0"

--- a/packages/experimental/Icon/package.json
+++ b/packages/experimental/Icon/package.json
@@ -33,7 +33,6 @@
   },
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
-    "@office-iss/react-native-win32": "^0.66.0",
     "@types/react-native": "^0.66.0",
     "@fluentui-react-native/scripts": "^0.1.1",
     "react-native": "^0.66.0",

--- a/packages/experimental/Switch/package.json
+++ b/packages/experimental/Switch/package.json
@@ -37,7 +37,6 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/test-tools": ">=0.1.1 <1.0.0",
-    "@office-iss/react-native-win32": "^0.66.0",
     "@types/react-native": "^0.66.0",
     "@fluentui-react-native/scripts": "^0.1.1",
     "react": "17.0.2",

--- a/packages/experimental/Tabs/package.json
+++ b/packages/experimental/Tabs/package.json
@@ -39,7 +39,6 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/test-tools": ">=0.1.1 <1.0.0",
-    "@office-iss/react-native-win32": "^0.66.0",
     "@types/react-native": "^0.66.0",
     "@fluentui-react-native/scripts": "^0.1.1",
     "react": "17.0.2",

--- a/packages/utils/adapters/package.json
+++ b/packages/utils/adapters/package.json
@@ -33,7 +33,7 @@
     "@fluentui-react-native/scripts": "^0.1.1"
   },
   "peerDependencies": {
-    "@office-iss/react-native-win32": "^0.66.0",
+    "@office-iss/react-native-win32": "^0.66.6",
     "react-native": ">=0.66.0",
     "react-native-windows": ">=0.66.0",
     "react-native-macos": "^0.66.0"

--- a/packages/utils/adapters/src/adapters.ts
+++ b/packages/utils/adapters/src/adapters.ts
@@ -10,6 +10,7 @@ export type IImageProps = ImageProps;
 const _viewMask: IFilterMask<IViewProps> = {
   children: true,
   accessible: true,
+  accessibilityAccessKey: true,
   accessibilityControls: true,
   accessibilityItemType: true,
   accessibilityLabel: true,

--- a/packages/utils/adapters/src/adapters.win32.ts
+++ b/packages/utils/adapters/src/adapters.win32.ts
@@ -10,6 +10,7 @@ export type IImageProps = ImageProps;
 const _viewMask: IFilterMask<IViewProps> = {
   children: true,
   accessible: true,
+  accessibilityAccessKey: true,
   accessibilityActions: true,
   accessibilityAnnotation: true,
   accessibilityControls: true,

--- a/packages/utils/interactive-hooks/package.json
+++ b/packages/utils/interactive-hooks/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/icon": "0.13.6",
-    "@office-iss/react-native-win32": "^0.66.0",
+    "@office-iss/react-native-win32": "^0.66.6",
     "@types/invariant": "^2.2.0",
     "@types/jest": "^26.0.0",
     "@types/react": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2226,10 +2226,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@office-iss/react-native-win32@^0.66.0":
-  version "0.66.5"
-  resolved "https://registry.yarnpkg.com/@office-iss/react-native-win32/-/react-native-win32-0.66.5.tgz#4ca165fc267ce4d8e23af38592b036e68530ebd3"
-  integrity sha512-Y61uqXgkPQ47Xg+DavB4ar7aVRdYe63pNHBLUePYdhWeWQP1COeg4ib1gojnCYGejXYBQ8coEahyrDRbPrGXhA==
+"@office-iss/react-native-win32@^0.66.6":
+  version "0.66.6"
+  resolved "https://registry.yarnpkg.com/@office-iss/react-native-win32/-/react-native-win32-0.66.6.tgz#b6c0fed0c2dbea66da684840920b7d478224fe01"
+  integrity sha512-DOFfzLA+JfsC3AFea57TO7C6NmAZ1yduSQtlqYY6l2scA9yUpw7iOqQIxb41iacKVxWwdQhF11IiF0vVJTJ3zA==
   dependencies:
     "@babel/runtime" "^7.0.0"
     "@jest/create-cache-key-function" "^27.0.1"


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Exposing the `accessibilityAccessKey` prop I added to RN Win32 in order to allow for access key functionality.
Also changing MenuItem and MenuTrigger to be based off of IViewProps so that the new props are visible downstream.

### Verification

E2E tests will help verify changes to packages. Still verifying downstream

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
