### PR TITLE
Switch Tabs components to use React Native Pressable

### DIFF
--- a/change/@fluentui-react-native-experimental-tabs-f5a9e30d-5bf0-497c-b360-4af32dab4b08.json
+++ b/change/@fluentui-react-native-experimental-tabs-f5a9e30d-5bf0-497c-b360-4af32dab4b08.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "se Pressable from React Native",
+  "packageName": "@fluentui-react-native/experimental-tabs",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-tabs-f5a9e30d-5bf0-497c-b360-4af32dab4b08.json
+++ b/change/@fluentui-react-native-experimental-tabs-f5a9e30d-5bf0-497c-b360-4af32dab4b08.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "se Pressable from React Native",
+  "comment": "Use Pressable from React Native",
   "packageName": "@fluentui-react-native/experimental-tabs",
   "email": "sanajmi@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-native-tabs-a0b87c51-d880-428d-9eb3-3521663c3a12.json
+++ b/change/@fluentui-react-native-tabs-a0b87c51-d880-428d-9eb3-3521663c3a12.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Use Pressable from React Native ",
+  "packageName": "@fluentui-react-native/tabs",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Tabs/src/Tabs.tsx
+++ b/packages/components/Tabs/src/Tabs.tsx
@@ -1,6 +1,6 @@
 /** @jsx withSlots */
 import * as React from 'react';
-import { View } from 'react-native';
+import { Pressable, View } from 'react-native';
 import { Text } from '@fluentui-react-native/text';
 import { FocusZone } from '@fluentui-react-native/focus-zone';
 import { tabsName, TabsType, TabsProps, TabsState, TabsSlotProps, TabsRenderData, TabsContextData } from './Tabs.types';
