### PR TITLE
Bumping FluentUI Apple version (0.8.3)

### DIFF
--- a/apps/fluent-tester/ios/Podfile.lock
+++ b/apps/fluent-tester/ios/Podfile.lock
@@ -10,85 +10,84 @@ PODS:
     - React-jsi (= 0.66.4)
     - ReactCommon/turbomodule/core (= 0.66.4)
   - fmt (6.2.1)
-  - FRNAvatar (0.16.1):
-    - MicrosoftFluentUI (= 0.6.1)
-    - MicrosoftFluentUI/Avatar_ios (= 0.6.1)
+  - FRNAvatar (0.16.4):
+    - MicrosoftFluentUI (= 0.8.3)
     - React
-  - FRNDatePicker (0.6.1):
-    - MicrosoftFluentUI (= 0.6.1)
+  - FRNDatePicker (0.7.0):
+    - MicrosoftFluentUI (= 0.8.3)
     - React
   - glog (0.3.5)
-  - MicrosoftFluentUI (0.6.1):
-    - MicrosoftFluentUI/ActivityIndicator_ios (= 0.6.1)
-    - MicrosoftFluentUI/Appearance_mac (= 0.6.1)
-    - MicrosoftFluentUI/Avatar_ios (= 0.6.1)
-    - MicrosoftFluentUI/AvatarGroup_ios (= 0.6.1)
-    - MicrosoftFluentUI/AvatarView_mac (= 0.6.1)
-    - MicrosoftFluentUI/BadgeField_ios (= 0.6.1)
-    - MicrosoftFluentUI/BadgeView_mac (= 0.6.1)
-    - MicrosoftFluentUI/BarButtonItems_ios (= 0.6.1)
-    - MicrosoftFluentUI/BottomCommanding_ios (= 0.6.1)
-    - MicrosoftFluentUI/BottomSheet_ios (= 0.6.1)
-    - MicrosoftFluentUI/Button_ios (= 0.6.1)
-    - MicrosoftFluentUI/Button_mac (= 0.6.1)
-    - MicrosoftFluentUI/Calendar_ios (= 0.6.1)
-    - MicrosoftFluentUI/Card_ios (= 0.6.1)
-    - MicrosoftFluentUI/CardNudge_ios (= 0.6.1)
-    - MicrosoftFluentUI/CommandBar_ios (= 0.6.1)
-    - MicrosoftFluentUI/Core_ios (= 0.6.1)
-    - MicrosoftFluentUI/Core_mac (= 0.6.1)
-    - MicrosoftFluentUI/DatePicker_mac (= 0.6.1)
-    - MicrosoftFluentUI/DotView_ios (= 0.6.1)
-    - MicrosoftFluentUI/Drawer_ios (= 0.6.1)
-    - MicrosoftFluentUI/DynamicColor_mac (= 0.6.1)
-    - MicrosoftFluentUI/EasyTapButton_ios (= 0.6.1)
-    - MicrosoftFluentUI/HUD_ios (= 0.6.1)
-    - MicrosoftFluentUI/IndeterminateProgressBar_ios (= 0.6.1)
-    - MicrosoftFluentUI/Label_ios (= 0.6.1)
-    - MicrosoftFluentUI/Link_mac (= 0.6.1)
-    - MicrosoftFluentUI/Navigation_ios (= 0.6.1)
-    - MicrosoftFluentUI/Notification_ios (= 0.6.1)
-    - MicrosoftFluentUI/Obscurable_ios (= 0.6.1)
-    - MicrosoftFluentUI/OtherCells_ios (= 0.6.1)
-    - MicrosoftFluentUI/PeoplePicker_ios (= 0.6.1)
-    - MicrosoftFluentUI/PersonaButton_ios (= 0.6.1)
-    - MicrosoftFluentUI/PersonaButtonCarousel_ios (= 0.6.1)
-    - MicrosoftFluentUI/PillButtonBar_ios (= 0.6.1)
-    - MicrosoftFluentUI/PopupMenu_ios (= 0.6.1)
-    - MicrosoftFluentUI/Presenters_ios (= 0.6.1)
-    - MicrosoftFluentUI/ResizingHandleView_ios (= 0.6.1)
-    - MicrosoftFluentUI/SegmentedControl_ios (= 0.6.1)
-    - MicrosoftFluentUI/Separator_ios (= 0.6.1)
-    - MicrosoftFluentUI/Separator_mac (= 0.6.1)
-    - MicrosoftFluentUI/Shimmer_ios (= 0.6.1)
-    - MicrosoftFluentUI/TabBar_ios (= 0.6.1)
-    - MicrosoftFluentUI/TableView_ios (= 0.6.1)
-    - MicrosoftFluentUI/Tooltip_ios (= 0.6.1)
-    - MicrosoftFluentUI/TouchForwardingView_ios (= 0.6.1)
-    - MicrosoftFluentUI/TwoLineTitleView_ios (= 0.6.1)
-    - MicrosoftFluentUI/Utilities_ios (= 0.6.1)
-  - MicrosoftFluentUI/ActivityIndicator_ios (0.6.1):
+  - MicrosoftFluentUI (0.8.3):
+    - MicrosoftFluentUI/ActivityIndicator_ios (= 0.8.3)
+    - MicrosoftFluentUI/Appearance_mac (= 0.8.3)
+    - MicrosoftFluentUI/Avatar_ios (= 0.8.3)
+    - MicrosoftFluentUI/AvatarGroup_ios (= 0.8.3)
+    - MicrosoftFluentUI/AvatarView_mac (= 0.8.3)
+    - MicrosoftFluentUI/BadgeField_ios (= 0.8.3)
+    - MicrosoftFluentUI/BadgeView_mac (= 0.8.3)
+    - MicrosoftFluentUI/BarButtonItems_ios (= 0.8.3)
+    - MicrosoftFluentUI/BottomCommanding_ios (= 0.8.3)
+    - MicrosoftFluentUI/BottomSheet_ios (= 0.8.3)
+    - MicrosoftFluentUI/Button_ios (= 0.8.3)
+    - MicrosoftFluentUI/Button_mac (= 0.8.3)
+    - MicrosoftFluentUI/Calendar_ios (= 0.8.3)
+    - MicrosoftFluentUI/Card_ios (= 0.8.3)
+    - MicrosoftFluentUI/CardNudge_ios (= 0.8.3)
+    - MicrosoftFluentUI/CommandBar_ios (= 0.8.3)
+    - MicrosoftFluentUI/Core_ios (= 0.8.3)
+    - MicrosoftFluentUI/Core_mac (= 0.8.3)
+    - MicrosoftFluentUI/DatePicker_mac (= 0.8.3)
+    - MicrosoftFluentUI/DotView_ios (= 0.8.3)
+    - MicrosoftFluentUI/Drawer_ios (= 0.8.3)
+    - MicrosoftFluentUI/DynamicColor_mac (= 0.8.3)
+    - MicrosoftFluentUI/EasyTapButton_ios (= 0.8.3)
+    - MicrosoftFluentUI/HUD_ios (= 0.8.3)
+    - MicrosoftFluentUI/IndeterminateProgressBar_ios (= 0.8.3)
+    - MicrosoftFluentUI/Label_ios (= 0.8.3)
+    - MicrosoftFluentUI/Link_mac (= 0.8.3)
+    - MicrosoftFluentUI/Navigation_ios (= 0.8.3)
+    - MicrosoftFluentUI/Notification_ios (= 0.8.3)
+    - MicrosoftFluentUI/Obscurable_ios (= 0.8.3)
+    - MicrosoftFluentUI/OtherCells_ios (= 0.8.3)
+    - MicrosoftFluentUI/PeoplePicker_ios (= 0.8.3)
+    - MicrosoftFluentUI/PersonaButton_ios (= 0.8.3)
+    - MicrosoftFluentUI/PersonaButtonCarousel_ios (= 0.8.3)
+    - MicrosoftFluentUI/PillButtonBar_ios (= 0.8.3)
+    - MicrosoftFluentUI/PopupMenu_ios (= 0.8.3)
+    - MicrosoftFluentUI/Presenters_ios (= 0.8.3)
+    - MicrosoftFluentUI/ResizingHandleView_ios (= 0.8.3)
+    - MicrosoftFluentUI/SegmentedControl_ios (= 0.8.3)
+    - MicrosoftFluentUI/Separator_ios (= 0.8.3)
+    - MicrosoftFluentUI/Separator_mac (= 0.8.3)
+    - MicrosoftFluentUI/Shimmer_ios (= 0.8.3)
+    - MicrosoftFluentUI/TabBar_ios (= 0.8.3)
+    - MicrosoftFluentUI/TableView_ios (= 0.8.3)
+    - MicrosoftFluentUI/Tooltip_ios (= 0.8.3)
+    - MicrosoftFluentUI/TouchForwardingView_ios (= 0.8.3)
+    - MicrosoftFluentUI/TwoLineTitleView_ios (= 0.8.3)
+    - MicrosoftFluentUI/Utilities_ios (= 0.8.3)
+  - MicrosoftFluentUI/ActivityIndicator_ios (0.8.3):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/Avatar_ios (0.6.1):
+  - MicrosoftFluentUI/Avatar_ios (0.8.3):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/AvatarGroup_ios (0.6.1):
+  - MicrosoftFluentUI/AvatarGroup_ios (0.8.3):
     - MicrosoftFluentUI/Avatar_ios
