### PR TITLE
fix typo in line height name

### DIFF
--- a/change/@fluentui-react-native-theme-types-24a33e32-9f9b-44ee-be17-426881147a1d.json
+++ b/change/@fluentui-react-native-theme-types-24a33e32-9f9b-44ee-be17-426881147a1d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Rename FontLightHeight to FontLineHeight",
+  "packageName": "@fluentui-react-native/theme-types",
+  "email": "adam.gleitman@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/theming/theme-types/src/Typography.types.ts
+++ b/packages/theming/theme-types/src/Typography.types.ts
@@ -94,7 +94,7 @@ export type FontWeight = keyof FontWeights | FontWeightValue;
 /**
  * A font line height value, specified in CSS pixels (px).
  */
-export type FontLightHeight = number;
+export type FontLineHeight = number;
 
 /**
  * A font variant value.


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

I just noticed that our typography types use the alias `FontLightHeight` instead of `FontLineHeight` to determine line height. Oops! Luckily, this symbol doesn't appear to be used anywhere else in this repo, so this should be a relatively easy fix.

### Verification

`yarn build` succeeds.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