@@ -144,7 +144,7 @@ export const Tabs = compose<TabsType>({
 
   settings,
   slots: {
-    root: View,
+    root: Pressable,
     label: Text,
     container: FocusZone,
     stack: { slotType: View, filter: filterViewProps },

--- a/packages/components/Tabs/src/Tabs.windows.tsx
+++ b/packages/components/Tabs/src/Tabs.windows.tsx
@@ -9,7 +9,7 @@ import { settings } from './Tabs.settings';
 import { mergeSettings } from '@uifabricshared/foundation-settings';
 import { filterViewProps } from '@fluentui-react-native/adapters';
 import { foregroundColorTokens, textTokens, backgroundColorTokens } from '@fluentui-react-native/tokens';
-import { useSelectedKey, useAsPressable } from '@fluentui-react-native/interactive-hooks';
+import { useSelectedKey, usePressableState } from '@fluentui-react-native/interactive-hooks';
 
 export const TabsContext = React.createContext<TabsContextData>({
   selectedKey: null,
@@ -77,7 +77,7 @@ export const Tabs = compose<TabsType>({
 
     const styleProps = useStyling(userProps, (override: string) => state[override] || userProps[override]);
 
-    const pressable = useAsPressable({ ...rest });
+    const pressable = usePressableState({ ...rest });
 
     const onKeyDown = (ev: any) => {
       if (ev.nativeEvent.key === 'ArrowRight' || ev.nativeEvent.key === 'ArrowLeft') {

--- a/packages/components/Tabs/src/Tabs.windows.tsx
+++ b/packages/components/Tabs/src/Tabs.windows.tsx
@@ -1,6 +1,6 @@
 /** @jsx withSlots */
 import * as React from 'react';
-import { View } from 'react-native';
+import { Pressable, View } from 'react-native';
 import { Text } from '@fluentui-react-native/text';
 import { tabsName, TabsType, TabsProps, TabsState, TabsSlotProps, TabsRenderData, TabsContextData } from './Tabs.types';
 import { compose, IUseComposeStyling } from '@uifabricshared/foundation-compose';
@@ -162,7 +162,7 @@ export const Tabs = compose<TabsType>({
 
   settings,
   slots: {
-    root: View,
+    root: Pressable,
     label: Text,
     stack: View,
     tabPanel: { slotType: View, filter: filterViewProps },

--- a/packages/components/Tabs/src/TabsItem.tsx
+++ b/packages/components/Tabs/src/TabsItem.tsx
@@ -1,6 +1,6 @@
 /** @jsx withSlots */
 import * as React from 'react';
-import { Platform, View } from 'react-native';
+import { Platform, Pressable, View } from 'react-native';
 import { compose, IUseComposeStyling } from '@uifabricshared/foundation-compose';
 import { ISlots, withSlots } from '@uifabricshared/foundation-composable';
 import { Text } from '@fluentui-react-native/text';
@@ -145,7 +145,7 @@ export const TabsItem = compose<TabsItemType>({
 
   settings,
   slots: {
-    root: View,
+    root: Pressable,
     stack: { slotType: View, filter: filterViewProps },
     icon: { slotType: Icon as React.ComponentType },
     content: Text,

--- a/packages/components/Tabs/src/TabsItem.tsx
+++ b/packages/components/Tabs/src/TabsItem.tsx
@@ -11,7 +11,7 @@ import { filterViewProps } from '@fluentui-react-native/adapters';
 import { mergeSettings } from '@uifabricshared/foundation-settings';
 import { TabsContext } from './Tabs';
 import { tabsItemName, TabsItemType, TabsItemProps, TabsItemSlotProps, TabsItemRenderData, TabsItemState } from './TabsItem.types';
-import { useAsPressable, useViewCommandFocus, createIconProps } from '@fluentui-react-native/interactive-hooks';
+import { usePressableState, useViewCommandFocus, createIconProps } from '@fluentui-react-native/interactive-hooks';
 
 export const TabsItem = compose<TabsItemType>({
   displayName: tabsItemName,
@@ -54,7 +54,7 @@ export const TabsItem = compose<TabsItemType>({
       setFocusState({ focused: false });
     }, [setFocusState]);
 
-    const pressable = useAsPressable({
+    const pressable = usePressableState({
       ...rest,
       onPress: changeSelection,
       onFocus: changeSelectionWithFocus,

--- a/packages/components/Tabs/src/TabsItem.windows.tsx
+++ b/packages/components/Tabs/src/TabsItem.windows.tsx
@@ -1,6 +1,6 @@
 /** @jsx withSlots */
 import * as React from 'react';
-import { View } from 'react-native';
+import { Pressable, View } from 'react-native';
 import { compose, IUseComposeStyling } from '@uifabricshared/foundation-compose';
 import { ISlots, withSlots } from '@uifabricshared/foundation-composable';
 import { Text } from '@fluentui-react-native/text';
@@ -129,7 +129,7 @@ export const TabsItem = compose<TabsItemType>({
 
   settings,
   slots: {
-    root: View,
+    root: Pressable,
     stack: { slotType: View, filter: filterViewProps },
     icon: { slotType: Icon as React.ComponentType },
     content: Text,

--- a/packages/components/Tabs/src/TabsItem.windows.tsx
+++ b/packages/components/Tabs/src/TabsItem.windows.tsx
@@ -11,7 +11,7 @@ import { filterViewProps } from '@fluentui-react-native/adapters';
 import { mergeSettings } from '@uifabricshared/foundation-settings';
 import { TabsContext } from './Tabs';
 import { tabsItemName, TabsItemType, TabsItemProps, TabsItemSlotProps, TabsItemRenderData, TabsItemState } from './TabsItem.types';
-import { useAsPressable, useViewCommandFocus, createIconProps } from '@fluentui-react-native/interactive-hooks';
+import { usePressableState, useViewCommandFocus, createIconProps } from '@fluentui-react-native/interactive-hooks';
 
 export const TabsItem = compose<TabsItemType>({
   displayName: tabsItemName,
@@ -40,7 +40,7 @@ export const TabsItem = compose<TabsItemType>({
       info.updateSelectedTabsItemRef && componentRef && info.updateSelectedTabsItemRef(componentRef);
     }, [componentRef, info, itemKey]);
 
-    const pressable = useAsPressable({
+    const pressable = usePressableState({
       ...rest,
       onPress: changeSelection,
     });

--- a/packages/components/Tabs/src/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/components/Tabs/src/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -37,15 +37,12 @@ exports[`Tabs FocusZone props 1`] = `
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -108,15 +105,12 @@ exports[`Tabs FocusZone props 1`] = `
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -179,15 +173,12 @@ exports[`Tabs FocusZone props 1`] = `
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -271,15 +262,12 @@ exports[`Tabs default props 1`] = `
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -342,15 +330,12 @@ exports[`Tabs default props 1`] = `
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -413,15 +398,12 @@ exports[`Tabs default props 1`] = `
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -506,15 +488,12 @@ exports[`Tabs disabled 1`] = `
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -578,15 +557,12 @@ exports[`Tabs disabled 1`] = `
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -649,15 +625,12 @@ exports[`Tabs disabled 1`] = `
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -742,15 +715,12 @@ exports[`Tabs header text and count 1`] = `
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -828,15 +798,12 @@ exports[`Tabs header text and count 1`] = `
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -914,15 +881,12 @@ exports[`Tabs header text and count 1`] = `
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -1020,15 +984,12 @@ exports[`Tabs headers only 1`] = `
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -1091,15 +1052,12 @@ exports[`Tabs headers only 1`] = `
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -1162,15 +1120,12 @@ exports[`Tabs headers only 1`] = `
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -1270,15 +1225,12 @@ exports[`Tabs props 1`] = `
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -1356,15 +1308,12 @@ exports[`Tabs props 1`] = `
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -1442,15 +1391,12 @@ exports[`Tabs props 1`] = `
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",

--- a/packages/components/Tabs/src/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/components/Tabs/src/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -4,6 +4,17 @@ exports[`Tabs FocusZone props 1`] = `
 <View
   accessibilityRole="tablist"
   accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
 >
   <RCTFocusZone
     navigateAtEnd="NavigateStopAtEnds"
@@ -34,15 +45,20 @@ exports[`Tabs FocusZone props 1`] = `
           }
         }
         accessible={true}
+        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -102,15 +118,20 @@ exports[`Tabs FocusZone props 1`] = `
           }
         }
         accessible={true}
+        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -170,15 +191,20 @@ exports[`Tabs FocusZone props 1`] = `
           }
         }
         accessible={true}
+        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -229,6 +255,17 @@ exports[`Tabs default props 1`] = `
 <View
   accessibilityRole="tablist"
   accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
 >
   <RCTFocusZone
     navigateAtEnd="NavigateStopAtEnds"
@@ -259,15 +296,20 @@ exports[`Tabs default props 1`] = `
           }
         }
         accessible={true}
+        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -327,15 +369,20 @@ exports[`Tabs default props 1`] = `
           }
         }
         accessible={true}
+        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -395,15 +442,20 @@ exports[`Tabs default props 1`] = `
           }
         }
         accessible={true}
+        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -454,6 +506,17 @@ exports[`Tabs disabled 1`] = `
 <View
   accessibilityRole="tablist"
   accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
 >
   <RCTFocusZone
     navigateAtEnd="NavigateStopAtEnds"
@@ -484,16 +547,20 @@ exports[`Tabs disabled 1`] = `
           }
         }
         accessible={true}
-        disabled={true}
+        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -553,16 +620,20 @@ exports[`Tabs disabled 1`] = `
           }
         }
         accessible={true}
-        disabled={true}
+        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -622,15 +693,20 @@ exports[`Tabs disabled 1`] = `
           }
         }
         accessible={true}
+        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -681,6 +757,17 @@ exports[`Tabs header text and count 1`] = `
 <View
   accessibilityRole="tablist"
   accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
 >
   <RCTFocusZone
     navigateAtEnd="NavigateStopAtEnds"
@@ -712,15 +799,20 @@ exports[`Tabs header text and count 1`] = `
           }
         }
         accessible={true}
+        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -795,15 +887,20 @@ exports[`Tabs header text and count 1`] = `
           }
         }
         accessible={true}
+        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -878,15 +975,20 @@ exports[`Tabs header text and count 1`] = `
           }
         }
         accessible={true}
+        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -951,6 +1053,17 @@ exports[`Tabs headers only 1`] = `
 <View
   accessibilityRole="tablist"
   accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
 >
   <RCTFocusZone
     navigateAtEnd="NavigateStopAtEnds"
@@ -981,15 +1094,20 @@ exports[`Tabs headers only 1`] = `
           }
         }
         accessible={true}
+        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -1049,15 +1167,20 @@ exports[`Tabs headers only 1`] = `
           }
         }
         accessible={true}
+        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -1117,15 +1240,20 @@ exports[`Tabs headers only 1`] = `
           }
         }
         accessible={true}
+        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -1177,6 +1305,17 @@ exports[`Tabs props 1`] = `
   accessibilityLabel="Tabs"
   accessibilityRole="tablist"
   accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
 >
   <Text
     style={
@@ -1221,16 +1360,20 @@ exports[`Tabs props 1`] = `
           }
         }
         accessible={true}
-        disabled={true}
+        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -1305,15 +1448,20 @@ exports[`Tabs props 1`] = `
           }
         }
         accessible={true}
+        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -1388,15 +1536,20 @@ exports[`Tabs props 1`] = `
           }
         }
         accessible={true}
+        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",

--- a/packages/experimental/Tabs/src/Tabs.tsx
+++ b/packages/experimental/Tabs/src/Tabs.tsx
@@ -1,6 +1,6 @@
 /** @jsx withSlots */
 import * as React from 'react';
-import { View } from 'react-native';
+import { Pressable, View } from 'react-native';
 import { tabsName, TabsType, TabsProps, TabsContextData } from './Tabs.types';
 import { TextV1 as Text } from '@fluentui-react-native/text';
 import { stylingSettings } from './Tabs.styling';
@@ -27,7 +27,7 @@ export const Tabs = compose<TabsType>({
   displayName: tabsName,
   ...stylingSettings,
   slots: {
-    root: View,
+    root: Pressable,
     label: Text,
     container: FocusZone,
     stack: View,

--- a/packages/experimental/Tabs/src/TabsItem.tsx
+++ b/packages/experimental/Tabs/src/TabsItem.tsx
@@ -1,6 +1,6 @@
 /** @jsx withSlots */
 import * as React from 'react';
-import { View } from 'react-native';
+import { Pressable, View } from 'react-native';
 import { tabsItemName, TabItemType, TabsItemProps } from './TabsItem.types';
 import { TextV1 as Text } from '@fluentui-react-native/text';
 import { stylingSettings } from './TabsItem.styling';
@@ -14,7 +14,7 @@ export const TabsItem = compose<TabItemType>({
   displayName: tabsItemName,
   ...stylingSettings,
   slots: {
-    root: View,
+    root: Pressable,
     stack: View,
     icon: Icon,
     indicator: View,

--- a/packages/experimental/Tabs/src/TabsItem.types.ts
+++ b/packages/experimental/Tabs/src/TabsItem.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ViewStyle, ColorValue } from 'react-native';
+import { PressableProps, ViewStyle, ColorValue } from 'react-native';
 import { FontTokens, IBorderTokens } from '@fluentui-react-native/tokens';
 import { IFocusable, IWithPressableEvents, IPressableState, IWithPressableOptions } from '@fluentui-react-native/interactive-hooks';
 import { IconProps, IconSourcesType } from '@fluentui-react-native/icon';
@@ -146,7 +146,7 @@ export interface TabsItemInfo {
 }
 
 export interface TabsItemSlotProps {
-  root: React.PropsWithRef<IViewProps>;
+  root: React.PropsWithRef<PressableProps>;
   icon: IconProps;
   stack: IViewProps;
   indicator: IViewProps;

--- a/packages/experimental/Tabs/src/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/experimental/Tabs/src/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -4,12 +4,23 @@ exports[`Tabs FocusZone props 1`] = `
 <View
   accessibilityRole="tablist"
   accessible={true}
+  collapsable={false}
   componentRef={
     Object {
       "current": null,
     }
   }
   defaultSelectedKey="2"
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
   style={
     Object {
       "display": "flex",
@@ -45,15 +56,20 @@ exports[`Tabs FocusZone props 1`] = `
           }
         }
         accessible={true}
+        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -111,15 +127,20 @@ exports[`Tabs FocusZone props 1`] = `
           }
         }
         accessible={true}
+        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -177,15 +198,20 @@ exports[`Tabs FocusZone props 1`] = `
           }
         }
         accessible={true}
+        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -239,11 +265,22 @@ exports[`Tabs default props 1`] = `
 <View
   accessibilityRole="tablist"
   accessible={true}
+  collapsable={false}
   componentRef={
     Object {
       "current": null,
     }
   }
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
   style={
     Object {
       "display": "flex",
@@ -279,15 +316,20 @@ exports[`Tabs default props 1`] = `
           }
         }
         accessible={true}
+        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -345,15 +387,20 @@ exports[`Tabs default props 1`] = `
           }
         }
         accessible={true}
+        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -411,15 +458,20 @@ exports[`Tabs default props 1`] = `
           }
         }
         accessible={true}
+        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -473,11 +525,22 @@ exports[`Tabs disabled 1`] = `
 <View
   accessibilityRole="tablist"
   accessible={true}
+  collapsable={false}
   componentRef={
     Object {
       "current": null,
     }
   }
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
   style={
     Object {
       "display": "flex",
@@ -513,15 +576,20 @@ exports[`Tabs disabled 1`] = `
           }
         }
         accessible={true}