-  - MicrosoftFluentUI/BadgeField_ios (0.6.1):
+  - MicrosoftFluentUI/BadgeField_ios (0.8.3):
     - MicrosoftFluentUI/Label_ios
-  - MicrosoftFluentUI/BarButtonItems_ios (0.6.1):
+  - MicrosoftFluentUI/BarButtonItems_ios (0.8.3):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/BottomCommanding_ios (0.6.1):
+  - MicrosoftFluentUI/BottomCommanding_ios (0.8.3):
     - MicrosoftFluentUI/BottomSheet_ios
     - MicrosoftFluentUI/OtherCells_ios
     - MicrosoftFluentUI/Separator_ios
     - MicrosoftFluentUI/TabBar_ios
     - MicrosoftFluentUI/TableView_ios
-  - MicrosoftFluentUI/BottomSheet_ios (0.6.1):
+  - MicrosoftFluentUI/BottomSheet_ios (0.8.3):
     - MicrosoftFluentUI/Obscurable_ios
     - MicrosoftFluentUI/ResizingHandleView_ios
-  - MicrosoftFluentUI/Button_ios (0.6.1):
+  - MicrosoftFluentUI/Button_ios (0.8.3):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/Calendar_ios (0.6.1):
+  - MicrosoftFluentUI/Calendar_ios (0.8.3):
     - MicrosoftFluentUI/BarButtonItems_ios
     - MicrosoftFluentUI/DotView_ios
     - MicrosoftFluentUI/Label_ios
@@ -96,86 +95,86 @@ PODS:
     - MicrosoftFluentUI/SegmentedControl_ios
     - MicrosoftFluentUI/Separator_ios
     - MicrosoftFluentUI/TwoLineTitleView_ios
-  - MicrosoftFluentUI/Card_ios (0.6.1):
+  - MicrosoftFluentUI/Card_ios (0.8.3):
     - MicrosoftFluentUI/Label_ios
-  - MicrosoftFluentUI/CardNudge_ios (0.6.1):
+  - MicrosoftFluentUI/CardNudge_ios (0.8.3):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/CommandBar_ios (0.6.1):
+  - MicrosoftFluentUI/CommandBar_ios (0.8.3):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/Core_ios (0.6.1)
-  - MicrosoftFluentUI/DotView_ios (0.6.1):
+  - MicrosoftFluentUI/Core_ios (0.8.3)
+  - MicrosoftFluentUI/DotView_ios (0.8.3):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/Drawer_ios (0.6.1):
+  - MicrosoftFluentUI/Drawer_ios (0.8.3):
     - MicrosoftFluentUI/Obscurable_ios
     - MicrosoftFluentUI/ResizingHandleView_ios
     - MicrosoftFluentUI/Separator_ios
     - MicrosoftFluentUI/TouchForwardingView_ios
-  - MicrosoftFluentUI/EasyTapButton_ios (0.6.1):
+  - MicrosoftFluentUI/EasyTapButton_ios (0.8.3):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/HUD_ios (0.6.1):
+  - MicrosoftFluentUI/HUD_ios (0.8.3):
     - MicrosoftFluentUI/ActivityIndicator_ios
     - MicrosoftFluentUI/Label_ios
     - MicrosoftFluentUI/TouchForwardingView_ios
-  - MicrosoftFluentUI/IndeterminateProgressBar_ios (0.6.1):
+  - MicrosoftFluentUI/IndeterminateProgressBar_ios (0.8.3):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/Label_ios (0.6.1):
+  - MicrosoftFluentUI/Label_ios (0.8.3):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/Navigation_ios (0.6.1):
+  - MicrosoftFluentUI/Navigation_ios (0.8.3):
     - MicrosoftFluentUI/ActivityIndicator_ios
     - MicrosoftFluentUI/Avatar_ios
     - MicrosoftFluentUI/Separator_ios
     - MicrosoftFluentUI/TwoLineTitleView_ios
-  - MicrosoftFluentUI/Notification_ios (0.6.1):
+  - MicrosoftFluentUI/Notification_ios (0.8.3):
     - MicrosoftFluentUI/Label_ios
     - MicrosoftFluentUI/Obscurable_ios
-  - MicrosoftFluentUI/Obscurable_ios (0.6.1):
+  - MicrosoftFluentUI/Obscurable_ios (0.8.3):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/OtherCells_ios (0.6.1):
+  - MicrosoftFluentUI/OtherCells_ios (0.8.3):
     - MicrosoftFluentUI/ActivityIndicator_ios
     - MicrosoftFluentUI/TableView_ios
-  - MicrosoftFluentUI/PeoplePicker_ios (0.6.1):
+  - MicrosoftFluentUI/PeoplePicker_ios (0.8.3):
     - MicrosoftFluentUI/Avatar_ios
     - MicrosoftFluentUI/BadgeField_ios
     - MicrosoftFluentUI/OtherCells_ios
     - MicrosoftFluentUI/Separator_ios
-  - MicrosoftFluentUI/PersonaButton_ios (0.6.1):
+  - MicrosoftFluentUI/PersonaButton_ios (0.8.3):
     - MicrosoftFluentUI/Avatar_ios
-  - MicrosoftFluentUI/PersonaButtonCarousel_ios (0.6.1):
+  - MicrosoftFluentUI/PersonaButtonCarousel_ios (0.8.3):
     - MicrosoftFluentUI/PersonaButton_ios
-  - MicrosoftFluentUI/PillButtonBar_ios (0.6.1):
+  - MicrosoftFluentUI/PillButtonBar_ios (0.8.3):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/PopupMenu_ios (0.6.1):
+  - MicrosoftFluentUI/PopupMenu_ios (0.8.3):
     - MicrosoftFluentUI/Drawer_ios
     - MicrosoftFluentUI/Label_ios
     - MicrosoftFluentUI/Separator_ios
     - MicrosoftFluentUI/TableView_ios
