### PR TITLE
Update SwitchProp comments

### DIFF
--- a/change/@fluentui-react-native-switch-4a7caec0-6ca9-465c-9ff7-d8030e9e2c7d.json
+++ b/change/@fluentui-react-native-switch-4a7caec0-6ca9-465c-9ff7-d8030e9e2c7d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated SwitchProp comments to better align with the prop comments on the Fluent UI React Switch documentation. Did not make any functional changes to the control, but wanted to update documentation to get it more ready for publishing as a V1 control.",
+  "packageName": "@fluentui-react-native/switch",
+  "email": "ejlayne@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Switch/src/Switch.types.ts
+++ b/packages/experimental/Switch/src/Switch.types.ts
@@ -143,8 +143,8 @@ export interface SwitchProps extends Omit<IWithPressableOptions<ViewProps>, 'onP
   defaultChecked?: boolean;
 
   /**
-   * Defines the controlled checked state of the Switch. If passed, Switch ignores the defaultChecked property. 
-   * This should only be used if the checked state is to be controlled at a higher level and there is a plan to 
+   * Defines the controlled checked state of the Switch. If passed, Switch ignores the defaultChecked property.
+   * This should only be used if the checked state is to be controlled at a higher level and there is a plan to
    * pass the correct value based on handling onChange events and re-rendering.
    */
   checked?: boolean;

--- a/packages/experimental/Switch/src/Switch.types.ts
+++ b/packages/experimental/Switch/src/Switch.types.ts
@@ -133,22 +133,24 @@ export interface SwitchProps extends Omit<IWithPressableOptions<ViewProps>, 'onP
   componentRef?: React.RefObject<IFocusable>;
 
   /**
-   * Callback function for changes to the switch's state and interaction event
+   * Callback to be called when the checked state value changes
    */
   onChange?: (e: InteractionEvent, checked?: boolean) => void;
 
   /**
-   * The default state of the Switch
+   * Defines whether the Switch is initially in a checked state or not when rendered
    */
   defaultChecked?: boolean;
 
   /**
-   * The Switch's state
+   * Defines the controlled checked state of the Switch. If passed, Switch ignores the defaultChecked property. 
+   * This should only be used if the checked state is to be controlled at a higher level and there is a plan to 
+   * pass the correct value based on handling onChange events and re-rendering.
    */
   checked?: boolean;
 
   /**
-   * A label to describe the Switch
+   * The Switch's label
    */
   label?: string;
 
@@ -163,7 +165,7 @@ export interface SwitchProps extends Omit<IWithPressableOptions<ViewProps>, 'onP
   onText?: string;
 
   /**
-   * Sets the position of the Switch's label. The position value 'after' is mutually
+   * The position of the label relative to the Switch. The position value 'after' is mutually
    * exclusive with the onText and offText props. This is due to variable width
    * of the text props causing the Switch's position to change when it shouldn't.
    */


### PR DESCRIPTION
Updated SwitchProp comments to better align with the prop comments on the Fluent UI React Switch documentation on https://react.fluentui.dev/?path=/docs/components-switch--default#default.

### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Updated SwitchProp comments to better align with the prop comments on the Fluent UI React Switch documentation. Did not make any functional changes to the control, but wanted to update documentation to get it more ready for publishing as a V1 control.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