+        collapsable={false}
         focusable={false}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -579,15 +647,20 @@ exports[`Tabs disabled 1`] = `
           }
         }
         accessible={true}
+        collapsable={false}
         focusable={false}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -645,15 +718,20 @@ exports[`Tabs disabled 1`] = `
           }
         }
         accessible={true}
+        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -707,11 +785,22 @@ exports[`Tabs header text and count 1`] = `
 <View
   accessibilityRole="tablist"
   accessible={true}
+  collapsable={false}
   componentRef={
     Object {
       "current": null,
     }
   }
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
   style={
     Object {
       "display": "flex",
@@ -748,15 +837,20 @@ exports[`Tabs header text and count 1`] = `
           }
         }
         accessible={true}
+        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -831,15 +925,20 @@ exports[`Tabs header text and count 1`] = `
           }
         }
         accessible={true}
+        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -914,15 +1013,20 @@ exports[`Tabs header text and count 1`] = `
           }
         }
         accessible={true}
+        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -992,12 +1096,23 @@ exports[`Tabs headers only 1`] = `
 <View
   accessibilityRole="tablist"
   accessible={true}
+  collapsable={false}
   componentRef={
     Object {
       "current": null,
     }
   }
+  focusable={true}
   headersOnly={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
   style={
     Object {
       "display": "flex",
@@ -1033,15 +1148,20 @@ exports[`Tabs headers only 1`] = `
           }
         }
         accessible={true}