-  - MicrosoftFluentUI/Presenters_ios (0.6.1):
+  - MicrosoftFluentUI/Presenters_ios (0.8.3):
     - MicrosoftFluentUI/Obscurable_ios
-  - MicrosoftFluentUI/ResizingHandleView_ios (0.6.1):
+  - MicrosoftFluentUI/ResizingHandleView_ios (0.8.3):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/SegmentedControl_ios (0.6.1):
+  - MicrosoftFluentUI/SegmentedControl_ios (0.8.3):
     - MicrosoftFluentUI/Separator_ios
-  - MicrosoftFluentUI/Separator_ios (0.6.1):
+  - MicrosoftFluentUI/Separator_ios (0.8.3):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/Shimmer_ios (0.6.1):
+  - MicrosoftFluentUI/Shimmer_ios (0.8.3):
     - MicrosoftFluentUI/Core_ios
     - MicrosoftFluentUI/Utilities_ios
-  - MicrosoftFluentUI/TabBar_ios (0.6.1):
+  - MicrosoftFluentUI/TabBar_ios (0.8.3):
     - MicrosoftFluentUI/Avatar_ios
     - MicrosoftFluentUI/Label_ios
     - MicrosoftFluentUI/Separator_ios
-  - MicrosoftFluentUI/TableView_ios (0.6.1):
+  - MicrosoftFluentUI/TableView_ios (0.8.3):
     - MicrosoftFluentUI/Label_ios
     - MicrosoftFluentUI/Separator_ios
-  - MicrosoftFluentUI/Tooltip_ios (0.6.1):
+  - MicrosoftFluentUI/Tooltip_ios (0.8.3):
     - MicrosoftFluentUI/Label_ios
     - MicrosoftFluentUI/TouchForwardingView_ios
-  - MicrosoftFluentUI/TouchForwardingView_ios (0.6.1):
+  - MicrosoftFluentUI/TouchForwardingView_ios (0.8.3):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/TwoLineTitleView_ios (0.6.1):
+  - MicrosoftFluentUI/TwoLineTitleView_ios (0.8.3):
     - MicrosoftFluentUI/EasyTapButton_ios
     - MicrosoftFluentUI/Label_ios
-  - MicrosoftFluentUI/Utilities_ios (0.6.1)
+  - MicrosoftFluentUI/Utilities_ios (0.8.3)
   - RCT-Folly (2021.06.28.00-v2):
     - boost
     - DoubleConversion
@@ -376,7 +375,7 @@ PODS:
     - glog
   - react-native-menu (0.1.2):
     - React
-  - react-native-slider (4.2.4):
+  - react-native-slider (4.3.1):
     - React-Core
   - React-perflogger (0.66.4)
   - React-RCTActionSheet (0.66.4):
@@ -443,11 +442,11 @@ PODS:
     - React-jsi (= 0.66.4)
     - React-logger (= 0.66.4)
     - React-perflogger (= 0.66.4)
-  - ReactTestApp-DevSupport (1.6.2):
+  - ReactTestApp-DevSupport (1.6.15):
     - React-Core
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
-  - RNCPicker (2.4.2):
+  - RNCPicker (2.4.4):
     - React-Core
   - RNSVG (12.3.0):
     - React-Core
@@ -584,10 +583,10 @@ SPEC CHECKSUMS:
   FBLazyVector: e5569e42a1c79ca00521846c223173a57aca1fe1
   FBReactNativeSpec: fe08c1cd7e2e205718d77ad14b34957cce949b58
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  FRNAvatar: 106dad851d08d0cea35d56310b64db6a065c2099
-  FRNDatePicker: 75eb1d59c15ec0cfe681e91316105cd2fc206bea
+  FRNAvatar: d830f11cbb1e9baa15c99ca0e64feb35992a064d
+  FRNDatePicker: 501a8b3d28baf39426ebe6297e3b88c3e5c0d58b
   glog: 5337263514dd6f09803962437687240c5dc39aa4
-  MicrosoftFluentUI: 28925cbf24aa550b9942f844d293b90d1a5db330
+  MicrosoftFluentUI: e30487dd18aba04beeed4caf1ce1988073f8b03a
   RCT-Folly: a21c126816d8025b547704b777a2ba552f3d9fa9
   RCTRequired: 4bf86c70714490bca4bf2696148638284622644b
   RCTTypeSafety: c475a7059eb77935fa53d2c17db299893f057d5d
@@ -601,7 +600,7 @@ SPEC CHECKSUMS:
   React-jsinspector: d0374f7509d407d2264168b6d0fad0b54e300b85
   React-logger: 933f80c97c633ee8965d609876848148e3fef438
   react-native-menu: 9fe07f72e075b250295eeae25425490cc9608951
-  react-native-slider: cecabb58ecffad671d2ad3ccc58c7f4d2d029e95
+  react-native-slider: d3ae4270cf8a8cc45a69912db0cc42b151560d5a
   React-perflogger: 93075d8931c32cd1fce8a98c15d2d5ccc4d891bd
   React-RCTActionSheet: 7d3041e6761b4f3044a37079ddcb156575fb6d89
   React-RCTAnimation: 743e88b55ac62511ae5c2e22803d4f503f2a3a13
@@ -614,9 +613,9 @@ SPEC CHECKSUMS:
   React-RCTVibration: e3ffca672dd3772536cb844274094b0e2c31b187
   React-runtimeexecutor: dec32ee6f2e2a26e13e58152271535fadff5455a
   ReactCommon: 57b69f6383eafcbd7da625bfa6003810332313c4
-  ReactTestApp-DevSupport: 2fa32bc5aec307737d9836a8e40dfaa3745e7525
+  ReactTestApp-DevSupport: 32727c74767e723fac69e6281652b5184cff77a1
   ReactTestApp-Resources: ecba662266ac5af3e30e1e3004c0fa8c0298b61a
-  RNCPicker: 0250e95ad170569a96f5b0555cdd5e65b9084dca
+  RNCPicker: 0b65be85fe7954fbb2062ef079e3d1cde252d888
   RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8
   Yoga: e7dc4e71caba6472ff48ad7d234389b91dadc280
 

--- a/apps/fluent-tester/macos/Podfile.lock
+++ b/apps/fluent-tester/macos/Podfile.lock
@@ -2,95 +2,94 @@ PODS:
   - boost (1.76.0)
   - boost-for-react-native (1.63.0)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.66.78)
-  - FBReactNativeSpec (0.66.78):
+  - FBLazyVector (0.66.80)
+  - FBReactNativeSpec (0.66.80):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.66.78)
-    - RCTTypeSafety (= 0.66.78)
-    - React-Core (= 0.66.78)
-    - React-jsi (= 0.66.78)
-    - ReactCommon/turbomodule/core (= 0.66.78)
+    - RCTRequired (= 0.66.80)
+    - RCTTypeSafety (= 0.66.80)
+    - React-Core (= 0.66.80)
+    - React-jsi (= 0.66.80)
+    - ReactCommon/turbomodule/core (= 0.66.80)
   - fmt (6.2.1)
-  - FRNAvatar (0.16.2):
-    - MicrosoftFluentUI (= 0.6.1)
-    - MicrosoftFluentUI/Avatar_ios (= 0.6.1)
+  - FRNAvatar (0.16.4):
+    - MicrosoftFluentUI (= 0.8.3)
     - React
-  - FRNCallout (0.21.8):
+  - FRNCallout (0.21.11):
     - React
-  - FRNCheckbox (0.12.12):
+  - FRNCheckbox (0.12.16):
     - React
-  - FRNMenuButton (0.8.23):
+  - FRNMenuButton (0.8.29):
     - React
-  - FRNRadioButton (0.15.10):
+  - FRNRadioButton (0.15.14):
     - React
   - glog (0.3.5)
-  - MicrosoftFluentUI (0.6.1):
-    - MicrosoftFluentUI/ActivityIndicator_ios (= 0.6.1)
-    - MicrosoftFluentUI/Appearance_mac (= 0.6.1)
-    - MicrosoftFluentUI/Avatar_ios (= 0.6.1)
-    - MicrosoftFluentUI/AvatarGroup_ios (= 0.6.1)
-    - MicrosoftFluentUI/AvatarView_mac (= 0.6.1)
-    - MicrosoftFluentUI/BadgeField_ios (= 0.6.1)
-    - MicrosoftFluentUI/BadgeView_mac (= 0.6.1)
-    - MicrosoftFluentUI/BarButtonItems_ios (= 0.6.1)
-    - MicrosoftFluentUI/BottomCommanding_ios (= 0.6.1)
-    - MicrosoftFluentUI/BottomSheet_ios (= 0.6.1)
-    - MicrosoftFluentUI/Button_ios (= 0.6.1)
-    - MicrosoftFluentUI/Button_mac (= 0.6.1)
-    - MicrosoftFluentUI/Calendar_ios (= 0.6.1)
-    - MicrosoftFluentUI/Card_ios (= 0.6.1)
-    - MicrosoftFluentUI/CardNudge_ios (= 0.6.1)
-    - MicrosoftFluentUI/CommandBar_ios (= 0.6.1)
-    - MicrosoftFluentUI/Core_ios (= 0.6.1)
-    - MicrosoftFluentUI/Core_mac (= 0.6.1)
-    - MicrosoftFluentUI/DatePicker_mac (= 0.6.1)
-    - MicrosoftFluentUI/DotView_ios (= 0.6.1)
-    - MicrosoftFluentUI/Drawer_ios (= 0.6.1)
-    - MicrosoftFluentUI/DynamicColor_mac (= 0.6.1)
-    - MicrosoftFluentUI/EasyTapButton_ios (= 0.6.1)
-    - MicrosoftFluentUI/HUD_ios (= 0.6.1)
-    - MicrosoftFluentUI/IndeterminateProgressBar_ios (= 0.6.1)
-    - MicrosoftFluentUI/Label_ios (= 0.6.1)
-    - MicrosoftFluentUI/Link_mac (= 0.6.1)
-    - MicrosoftFluentUI/Navigation_ios (= 0.6.1)
-    - MicrosoftFluentUI/Notification_ios (= 0.6.1)
-    - MicrosoftFluentUI/Obscurable_ios (= 0.6.1)
-    - MicrosoftFluentUI/OtherCells_ios (= 0.6.1)
-    - MicrosoftFluentUI/PeoplePicker_ios (= 0.6.1)
-    - MicrosoftFluentUI/PersonaButton_ios (= 0.6.1)
-    - MicrosoftFluentUI/PersonaButtonCarousel_ios (= 0.6.1)
-    - MicrosoftFluentUI/PillButtonBar_ios (= 0.6.1)
-    - MicrosoftFluentUI/PopupMenu_ios (= 0.6.1)
-    - MicrosoftFluentUI/Presenters_ios (= 0.6.1)
-    - MicrosoftFluentUI/ResizingHandleView_ios (= 0.6.1)
-    - MicrosoftFluentUI/SegmentedControl_ios (= 0.6.1)
-    - MicrosoftFluentUI/Separator_ios (= 0.6.1)
-    - MicrosoftFluentUI/Separator_mac (= 0.6.1)
-    - MicrosoftFluentUI/Shimmer_ios (= 0.6.1)
-    - MicrosoftFluentUI/TabBar_ios (= 0.6.1)
-    - MicrosoftFluentUI/TableView_ios (= 0.6.1)
-    - MicrosoftFluentUI/Tooltip_ios (= 0.6.1)
-    - MicrosoftFluentUI/TouchForwardingView_ios (= 0.6.1)
-    - MicrosoftFluentUI/TwoLineTitleView_ios (= 0.6.1)
-    - MicrosoftFluentUI/Utilities_ios (= 0.6.1)
-  - MicrosoftFluentUI/Appearance_mac (0.6.1)
-  - MicrosoftFluentUI/AvatarView_mac (0.6.1):
+  - MicrosoftFluentUI (0.8.3):
+    - MicrosoftFluentUI/ActivityIndicator_ios (= 0.8.3)
+    - MicrosoftFluentUI/Appearance_mac (= 0.8.3)
+    - MicrosoftFluentUI/Avatar_ios (= 0.8.3)
+    - MicrosoftFluentUI/AvatarGroup_ios (= 0.8.3)
+    - MicrosoftFluentUI/AvatarView_mac (= 0.8.3)
+    - MicrosoftFluentUI/BadgeField_ios (= 0.8.3)
+    - MicrosoftFluentUI/BadgeView_mac (= 0.8.3)
+    - MicrosoftFluentUI/BarButtonItems_ios (= 0.8.3)
+    - MicrosoftFluentUI/BottomCommanding_ios (= 0.8.3)
+    - MicrosoftFluentUI/BottomSheet_ios (= 0.8.3)
+    - MicrosoftFluentUI/Button_ios (= 0.8.3)
+    - MicrosoftFluentUI/Button_mac (= 0.8.3)
+    - MicrosoftFluentUI/Calendar_ios (= 0.8.3)
+    - MicrosoftFluentUI/Card_ios (= 0.8.3)
+    - MicrosoftFluentUI/CardNudge_ios (= 0.8.3)
+    - MicrosoftFluentUI/CommandBar_ios (= 0.8.3)
+    - MicrosoftFluentUI/Core_ios (= 0.8.3)
+    - MicrosoftFluentUI/Core_mac (= 0.8.3)
+    - MicrosoftFluentUI/DatePicker_mac (= 0.8.3)
+    - MicrosoftFluentUI/DotView_ios (= 0.8.3)
+    - MicrosoftFluentUI/Drawer_ios (= 0.8.3)
+    - MicrosoftFluentUI/DynamicColor_mac (= 0.8.3)
+    - MicrosoftFluentUI/EasyTapButton_ios (= 0.8.3)
+    - MicrosoftFluentUI/HUD_ios (= 0.8.3)
+    - MicrosoftFluentUI/IndeterminateProgressBar_ios (= 0.8.3)
+    - MicrosoftFluentUI/Label_ios (= 0.8.3)
+    - MicrosoftFluentUI/Link_mac (= 0.8.3)
+    - MicrosoftFluentUI/Navigation_ios (= 0.8.3)
+    - MicrosoftFluentUI/Notification_ios (= 0.8.3)
+    - MicrosoftFluentUI/Obscurable_ios (= 0.8.3)
+    - MicrosoftFluentUI/OtherCells_ios (= 0.8.3)
+    - MicrosoftFluentUI/PeoplePicker_ios (= 0.8.3)
+    - MicrosoftFluentUI/PersonaButton_ios (= 0.8.3)
+    - MicrosoftFluentUI/PersonaButtonCarousel_ios (= 0.8.3)
+    - MicrosoftFluentUI/PillButtonBar_ios (= 0.8.3)
+    - MicrosoftFluentUI/PopupMenu_ios (= 0.8.3)
+    - MicrosoftFluentUI/Presenters_ios (= 0.8.3)
+    - MicrosoftFluentUI/ResizingHandleView_ios (= 0.8.3)
+    - MicrosoftFluentUI/SegmentedControl_ios (= 0.8.3)
+    - MicrosoftFluentUI/Separator_ios (= 0.8.3)
+    - MicrosoftFluentUI/Separator_mac (= 0.8.3)
+    - MicrosoftFluentUI/Shimmer_ios (= 0.8.3)
+    - MicrosoftFluentUI/TabBar_ios (= 0.8.3)
+    - MicrosoftFluentUI/TableView_ios (= 0.8.3)
+    - MicrosoftFluentUI/Tooltip_ios (= 0.8.3)
+    - MicrosoftFluentUI/TouchForwardingView_ios (= 0.8.3)
+    - MicrosoftFluentUI/TwoLineTitleView_ios (= 0.8.3)
+    - MicrosoftFluentUI/Utilities_ios (= 0.8.3)
+  - MicrosoftFluentUI/Appearance_mac (0.8.3)
+  - MicrosoftFluentUI/AvatarView_mac (0.8.3):
     - MicrosoftFluentUI/Core_mac
     - MicrosoftFluentUI/DynamicColor_mac