+        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -1099,15 +1219,20 @@ exports[`Tabs headers only 1`] = `
           }
         }
         accessible={true}
+        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -1165,15 +1290,20 @@ exports[`Tabs headers only 1`] = `
           }
         }
         accessible={true}
+        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -1225,13 +1355,24 @@ exports[`Tabs props 1`] = `
 <View
   accessibilityRole="tablist"
   accessible={true}
+  collapsable={false}
   componentRef={
     Object {
       "current": null,
     }
   }
   defaultSelectedKey="2"
+  focusable={true}
   headersOnly={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
   style={
     Object {
       "display": "flex",
@@ -1283,15 +1424,20 @@ exports[`Tabs props 1`] = `
           }
         }
         accessible={true}
+        collapsable={false}
         focusable={false}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -1366,15 +1512,20 @@ exports[`Tabs props 1`] = `
           }
         }
         accessible={true}
+        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -1449,15 +1600,20 @@ exports[`Tabs props 1`] = `
           }
         }
         accessible={true}
+        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
+        onClick={[Function]}
         onFocus={[Function]}
         onHoverIn={[Function]}
         onHoverOut={[Function]}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "alignItems": "center",

--- a/packages/experimental/Tabs/src/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/experimental/Tabs/src/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -48,15 +48,12 @@ exports[`Tabs FocusZone props 1`] = `
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -117,15 +114,12 @@ exports[`Tabs FocusZone props 1`] = `
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -186,15 +180,12 @@ exports[`Tabs FocusZone props 1`] = `
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -291,15 +282,12 @@ exports[`Tabs default props 1`] = `
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -360,15 +348,12 @@ exports[`Tabs default props 1`] = `
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -429,15 +414,12 @@ exports[`Tabs default props 1`] = `
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -534,15 +516,12 @@ exports[`Tabs disabled 1`] = `
         focusable={false}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -603,15 +582,12 @@ exports[`Tabs disabled 1`] = `
         focusable={false}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -672,15 +648,12 @@ exports[`Tabs disabled 1`] = `
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -778,15 +751,12 @@ exports[`Tabs header text and count 1`] = `
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -864,15 +834,12 @@ exports[`Tabs header text and count 1`] = `
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -950,15 +917,12 @@ exports[`Tabs header text and count 1`] = `
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -1072,15 +1036,12 @@ exports[`Tabs headers only 1`] = `
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -1141,15 +1102,12 @@ exports[`Tabs headers only 1`] = `
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -1210,15 +1168,12 @@ exports[`Tabs headers only 1`] = `
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -1331,15 +1286,12 @@ exports[`Tabs props 1`] = `
         focusable={false}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -1417,15 +1369,12 @@ exports[`Tabs props 1`] = `
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",
@@ -1503,15 +1452,12 @@ exports[`Tabs props 1`] = `
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
+        onHoverIn={[Function]}
+        onHoverOut={[Function]}
         onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
           Object {
             "alignItems": "center",

--- a/packages/experimental/Tabs/src/useTabsItem.ts
+++ b/packages/experimental/Tabs/src/useTabsItem.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useAsPressable, useKeyProps, useOnPressWithFocus, useViewCommandFocus } from '@fluentui-react-native/interactive-hooks';
+import { usePressableState, useKeyProps, useOnPressWithFocus, useViewCommandFocus } from '@fluentui-react-native/interactive-hooks';
 import { TabsItemProps, TabsItemInfo } from './TabsItem.types';
 import { TabsContext } from './Tabs';
 