-  - MicrosoftFluentUI/BadgeView_mac (0.6.1):
+  - MicrosoftFluentUI/BadgeView_mac (0.8.3):
     - MicrosoftFluentUI/Core_mac
     - MicrosoftFluentUI/DynamicColor_mac
-  - MicrosoftFluentUI/Button_mac (0.6.1):
+  - MicrosoftFluentUI/Button_mac (0.8.3):
     - MicrosoftFluentUI/Core_mac
-  - MicrosoftFluentUI/Core_mac (0.6.1)
-  - MicrosoftFluentUI/DatePicker_mac (0.6.1):
+  - MicrosoftFluentUI/Core_mac (0.8.3)
+  - MicrosoftFluentUI/DatePicker_mac (0.8.3):
     - MicrosoftFluentUI/Appearance_mac
     - MicrosoftFluentUI/Core_mac
-  - MicrosoftFluentUI/DynamicColor_mac (0.6.1):
+  - MicrosoftFluentUI/DynamicColor_mac (0.8.3):
     - MicrosoftFluentUI/Appearance_mac
-  - MicrosoftFluentUI/Link_mac (0.6.1):
+  - MicrosoftFluentUI/Link_mac (0.8.3):
     - MicrosoftFluentUI/Core_mac
-  - MicrosoftFluentUI/Separator_mac (0.6.1):
+  - MicrosoftFluentUI/Separator_mac (0.8.3):
     - MicrosoftFluentUI/Core_mac
   - RCT-Folly (2021.06.28.00-v2):
     - boost
@@ -103,261 +102,261 @@ PODS:
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
-  - RCTFocusZone (0.10.8):
+  - RCTFocusZone (0.10.12):
     - React
-  - RCTRequired (0.66.78)
-  - RCTTypeSafety (0.66.78):
-    - FBLazyVector (= 0.66.78)
+  - RCTRequired (0.66.80)
+  - RCTTypeSafety (0.66.80):
+    - FBLazyVector (= 0.66.80)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.66.78)
-    - React-Core (= 0.66.78)
-  - React (0.66.78):
-    - React-Core (= 0.66.78)
-    - React-Core/DevSupport (= 0.66.78)
-    - React-Core/RCTWebSocket (= 0.66.78)
-    - React-RCTActionSheet (= 0.66.78)
-    - React-RCTAnimation (= 0.66.78)
-    - React-RCTBlob (= 0.66.78)
-    - React-RCTImage (= 0.66.78)
-    - React-RCTLinking (= 0.66.78)
-    - React-RCTNetwork (= 0.66.78)
-    - React-RCTSettings (= 0.66.78)
-    - React-RCTText (= 0.66.78)
-    - React-RCTVibration (= 0.66.78)
-  - React-callinvoker (0.66.78)
-  - React-Core (0.66.78):
+    - RCTRequired (= 0.66.80)
+    - React-Core (= 0.66.80)
+  - React (0.66.80):
+    - React-Core (= 0.66.80)
+    - React-Core/DevSupport (= 0.66.80)
+    - React-Core/RCTWebSocket (= 0.66.80)
+    - React-RCTActionSheet (= 0.66.80)
+    - React-RCTAnimation (= 0.66.80)
+    - React-RCTBlob (= 0.66.80)
+    - React-RCTImage (= 0.66.80)
+    - React-RCTLinking (= 0.66.80)
+    - React-RCTNetwork (= 0.66.80)
+    - React-RCTSettings (= 0.66.80)
+    - React-RCTText (= 0.66.80)
+    - React-RCTVibration (= 0.66.80)
+  - React-callinvoker (0.66.80)
+  - React-Core (0.66.80):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.66.78)
-    - React-cxxreact (= 0.66.78)
-    - React-jsi (= 0.66.78)
-    - React-jsiexecutor (= 0.66.78)
-    - React-perflogger (= 0.66.78)
+    - React-Core/Default (= 0.66.80)
+    - React-cxxreact (= 0.66.80)
+    - React-jsi (= 0.66.80)
+    - React-jsiexecutor (= 0.66.80)
+    - React-perflogger (= 0.66.80)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.66.78):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default
-    - React-cxxreact (= 0.66.78)
-    - React-jsi (= 0.66.78)
-    - React-jsiexecutor (= 0.66.78)
-    - React-perflogger (= 0.66.78)
-    - Yoga
-  - React-Core/Default (0.66.78):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.66.78)
-    - React-jsi (= 0.66.78)
-    - React-jsiexecutor (= 0.66.78)
-    - React-perflogger (= 0.66.78)
-    - Yoga
-  - React-Core/DevSupport (0.66.78):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.66.78)
-    - React-Core/RCTWebSocket (= 0.66.78)
-    - React-cxxreact (= 0.66.78)
-    - React-jsi (= 0.66.78)
-    - React-jsiexecutor (= 0.66.78)
-    - React-jsinspector (= 0.66.78)
-    - React-perflogger (= 0.66.78)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.66.78):
+  - React-Core/CoreModulesHeaders (0.66.80):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.78)
-    - React-jsi (= 0.66.78)
-    - React-jsiexecutor (= 0.66.78)
-    - React-perflogger (= 0.66.78)
+    - React-cxxreact (= 0.66.80)
+    - React-jsi (= 0.66.80)
+    - React-jsiexecutor (= 0.66.80)
+    - React-perflogger (= 0.66.80)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.66.78):
+  - React-Core/Default (0.66.80):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-cxxreact (= 0.66.80)
+    - React-jsi (= 0.66.80)
+    - React-jsiexecutor (= 0.66.80)
+    - React-perflogger (= 0.66.80)
+    - Yoga
+  - React-Core/DevSupport (0.66.80):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-Core/Default (= 0.66.80)
+    - React-Core/RCTWebSocket (= 0.66.80)
+    - React-cxxreact (= 0.66.80)
+    - React-jsi (= 0.66.80)
+    - React-jsiexecutor (= 0.66.80)
+    - React-jsinspector (= 0.66.80)
+    - React-perflogger (= 0.66.80)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.66.80):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.78)
-    - React-jsi (= 0.66.78)
-    - React-jsiexecutor (= 0.66.78)
-    - React-perflogger (= 0.66.78)
+    - React-cxxreact (= 0.66.80)
+    - React-jsi (= 0.66.80)
+    - React-jsiexecutor (= 0.66.80)
+    - React-perflogger (= 0.66.80)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.66.78):
+  - React-Core/RCTAnimationHeaders (0.66.80):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.78)
-    - React-jsi (= 0.66.78)
-    - React-jsiexecutor (= 0.66.78)
-    - React-perflogger (= 0.66.78)
+    - React-cxxreact (= 0.66.80)
+    - React-jsi (= 0.66.80)
+    - React-jsiexecutor (= 0.66.80)
+    - React-perflogger (= 0.66.80)
     - Yoga
-  - React-Core/RCTImageHeaders (0.66.78):
+  - React-Core/RCTBlobHeaders (0.66.80):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.78)
-    - React-jsi (= 0.66.78)
-    - React-jsiexecutor (= 0.66.78)
-    - React-perflogger (= 0.66.78)
+    - React-cxxreact (= 0.66.80)
+    - React-jsi (= 0.66.80)
+    - React-jsiexecutor (= 0.66.80)
+    - React-perflogger (= 0.66.80)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.66.78):
+  - React-Core/RCTImageHeaders (0.66.80):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.78)
-    - React-jsi (= 0.66.78)
-    - React-jsiexecutor (= 0.66.78)
-    - React-perflogger (= 0.66.78)
+    - React-cxxreact (= 0.66.80)
+    - React-jsi (= 0.66.80)
+    - React-jsiexecutor (= 0.66.80)
+    - React-perflogger (= 0.66.80)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.66.78):
+  - React-Core/RCTLinkingHeaders (0.66.80):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.78)
-    - React-jsi (= 0.66.78)
-    - React-jsiexecutor (= 0.66.78)
-    - React-perflogger (= 0.66.78)
+    - React-cxxreact (= 0.66.80)
+    - React-jsi (= 0.66.80)
+    - React-jsiexecutor (= 0.66.80)
+    - React-perflogger (= 0.66.80)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.66.78):
+  - React-Core/RCTNetworkHeaders (0.66.80):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.78)
-    - React-jsi (= 0.66.78)
-    - React-jsiexecutor (= 0.66.78)
-    - React-perflogger (= 0.66.78)
+    - React-cxxreact (= 0.66.80)
+    - React-jsi (= 0.66.80)
+    - React-jsiexecutor (= 0.66.80)
+    - React-perflogger (= 0.66.80)
     - Yoga
-  - React-Core/RCTTextHeaders (0.66.78):
+  - React-Core/RCTSettingsHeaders (0.66.80):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.78)
-    - React-jsi (= 0.66.78)
-    - React-jsiexecutor (= 0.66.78)
-    - React-perflogger (= 0.66.78)
+    - React-cxxreact (= 0.66.80)
+    - React-jsi (= 0.66.80)
+    - React-jsiexecutor (= 0.66.80)
+    - React-perflogger (= 0.66.80)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.66.78):
+  - React-Core/RCTTextHeaders (0.66.80):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.78)
-    - React-jsi (= 0.66.78)
-    - React-jsiexecutor (= 0.66.78)
-    - React-perflogger (= 0.66.78)
+    - React-cxxreact (= 0.66.80)
+    - React-jsi (= 0.66.80)
+    - React-jsiexecutor (= 0.66.80)
+    - React-perflogger (= 0.66.80)
     - Yoga
-  - React-Core/RCTWebSocket (0.66.78):
+  - React-Core/RCTVibrationHeaders (0.66.80):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.66.78)
-    - React-cxxreact (= 0.66.78)
-    - React-jsi (= 0.66.78)
-    - React-jsiexecutor (= 0.66.78)
-    - React-perflogger (= 0.66.78)
+    - React-Core/Default
+    - React-cxxreact (= 0.66.80)
+    - React-jsi (= 0.66.80)
+    - React-jsiexecutor (= 0.66.80)
+    - React-perflogger (= 0.66.80)
     - Yoga
-  - React-CoreModules (0.66.78):
-    - FBReactNativeSpec (= 0.66.78)
+  - React-Core/RCTWebSocket (0.66.80):
+    - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.66.78)
-    - React-Core/CoreModulesHeaders (= 0.66.78)
-    - React-jsi (= 0.66.78)
-    - React-RCTImage (= 0.66.78)
-    - ReactCommon/turbomodule/core (= 0.66.78)
-  - React-cxxreact (0.66.78):
+    - React-Core/Default (= 0.66.80)
+    - React-cxxreact (= 0.66.80)
+    - React-jsi (= 0.66.80)
+    - React-jsiexecutor (= 0.66.80)
+    - React-perflogger (= 0.66.80)
+    - Yoga
+  - React-CoreModules (0.66.80):
+    - FBReactNativeSpec (= 0.66.80)
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - RCTTypeSafety (= 0.66.80)
+    - React-Core/CoreModulesHeaders (= 0.66.80)
+    - React-jsi (= 0.66.80)
+    - React-RCTImage (= 0.66.80)
+    - ReactCommon/turbomodule/core (= 0.66.80)
+  - React-cxxreact (0.66.80):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.66.78)
-    - React-jsi (= 0.66.78)
-    - React-jsinspector (= 0.66.78)
-    - React-logger (= 0.66.78)
-    - React-perflogger (= 0.66.78)
-    - React-runtimeexecutor (= 0.66.78)
-  - React-jsi (0.66.78):
+    - React-callinvoker (= 0.66.80)
+    - React-jsi (= 0.66.80)
+    - React-jsinspector (= 0.66.80)
+    - React-logger (= 0.66.80)
+    - React-perflogger (= 0.66.80)
+    - React-runtimeexecutor (= 0.66.80)
+  - React-jsi (0.66.80):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-jsi/Default (= 0.66.78)
-  - React-jsi/Default (0.66.78):
+    - React-jsi/Default (= 0.66.80)
+  - React-jsi/Default (0.66.80):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-  - React-jsiexecutor (0.66.78):
+  - React-jsiexecutor (0.66.80):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.66.78)
-    - React-jsi (= 0.66.78)
-    - React-perflogger (= 0.66.78)
-  - React-jsinspector (0.66.78)
-  - React-logger (0.66.78):
+    - React-cxxreact (= 0.66.80)
+    - React-jsi (= 0.66.80)
+    - React-perflogger (= 0.66.80)
+  - React-jsinspector (0.66.80)
+  - React-logger (0.66.80):
     - glog