@@ -26,7 +26,7 @@ export const useTabsItem = (props: TabsItemProps): TabsItemInfo => {
 
   const changeSelectionWithFocus = useOnPressWithFocus(componentRef, changeSelection);
 
-  const pressable = useAsPressable({
+  const pressable = usePressableState({
     ...rest,
     onPress: changeSelectionWithFocus,
     onFocus: changeSelection,

--- a/packages/experimental/Tabs/src/useTabsItem.windows.ts
+++ b/packages/experimental/Tabs/src/useTabsItem.windows.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useAsPressable, useViewCommandFocus } from '@fluentui-react-native/interactive-hooks';
+import { usePressableState, useViewCommandFocus } from '@fluentui-react-native/interactive-hooks';
 import { TabsItemProps, TabsItemInfo, TabsItemState } from './TabsItem.types';
 import { TabsContext } from './Tabs';
 
@@ -23,7 +23,7 @@ export const useTabsItem = (props: TabsItemProps): TabsItemInfo => {
     info.updateSelectedTabsItemRef && componentRef && info.updateSelectedTabsItemRef(componentRef);
   }, [componentRef, info, itemKey]);
 
-  const pressable = useAsPressable({
+  const pressable = usePressableState({
     ...rest,
     onPress: changeSelection,
   });


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [ ] android

### Description of changes

Following up from #1070, let's move over components off of `useAsPressable` / our fork of Pressable and onto Pressable from React Native, which contains the newer support for pointer events / android ripple / codegen commands.

### Verification

Hover, Focus, and Press work as expected on macOS. E2E testing on CI should confirm as much for windows/win32, but I'll try and test it out myself too.

https://user-images.githubusercontent.com/6722175/191470443-2362ba5c-305d-43f0-8ed5-071848617f54.mov


### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [x] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