-  - React-perflogger (0.66.78)
-  - React-RCTActionSheet (0.66.78):
-    - React-Core/RCTActionSheetHeaders (= 0.66.78)
-  - React-RCTAnimation (0.66.78):
-    - FBReactNativeSpec (= 0.66.78)
+  - React-perflogger (0.66.80)
+  - React-RCTActionSheet (0.66.80):
+    - React-Core/RCTActionSheetHeaders (= 0.66.80)
+  - React-RCTAnimation (0.66.80):
+    - FBReactNativeSpec (= 0.66.80)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.66.78)
-    - React-Core/RCTAnimationHeaders (= 0.66.78)
-    - React-jsi (= 0.66.78)
-    - ReactCommon/turbomodule/core (= 0.66.78)
-  - React-RCTBlob (0.66.78):
-    - FBReactNativeSpec (= 0.66.78)
+    - RCTTypeSafety (= 0.66.80)
+    - React-Core/RCTAnimationHeaders (= 0.66.80)
+    - React-jsi (= 0.66.80)
+    - ReactCommon/turbomodule/core (= 0.66.80)
+  - React-RCTBlob (0.66.80):
+    - FBReactNativeSpec (= 0.66.80)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/RCTBlobHeaders (= 0.66.78)
-    - React-Core/RCTWebSocket (= 0.66.78)
-    - React-jsi (= 0.66.78)
-    - React-RCTNetwork (= 0.66.78)
-    - ReactCommon/turbomodule/core (= 0.66.78)
-  - React-RCTImage (0.66.78):
-    - FBReactNativeSpec (= 0.66.78)
+    - React-Core/RCTBlobHeaders (= 0.66.80)
+    - React-Core/RCTWebSocket (= 0.66.80)
+    - React-jsi (= 0.66.80)
+    - React-RCTNetwork (= 0.66.80)
+    - ReactCommon/turbomodule/core (= 0.66.80)
+  - React-RCTImage (0.66.80):
+    - FBReactNativeSpec (= 0.66.80)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.66.78)
-    - React-Core/RCTImageHeaders (= 0.66.78)
-    - React-jsi (= 0.66.78)
-    - React-RCTNetwork (= 0.66.78)
-    - ReactCommon/turbomodule/core (= 0.66.78)
-  - React-RCTLinking (0.66.78):
-    - FBReactNativeSpec (= 0.66.78)
-    - React-Core/RCTLinkingHeaders (= 0.66.78)
-    - React-jsi (= 0.66.78)
-    - ReactCommon/turbomodule/core (= 0.66.78)
-  - React-RCTNetwork (0.66.78):
-    - FBReactNativeSpec (= 0.66.78)
+    - RCTTypeSafety (= 0.66.80)
+    - React-Core/RCTImageHeaders (= 0.66.80)
+    - React-jsi (= 0.66.80)
+    - React-RCTNetwork (= 0.66.80)
+    - ReactCommon/turbomodule/core (= 0.66.80)
+  - React-RCTLinking (0.66.80):
+    - FBReactNativeSpec (= 0.66.80)
+    - React-Core/RCTLinkingHeaders (= 0.66.80)
+    - React-jsi (= 0.66.80)
+    - ReactCommon/turbomodule/core (= 0.66.80)
+  - React-RCTNetwork (0.66.80):
+    - FBReactNativeSpec (= 0.66.80)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.66.78)
-    - React-Core/RCTNetworkHeaders (= 0.66.78)
-    - React-jsi (= 0.66.78)
-    - ReactCommon/turbomodule/core (= 0.66.78)
-  - React-RCTSettings (0.66.78):
-    - FBReactNativeSpec (= 0.66.78)
+    - RCTTypeSafety (= 0.66.80)
+    - React-Core/RCTNetworkHeaders (= 0.66.80)
+    - React-jsi (= 0.66.80)
+    - ReactCommon/turbomodule/core (= 0.66.80)
+  - React-RCTSettings (0.66.80):
+    - FBReactNativeSpec (= 0.66.80)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.66.78)
-    - React-Core/RCTSettingsHeaders (= 0.66.78)
-    - React-jsi (= 0.66.78)
-    - ReactCommon/turbomodule/core (= 0.66.78)
-  - React-RCTText (0.66.78):
-    - React-Core/RCTTextHeaders (= 0.66.78)
-  - React-RCTVibration (0.66.78):
-    - FBReactNativeSpec (= 0.66.78)
+    - RCTTypeSafety (= 0.66.80)
+    - React-Core/RCTSettingsHeaders (= 0.66.80)
+    - React-jsi (= 0.66.80)
+    - ReactCommon/turbomodule/core (= 0.66.80)
+  - React-RCTText (0.66.80):
+    - React-Core/RCTTextHeaders (= 0.66.80)
+  - React-RCTVibration (0.66.80):
+    - FBReactNativeSpec (= 0.66.80)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/RCTVibrationHeaders (= 0.66.78)
-    - React-jsi (= 0.66.78)
-    - ReactCommon/turbomodule/core (= 0.66.78)
-  - React-runtimeexecutor (0.66.78):
-    - React-jsi (= 0.66.78)
-  - ReactCommon/turbomodule/core (0.66.78):
+    - React-Core/RCTVibrationHeaders (= 0.66.80)
+    - React-jsi (= 0.66.80)
+    - ReactCommon/turbomodule/core (= 0.66.80)
+  - React-runtimeexecutor (0.66.80):
+    - React-jsi (= 0.66.80)
+  - ReactCommon/turbomodule/core (0.66.80):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.66.78)
-    - React-Core (= 0.66.78)
-    - React-cxxreact (= 0.66.78)
-    - React-jsi (= 0.66.78)
-    - React-logger (= 0.66.78)
-    - React-perflogger (= 0.66.78)
-  - ReactTestApp-DevSupport (1.6.12):
+    - React-callinvoker (= 0.66.80)
+    - React-Core (= 0.66.80)
+    - React-cxxreact (= 0.66.80)
+    - React-jsi (= 0.66.80)
+    - React-logger (= 0.66.80)
+    - React-perflogger (= 0.66.80)
+  - ReactTestApp-DevSupport (1.6.15):
     - React-Core
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
@@ -505,46 +504,46 @@ SPEC CHECKSUMS:
   boost: 613e39eac4239cc72b15421247b5ab05361266a2
   boost-for-react-native: 8f7c9ecfe357664c072ffbe2432569667cbf1f1b
   DoubleConversion: ed15e075aa758ac0e4c1f8b830bd4e4d40d669e8
-  FBLazyVector: f84dacd5ef88d7f35732a78ce604cd635425a98c
-  FBReactNativeSpec: 3c663b305b4ab398666819ab3191cb36160d91f1
+  FBLazyVector: b42d898dd79a1d6b1778cb43c42e757c6f879f1a
+  FBReactNativeSpec: 5e890d8572d6d53b6135dca987f9bb0ff2018028
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  FRNAvatar: 0080b4c6f613ccac725c81fe896d757b1242d331
-  FRNCallout: 63bd51ce81dc6af369973ad75ca1e5f70975f6b6
-  FRNCheckbox: eb2e6d970fbf86974fc574f45964f1a8fe9c80b2
-  FRNMenuButton: 82df6c5ac261519e7ff29dc1e2cd69d7a1bcb0b3
-  FRNRadioButton: 04feacd6283c1727fbe0fc655171230c5b0efb2c
+  FRNAvatar: d830f11cbb1e9baa15c99ca0e64feb35992a064d
+  FRNCallout: 931a596897c33a2be7438dee95c9717041613122
+  FRNCheckbox: 5442ad927c59c36a2190965f3a5357766c291f05
+  FRNMenuButton: 56221c051986f5112dc2a3d88244aad6cc2cb18a
+  FRNRadioButton: 73aa0878c26b4be975de4b1bc56144908da999ee
   glog: 42c4bf47024808486e90b25ea9e5ac3959047641
-  MicrosoftFluentUI: 28925cbf24aa550b9942f844d293b90d1a5db330
+  MicrosoftFluentUI: e30487dd18aba04beeed4caf1ce1988073f8b03a
   RCT-Folly: 43adc9ce880eb76792f88c011773cb5c664c1419
-  RCTFocusZone: 5cc02f3e85013e09966371edaf7230449616e0b6
-  RCTRequired: bdc986277fb77ed5bd1a07ef1f881478c1092dc2
-  RCTTypeSafety: 289e1529b0cdc770b7fb75f1ffe63422d915c3ab
-  React: 70bae25f33d025d56bda407dfbf285b0b176c392
-  React-callinvoker: 6828f06d053f22d001776c84c8bb37384ed0f515
-  React-Core: d16f3b9fbb65e32966a8256a0a1541030b9329cc
-  React-CoreModules: 091380cc850bc406d58b6ff28cdb5f6180c20ce8
-  React-cxxreact: dd6297783c2f918629c47529fadf2ef6cc3eb91b
-  React-jsi: 92dfe7c906990c95a55f7c171a3ccbe0f9eedca7
-  React-jsiexecutor: 7b9a74f6cead7358bac2b2f27f00c4850291d039
-  React-jsinspector: 27593cfff5158e5d9ce0801c5a16a3cd6745567a
-  React-logger: 7b8f63886878b35de459137405c509a8aea2eb69
-  React-perflogger: 558aeaf58714a9ea49546f989dd23d33523b98a0
-  React-RCTActionSheet: f00e6489edb97acb58b7bb498963985d7da3977d
-  React-RCTAnimation: d6616ec8425c70125b790b896c31929461b5626c
-  React-RCTBlob: f50c38dc1d8a3fe02254ded02102b637a28c0ad6
-  React-RCTImage: f6a92d18c37e575c6e0e48e9515cafeb036fb912
-  React-RCTLinking: f64058daf247d099b3c0c74e3e350c94721d8e0d
-  React-RCTNetwork: 8ce48a6c69c6a6cd69a8263b95b4c945a1b30671
-  React-RCTSettings: 6bfb9642804bbd7f65b8c600d227897ea520f8b0
-  React-RCTText: c7d8502260c326e376aa269337d2a5599c1afb70
-  React-RCTVibration: a3ed5ae58a872fb1e183df7824eff7482a200b63
-  React-runtimeexecutor: 5df91dfb95145cd2f4e9367ae6fbf38b8cb5f4f3
-  ReactCommon: ad15b6bbd9181a4dfdc525704d69fcbf2f177610
-  ReactTestApp-DevSupport: 915d0c145362e86eba15e6a6be94fc28576d01c6
+  RCTFocusZone: 40c299e21d1087ea7552853162a6b9cedac8ed18
+  RCTRequired: 07f31ad9aea108b0eaf474c21c88c79ff62de365
+  RCTTypeSafety: 68166cdb33e431767b2dcec04b2a5a39b6ae5334
+  React: 5abd5f308dd39b20110563f55037ec8f027ad253
+  React-callinvoker: 8ed589a3b73fda899606e85298cd73e1de853eb7
+  React-Core: b5c0b78bdbf33a6b82c2d307851d70ecc99f4c04
+  React-CoreModules: 6a63c2b56e74e1054471857cf5849d5d099a8d63
+  React-cxxreact: 2826565b8e801ecb411413544c3b91687519a245
+  React-jsi: e828d8c765962c7c4bb33f544735228becbe0b2c
+  React-jsiexecutor: 5032f09c454cf5c02c4dec2cfe8f204bc37ee13a
+  React-jsinspector: dab04460dc539292a493b91442a8ab99d7488af9
+  React-logger: 6526c43ce21ede092211416a7321c05fcc9ce12c
+  React-perflogger: ca980fd6ca2a736b253751ae4f8cd4317af79991
+  React-RCTActionSheet: b6330d83fe9311aaf7f6a8a3e5f501f19d83b5cf
+  React-RCTAnimation: 95ad90dccd3b8e32cbf20fe39da2c9cba7f32b29
+  React-RCTBlob: c70927834b7f04e4639eb760a367778f32a8307d
+  React-RCTImage: 3d0db71d9b131ee39696f5ec038d42e54fae9155
+  React-RCTLinking: 89893b82b34aaac77d7d384729a9057bfe1aa721
+  React-RCTNetwork: 3af5484e8be4e038df75074a954357d4235b03f5
+  React-RCTSettings: 6f806530bbcfc47151e327f918996a0d709b51de
+  React-RCTText: 8b9c22fa45aaa9f5ff76abd28c92e7e96a76115b
+  React-RCTVibration: 23001e27314533e09a6f94fed5408dc73ef10523
+  React-runtimeexecutor: 7650506546b4d75e75b6245f9ec03200c0371181
+  ReactCommon: e0f884412211a2e119ea0df18ca6da9334d31569
+  ReactTestApp-DevSupport: 32727c74767e723fac69e6281652b5184cff77a1
   ReactTestApp-Resources: 8c0164a3cc5052418c92018e2af0e05d564aa307
   RNCPicker: 0b65be85fe7954fbb2062ef079e3d1cde252d888
   RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8
-  Yoga: 512759fa5814e48fe52625156ff4af847972db4a
+  Yoga: c9910e717bc4ca0dff059aaef88015eba12c2799
 
 PODFILE CHECKSUM: 553ec4eec9578ceafbc92e27e0789d7ddcd88c74
 

--- a/change/@fluentui-react-native-experimental-avatar-148024cc-b9b3-4fff-b017-be3217d6f6c9.json
+++ b/change/@fluentui-react-native-experimental-avatar-148024cc-b9b3-4fff-b017-be3217d6f6c9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bumping FUA version",
+  "packageName": "@fluentui-react-native/experimental-avatar",
+  "email": "sophialee.0416@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-native-date-picker-cc4b5149-dbc4-4e75-8efe-acc5730543db.json
+++ b/change/@fluentui-react-native-experimental-native-date-picker-cc4b5149-dbc4-4e75-8efe-acc5730543db.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bumping FUA version",
+  "packageName": "@fluentui-react-native/experimental-native-date-picker",
+  "email": "sophialee.0416@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-46358238-e7e8-4139-88ec-91bae14bb7be.json
+++ b/change/@fluentui-react-native-tester-46358238-e7e8-4139-88ec-91bae14bb7be.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bumping FUA version",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "sophialee.0416@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Avatar/FRNAvatar.podspec
+++ b/packages/experimental/Avatar/FRNAvatar.podspec
@@ -16,11 +16,11 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = "14.0"
   s.ios.source_files      = "ios/*.{swift,h,m}"
-  s.ios.dependency 'MicrosoftFluentUI/Avatar_ios', '0.6.1'
+  s.ios.dependency 'MicrosoftFluentUI', '0.8.3'
 
   s.osx.deployment_target = "10.15"
   s.osx.source_files      = "macos/*.{swift,h,m}"
-  s.osx.dependency 'MicrosoftFluentUI', '0.6.1'
+  s.osx.dependency 'MicrosoftFluentUI', '0.8.3'
 
   s.dependency 'React'
 end

--- a/packages/experimental/NativeDatePicker/FRNDatePicker.podspec
+++ b/packages/experimental/NativeDatePicker/FRNDatePicker.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = "14.0"
   s.ios.source_files      = "ios/*.{swift,h,m}"
-  s.ios.dependency 'MicrosoftFluentUI', '0.6.1'
+  s.ios.dependency 'MicrosoftFluentUI', '0.8.3'
 
 end


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Bumping FluentUI Apple version to 0.8.3

### Verification

Ran test app, no crashes and things are looking good

| Avatar Native                                       | Datepicker Native                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/22566866/191353872-314bafd9-156c-4bc7-8abd-1b43f708a41f.png) | ![image](https://user-images.githubusercontent.com/22566866/191353938-c17be8c4-fa36-4abd-8f00-d1e1f0e9cb0e.png) |

Mac app:
<img width="794" alt="image" src="https://user-images.githubusercontent.com/22566866/191356718-a3633855-be2a-4124-87cd-81347eabfc8a.png">

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
