### PR TITLE
[DRAFT] sequential e2 e

### DIFF
--- a/apps/fluent-tester/src/E2E/ActivityIndicator/pages/ActivityIndicatorPageObject.ts
+++ b/apps/fluent-tester/src/E2E/ActivityIndicator/pages/ActivityIndicatorPageObject.ts
@@ -3,14 +3,14 @@ import {
   ACTIVITY_INDICATOR_TESTPAGE,
   ACTIVITY_INDICATOR_TEST_COMPONENT,
 } from '../../../TestComponents/ActivityIndicator/consts';
-import { BasePage, By } from '../../common/BasePage';
+import { BasePage, GetElement } from '../../common/BasePage';
 
 class ActivityIndicatorPageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
   get _testPage() {
-    return By(ACTIVITY_INDICATOR_TESTPAGE);
+    return GetElement(ACTIVITY_INDICATOR_TESTPAGE);
   }
 
   get _pageName() {
@@ -18,11 +18,11 @@ class ActivityIndicatorPageObject extends BasePage {
   }
 
   get _primaryComponent() {
-    return By(ACTIVITY_INDICATOR_TEST_COMPONENT);
+    return GetElement(ACTIVITY_INDICATOR_TEST_COMPONENT);
   }
 
   get _pageButton() {
-    return By(HOMEPAGE_ACTIVITY_INDICATOR_BUTTON);
+    return GetElement(HOMEPAGE_ACTIVITY_INDICATOR_BUTTON);
   }
 }
 

--- a/apps/fluent-tester/src/E2E/Avatar/pages/AvatarPageObject.ts
+++ b/apps/fluent-tester/src/E2E/Avatar/pages/AvatarPageObject.ts
@@ -4,7 +4,7 @@ import {
   AVATAR_TEST_COMPONENT,
   AVATAR_SECONDARY_TEST_COMPONENT,
 } from '../../../TestComponents/Avatar/consts';
-import { BasePage, By } from '../../common/BasePage';
+import { BasePage, GetElement } from '../../common/BasePage';
 
 export const enum AvatarComponentSelector {
   PrimaryComponent, //this._primaryComponent
@@ -12,47 +12,47 @@ export const enum AvatarComponentSelector {
 }
 class AvatarPageObject extends BasePage {
   async getPrimaryComponentAttribute(attribute: string): Promise<string> {
-    return await this._primaryComponent.getAttribute(attribute);
+    return await (await this._primaryComponent).getAttribute(attribute);
   }
 
   async getSecondaryComponentAttribute(attribute: string): Promise<string> {
-    return await this._secondaryComponent.getAttribute(attribute);
+    return await (await this._secondaryComponent).getAttribute(attribute);
   }
 
   async getAvatarAccessibilityLabel(componentSelector: AvatarComponentSelector): Promise<string> {
     return componentSelector == AvatarComponentSelector.SecondaryComponent
-      ? await this._secondaryComponent.getAttribute('Name')
-      : await this._primaryComponent.getAttribute('Name');
+      ? await (await this._secondaryComponent).getAttribute('Name')
+      : await (await this._primaryComponent).getAttribute('Name');
   }
 
   async getAvatarAccessibilityHint(componentSelector: AvatarComponentSelector): Promise<string> {
     return componentSelector == AvatarComponentSelector.SecondaryComponent
-      ? await this._secondaryComponent.getAttribute('HelpText')
-      : await this._primaryComponent.getAttribute('HelpText');
+      ? await (await this._secondaryComponent).getAttribute('HelpText')
+      : await (await this._primaryComponent).getAttribute('HelpText');
   }
 
   async getAvatarAccessibilityRole(componentSelector: AvatarComponentSelector): Promise<string> {
     return componentSelector == AvatarComponentSelector.SecondaryComponent
-      ? await this._secondaryComponent.getAttribute('ControlType')
-      : await this._primaryComponent.getAttribute('ControlType');
+      ? await (await this._secondaryComponent).getAttribute('ControlType')
+      : await (await this._primaryComponent).getAttribute('ControlType');
   }
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
   get _testPage() {
-    return By(AVATAR_TESTPAGE);
+    return GetElement(AVATAR_TESTPAGE);
   }
 
   get _pageButton() {
-    return By(HOMEPAGE_AVATAR_BUTTON);
+    return GetElement(HOMEPAGE_AVATAR_BUTTON);
   }
 
   get _primaryComponent() {
-    return By(AVATAR_TEST_COMPONENT);
+    return GetElement(AVATAR_TEST_COMPONENT);
   }
 
   get _secondaryComponent() {
-    return By(AVATAR_SECONDARY_TEST_COMPONENT);
+    return GetElement(AVATAR_SECONDARY_TEST_COMPONENT);
   }
 }
 

--- a/apps/fluent-tester/src/E2E/Badge/pages/BasicBadgePageObject.ts
+++ b/apps/fluent-tester/src/E2E/Badge/pages/BasicBadgePageObject.ts
@@ -4,7 +4,7 @@ import {
   BADGE_TEST_COMPONENT,
   BADGE_SECONDARY_TEST_COMPONENT,
 } from '../../../TestComponents/Badge/consts';
-import { BasePage, By } from '../../common/BasePage';
+import { BasePage, GetElement } from '../../common/BasePage';
 
 export const enum BadgeComponentSelector {
   PrimaryComponent, //this._primaryComponent
@@ -13,30 +13,30 @@ export const enum BadgeComponentSelector {
 
 class BasicBadgePageObject extends BasePage {
   async getPrimaryComponentAttribute(attribute: string): Promise<string> {
-    return await this._primaryComponent.getAttribute(attribute);
+    return await (await this._primaryComponent).getAttribute(attribute);
   }
 
   async getSecondaryComponentAttribute(attribute: string): Promise<string> {
-    return await this._secondaryComponent.getAttribute(attribute);
+    return await (await this._secondaryComponent).getAttribute(attribute);
   }
 
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
   get _testPage() {
-    return By(BADGE_TESTPAGE);
+    return GetElement(BADGE_TESTPAGE);
   }
 
   get _pageButton() {
-    return By(HOMEPAGE_BADGE_BUTTON);
+    return GetElement(HOMEPAGE_BADGE_BUTTON);
   }
 
   get _primaryComponent() {
-    return By(BADGE_TEST_COMPONENT);
+    return GetElement(BADGE_TEST_COMPONENT);
   }
 
   get _secondaryComponent() {
-    return By(BADGE_SECONDARY_TEST_COMPONENT);
+    return GetElement(BADGE_SECONDARY_TEST_COMPONENT);
   }
 }
 

--- a/apps/fluent-tester/src/E2E/Button/pages/ButtonPageObject.ts
+++ b/apps/fluent-tester/src/E2E/Button/pages/ButtonPageObject.ts
@@ -5,7 +5,7 @@ import {
   HOMEPAGE_BUTTON_BUTTON,
   BUTTON_ON_PRESS_DEPRECATED,
 } from '../../../TestComponents/Button/consts';
-import { BasePage, By } from '../../common/BasePage';
+import { BasePage, GetElement } from '../../common/BasePage';
 
 /* This enum gives the spec file an EASY way to interact with SPECIFIC UI elements on the page.
  * The spec file should import this enum and use it when wanting to interact with different elements on the page. */
@@ -18,7 +18,7 @@ class ButtonPageObject extends BasePage {
   /**************** UI Element Interaction Methods ******************/
   /******************************************************************/
   async didOnClickCallbackFire(): Promise<boolean> {
-    const callbackText = await By(BUTTON_ON_PRESS_DEPRECATED);
+    const callbackText = await GetElement(BUTTON_ON_PRESS_DEPRECATED);
     await browser.waitUntil(async () => await callbackText.isDisplayed(), {
       timeout: this.waitForUIEvent,
       timeoutMsg: 'The OnClick callback did not fire.',
@@ -45,7 +45,7 @@ class ButtonPageObject extends BasePage {
   /**************** Getters ****************/
   /*****************************************/
   get _testPage() {
-    return By(BUTTON_TESTPAGE);
+    return GetElement(BUTTON_TESTPAGE);
   }
 
   get _pageName() {
@@ -53,15 +53,15 @@ class ButtonPageObject extends BasePage {
   }
 
   get _primaryComponent() {
-    return By(BUTTON_TEST_COMPONENT_DEPRECATED);
+    return GetElement(BUTTON_TEST_COMPONENT_DEPRECATED);
   }
 
   get _secondaryComponent() {
-    return By(BUTTON_NO_A11Y_LABEL_COMPONENT_DEPRECATED);
+    return GetElement(BUTTON_NO_A11Y_LABEL_COMPONENT_DEPRECATED);
   }
 
   get _pageButton() {
-    return By(HOMEPAGE_BUTTON_BUTTON);
+    return GetElement(HOMEPAGE_BUTTON_BUTTON);
   }
 }
 

--- a/apps/fluent-tester/src/E2E/Button/pages/ButtonPageObject.ts
+++ b/apps/fluent-tester/src/E2E/Button/pages/ButtonPageObject.ts
@@ -20,7 +20,7 @@ class ButtonPageObject extends BasePage {
   async didOnClickCallbackFire(): Promise<boolean> {
     const callbackText = await By(BUTTON_ON_PRESS_DEPRECATED);
     await browser.waitUntil(async () => await callbackText.isDisplayed(), {
-      timeout: this.waitForPageTimeout,
+      timeout: this.waitForUIEvent,
       timeoutMsg: 'The OnClick callback did not fire.',
       interval: 1000,
     });

--- a/apps/fluent-tester/src/E2E/Button/specs/Button.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Button/specs/Button.spec.win.ts
@@ -64,15 +64,15 @@ describe('Button Functional Testing', () => {
   });
 
   it('Validate OnClick() callback was fired -> Type "Enter"', async () => {
-    await ButtonPageObject.sendKey(ButtonSelector.PrimaryButton, Keys.Enter);
+    await ButtonPageObject.sendKey(ButtonSelector.PrimaryButton, Keys.ENTER);
     await expect(await ButtonPageObject.didOnClickCallbackFire()).toBeTruthy();
     await expect(await ButtonPageObject.didAssertPopup()).toBeFalsy(ButtonPageObject.ERRORMESSAGE_ASSERT);
 
     await ButtonPageObject.clickComponent(); // Reset Button State
   });
 
-  it('Validate OnClick() callback was fired -> Type "Spacebar"', async () => {
-    await ButtonPageObject.sendKey(ButtonSelector.PrimaryButton, Keys.Spacebar);
+  it('Validate OnClick() callback was fired -> Type "SPACE"', async () => {
+    await ButtonPageObject.sendKey(ButtonSelector.PrimaryButton, Keys.SPACE);
     await expect(await ButtonPageObject.didOnClickCallbackFire()).toBeTruthy();
     await expect(await ButtonPageObject.didAssertPopup()).toBeFalsy(ButtonPageObject.ERRORMESSAGE_ASSERT);
   });

--- a/apps/fluent-tester/src/E2E/ButtonExperimental/pages/ButtonExperimentalPageObject.ts
+++ b/apps/fluent-tester/src/E2E/ButtonExperimental/pages/ButtonExperimentalPageObject.ts
@@ -5,7 +5,7 @@ import {
   HOMEPAGE_BUTTON_BUTTON,
   BUTTON_ON_PRESS,
 } from '../../../TestComponents/Button/consts';
-import { BasePage, By, GetElement } from '../../common/BasePage';
+import { BasePage, GetElement } from '../../common/BasePage';
 import { Keys } from '../../common/consts';
 
 /* This enum gives the spec file an EASY way to interact with SPECIFIC UI elements on the page.
@@ -18,7 +18,7 @@ class ButtonExperimentalPageObject extends BasePage {
   /**************** UI Element Interaction Methods ******************/
   /******************************************************************/
   async didOnClickCallbackFire(): Promise<boolean> {
-    const callbackText = await By(BUTTON_ON_PRESS);
+    const callbackText = await GetElement(BUTTON_ON_PRESS);
     await browser.waitUntil(async () => await callbackText.isDisplayed(), {
       timeout: this.waitForUIEvent,
       timeoutMsg: 'The OnClick callback did not fire.',
@@ -54,7 +54,7 @@ class ButtonExperimentalPageObject extends BasePage {
   /**************** Getters ****************/
   /*****************************************/
   get _testPage() {
-    return By(BUTTON_TESTPAGE);
+    return GetElement(BUTTON_TESTPAGE);
   }
 
   get _pageName() {
@@ -62,15 +62,15 @@ class ButtonExperimentalPageObject extends BasePage {
   }
 
   get _primaryComponent() {
-    return By(BUTTON_TEST_COMPONENT);
+    return GetElement(BUTTON_TEST_COMPONENT);
   }
 
   get _secondaryComponent() {
-    return By(BUTTON_NO_A11Y_LABEL_COMPONENT);
+    return GetElement(BUTTON_NO_A11Y_LABEL_COMPONENT);
   }
 
   get _pageButton() {
-    return By(HOMEPAGE_BUTTON_BUTTON);
+    return GetElement(HOMEPAGE_BUTTON_BUTTON);
   }
 }
 

--- a/apps/fluent-tester/src/E2E/ButtonExperimental/pages/ButtonExperimentalPageObject.ts
+++ b/apps/fluent-tester/src/E2E/ButtonExperimental/pages/ButtonExperimentalPageObject.ts
@@ -5,7 +5,8 @@ import {
   HOMEPAGE_BUTTON_BUTTON,
   BUTTON_ON_PRESS,
 } from '../../../TestComponents/Button/consts';
-import { BasePage, By } from '../../common/BasePage';
+import { BasePage, By, GetElement } from '../../common/BasePage';
+import { Keys } from '../../common/consts';
 
 /* This enum gives the spec file an EASY way to interact with SPECIFIC UI elements on the page.
  * The spec file should import this enum and use it when wanting to interact with different elements on the page. */
@@ -25,6 +26,15 @@ class ButtonExperimentalPageObject extends BasePage {
     });
 
     return await callbackText.isDisplayed();
+  }
+
+  // This is a special case. Currently, the Button spec and the ButtonExperimental spec examples are both on
+  // the same test page. We need to refresh the app so we cab re-navigate + re-scroll to the Button
+  // Experimental component. Once the deprecated button is fully deprecated and we can remove that spec file,
+  // we can rid of this function.
+  async refreshButtonPage(): Promise<void> {
+    const FocusButton = await GetElement('Focus_Button');
+    await FocusButton.addValue(Keys.F5);
   }
 
   /* Sends a Keyboarding command on a specific UI element */

--- a/apps/fluent-tester/src/E2E/ButtonExperimental/pages/ButtonExperimentalPageObject.ts
+++ b/apps/fluent-tester/src/E2E/ButtonExperimental/pages/ButtonExperimentalPageObject.ts
@@ -19,7 +19,7 @@ class ButtonExperimentalPageObject extends BasePage {
   async didOnClickCallbackFire(): Promise<boolean> {
     const callbackText = await By(BUTTON_ON_PRESS);
     await browser.waitUntil(async () => await callbackText.isDisplayed(), {
-      timeout: this.waitForPageTimeout,
+      timeout: this.waitForUIEvent,
       timeoutMsg: 'The OnClick callback did not fire.',
       interval: 1000,
     });

--- a/apps/fluent-tester/src/E2E/ButtonExperimental/specs/ButtonExperimental.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/ButtonExperimental/specs/ButtonExperimental.spec.win.ts
@@ -69,15 +69,15 @@ describe('Experimental Button Functional Testing', async () => {
   });
 
   it('Validate OnClick() callback was fired -> Type "Enter"', async () => {
-    await ButtonExperimentalPageObject.sendKey(ButtonSelector.PrimaryButton, Keys.Enter);
+    await ButtonExperimentalPageObject.sendKey(ButtonSelector.PrimaryButton, Keys.ENTER);
     await expect(await ButtonExperimentalPageObject.didOnClickCallbackFire()).toBeTruthy();
     await expect(await ButtonExperimentalPageObject.didAssertPopup()).toBeFalsy(ButtonExperimentalPageObject.ERRORMESSAGE_ASSERT);
 
     await ButtonExperimentalPageObject.clickComponent(); // Reset Button State
   });
 
-  it('Validate OnClick() callback was fired -> Type "Spacebar"', async () => {
-    await ButtonExperimentalPageObject.sendKey(ButtonSelector.PrimaryButton, Keys.Spacebar);
+  it('Validate OnClick() callback was fired -> Type "SPACE"', async () => {
+    await ButtonExperimentalPageObject.sendKey(ButtonSelector.PrimaryButton, Keys.SPACE);
     await expect(await ButtonExperimentalPageObject.didOnClickCallbackFire()).toBeTruthy();
     await expect(await ButtonExperimentalPageObject.didAssertPopup()).toBeFalsy(ButtonExperimentalPageObject.ERRORMESSAGE_ASSERT);
   });

--- a/apps/fluent-tester/src/E2E/ButtonExperimental/specs/ButtonExperimental.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/ButtonExperimental/specs/ButtonExperimental.spec.win.ts
@@ -6,7 +6,8 @@ import { BUTTON_ACCESSIBILITY_LABEL, BUTTON_TEST_COMPONENT_LABEL } from '../../.
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Experimental Button Testing Initialization', function () {
-  it('Wait for app load', async () => {
+  it('Reload Experimental Button Page and Wait for app load', async () => {
+    await ButtonExperimentalPageObject.refreshButtonPage();
     await NavigateAppPage.waitForPageDisplayed(BOOT_APP_TIMEOUT);
     await expect(await NavigateAppPage.isPageLoaded()).toBeTruthy(NavigateAppPage.ERRORMESSAGE_APPLOAD);
   });

--- a/apps/fluent-tester/src/E2E/Callout/pages/CalloutPageObject.win.ts
+++ b/apps/fluent-tester/src/E2E/Callout/pages/CalloutPageObject.win.ts
@@ -16,9 +16,15 @@ class CalloutPageObject extends BasePage {
 
   /* OVERRIDE: This must scroll to the button that opens the callout, not the callout (since it's not visible on load.) */
   async scrollToTestElement(): Promise<void> {
-    while (!(await this._buttonToOpenCallout.isDisplayed())) {
-      await driver.touchScroll(COMPONENT_SCROLL_COORDINATES.x, COMPONENT_SCROLL_COORDINATES.y, await this._testPage.elementId);
-    }
+    await browser.waitUntil(
+      async () => {
+        await driver.touchScroll(COMPONENT_SCROLL_COORDINATES.x, COMPONENT_SCROLL_COORDINATES.y, await this._testPage.elementId);
+        return await this._buttonToOpenCallout.isDisplayed();
+      },
+      {
+        timeoutMsg: 'Could not find the Button to open the menu.',
+      },
+    );
   }
 
   /*****************************************/

--- a/apps/fluent-tester/src/E2E/Callout/pages/CalloutPageObject.win.ts
+++ b/apps/fluent-tester/src/E2E/Callout/pages/CalloutPageObject.win.ts
@@ -4,34 +4,21 @@ import {
   HOMEPAGE_CALLOUT_BUTTON,
   BUTTON_TO_OPEN_CALLOUT,
 } from '../../../TestComponents/Callout/consts';
-import { BasePage, By, COMPONENT_SCROLL_COORDINATES } from '../../common/BasePage';
+import { BasePage, GetElement } from '../../common/BasePage';
 
 class CalloutPageObject extends BasePage {
   /******************************************************************/
   /**************** UI Element Interaction Methods ******************/
   /******************************************************************/
   async didCalloutLoad(): Promise<boolean> {
-    return await this._primaryComponent.isDisplayed();
-  }
-
-  /* OVERRIDE: This must scroll to the button that opens the callout, not the callout (since it's not visible on load.) */
-  async scrollToTestElement(): Promise<void> {
-    await browser.waitUntil(
-      async () => {
-        await driver.touchScroll(COMPONENT_SCROLL_COORDINATES.x, COMPONENT_SCROLL_COORDINATES.y, await this._testPage.elementId);
-        return await this._buttonToOpenCallout.isDisplayed();
-      },
-      {
-        timeoutMsg: 'Could not find the Button to open the menu.',
-      },
-    );
+    return await (await this._primaryComponent).isDisplayed();
   }
 
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
   get _testPage() {
-    return By(CALLOUT_TESTPAGE);
+    return GetElement(CALLOUT_TESTPAGE);
   }
 
   get _pageName() {
@@ -39,15 +26,15 @@ class CalloutPageObject extends BasePage {
   }
 
   get _primaryComponent() {
-    return By(CALLOUT_TEST_COMPONENT);
+    return GetElement(CALLOUT_TEST_COMPONENT);
   }
 
   get _pageButton() {
-    return By(HOMEPAGE_CALLOUT_BUTTON);
+    return GetElement(HOMEPAGE_CALLOUT_BUTTON);
   }
 
   get _buttonToOpenCallout() {
-    return By(BUTTON_TO_OPEN_CALLOUT);
+    return GetElement(BUTTON_TO_OPEN_CALLOUT);
   }
 }
 

--- a/apps/fluent-tester/src/E2E/Checkbox/pages/CheckboxPageObject.ts
+++ b/apps/fluent-tester/src/E2E/Checkbox/pages/CheckboxPageObject.ts
@@ -5,7 +5,7 @@ import {
   HOMEPAGE_CHECKBOX_BUTTON,
   CHECKBOX_ON_PRESS,
 } from '../../../TestComponents/Checkbox/consts';
-import { BasePage, By } from '../../common/BasePage';
+import { BasePage, GetElement } from '../../common/BasePage';
 
 /* This enum gives the spec file an EASY way to interact with SPECIFIC UI elements on the page.
  * The spec file should import this enum and use it when wanting to interact with different elements on the page. */
@@ -18,7 +18,7 @@ class CheckboxPageObject extends BasePage {
   /**************** UI Element Interaction Methods ******************/
   /******************************************************************/
   async isCheckboxChecked(): Promise<boolean> {
-    return await this._primaryComponent.isSelected();
+    return await (await this._primaryComponent).isSelected();
   }
 
   async waitForCheckboxChecked(timeout?: number): Promise<void> {
@@ -32,12 +32,12 @@ class CheckboxPageObject extends BasePage {
   /* Useful in beforeEach() hook to reset the checkbox before every test */
   async toggleCheckboxToUnchecked(): Promise<void> {
     if (await this.isCheckboxChecked()) {
-      await this._primaryComponent.click();
+      await (await this._primaryComponent).click();
     }
   }
 
   async didOnChangeCallbackFire(): Promise<boolean> {
-    const callbackText = await By(CHECKBOX_ON_PRESS);
+    const callbackText = await GetElement(CHECKBOX_ON_PRESS);
     await browser.waitUntil(async () => await callbackText.isDisplayed(), {
       timeout: this.waitForUIEvent,
       timeoutMsg: 'The OnChange callback did not fire.',
@@ -64,7 +64,7 @@ class CheckboxPageObject extends BasePage {
   /**************** Getters ****************/
   /*****************************************/
   get _testPage() {
-    return By(CHECKBOX_TESTPAGE);
+    return GetElement(CHECKBOX_TESTPAGE);
   }
 
   get _pageName() {
@@ -72,15 +72,15 @@ class CheckboxPageObject extends BasePage {
   }
 
   get _primaryComponent() {
-    return By(CHECKBOX_TEST_COMPONENT);
+    return GetElement(CHECKBOX_TEST_COMPONENT);
   }
 
   get _secondaryComponent() {
-    return By(CHECKBOX_NO_A11Y_LABEL_COMPONENT);
+    return GetElement(CHECKBOX_NO_A11Y_LABEL_COMPONENT);
   }
 
   get _pageButton() {
-    return By(HOMEPAGE_CHECKBOX_BUTTON);
+    return GetElement(HOMEPAGE_CHECKBOX_BUTTON);
   }
 }
 

--- a/apps/fluent-tester/src/E2E/Checkbox/pages/CheckboxPageObject.ts
+++ b/apps/fluent-tester/src/E2E/Checkbox/pages/CheckboxPageObject.ts
@@ -23,7 +23,7 @@ class CheckboxPageObject extends BasePage {
 
   async waitForCheckboxChecked(timeout?: number): Promise<void> {
     await browser.waitUntil(async () => await this.isCheckboxChecked(), {
-      timeout: timeout ?? this.waitForPageTimeout,
+      timeout: timeout ?? this.waitForUIEvent,
       timeoutMsg: 'The Checkbox was not toggled correctly',
       interval: 1000,
     });
@@ -39,7 +39,7 @@ class CheckboxPageObject extends BasePage {
   async didOnChangeCallbackFire(): Promise<boolean> {
     const callbackText = await By(CHECKBOX_ON_PRESS);
     await browser.waitUntil(async () => await callbackText.isDisplayed(), {
-      timeout: this.waitForPageTimeout,
+      timeout: this.waitForUIEvent,
       timeoutMsg: 'The OnChange callback did not fire.',
       interval: 1000,
     });

--- a/apps/fluent-tester/src/E2E/Checkbox/specs/Checkbox.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Checkbox/specs/Checkbox.spec.win.ts
@@ -76,9 +76,9 @@ describe('Checkbox Functional Testing', () => {
     await expect(await CheckboxPageObject.didAssertPopup()).toBeFalsy(CheckboxPageObject.ERRORMESSAGE_ASSERT);
   });
 
-  it('Click the "Spacebar" on a Checkbox and verify it toggles', async () => {
+  it('Click the "SPACE" on a Checkbox and verify it toggles', async () => {
     /* Presses the "space bar" to select the Checkbox */
-    await CheckboxPageObject.sendKey(CheckboxSelector.Primary, Keys.Spacebar);
+    await CheckboxPageObject.sendKey(CheckboxSelector.Primary, Keys.SPACE);
     await CheckboxPageObject.waitForCheckboxChecked(PAGE_TIMEOUT);
 
     /* Validate the Checkbox is selected */

--- a/apps/fluent-tester/src/E2E/Checkbox/specs/Checkbox.spec.windows.ts
+++ b/apps/fluent-tester/src/E2E/Checkbox/specs/Checkbox.spec.windows.ts
@@ -75,9 +75,9 @@ describe('Checkbox Accessibility Testing', () => {
 //     await expect(await CheckboxPageObject.isCheckboxChecked()).toBeFalsy();
 //   });
 
-//   it('Click the "Spacebar" on a Checkbox and verify it toggles', () => {
+//   it('Click the "SPACE" on a Checkbox and verify it toggles', () => {
 //     /* Presses the "space bar" to select the Checkbox */
-//     CheckboxPageObject.sendKey(CHECKBOX_TEST_COMPONENT, Keys.Spacebar);
+//     CheckboxPageObject.sendKey(CHECKBOX_TEST_COMPONENT, Keys.SPACE);
 //     CheckboxPageObject.waitForCheckboxChecked(PAGE_TIMEOUT);
 
 //     /* Validate the Checkbox is selected */

--- a/apps/fluent-tester/src/E2E/CheckboxExperimental/pages/ExperimentalCheckboxPageObject.ts
+++ b/apps/fluent-tester/src/E2E/CheckboxExperimental/pages/ExperimentalCheckboxPageObject.ts
@@ -5,7 +5,7 @@ import {
   EXPERIMENTAL_CHECKBOX_NO_A11Y_LABEL_COMPONENT,
   EXPERIMENTAL_CHECKBOX_ON_PRESS,
 } from '../../../TestComponents/CheckboxExperimental/consts';
-import { BasePage, By } from '../../common/BasePage';
+import { BasePage, GetElement } from '../../common/BasePage';
 
 /* This enum gives the spec file an EASY way to interact with SPECIFIC UI elements on the page.
  * The spec file should import this enum and use it when wanting to interact with different elements on the page. */
@@ -18,7 +18,7 @@ class ExperimentalCheckboxPageObject extends BasePage {
   /**************** UI Element Interaction Methods ******************/
   /******************************************************************/
   async isCheckboxChecked(): Promise<boolean> {
-    return await this._primaryComponent.isSelected();
+    return await (await this._primaryComponent).isSelected();
   }
 
   async waitForCheckboxChecked(timeout?: number): Promise<void> {
@@ -32,12 +32,12 @@ class ExperimentalCheckboxPageObject extends BasePage {
   /* Useful in beforeEach() hook to reset the checkbox before every test */
   async toggleCheckboxToUnchecked(): Promise<void> {
     if (await this.isCheckboxChecked()) {
-      await this._primaryComponent.click();
+      await (await this._primaryComponent).click();
     }
   }
 
   async didOnChangeCallbackFire(): Promise<boolean> {
-    const callbackText = await By(EXPERIMENTAL_CHECKBOX_ON_PRESS);
+    const callbackText = await GetElement(EXPERIMENTAL_CHECKBOX_ON_PRESS);
     await browser.waitUntil(async () => await callbackText.isDisplayed(), {
       timeout: this.waitForUIEvent,
       timeoutMsg: 'The OnChange callback did not fire.',
@@ -64,7 +64,7 @@ class ExperimentalCheckboxPageObject extends BasePage {
   /**************** Getters ****************/
   /*****************************************/
   get _testPage() {
-    return By(EXPERIMENTAL_CHECKBOX_TESTPAGE);
+    return GetElement(EXPERIMENTAL_CHECKBOX_TESTPAGE);
   }
 
   get _pageName() {
@@ -72,15 +72,15 @@ class ExperimentalCheckboxPageObject extends BasePage {
   }
 
   get _primaryComponent() {
-    return By(EXPERIMENTAL_CHECKBOX_TEST_COMPONENT);
+    return GetElement(EXPERIMENTAL_CHECKBOX_TEST_COMPONENT);
   }
 
   get _secondaryComponent() {
-    return By(EXPERIMENTAL_CHECKBOX_NO_A11Y_LABEL_COMPONENT);
+    return GetElement(EXPERIMENTAL_CHECKBOX_NO_A11Y_LABEL_COMPONENT);
   }
 
   get _pageButton() {
-    return By(HOMEPAGE_CHECKBOX_EXPERIMENTAL_BUTTON);
+    return GetElement(HOMEPAGE_CHECKBOX_EXPERIMENTAL_BUTTON);
   }
 }
 

--- a/apps/fluent-tester/src/E2E/CheckboxExperimental/pages/ExperimentalCheckboxPageObject.ts
+++ b/apps/fluent-tester/src/E2E/CheckboxExperimental/pages/ExperimentalCheckboxPageObject.ts
@@ -23,7 +23,7 @@ class ExperimentalCheckboxPageObject extends BasePage {
 
   async waitForCheckboxChecked(timeout?: number): Promise<void> {
     await browser.waitUntil(async () => await this.isCheckboxChecked(), {
-      timeout: timeout ?? this.waitForPageTimeout,
+      timeout: timeout ?? this.waitForUIEvent,
       timeoutMsg: 'The Checkbox was not toggled correctly',
       interval: 1000,
     });
@@ -39,7 +39,7 @@ class ExperimentalCheckboxPageObject extends BasePage {
   async didOnChangeCallbackFire(): Promise<boolean> {
     const callbackText = await By(EXPERIMENTAL_CHECKBOX_ON_PRESS);
     await browser.waitUntil(async () => await callbackText.isDisplayed(), {
-      timeout: this.waitForPageTimeout,
+      timeout: this.waitForUIEvent,
       timeoutMsg: 'The OnChange callback did not fire.',
       interval: 1000,
     });

--- a/apps/fluent-tester/src/E2E/CheckboxExperimental/specs/ExperimentalCheckbox.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/CheckboxExperimental/specs/ExperimentalCheckbox.spec.win.ts
@@ -80,16 +80,16 @@ describe('Checkbox Functional Testing', () => {
     await ExperimentalCheckboxPageObject.clickComponent();
     await ExperimentalCheckboxPageObject.waitForCheckboxChecked(PAGE_TIMEOUT);
 
-    expect(await ExperimentalCheckboxPageObject.didOnChangeCallbackFire()).toBeTruthy();
+    await expect(await ExperimentalCheckboxPageObject.didOnChangeCallbackFire()).toBeTruthy();
 
     /* Validate the Checkbox is toggled ON */
-    expect(await ExperimentalCheckboxPageObject.isCheckboxChecked()).toBeTruthy();
+    await expect(await ExperimentalCheckboxPageObject.isCheckboxChecked()).toBeTruthy();
 
     await ExperimentalCheckboxPageObject.clickComponent();
 
     /* Validate the Checkbox is toggled OFF */
-    expect(await ExperimentalCheckboxPageObject.isCheckboxChecked()).toBeFalsy();
-    expect(await ExperimentalCheckboxPageObject.didAssertPopup()).toBeFalsy(ExperimentalCheckboxPageObject.ERRORMESSAGE_ASSERT);
+    await expect(await ExperimentalCheckboxPageObject.isCheckboxChecked()).toBeFalsy();
+    await expect(await ExperimentalCheckboxPageObject.didAssertPopup()).toBeFalsy(ExperimentalCheckboxPageObject.ERRORMESSAGE_ASSERT);
   });
 
   it('Click the "Spacebar" on a Checkbox and verify it toggles', async () => {

--- a/apps/fluent-tester/src/E2E/CheckboxExperimental/specs/ExperimentalCheckbox.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/CheckboxExperimental/specs/ExperimentalCheckbox.spec.win.ts
@@ -92,9 +92,9 @@ describe('Checkbox Functional Testing', () => {
     await expect(await ExperimentalCheckboxPageObject.didAssertPopup()).toBeFalsy(ExperimentalCheckboxPageObject.ERRORMESSAGE_ASSERT);
   });
 
-  it('Click the "Spacebar" on a Checkbox and verify it toggles', async () => {
+  it('Click the "SPACE" on a Checkbox and verify it toggles', async () => {
     /* Presses the "space bar" to select the Checkbox */
-    await ExperimentalCheckboxPageObject.sendKey(ExperimentalCheckboxSelector.Primary, Keys.Spacebar);
+    await ExperimentalCheckboxPageObject.sendKey(ExperimentalCheckboxSelector.Primary, Keys.SPACE);
     await ExperimentalCheckboxPageObject.waitForCheckboxChecked(PAGE_TIMEOUT);
 
     /* Validate the Checkbox is selected */

--- a/apps/fluent-tester/src/E2E/ContextualMenu/pages/ContextualMenuPageObject.win.ts
+++ b/apps/fluent-tester/src/E2E/ContextualMenu/pages/ContextualMenuPageObject.win.ts
@@ -19,7 +19,7 @@ class ContextualMenuPageObject extends BasePage {
   /******************************************************************/
   async waitForContextualMenuItemsToOpen(timeout?: number): Promise<void> {
     await browser.waitUntil(async () => await this.contextualMenuItemDisplayed(), {
-      timeout: timeout ?? this.waitForPageTimeout,
+      timeout: timeout ?? this.waitForUIEvent,
       timeoutMsg: 'The Contextual Menu Items did not open.',
       interval: 1000,
     });

--- a/apps/fluent-tester/src/E2E/ContextualMenu/pages/ContextualMenuPageObject.win.ts
+++ b/apps/fluent-tester/src/E2E/ContextualMenu/pages/ContextualMenuPageObject.win.ts
@@ -4,7 +4,7 @@ import {
   HOMEPAGE_CONTEXTUALMENU_BUTTON,
   CONTEXTUALMENUITEM_TEST_COMPONENT,
 } from '../../../TestComponents/ContextualMenu/consts';
-import { BasePage, By } from '../../common/BasePage';
+import { BasePage, GetElement } from '../../common/BasePage';
 
 /* This enum gives the spec file an EASY way to interact with SPECIFIC UI elements on the page.
  * The spec file should import this enum and use it when wanting to interact with different elements on the page. */
@@ -27,7 +27,7 @@ class ContextualMenuPageObject extends BasePage {
 
   /* Whether the contextual menu item is displayed or not. It should be displayed after clicking on the MenuButton */
   async contextualMenuItemDisplayed(): Promise<boolean> {
-    return await this._contextualMenuItem.isDisplayed();
+    return await (await this._contextualMenuItem).isDisplayed();
   }
 
   /* Sends a Keyboarding command on a specific UI element */
@@ -50,7 +50,7 @@ class ContextualMenuPageObject extends BasePage {
   /**************** Getters ****************/
   /*****************************************/
   get _testPage() {
-    return By(CONTEXTUALMENU_TESTPAGE);
+    return GetElement(CONTEXTUALMENU_TESTPAGE);
   }
 
   get _pageName() {
@@ -58,15 +58,15 @@ class ContextualMenuPageObject extends BasePage {
   }
 
   get _primaryComponent() {
-    return By(CONTEXTUALMENU_TEST_COMPONENT);
+    return GetElement(CONTEXTUALMENU_TEST_COMPONENT);
   }
 
   get _pageButton() {
-    return By(HOMEPAGE_CONTEXTUALMENU_BUTTON);
+    return GetElement(HOMEPAGE_CONTEXTUALMENU_BUTTON);
   }
 
   get _contextualMenuItem() {
-    return By(CONTEXTUALMENUITEM_TEST_COMPONENT);
+    return GetElement(CONTEXTUALMENUITEM_TEST_COMPONENT);
   }
 }
 

--- a/apps/fluent-tester/src/E2E/ContextualMenu/specs/ContextualMenu.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/ContextualMenu/specs/ContextualMenu.spec.win.ts
@@ -30,7 +30,7 @@ describe('ContextualMenu Functional Tests', async () => {
     await ContextualMenuPageObjectObject.scrollToTestElement();
     await ContextualMenuPageObjectObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
 
-    await ContextualMenuPageObjectObject.sendKey(ContextualMenuSelector.ContextualMenu, Keys.Escape); // Reset ContextualMenu state for next test
+    await ContextualMenuPageObjectObject.sendKey(ContextualMenuSelector.ContextualMenu, Keys.ESCAPE); // Reset ContextualMenu state for next test
   });
 
   it('Click on ContextualMenu Button and validate that the list of ContextualMenu Items open', async () => {
@@ -42,9 +42,9 @@ describe('ContextualMenu Functional Tests', async () => {
     await expect(await ContextualMenuPageObjectObject.didAssertPopup()).toBeFalsy(ContextualMenuPageObjectObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
   });
 
-  it('Type "SpaceBar" to select the ContextualMenu and validate that the list of ContextualMenu Items open', async () => {
+  it('Type "SPACE" to select the ContextualMenu and validate that the list of ContextualMenu Items open', async () => {
     /* Type a space on the ContextualMenu */
-    await ContextualMenuPageObjectObject.sendKey(ContextualMenuSelector.ContextualMenu, Keys.Spacebar);
+    await ContextualMenuPageObjectObject.sendKey(ContextualMenuSelector.ContextualMenu, Keys.SPACE);
     await ContextualMenuPageObjectObject.waitForContextualMenuItemsToOpen(PAGE_TIMEOUT);
 
     await expect(await ContextualMenuPageObjectObject.contextualMenuItemDisplayed()).toBeTruthy();
@@ -53,6 +53,6 @@ describe('ContextualMenu Functional Tests', async () => {
 
   /* Runs after all tests. This ensures the ContextualMenu closes. If it stays open, the test driver won't be able to close the test app */
   afterAll(async () => {
-    await ContextualMenuPageObjectObject.sendKey(ContextualMenuSelector.ContextualMenu, Keys.Escape); // Reset ContextualMenu state for next test
+    await ContextualMenuPageObjectObject.sendKey(ContextualMenuSelector.ContextualMenu, Keys.ESCAPE); // Reset ContextualMenu state for next test
   });
 });

--- a/apps/fluent-tester/src/E2E/FocusTrapZone/pages/FocusTrapZonePageObject.win.ts
+++ b/apps/fluent-tester/src/E2E/FocusTrapZone/pages/FocusTrapZonePageObject.win.ts
@@ -3,21 +3,21 @@ import {
   FOCUSTRAPZONE_TEST_COMPONENT,
   HOMEPAGE_FOCUSTRAPZONE_BUTTON,
 } from '../../../TestComponents/FocusTrapZone/consts';
-import { BasePage, By } from '../../common/BasePage';
+import { BasePage, GetElement } from '../../common/BasePage';
 
 class FocusTrapZonePageObject extends BasePage {
   // OVERRIDE: We use isExisting() here instead of isDisplayed() because FocusTrapZone does not have any UI to it, it's simply
   // a wrapper that adds keyboard focus functionality
   async waitForPrimaryElementDisplayed(timeout?: number): Promise<void> {
     const errorMsg = 'The FocusTrapZone UI Element did not load correctly. Please see logs.';
-    await this.waitForCondition(async () => await this._primaryComponent.isExisting(), errorMsg, timeout);
+    await this.waitForCondition(async () => await (await this._primaryComponent).isExisting(), errorMsg, timeout);
   }
 
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
   get _testPage() {
-    return By(FOCUSTRAPZONE_TESTPAGE);
+    return GetElement(FOCUSTRAPZONE_TESTPAGE);
   }
 
   get _pageName() {
@@ -25,11 +25,11 @@ class FocusTrapZonePageObject extends BasePage {
   }
 
   get _primaryComponent() {
-    return By(FOCUSTRAPZONE_TEST_COMPONENT);
+    return GetElement(FOCUSTRAPZONE_TEST_COMPONENT);
   }
 
   get _pageButton() {
-    return By(HOMEPAGE_FOCUSTRAPZONE_BUTTON);
+    return GetElement(HOMEPAGE_FOCUSTRAPZONE_BUTTON);
   }
 }
 

--- a/apps/fluent-tester/src/E2E/FocusZone/pages/FocusZonePageObject.ts
+++ b/apps/fluent-tester/src/E2E/FocusZone/pages/FocusZonePageObject.ts
@@ -1,19 +1,19 @@
 import { FOCUSZONE_TESTPAGE, FOCUSZONE_TEST_COMPONENT, HOMEPAGE_FOCUSZONE_BUTTON } from '../../../TestComponents/FocusZone/consts';
-import { BasePage, By } from '../../common/BasePage';
+import { BasePage, GetElement } from '../../common/BasePage';
 
 class FocusZonePageObject extends BasePage {
   // OVERRIDE: We use isExisting() here instead of isDisplayed() because FocusZone does not have any UI to it, it's simply
   // a wrapper that adds keyboard focus functionality
   async waitForPrimaryElementDisplayed(timeout?: number): Promise<void> {
     const errorMsg = 'The FocusZone UI Element did not load correctly. Please see logs.';
-    await this.waitForCondition(async () => await this._primaryComponent.isExisting(), errorMsg, timeout);
+    await this.waitForCondition(async () => await (await this._primaryComponent).isExisting(), errorMsg, timeout);
   }
 
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
   get _testPage() {
-    return By(FOCUSZONE_TESTPAGE);
+    return GetElement(FOCUSZONE_TESTPAGE);
   }
 
   get _pageName() {
@@ -21,11 +21,11 @@ class FocusZonePageObject extends BasePage {
   }
 
   get _primaryComponent() {
-    return By(FOCUSZONE_TEST_COMPONENT);
+    return GetElement(FOCUSZONE_TEST_COMPONENT);
   }
 
   get _pageButton() {
-    return By(HOMEPAGE_FOCUSZONE_BUTTON);
+    return GetElement(HOMEPAGE_FOCUSZONE_BUTTON);
   }
 }
 

--- a/apps/fluent-tester/src/E2E/Icon/pages/IconPageObject.ts
+++ b/apps/fluent-tester/src/E2E/Icon/pages/IconPageObject.ts
@@ -4,14 +4,14 @@ import {
   HOMEPAGE_ICON_BUTTON,
   ICON_NO_A11Y_LABEL_COMPONENT,
 } from '../../../TestComponents/Icon/consts';
-import { BasePage, By } from '../../common/BasePage';
+import { BasePage, GetElement } from '../../common/BasePage';
 
 class IconPageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
   get _testPage() {
-    return By(ICON_TESTPAGE);
+    return GetElement(ICON_TESTPAGE);
   }
 
   get _pageName() {
@@ -19,15 +19,15 @@ class IconPageObject extends BasePage {
   }
 
   get _primaryComponent() {
-    return By(ICON_TEST_COMPONENT);
+    return GetElement(ICON_TEST_COMPONENT);
   }
 
   get _secondaryComponent() {
-    return By(ICON_NO_A11Y_LABEL_COMPONENT);
+    return GetElement(ICON_NO_A11Y_LABEL_COMPONENT);
   }
 
   get _pageButton() {
-    return By(HOMEPAGE_ICON_BUTTON);
+    return GetElement(HOMEPAGE_ICON_BUTTON);
   }
 }
 

--- a/apps/fluent-tester/src/E2E/Link/pages/LinkPageObject.ts
+++ b/apps/fluent-tester/src/E2E/Link/pages/LinkPageObject.ts
@@ -4,14 +4,14 @@ import {
   HOMEPAGE_LINK_BUTTON,
   LINK_NO_A11Y_LABEL_COMPONENT,
 } from '../../../TestComponents/Link/consts';
-import { BasePage, By } from '../../common/BasePage';
+import { BasePage, GetElement } from '../../common/BasePage';
 
 class LinkPageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
   get _testPage() {
-    return By(LINK_TESTPAGE);
+    return GetElement(LINK_TESTPAGE);
   }
 
   get _pageName() {
@@ -19,15 +19,15 @@ class LinkPageObject extends BasePage {
   }
 
   get _primaryComponent() {
-    return By(LINK_TEST_COMPONENT);
+    return GetElement(LINK_TEST_COMPONENT);
   }
 
   get _secondaryComponent() {
-    return By(LINK_NO_A11Y_LABEL_COMPONENT);
+    return GetElement(LINK_NO_A11Y_LABEL_COMPONENT);
   }
 
   get _pageButton() {
-    return By(HOMEPAGE_LINK_BUTTON);
+    return GetElement(HOMEPAGE_LINK_BUTTON);
   }
 }
 

--- a/apps/fluent-tester/src/E2E/Menu/pages/MenuPageObject.ts
+++ b/apps/fluent-tester/src/E2E/Menu/pages/MenuPageObject.ts
@@ -8,7 +8,7 @@ import {
   MENUITEM_TEST_COMPONENT,
   MENUPOPOVER_TEST_COMPONENT,
 } from '../../../TestComponents/Menu/consts';
-import { BasePage, By } from '../../common/BasePage';
+import { BasePage, GetElement } from '../../common/BasePage';
 
 /* This enum gives the spec file an EASY way to interact with SPECIFIC UI elements on the page.
  * The spec file should import this enum and use it when wanting to interact with different elements on the page. */
@@ -23,7 +23,7 @@ class MenuPageObject extends BasePage {
   /**************** UI Element Interaction Methods ******************/
   /******************************************************************/
   async didMenuOpen(): Promise<boolean> {
-    const callbackText = await By(MENU_ON_OPEN);
+    const callbackText = await GetElement(MENU_ON_OPEN);
     await browser.waitUntil(async () => await callbackText.isDisplayed(), {
       timeout: this.waitForUIEvent,
       timeoutMsg: 'The Menu did not open.',
@@ -34,7 +34,7 @@ class MenuPageObject extends BasePage {
   }
 
   async didMenuClose(): Promise<boolean> {
-    const callbackText = await By(MENU_ON_CLOSE);
+    const callbackText = await GetElement(MENU_ON_CLOSE);
     await browser.waitUntil(async () => await callbackText.isDisplayed(), {
       timeout: this.waitForUIEvent,
       timeoutMsg: 'The Menu did not close.',
@@ -47,22 +47,22 @@ class MenuPageObject extends BasePage {
   async getMenuItemAccessibilityLabel(componentSelector: MenuComponentSelector): Promise<string> {
     switch (componentSelector) {
       case MenuComponentSelector.PrimaryComponent:
-        return await this._primaryComponent.getAttribute('Name');
+        return await (await this._primaryComponent).getAttribute('Name');
 
       case MenuComponentSelector.SecondaryComponent:
-        return await this._secondaryComponent.getAttribute('Name');
+        return await (await this._secondaryComponent).getAttribute('Name');
 
       case MenuComponentSelector.TertiaryComponent:
-        return await this._tertiaryComponent.getAttribute('Name');
+        return await (await this._tertiaryComponent).getAttribute('Name');
     }
   }
 
   async getMenuAccessibilityRole(): Promise<string> {
-    return await this._menuPopoverComponent.getAttribute('ControlType');
+    return await (await this._menuPopoverComponent).getAttribute('ControlType');
   }
 
   async getMenuItemAccessibilityRole(): Promise<string> {
-    return await this._secondaryComponent.getAttribute('ControlType');
+    return await (await this._secondaryComponent).getAttribute('ControlType');
   }
 
   /* Sends a Keyboarding command on a specific UI element */
@@ -82,7 +82,7 @@ class MenuPageObject extends BasePage {
   /**************** Getters ****************/
   /*****************************************/
   get _testPage() {
-    return By(MENU_TESTPAGE);
+    return GetElement(MENU_TESTPAGE);
   }
 
   get _pageName() {
@@ -90,23 +90,23 @@ class MenuPageObject extends BasePage {
   }
 
   get _primaryComponent() {
-    return By(MENUTRIGGER_TEST_COMPONENT);
+    return GetElement(MENUTRIGGER_TEST_COMPONENT);
   }
 
   get _secondaryComponent() {
-    return By(MENUITEM_TEST_COMPONENT);
+    return GetElement(MENUITEM_TEST_COMPONENT);
   }
 
   get _tertiaryComponent() {
-    return By(MENUITEM_NO_A11Y_LABEL_COMPONENT);
+    return GetElement(MENUITEM_NO_A11Y_LABEL_COMPONENT);
   }
 
   get _pageButton() {
-    return By(HOMEPAGE_MENU_BUTTON);
+    return GetElement(HOMEPAGE_MENU_BUTTON);
   }
 
   get _menuPopoverComponent() {
-    return By(MENUPOPOVER_TEST_COMPONENT);
+    return GetElement(MENUPOPOVER_TEST_COMPONENT);
   }
 }
 

--- a/apps/fluent-tester/src/E2E/Menu/pages/MenuPageObject.ts
+++ b/apps/fluent-tester/src/E2E/Menu/pages/MenuPageObject.ts
@@ -58,7 +58,7 @@ class MenuPageObject extends BasePage {
   }
 
   async getMenuAccessibilityRole(): Promise<string> {
-    return await By(MENUPOPOVER_TEST_COMPONENT).getAttribute('ControlType');
+    return await this._menuPopoverComponent.getAttribute('ControlType');
   }
 
   async getMenuItemAccessibilityRole(): Promise<string> {
@@ -103,6 +103,10 @@ class MenuPageObject extends BasePage {
 
   get _pageButton() {
     return By(HOMEPAGE_MENU_BUTTON);
+  }
+
+  get _menuPopoverComponent() {
+    return By(MENUPOPOVER_TEST_COMPONENT);
   }
 }
 

--- a/apps/fluent-tester/src/E2E/Menu/pages/MenuPageObject.ts
+++ b/apps/fluent-tester/src/E2E/Menu/pages/MenuPageObject.ts
@@ -25,7 +25,7 @@ class MenuPageObject extends BasePage {
   async didMenuOpen(): Promise<boolean> {
     const callbackText = await By(MENU_ON_OPEN);
     await browser.waitUntil(async () => await callbackText.isDisplayed(), {
-      timeout: this.waitForPageTimeout,
+      timeout: this.waitForUIEvent,
       timeoutMsg: 'The Menu did not open.',
       interval: 1000,
     });
@@ -36,7 +36,7 @@ class MenuPageObject extends BasePage {
   async didMenuClose(): Promise<boolean> {
     const callbackText = await By(MENU_ON_CLOSE);
     await browser.waitUntil(async () => await callbackText.isDisplayed(), {
-      timeout: this.waitForPageTimeout,
+      timeout: this.waitForUIEvent,
       timeoutMsg: 'The Menu did not close.',
       interval: 1000,
     });

--- a/apps/fluent-tester/src/E2E/Menu/specs/Menu.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Menu/specs/Menu.spec.win.ts
@@ -42,19 +42,19 @@ describe('Menu Functional Testing', () => {
   });
 
   it('Validate OnOpenChange() callback was fired -> Type "Enter"', async () => {
-    await MenuPageObject.sendKey(MenuComponentSelector.PrimaryComponent, Keys.Enter);
+    await MenuPageObject.sendKey(MenuComponentSelector.PrimaryComponent, Keys.ENTER);
     await expect(await MenuPageObject.didMenuOpen()).toBeTruthy();
 
-    await MenuPageObject.sendKey(MenuComponentSelector.PrimaryComponent, Keys.Enter);
+    await MenuPageObject.sendKey(MenuComponentSelector.PrimaryComponent, Keys.ENTER);
     await expect(await MenuPageObject.didMenuClose()).toBeTruthy();
     await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
   });
 
-  it('Validate OnOpenChange() callback was fired -> Type "Spacebar"', async () => {
-    await MenuPageObject.sendKey(MenuComponentSelector.PrimaryComponent, Keys.Spacebar);
+  it('Validate OnOpenChange() callback was fired -> Type "SPACE"', async () => {
+    await MenuPageObject.sendKey(MenuComponentSelector.PrimaryComponent, Keys.SPACE);
     await expect(await MenuPageObject.didMenuOpen()).toBeTruthy();
 
-    await MenuPageObject.sendKey(MenuComponentSelector.PrimaryComponent, Keys.Spacebar);
+    await MenuPageObject.sendKey(MenuComponentSelector.PrimaryComponent, Keys.SPACE);
     await expect(await MenuPageObject.didMenuClose()).toBeTruthy();
     await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
   });
@@ -67,22 +67,22 @@ describe('Menu Accessibility Testing', () => {
   });
 
   it('Menu - Validate accessibilityRole of menu item is correct', async () => {
-    await MenuPageObject.sendKey(MenuComponentSelector.PrimaryComponent, Keys.Enter);
+    await MenuPageObject.sendKey(MenuComponentSelector.PrimaryComponent, Keys.ENTER);
     await expect(await MenuPageObject.didMenuOpen()).toBeTruthy();
 
     await expect(await MenuPageObject.getMenuItemAccessibilityRole()).toEqual(MENUITEM_A11Y_ROLE);
     await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
 
-    await MenuPageObject.sendKey(MenuComponentSelector.PrimaryComponent, Keys.Enter);
+    await MenuPageObject.sendKey(MenuComponentSelector.PrimaryComponent, Keys.ENTER);
   });
 
   it('Menu - Do not set accessibilityLabel -> Default to MenuItem label', async () => {
-    await MenuPageObject.sendKey(MenuComponentSelector.PrimaryComponent, Keys.Enter);
+    await MenuPageObject.sendKey(MenuComponentSelector.PrimaryComponent, Keys.ENTER);
     await expect(await MenuPageObject.didMenuOpen()).toBeTruthy();
 
     await expect(await MenuPageObject.getMenuItemAccessibilityLabel(MenuComponentSelector.TertiaryComponent)).toEqual(MENUITEM_TEST_LABEL);
     await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
 
-    await MenuPageObject.sendKey(MenuComponentSelector.PrimaryComponent, Keys.Enter);
+    await MenuPageObject.sendKey(MenuComponentSelector.PrimaryComponent, Keys.ENTER);
   });
 });

--- a/apps/fluent-tester/src/E2E/Menu/specs/Menu.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Menu/specs/Menu.spec.win.ts
@@ -1,7 +1,7 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import MenuPageObject, { MenuComponentSelector } from '../pages/MenuPageObject';
-import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT, Keys, MENUITEM_A11Y_ROLE, MENU_A11Y_ROLE } from '../../common/consts';
-import { MENUITEM_ACCESSIBILITY_LABEL, MENUITEM_TEST_LABEL } from '../../../TestComponents/Menu/consts';
+import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT, Keys, MENUITEM_A11Y_ROLE } from '../../common/consts';
+import { MENUITEM_TEST_LABEL } from '../../../TestComponents/Menu/consts';
 import { Platform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
@@ -71,28 +71,6 @@ describe('Menu Accessibility Testing', () => {
     await expect(await MenuPageObject.didMenuOpen()).toBeTruthy();
 
     await expect(await MenuPageObject.getMenuItemAccessibilityRole()).toEqual(MENUITEM_A11Y_ROLE);
-    await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
-
-    await MenuPageObject.sendKey(MenuComponentSelector.PrimaryComponent, Keys.Enter);
-  });
-
-  it('Menu - Validate accessibilityRole of menu is correct', async () => {
-    await MenuPageObject.sendKey(MenuComponentSelector.PrimaryComponent, Keys.Enter);
-    await expect(await MenuPageObject.didMenuOpen()).toBeTruthy();
-
-    await expect(await MenuPageObject.getMenuAccessibilityRole()).toEqual(MENU_A11Y_ROLE);
-    await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
-
-    await MenuPageObject.sendKey(MenuComponentSelector.PrimaryComponent, Keys.Enter);
-  });
-
-  it('Menu - Set accessibilityLabel', async () => {
-    await MenuPageObject.sendKey(MenuComponentSelector.PrimaryComponent, Keys.Enter);
-    await expect(await MenuPageObject.didMenuOpen()).toBeTruthy();
-
-    await expect(await MenuPageObject.getMenuItemAccessibilityLabel(MenuComponentSelector.SecondaryComponent)).toEqual(
-      MENUITEM_ACCESSIBILITY_LABEL,
-    );
     await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
 
     await MenuPageObject.sendKey(MenuComponentSelector.PrimaryComponent, Keys.Enter);

--- a/apps/fluent-tester/src/E2E/Menu/specs/Menu.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Menu/specs/Menu.spec.win.ts
@@ -57,7 +57,7 @@ describe('Menu Functional Testing', () => {
     await expect(await MenuPageObject.didMenuOpen()).toBeTruthy();
     await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
 
-    MenuPageObject.sendKey(MenuComponentSelector.PrimaryComponent, Keys.Spacebar);
+    await MenuPageObject.sendKey(MenuComponentSelector.PrimaryComponent, Keys.Spacebar);
     await expect(await MenuPageObject.didMenuClose()).toBeTruthy();
     await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
   });

--- a/apps/fluent-tester/src/E2E/Menu/specs/Menu.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Menu/specs/Menu.spec.win.ts
@@ -1,7 +1,7 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import MenuPageObject, { MenuComponentSelector } from '../pages/MenuPageObject';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT, Keys, MENUITEM_A11Y_ROLE, MENU_A11Y_ROLE } from '../../common/consts';
-import { MENUITEM_ACCESSIBILITY_LABEL, MENUITEM_TEST_LABEL } from '../../../TestComponents/Menu';
+import { MENUITEM_ACCESSIBILITY_LABEL, MENUITEM_TEST_LABEL } from '../../../TestComponents/Menu/consts';
 import { Platform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open

--- a/apps/fluent-tester/src/E2E/Menu/specs/Menu.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Menu/specs/Menu.spec.win.ts
@@ -35,7 +35,6 @@ describe('Menu Functional Testing', () => {
   it('Validate OnOpenChange() callback was fired -> Click', async () => {
     await MenuPageObject.clickComponent();
     await expect(await MenuPageObject.didMenuOpen()).toBeTruthy();
-    await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
 
     await MenuPageObject.clickComponent();
     await expect(await MenuPageObject.didMenuClose()).toBeTruthy();
@@ -45,7 +44,6 @@ describe('Menu Functional Testing', () => {
   it('Validate OnOpenChange() callback was fired -> Type "Enter"', async () => {
     await MenuPageObject.sendKey(MenuComponentSelector.PrimaryComponent, Keys.Enter);
     await expect(await MenuPageObject.didMenuOpen()).toBeTruthy();
-    await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
 
     await MenuPageObject.sendKey(MenuComponentSelector.PrimaryComponent, Keys.Enter);
     await expect(await MenuPageObject.didMenuClose()).toBeTruthy();
@@ -55,7 +53,6 @@ describe('Menu Functional Testing', () => {
   it('Validate OnOpenChange() callback was fired -> Type "Spacebar"', async () => {
     await MenuPageObject.sendKey(MenuComponentSelector.PrimaryComponent, Keys.Spacebar);
     await expect(await MenuPageObject.didMenuOpen()).toBeTruthy();
-    await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
 
     await MenuPageObject.sendKey(MenuComponentSelector.PrimaryComponent, Keys.Spacebar);
     await expect(await MenuPageObject.didMenuClose()).toBeTruthy();
@@ -64,13 +61,14 @@ describe('Menu Functional Testing', () => {
 });
 
 describe('Menu Accessibility Testing', () => {
-  it('Menu - Validate accessibilityRole of menu item is correct', async () => {
+  beforeEach(async () => {
     await MenuPageObject.scrollToTestElement();
     await MenuPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
+  });
 
+  it('Menu - Validate accessibilityRole of menu item is correct', async () => {
     await MenuPageObject.sendKey(MenuComponentSelector.PrimaryComponent, Keys.Enter);
     await expect(await MenuPageObject.didMenuOpen()).toBeTruthy();
-    await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
 
     await expect(await MenuPageObject.getMenuItemAccessibilityRole()).toEqual(MENUITEM_A11Y_ROLE);
     await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
@@ -79,12 +77,8 @@ describe('Menu Accessibility Testing', () => {
   });
 
   it('Menu - Validate accessibilityRole of menu is correct', async () => {
-    await MenuPageObject.scrollToTestElement();
-    await MenuPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
-
     await MenuPageObject.sendKey(MenuComponentSelector.PrimaryComponent, Keys.Enter);
     await expect(await MenuPageObject.didMenuOpen()).toBeTruthy();
-    await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
 
     await expect(await MenuPageObject.getMenuAccessibilityRole()).toEqual(MENU_A11Y_ROLE);
     await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
@@ -93,12 +87,8 @@ describe('Menu Accessibility Testing', () => {
   });
 
   it('Menu - Set accessibilityLabel', async () => {
-    await MenuPageObject.scrollToTestElement();
-    await MenuPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
-
     await MenuPageObject.sendKey(MenuComponentSelector.PrimaryComponent, Keys.Enter);
     await expect(await MenuPageObject.didMenuOpen()).toBeTruthy();
-    await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
 
     await expect(await MenuPageObject.getMenuItemAccessibilityLabel(MenuComponentSelector.SecondaryComponent)).toEqual(
       MENUITEM_ACCESSIBILITY_LABEL,
@@ -109,12 +99,8 @@ describe('Menu Accessibility Testing', () => {
   });
 
   it('Menu - Do not set accessibilityLabel -> Default to MenuItem label', async () => {
-    await MenuPageObject.scrollToTestElement();
-    await MenuPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
-
     await MenuPageObject.sendKey(MenuComponentSelector.PrimaryComponent, Keys.Enter);
     await expect(await MenuPageObject.didMenuOpen()).toBeTruthy();
-    await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
 
     await expect(await MenuPageObject.getMenuItemAccessibilityLabel(MenuComponentSelector.TertiaryComponent)).toEqual(MENUITEM_TEST_LABEL);
     await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);

--- a/apps/fluent-tester/src/E2E/MenuButton/pages/MenuButtonPageObject.win.ts
+++ b/apps/fluent-tester/src/E2E/MenuButton/pages/MenuButtonPageObject.win.ts
@@ -18,7 +18,7 @@ class MenuButtonPageObject extends BasePage {
   /******************************************************************/
   async waitForMenuItemsToOpen(timeout?: number): Promise<void> {
     await browser.waitUntil(async () => await this.menuItemDisplayed(), {
-      timeout: timeout ?? this.waitForPageTimeout,
+      timeout: timeout ?? this.waitForUIEvent,
       timeoutMsg: 'The Menu Items did not open.',
       interval: 1000,
     });

--- a/apps/fluent-tester/src/E2E/MenuButton/pages/MenuButtonPageObject.win.ts
+++ b/apps/fluent-tester/src/E2E/MenuButton/pages/MenuButtonPageObject.win.ts
@@ -5,7 +5,7 @@ import {
   MENU_BUTTON_NO_A11Y_LABEL_COMPONENT,
   MENU_ITEM_1_COMPONENT,
 } from '../../../TestComponents/MenuButton/consts';
-import { BasePage, By } from '../../common/BasePage';
+import { BasePage, GetElement } from '../../common/BasePage';
 
 export const enum MenuButtonSelector {
   MenuButton = 0, // this._primarySelector
@@ -26,7 +26,7 @@ class MenuButtonPageObject extends BasePage {
 
   /* Whether the menu item is displayed or not. It should be displayed after clicking on the MenuButton */
   async menuItemDisplayed(): Promise<boolean> {
-    return await this._menuItem.isDisplayed();
+    return await (await this._menuItem).isDisplayed();
   }
 
   /* Sends a Keyboarding command on a specific UI element */
@@ -48,7 +48,7 @@ class MenuButtonPageObject extends BasePage {
   /**************** Getters ****************/
   /*****************************************/
   get _testPage() {
-    return By(MENU_BUTTON_TESTPAGE);
+    return GetElement(MENU_BUTTON_TESTPAGE);
   }
 
   get _pageName() {
@@ -56,19 +56,19 @@ class MenuButtonPageObject extends BasePage {
   }
 
   get _primaryComponent() {
-    return By(MENU_BUTTON_TEST_COMPONENT);
+    return GetElement(MENU_BUTTON_TEST_COMPONENT);
   }
 
   get _secondaryComponent() {
-    return By(MENU_BUTTON_NO_A11Y_LABEL_COMPONENT);
+    return GetElement(MENU_BUTTON_NO_A11Y_LABEL_COMPONENT);
   }
 
   get _pageButton() {
-    return By(HOMEPAGE_MENUBUTTON_BUTTON);
+    return GetElement(HOMEPAGE_MENUBUTTON_BUTTON);
   }
 
   get _menuItem() {
-    return By(MENU_ITEM_1_COMPONENT);
+    return GetElement(MENU_ITEM_1_COMPONENT);
   }
 }
 

--- a/apps/fluent-tester/src/E2E/MenuButton/specs/MenuButton.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/MenuButton/specs/MenuButton.spec.win.ts
@@ -55,7 +55,7 @@ describe('MenuButton Functional Testing', () => {
     await MenuButtonPageObject.scrollToTestElement();
     await MenuButtonPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
 
-    await MenuButtonPageObject.sendKey(MenuButtonSelector.MenuButton, Keys.Escape); // Reset MenuButton state for next test
+    await MenuButtonPageObject.sendKey(MenuButtonSelector.MenuButton, Keys.ESCAPE); // Reset MenuButton state for next test
   });
 
   it('Click on MenuButton and validate that the list of Menu Items open', async () => {
@@ -67,9 +67,9 @@ describe('MenuButton Functional Testing', () => {
     await expect(await MenuButtonPageObject.didAssertPopup()).toBeFalsy(MenuButtonPageObject.ERRORMESSAGE_ASSERT);
   });
 
-  it('Type "SpaceBar" to select the MenuButton and validate that the list of Menu Items open', async () => {
+  it('Type "SPACE" to select the MenuButton and validate that the list of Menu Items open', async () => {
     /* Type a space on the MenuButton */
-    await MenuButtonPageObject.sendKey(MenuButtonSelector.MenuButton, Keys.Spacebar);
+    await MenuButtonPageObject.sendKey(MenuButtonSelector.MenuButton, Keys.SPACE);
     await MenuButtonPageObject.waitForMenuItemsToOpen(PAGE_TIMEOUT);
 
     await expect(await MenuButtonPageObject.menuItemDisplayed()).toBeTruthy();
@@ -78,6 +78,6 @@ describe('MenuButton Functional Testing', () => {
 
   /* Runs after all tests. This ensures the MenuButton closes. If it stays open, the test driver won't be able to close the test app */
   afterAll(async () => {
-    await MenuButtonPageObject.sendKey(MenuButtonSelector.MenuButton, Keys.Escape);
+    await MenuButtonPageObject.sendKey(MenuButtonSelector.MenuButton, Keys.ESCAPE);
   });
 });

--- a/apps/fluent-tester/src/E2E/MenuButtonExperimental/pages/ExperimentalMenuButtonPageObject.win.ts
+++ b/apps/fluent-tester/src/E2E/MenuButtonExperimental/pages/ExperimentalMenuButtonPageObject.win.ts
@@ -4,14 +4,14 @@ import {
   HOMEPAGE_EXPERIMENTAL_MENU_BUTTON,
   EXPERIMENTAL_MENU_BUTTON_NO_A11Y_LABEL_COMPONENT,
 } from '../../../TestComponents/MenuButtonExperimental/consts';
-import { BasePage, By } from '../../common/BasePage';
+import { BasePage, GetElement } from '../../common/BasePage';
 
 class ExperimentalMenuButtonPageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
   get _testPage() {
-    return By(MENU_BUTTON_EXPERIMENTAL_TESTPAGE);
+    return GetElement(MENU_BUTTON_EXPERIMENTAL_TESTPAGE);
   }
 
   get _pageName() {
@@ -19,15 +19,15 @@ class ExperimentalMenuButtonPageObject extends BasePage {
   }
 
   get _primaryComponent() {
-    return By(EXPERIMENTAL_MENU_BUTTON_TEST_COMPONENT);
+    return GetElement(EXPERIMENTAL_MENU_BUTTON_TEST_COMPONENT);
   }
 
   get _secondaryComponent() {
-    return By(EXPERIMENTAL_MENU_BUTTON_NO_A11Y_LABEL_COMPONENT);
+    return GetElement(EXPERIMENTAL_MENU_BUTTON_NO_A11Y_LABEL_COMPONENT);
   }
 
   get _pageButton() {
-    return By(HOMEPAGE_EXPERIMENTAL_MENU_BUTTON);
+    return GetElement(HOMEPAGE_EXPERIMENTAL_MENU_BUTTON);
   }
 }
 

--- a/apps/fluent-tester/src/E2E/Persona/pages/PersonaPageObject.ts
+++ b/apps/fluent-tester/src/E2E/Persona/pages/PersonaPageObject.ts
@@ -1,12 +1,12 @@
 import { PERSONA_TESTPAGE, PERSONA_TEST_COMPONENT, HOMEPAGE_PERSONA_BUTTON } from '../../../TestComponents/Persona/consts';
-import { BasePage, By } from '../../common/BasePage';
+import { BasePage, GetElement } from '../../common/BasePage';
 
 class PersonaPageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
   get _testPage() {
-    return By(PERSONA_TESTPAGE);
+    return GetElement(PERSONA_TESTPAGE);
   }
 
   get _pageName() {
@@ -14,11 +14,11 @@ class PersonaPageObject extends BasePage {
   }
 
   get _primaryComponent() {
-    return By(PERSONA_TEST_COMPONENT);
+    return GetElement(PERSONA_TEST_COMPONENT);
   }
 
   get _pageButton() {
-    return By(HOMEPAGE_PERSONA_BUTTON);
+    return GetElement(HOMEPAGE_PERSONA_BUTTON);
   }
 }
 

--- a/apps/fluent-tester/src/E2E/PersonaCoin/pages/PersonaCoinPageObject.ts
+++ b/apps/fluent-tester/src/E2E/PersonaCoin/pages/PersonaCoinPageObject.ts
@@ -1,12 +1,12 @@
 import { PERSONACOIN_TESTPAGE, PERSONACOIN_TEST_COMPONENT, HOMEPAGE_PERSONACOIN_BUTTON } from '../../../TestComponents/PersonaCoin/consts';
-import { BasePage, By } from '../../common/BasePage';
+import { BasePage, GetElement } from '../../common/BasePage';
 
 class PersonaCoinPageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
   get _testPage() {
-    return By(PERSONACOIN_TESTPAGE);
+    return GetElement(PERSONACOIN_TESTPAGE);
   }
 
   get _pageName() {
@@ -14,11 +14,11 @@ class PersonaCoinPageObject extends BasePage {
   }
 
   get _primaryComponent() {
-    return By(PERSONACOIN_TEST_COMPONENT);
+    return GetElement(PERSONACOIN_TEST_COMPONENT);
   }
 
   get _pageButton() {
-    return By(HOMEPAGE_PERSONACOIN_BUTTON);
+    return GetElement(HOMEPAGE_PERSONACOIN_BUTTON);
   }
 }
 

--- a/apps/fluent-tester/src/E2E/Pressable/pages/PressablePageObject.ts
+++ b/apps/fluent-tester/src/E2E/Pressable/pages/PressablePageObject.ts
@@ -1,12 +1,12 @@
 import { PRESSABLE_TESTPAGE, PRESSABLE_TEST_COMPONENT, HOMEPAGE_PRESSABLE_BUTTON } from '../../../TestComponents/Pressable/consts';
-import { BasePage, By } from '../../common/BasePage';
+import { BasePage, GetElement } from '../../common/BasePage';
 
 class PressablePageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
   get _testPage() {
-    return By(PRESSABLE_TESTPAGE);
+    return GetElement(PRESSABLE_TESTPAGE);
   }
 
   get _pageName() {
@@ -14,11 +14,11 @@ class PressablePageObject extends BasePage {
   }
 
   get _primaryComponent() {
-    return By(PRESSABLE_TEST_COMPONENT);
+    return GetElement(PRESSABLE_TEST_COMPONENT);
   }
 
   get _pageButton() {
-    return By(HOMEPAGE_PRESSABLE_BUTTON);
+    return GetElement(HOMEPAGE_PRESSABLE_BUTTON);
   }
 }
 

--- a/apps/fluent-tester/src/E2E/README.md
+++ b/apps/fluent-tester/src/E2E/README.md
@@ -39,9 +39,7 @@ and drag & drop the **XCode Helper** app to **Security & Privacy -> Privacy -> A
 2. Bundle the test app (pick specific platform you want to test, we'll use win32)
    - C:\repo\fluentui-react-native>`cd apps\win32`
    - C:\repo\fluentui-react-native\apps\win32> `yarn bundle`
-3. Hook up appium to the WinAppDriver (only needed once)
-   - C:\repo\fluentui-react-native\apps\win32> `yarn appium driver install windows`
-4. Run E2E tests
+3. Run E2E tests
    - C:\repo\fluentui-react-native\apps\win32> `yarn e2etest`
 
 ## UWP Steps
@@ -50,9 +48,7 @@ and drag & drop the **XCode Helper** app to **Security & Privacy -> Privacy -> A
 2. Start the server
    - C:\repo\fluentui-react-native> `cd apps\windows`
    - C:\repo\fluentui-react-native\apps\windows> `yarn start`
-3. Hook up appium to the WinAppDriver (only needed once)
-   - C:\repo\fluentui-react-native\apps\win32> `yarn appium driver install windows`
-4. Open a new command prompt and run the E2E tests
+3. Open a new command prompt and run the E2E tests
    - C:\repo\fluentui-react-native\apps\windows> `yarn e2etest`
 
 _Note: It could take up to a minute to load the test app with WebDriverIO, don't panic, the tests will run :)_
@@ -63,12 +59,10 @@ _Note: It could take up to a minute to load the test app with WebDriverIO, don't
 2. POD Install
    - C:\repo\fluentui-react-native> `cd apps\fluent-tester\macos`
    - C:\repo\fluentui-react-native\apps\fluent-tester\macos> `pod install`
-3. Install Appium's MacOS Driver (only needed once)
-   - C:\repo\fluentui-react-native\apps\fluent-tester\E2E> `yarn appium driver install mac2`
-4. Start the server
+3. Start the server
    - C:\repo\fluentui-react-native> `cd apps\fluent-tester`
    - C:\repo\fluentui-react-native\apps\fluent-tester> `yarn start`
-5. Open a new command prompt and run the E2E tests
+4. Open a new command prompt and run the E2E tests
    - C:\repo\fluentui-react-native\apps\fluent-tester> `yarn e2etest:macos`
 
 _Note: It could take up to a minute to load the test app with WebDriverIO, don't panic, the tests will run :)_

--- a/apps/fluent-tester/src/E2E/RadioGroup/pages/RadioGroupPageObject.ts
+++ b/apps/fluent-tester/src/E2E/RadioGroup/pages/RadioGroupPageObject.ts
@@ -49,7 +49,7 @@ class RadioGroupPage extends BasePage {
 
   async waitForRadioButtonSelected(radioButtonSelector: RadioButtonSelector, timeout?: number): Promise<void> {
     await browser.waitUntil(async () => await this.isRadioButtonSelected(radioButtonSelector), {
-      timeout: timeout ?? this.waitForPageTimeout,
+      timeout: timeout ?? this.waitForUIEvent,
       timeoutMsg: 'RadioButton was not selected correctly.',
       interval: 1000,
     });

--- a/apps/fluent-tester/src/E2E/RadioGroup/pages/RadioGroupPageObject.ts
+++ b/apps/fluent-tester/src/E2E/RadioGroup/pages/RadioGroupPageObject.ts
@@ -8,7 +8,7 @@ import {
   THIRD_RADIO_BUTTON,
   FOURTH_RADIO_BUTTON,
 } from '../../../TestComponents/RadioGroup/consts';
-import { BasePage, By } from '../../common/BasePage';
+import { BasePage, GetElement } from '../../common/BasePage';
 
 /* This enum gives the spec file an EASY way to interact with SPECIFIC UI elements on the page.
  * The main RadioGroup we are testing has FOUR RadioButtons. The spec file will
@@ -32,11 +32,11 @@ class RadioGroupPage extends BasePage {
   /* This resets the RadioGroup selection by clicking/selecting the 1st RadioButton in the RadioGroup.
    * Useful in beforeEach() hooks to reset the RadioGroup before additional tests */
   async resetRadioGroupSelection(): Promise<void> {
-    await this._firstRadioButton.click();
+    await (await this._firstRadioButton).click();
   }
 
   async getRadioButtonAccesibilityRole(): Promise<string> {
-    return await this._firstRadioButton.getAttribute('ControlType');
+    return await (await this._firstRadioButton).getAttribute('ControlType');
   }
 
   async isRadioButtonSelected(radioButtonSelector: RadioButtonSelector): Promise<boolean> {
@@ -77,7 +77,7 @@ class RadioGroupPage extends BasePage {
   /**************** Getters ****************/
   /*****************************************/
   get _testPage() {
-    return By(RADIOGROUP_TESTPAGE);
+    return GetElement(RADIOGROUP_TESTPAGE);
   }
 
   get _pageName() {
@@ -85,15 +85,15 @@ class RadioGroupPage extends BasePage {
   }
 
   get _primaryComponent() {
-    return By(RADIOGROUP_TEST_COMPONENT);
+    return GetElement(RADIOGROUP_TEST_COMPONENT);
   }
 
   get _secondaryComponent() {
-    return By(RADIOGROUP_NO_A11Y_LABEL_COMPONENT);
+    return GetElement(RADIOGROUP_NO_A11Y_LABEL_COMPONENT);
   }
 
   get _pageButton() {
-    return By(HOMEPAGE_RADIOGROUP_BUTTON);
+    return GetElement(HOMEPAGE_RADIOGROUP_BUTTON);
   }
 
   /***************/
@@ -102,19 +102,19 @@ class RadioGroupPage extends BasePage {
 
   /* The first RadioGroup has 4 radio buttons, all listed below */
   get _firstRadioButton() {
-    return By(FIRST_RADIO_BUTTON);
+    return GetElement(FIRST_RADIO_BUTTON);
   }
 
   get _secondRadioButton() {
-    return By(SECOND_RADIO_BUTTON);
+    return GetElement(SECOND_RADIO_BUTTON);
   }
 
   get _thirdRadioButton() {
-    return By(THIRD_RADIO_BUTTON);
+    return GetElement(THIRD_RADIO_BUTTON);
   }
 
   get _fourthRadioButton() {
-    return By(FOURTH_RADIO_BUTTON);
+    return GetElement(FOURTH_RADIO_BUTTON);
   }
 }
 

--- a/apps/fluent-tester/src/E2E/RadioGroup/specs/RadioGroup.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/RadioGroup/specs/RadioGroup.spec.win.ts
@@ -94,7 +94,7 @@ describe('RadioGroup Functional Testing', async () => {
 
   it('Keyboard to RadioButton and check for Selection state', async () => {
     // Presses the ArrowDown key while the first (A) RadioButton is selected
-    await RadioGroupPageObject.sendKey(Keys.Down_Arrow, RadioButtonSelector.First);
+    await RadioGroupPageObject.sendKey(Keys.ARROW_DOWN, RadioButtonSelector.First);
     await RadioGroupPageObject.waitForRadioButtonSelected(RadioButtonSelector.Second, 5000);
 
     /* Validate the RadioButton is selected */
@@ -104,7 +104,7 @@ describe('RadioGroup Functional Testing', async () => {
 
   it("Keyboard to DISABLED RadioButton and validate it doesn't get selected", async () => {
     // Presses the ArrowDown key while the second (B) RadioButton is selected
-    await RadioGroupPageObject.sendKey(Keys.Down_Arrow, RadioButtonSelector.Second);
+    await RadioGroupPageObject.sendKey(Keys.ARROW_DOWN, RadioButtonSelector.Second);
     await RadioGroupPageObject.waitForRadioButtonSelected(RadioButtonSelector.Fourth, 5000); // It should skip RadioButton 3 since it is disabled
 
     /* Validate the RadioButton is selected */

--- a/apps/fluent-tester/src/E2E/Separator/pages/SeparatorPageObject.ts
+++ b/apps/fluent-tester/src/E2E/Separator/pages/SeparatorPageObject.ts
@@ -1,12 +1,12 @@
 import { SEPARATOR_TESTPAGE, SEPARATOR_TEST_COMPONENT, HOMEPAGE_SEPARATOR_BUTTON } from '../../../TestComponents/Separator/consts';
-import { BasePage, By } from '../../common/BasePage';
+import { BasePage, GetElement } from '../../common/BasePage';
 
 class SeparatorPageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
   get _testPage() {
-    return By(SEPARATOR_TESTPAGE);
+    return GetElement(SEPARATOR_TESTPAGE);
   }
 
   get _pageName() {
@@ -14,11 +14,11 @@ class SeparatorPageObject extends BasePage {
   }
 
   get _primaryComponent() {
-    return By(SEPARATOR_TEST_COMPONENT);
+    return GetElement(SEPARATOR_TEST_COMPONENT);
   }
 
   get _pageButton() {
-    return By(HOMEPAGE_SEPARATOR_BUTTON);
+    return GetElement(HOMEPAGE_SEPARATOR_BUTTON);
   }
 }
 

--- a/apps/fluent-tester/src/E2E/Shimmer/pages/ShimmerPageObject.win.ts
+++ b/apps/fluent-tester/src/E2E/Shimmer/pages/ShimmerPageObject.win.ts
@@ -1,12 +1,12 @@
 import { HOMEPAGE_SHIMMER_BUTTON, SHIMMER_TESTPAGE, SHIMMER_TEST_COMPONENT } from '../../../TestComponents/Shimmer/consts';
-import { BasePage, By } from '../../common/BasePage';
+import { BasePage, GetElement } from '../../common/BasePage';
 
 class ShimmerPageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
   get _testPage() {
-    return By(SHIMMER_TESTPAGE);
+    return GetElement(SHIMMER_TESTPAGE);
   }
 
   get _pageName() {
@@ -14,11 +14,11 @@ class ShimmerPageObject extends BasePage {
   }
 
   get _primaryComponent() {
-    return By(SHIMMER_TEST_COMPONENT);
+    return GetElement(SHIMMER_TEST_COMPONENT);
   }
 
   get _pageButton() {
-    return By(HOMEPAGE_SHIMMER_BUTTON);
+    return GetElement(HOMEPAGE_SHIMMER_BUTTON);
   }
 }
 

--- a/apps/fluent-tester/src/E2E/Svg/pages/SvgPageObject.ts
+++ b/apps/fluent-tester/src/E2E/Svg/pages/SvgPageObject.ts
@@ -1,12 +1,12 @@
 import { SVG_TESTPAGE, SVG_TEST_COMPONENT, HOMEPAGE_SVG_BUTTON } from '../../../TestComponents/Svg/consts';
-import { BasePage, By } from '../../common/BasePage';
+import { BasePage, GetElement } from '../../common/BasePage';
 
 class SvgPageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
   get _testPage() {
-    return By(SVG_TESTPAGE);
+    return GetElement(SVG_TESTPAGE);
   }
 
   get _pageName() {
@@ -14,11 +14,11 @@ class SvgPageObject extends BasePage {
   }
 
   get _primaryComponent() {
-    return By(SVG_TEST_COMPONENT);
+    return GetElement(SVG_TEST_COMPONENT);
   }
 
   get _pageButton() {
-    return By(HOMEPAGE_SVG_BUTTON);
+    return GetElement(HOMEPAGE_SVG_BUTTON);
   }
 }
 

--- a/apps/fluent-tester/src/E2E/Switch/pages/SwitchPageObject.ts
+++ b/apps/fluent-tester/src/E2E/Switch/pages/SwitchPageObject.ts
@@ -24,7 +24,7 @@ class SwitchPageObject extends BasePage {
 
   async waitForSwitchChecked(timeout?: number): Promise<void> {
     await browser.waitUntil(async () => await this.isSwitchChecked(), {
-      timeout: timeout ?? this.waitForPageTimeout,
+      timeout: timeout ?? this.waitForUIEvent,
       timeoutMsg: 'The Switch was not toggled correctly',
       interval: 1000,
     });
@@ -39,7 +39,7 @@ class SwitchPageObject extends BasePage {
   async didOnChangeCallbackFire(): Promise<boolean> {
     const callbackText = await By(SWITCH_ON_PRESS);
     await browser.waitUntil(async () => await callbackText.isDisplayed(), {
-      timeout: this.waitForPageTimeout,
+      timeout: this.waitForUIEvent,
       timeoutMsg: 'The OnChange callback did not fire.',
       interval: 1000,
     });

--- a/apps/fluent-tester/src/E2E/Switch/pages/SwitchPageObject.ts
+++ b/apps/fluent-tester/src/E2E/Switch/pages/SwitchPageObject.ts
@@ -23,7 +23,7 @@ class SwitchPageObject extends BasePage {
   }
 
   async waitForSwitchChecked(timeout?: number): Promise<void> {
-    browser.waitUntil(async () => await this.isSwitchChecked(), {
+    await browser.waitUntil(async () => await this.isSwitchChecked(), {
       timeout: timeout ?? this.waitForPageTimeout,
       timeoutMsg: 'The Switch was not toggled correctly',
       interval: 1000,
@@ -38,7 +38,7 @@ class SwitchPageObject extends BasePage {
 
   async didOnChangeCallbackFire(): Promise<boolean> {
     const callbackText = await By(SWITCH_ON_PRESS);
-    browser.waitUntil(async () => await callbackText.isDisplayed(), {
+    await browser.waitUntil(async () => await callbackText.isDisplayed(), {
       timeout: this.waitForPageTimeout,
       timeoutMsg: 'The OnChange callback did not fire.',
       interval: 1000,

--- a/apps/fluent-tester/src/E2E/Switch/pages/SwitchPageObject.ts
+++ b/apps/fluent-tester/src/E2E/Switch/pages/SwitchPageObject.ts
@@ -5,7 +5,7 @@ import {
   HOMEPAGE_SWITCH_BUTTON,
   SWITCH_ON_PRESS,
 } from '../../../TestComponents/Switch/consts';
-import { BasePage, By } from '../../common/BasePage';
+import { BasePage, GetElement } from '../../common/BasePage';
 
 /* This enum gives the spec file an EASY way to interact with SPECIFIC UI elements on the page.
  * The spec file should import this enum and use it when wanting to interact with different elements on the page. */
@@ -19,7 +19,7 @@ class SwitchPageObject extends BasePage {
   /**************** UI Element Interaction Methods ******************/
   /******************************************************************/
   async isSwitchChecked(): Promise<boolean> {
-    return await this._primaryComponent.isSelected();
+    return await (await this._primaryComponent).isSelected();
   }
 
   async waitForSwitchChecked(timeout?: number): Promise<void> {
@@ -32,12 +32,12 @@ class SwitchPageObject extends BasePage {
 
   async toggleSwitchToUnchecked(): Promise<void> {
     if (await this.isSwitchChecked()) {
-      await this._primaryComponent.click();
+      await (await this._primaryComponent).click();
     }
   }
 
   async didOnChangeCallbackFire(): Promise<boolean> {
-    const callbackText = await By(SWITCH_ON_PRESS);
+    const callbackText = await GetElement(SWITCH_ON_PRESS);
     await browser.waitUntil(async () => await callbackText.isDisplayed(), {
       timeout: this.waitForUIEvent,
       timeoutMsg: 'The OnChange callback did not fire.',
@@ -66,7 +66,7 @@ class SwitchPageObject extends BasePage {
   /**************** Getters ****************/
   /*****************************************/
   get _testPage() {
-    return By(SWITCH_TESTPAGE);
+    return GetElement(SWITCH_TESTPAGE);
   }
 
   get _pageName() {
@@ -74,15 +74,15 @@ class SwitchPageObject extends BasePage {
   }
 
   get _primaryComponent() {
-    return By(SWITCH_TEST_COMPONENT);
+    return GetElement(SWITCH_TEST_COMPONENT);
   }
 
   get _secondaryComponent() {
-    return By(SWITCH_NO_A11Y_LABEL_COMPONENT);
+    return GetElement(SWITCH_NO_A11Y_LABEL_COMPONENT);
   }
 
   get _pageButton() {
-    return By(HOMEPAGE_SWITCH_BUTTON);
+    return GetElement(HOMEPAGE_SWITCH_BUTTON);
   }
 }
 

--- a/apps/fluent-tester/src/E2E/Switch/specs/Switch.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Switch/specs/Switch.spec.win.ts
@@ -81,7 +81,7 @@ describe('Switch Functional Testing', () => {
     await expect(await SwitchPageObject.isSwitchChecked()).toBeFalsy();
 
     /* Presses the "Enter" to select the Switch */
-    await SwitchPageObject.sendKey(SwitchComponentSelector.PrimaryComponent, Keys.Enter);
+    await SwitchPageObject.sendKey(SwitchComponentSelector.PrimaryComponent, Keys.ENTER);
     await SwitchPageObject.waitForSwitchChecked(PAGE_TIMEOUT);
 
     await expect(await SwitchPageObject.didOnChangeCallbackFire()).toBeTruthy();
@@ -90,19 +90,19 @@ describe('Switch Functional Testing', () => {
     await expect(await SwitchPageObject.isSwitchChecked()).toBeTruthy();
     await expect(await SwitchPageObject.didAssertPopup()).toBeFalsy(SwitchPageObject.ERRORMESSAGE_ASSERT);
 
-    await SwitchPageObject.sendKey(SwitchComponentSelector.PrimaryComponent, Keys.Enter);
+    await SwitchPageObject.sendKey(SwitchComponentSelector.PrimaryComponent, Keys.ENTER);
 
     /* Validate the Switch is toggled OFF */
     await expect(await SwitchPageObject.isSwitchChecked()).toBeFalsy();
     await expect(await SwitchPageObject.didAssertPopup()).toBeFalsy(SwitchPageObject.ERRORMESSAGE_ASSERT);
   });
 
-  it("Click the 'Spacebar' on a Switch and verify it toggles correctly AND calls the user's onChange", async () => {
+  it("Click the 'SPACE' on a Switch and verify it toggles correctly AND calls the user's onChange", async () => {
     /* Validate the Switch is initially toggled OFF */
     await expect(await SwitchPageObject.isSwitchChecked()).toBeFalsy();
 
     /* Presses the "space bar" to select the Switch */
-    await SwitchPageObject.sendKey(SwitchComponentSelector.PrimaryComponent, Keys.Spacebar);
+    await SwitchPageObject.sendKey(SwitchComponentSelector.PrimaryComponent, Keys.SPACE);
     await SwitchPageObject.waitForSwitchChecked(PAGE_TIMEOUT);
 
     await expect(await SwitchPageObject.didOnChangeCallbackFire()).toBeTruthy();
@@ -111,7 +111,7 @@ describe('Switch Functional Testing', () => {
     await expect(await SwitchPageObject.isSwitchChecked()).toBeTruthy();
     await expect(await SwitchPageObject.didAssertPopup()).toBeFalsy(SwitchPageObject.ERRORMESSAGE_ASSERT);
 
-    await SwitchPageObject.sendKey(SwitchComponentSelector.PrimaryComponent, Keys.Spacebar);
+    await SwitchPageObject.sendKey(SwitchComponentSelector.PrimaryComponent, Keys.SPACE);
 
     /* Validate the Switch is toggled OFF */
     await expect(await SwitchPageObject.isSwitchChecked()).toBeFalsy();

--- a/apps/fluent-tester/src/E2E/Tabs/pages/TabsPageObject.ts
+++ b/apps/fluent-tester/src/E2E/Tabs/pages/TabsPageObject.ts
@@ -9,7 +9,7 @@ import {
   SECOND_TABS_ITEM_CONTENT,
   THIRD_TABS_ITEM_CONTENT,
 } from '../../../TestComponents/Tabs/consts';
-import { BasePage, By } from '../../common/BasePage';
+import { BasePage, GetElement } from '../../common/BasePage';
 
 /* This enum gives the spec file an EASY way to interact with SPECIFIC UI elements on the page.
  * The spec file should import this enum and use it when wanting to interact with different elements on the page.
@@ -76,7 +76,7 @@ class TabsPageObject extends BasePage {
   /**************** Getters ****************/
   /*****************************************/
   get _testPage() {
-    return By(TABS_TESTPAGE);
+    return GetElement(TABS_TESTPAGE);
   }
 
   get _pageName() {
@@ -84,37 +84,37 @@ class TabsPageObject extends BasePage {
   }
 
   get _primaryComponent() {
-    return By(TABS_TEST_COMPONENT);
+    return GetElement(TABS_TEST_COMPONENT);
   }
 
   get _pageButton() {
-    return By(HOMEPAGE_TABS_BUTTON);
+    return GetElement(HOMEPAGE_TABS_BUTTON);
   }
 
   /* The first tab group has 3 Tab item headers, all listed below */
   get _firstTabItem() {
-    return By(FIRST_TABS_ITEM);
+    return GetElement(FIRST_TABS_ITEM);
   }
 
   get _secondTabItem() {
-    return By(SECOND_TABS_ITEM);
+    return GetElement(SECOND_TABS_ITEM);
   }
 
   get _thirdTabItem() {
-    return By(THIRD_TABS_ITEM);
+    return GetElement(THIRD_TABS_ITEM);
   }
 
   /* Content shown when tab item is clicked */
   get _firstTabItemContent() {
-    return By(FIRST_TABS_ITEM_CONTENT);
+    return GetElement(FIRST_TABS_ITEM_CONTENT);
   }
 
   get _secondTabItemContent() {
-    return By(SECOND_TABS_ITEM_CONTENT);
+    return GetElement(SECOND_TABS_ITEM_CONTENT);
   }
 
   get _thirdTabItemContent() {
-    return By(THIRD_TABS_ITEM_CONTENT);
+    return GetElement(THIRD_TABS_ITEM_CONTENT);
   }
 }
 

--- a/apps/fluent-tester/src/E2E/Tabs/pages/TabsPageObject.ts
+++ b/apps/fluent-tester/src/E2E/Tabs/pages/TabsPageObject.ts
@@ -27,7 +27,7 @@ class TabsPageObject extends BasePage {
   /******************************************************************/
   async waitForTabsItemsToOpen(tabItemSelector: TabItemSelector, timeout?: number): Promise<void> {
     await browser.waitUntil(async () => await this.didTabItemContentLoad(tabItemSelector), {
-      timeout: timeout ?? this.waitForPageTimeout,
+      timeout: timeout ?? this.waitForUIEvent,
       timeoutMsg: 'The Tab Items content did not open.',
       interval: 1000,
     });

--- a/apps/fluent-tester/src/E2E/Tabs/specs/Tabs.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Tabs/specs/Tabs.spec.win.ts
@@ -62,25 +62,25 @@ describe('Tabs Functional Tests', () => {
 
   it('Keyboarding: Arrow Navigation: Right -> Down -> Left -> Up -> Validate the correct TabItem content is shown', async () => {
     /* At First tab element, press Right Arrow to navigate to the Second tab element */
-    await TabsPageObject.sendKey(Keys.Right_Arrow, TabItemSelector.First);
+    await TabsPageObject.sendKey(Keys.ARROW_RIGHT, TabItemSelector.First);
     await TabsPageObject.waitForTabsItemsToOpen(TabItemSelector.Second, PAGE_TIMEOUT);
 
     await expect(await TabsPageObject.didTabItemContentLoad(TabItemSelector.Second)).toBeTruthy();
 
     /* At Second tab element, press Down Arrow to navigate to the Third tab element */
-    await TabsPageObject.sendKey(Keys.Down_Arrow, TabItemSelector.Second);
+    await TabsPageObject.sendKey(Keys.ARROW_DOWN, TabItemSelector.Second);
     await TabsPageObject.waitForTabsItemsToOpen(TabItemSelector.Third, PAGE_TIMEOUT);
 
     await expect(await TabsPageObject.didTabItemContentLoad(TabItemSelector.Third)).toBeTruthy();
 
     /* At Third tab element, press Left Arrow to navigate to the Second tab element */
-    await TabsPageObject.sendKey(Keys.Left_Arrow, TabItemSelector.Third);
+    await TabsPageObject.sendKey(Keys.ARROW_LEFT, TabItemSelector.Third);
     await TabsPageObject.waitForTabsItemsToOpen(TabItemSelector.Second, PAGE_TIMEOUT);
 
     await expect(await TabsPageObject.didTabItemContentLoad(TabItemSelector.Second)).toBeTruthy();
 
     /* At Second tab element, press Up Arrow to navigate to the First tab element */
-    await TabsPageObject.sendKey(Keys.Up_Arrow, TabItemSelector.Second);
+    await TabsPageObject.sendKey(Keys.ARROW_UP, TabItemSelector.Second);
     await TabsPageObject.waitForTabsItemsToOpen(TabItemSelector.First, PAGE_TIMEOUT);
 
     await expect(await TabsPageObject.didTabItemContentLoad(TabItemSelector.First)).toBeTruthy();

--- a/apps/fluent-tester/src/E2E/Tabs/specs/Tabs.spec.windows.ts
+++ b/apps/fluent-tester/src/E2E/Tabs/specs/Tabs.spec.windows.ts
@@ -59,25 +59,25 @@ describe('Tabs Functional Tests', () => {
   // Keyboarding is currently not integrated for UWP tabs - Task #5758598
   // it('Keyboarding: Arrow Navigation: Right -> Down -> Left -> Up -> Validate the correct TabItem content is shown', () => {
   //   /* At First tab element, press Right Arrow to navigate to the Second tab element */
-  //   TabsPageObject.sendKey(Keys.Right_Arrow, TabItemSelector.First);
+  //   TabsPageObject.sendKey(Keys.ARROW_RIGHT, TabItemSelector.First);
   //   TabsPageObject.waitForTabsItemsToOpen(TabItemSelector.Second, PAGE_TIMEOUT);
 
   //   expect(TabsPageObject.didTabItemContentLoad(TabItemSelector.Second)).toBeTruthy();
 
   //   /* At Second tab element, press Down Arrow to navigate to the Third tab element */
-  //   TabsPageObject.sendKey(Keys.Down_Arrow, TabItemSelector.Second);
+  //   TabsPageObject.sendKey(Keys.ARROW_DOWN, TabItemSelector.Second);
   //   TabsPageObject.waitForTabsItemsToOpen(TabItemSelector.Third, PAGE_TIMEOUT);
 
   //   expect(TabsPageObject.didTabItemContentLoad(TabItemSelector.Third)).toBeTruthy();
 
   //   /* At Third tab element, press Left Arrow to navigate to the Second tab element */
-  //   TabsPageObject.sendKey(Keys.Left_Arrow, TabItemSelector.Third);
+  //   TabsPageObject.sendKey(Keys.ARROW_LEFT, TabItemSelector.Third);
   //   TabsPageObject.waitForTabsItemsToOpen(TabItemSelector.Second, PAGE_TIMEOUT);
 
   //   expect(TabsPageObject.didTabItemContentLoad(TabItemSelector.Second)).toBeTruthy();
 
   //   /* At Second tab element, press Up Arrow to navigate to the First tab element */
-  //   TabsPageObject.sendKey(Keys.Up_Arrow, TabItemSelector.Second);
+  //   TabsPageObject.sendKey(Keys.ARROW_UP, TabItemSelector.Second);
   //   TabsPageObject.waitForTabsItemsToOpen(TabItemSelector.First, PAGE_TIMEOUT);
 
   //   expect(TabsPageObject.didTabItemContentLoad(TabItemSelector.First)).toBeTruthy();

--- a/apps/fluent-tester/src/E2E/TabsExperimental/pages/ExperimentalTabsPageObject.ts
+++ b/apps/fluent-tester/src/E2E/TabsExperimental/pages/ExperimentalTabsPageObject.ts
@@ -4,21 +4,21 @@ import {
   EXPERIMENTAL_TABS_TEST_COMPONENT,
   HOMEPAGE_EXPERIMENTAL_TABS_BUTTON,
 } from '../../../TestComponents/TabsExperimental/consts';
-import { BasePage, By } from '../../common/BasePage';
+import { BasePage, GetElement } from '../../common/BasePage';
 
 class ExperimentalTabsPageObject extends BasePage {
   /******************************************************************/
   /**************** UI Element Interaction Methods ******************/
   /******************************************************************/
   async getTabItemAccesibilityRole(): Promise<string> {
-    return await this._tabItem.getAttribute('ControlType');
+    return await (await this._tabItem).getAttribute('ControlType');
   }
 
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
   get _testPage() {
-    return By(EXPERIMENTAL_TABS_TESTPAGE);
+    return GetElement(EXPERIMENTAL_TABS_TESTPAGE);
   }
 
   get _pageName() {
@@ -26,18 +26,18 @@ class ExperimentalTabsPageObject extends BasePage {
   }
 
   get _primaryComponent() {
-    return By(EXPERIMENTAL_TABS_TEST_COMPONENT);
+    return GetElement(EXPERIMENTAL_TABS_TEST_COMPONENT);
   }
 
   get _pageButton() {
-    return By(HOMEPAGE_EXPERIMENTAL_TABS_BUTTON);
+    return GetElement(HOMEPAGE_EXPERIMENTAL_TABS_BUTTON);
   }
 
   /***********/
   /* TabItem *
   /***********/
   get _tabItem() {
-    return By(EXPERIMENTAL_TABS_ITEM_TEST_COMPONENT);
+    return GetElement(EXPERIMENTAL_TABS_ITEM_TEST_COMPONENT);
   }
 }
 

--- a/apps/fluent-tester/src/E2E/Text/pages/TextPageObject.ts
+++ b/apps/fluent-tester/src/E2E/Text/pages/TextPageObject.ts
@@ -1,12 +1,12 @@
 import { TEXT_TESTPAGE, FIRST_TEXT_COMPONENT, HOMEPAGE_TEXT_BUTTON, SECOND_TEXT_COMPONENT } from '../../../TestComponents/Text/consts';
-import { BasePage, By } from '../../common/BasePage';
+import { BasePage, GetElement } from '../../common/BasePage';
 
 class TextPageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
   get _testPage() {
-    return By(TEXT_TESTPAGE);
+    return GetElement(TEXT_TESTPAGE);
   }
 
   get _pageName() {
@@ -14,15 +14,15 @@ class TextPageObject extends BasePage {
   }
 
   get _primaryComponent() {
-    return By(FIRST_TEXT_COMPONENT);
+    return GetElement(FIRST_TEXT_COMPONENT);
   }
 
   get _secondaryComponent() {
-    return By(SECOND_TEXT_COMPONENT);
+    return GetElement(SECOND_TEXT_COMPONENT);
   }
 
   get _pageButton() {
-    return By(HOMEPAGE_TEXT_BUTTON);
+    return GetElement(HOMEPAGE_TEXT_BUTTON);
   }
 }
 

--- a/apps/fluent-tester/src/E2E/TextExperimental/pages/ExperimentalTextPageObject.win.ts
+++ b/apps/fluent-tester/src/E2E/TextExperimental/pages/ExperimentalTextPageObject.win.ts
@@ -3,14 +3,14 @@ import {
   EXPERIMENTAL_TEXT_TEST_COMPONENT,
   HOMEPAGE_EXPERIMENTAL_TEXT_BUTTON,
 } from '../../../TestComponents/TextExperimental/consts';
-import { BasePage, By } from '../../common/BasePage';
+import { BasePage, GetElement } from '../../common/BasePage';
 
 class ExperimentalTextPageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
   get _testPage() {
-    return By(EXPERIMENTAL_TEXT_TESTPAGE);
+    return GetElement(EXPERIMENTAL_TEXT_TESTPAGE);
   }
 
   get _pageName() {
@@ -18,11 +18,11 @@ class ExperimentalTextPageObject extends BasePage {
   }
 
   get _primaryComponent() {
-    return By(EXPERIMENTAL_TEXT_TEST_COMPONENT);
+    return GetElement(EXPERIMENTAL_TEXT_TEST_COMPONENT);
   }
 
   get _pageButton() {
-    return By(HOMEPAGE_EXPERIMENTAL_TEXT_BUTTON);
+    return GetElement(HOMEPAGE_EXPERIMENTAL_TEXT_BUTTON);
   }
 }
 

--- a/apps/fluent-tester/src/E2E/Theme/pages/ThemePageObject.win.ts
+++ b/apps/fluent-tester/src/E2E/Theme/pages/ThemePageObject.win.ts
@@ -1,12 +1,12 @@
 import { THEME_TESTPAGE, THEME_TEST_COMPONENT, HOMEPAGE_THEME_BUTTON } from '../../../TestComponents/Theme/consts';
-import { BasePage, By } from '../../common/BasePage';
+import { BasePage, GetElement } from '../../common/BasePage';
 
 class ThemePageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
   get _testPage() {
-    return By(THEME_TESTPAGE);
+    return GetElement(THEME_TESTPAGE);
   }
 
   get _pageName() {
@@ -14,11 +14,11 @@ class ThemePageObject extends BasePage {
   }
 
   get _primaryComponent() {
-    return By(THEME_TEST_COMPONENT);
+    return GetElement(THEME_TEST_COMPONENT);
   }
 
   get _pageButton() {
-    return By(HOMEPAGE_THEME_BUTTON);
+    return GetElement(HOMEPAGE_THEME_BUTTON);
   }
 }
 

--- a/apps/fluent-tester/src/E2E/Tokens/pages/TokensPageObject.win.ts
+++ b/apps/fluent-tester/src/E2E/Tokens/pages/TokensPageObject.win.ts
@@ -1,12 +1,12 @@
 import { HOMEPAGE_TOKEN_BUTTON, TOKEN_TESTPAGE, TOKENS_TEST_COMPONENT } from '../../../TestComponents/Tokens/consts';
-import { BasePage, By } from '../../common/BasePage';
+import { BasePage, GetElement } from '../../common/BasePage';
 
 class TokenPageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
   get _testPage() {
-    return By(TOKEN_TESTPAGE);
+    return GetElement(TOKEN_TESTPAGE);
   }
 
   get _pageName() {
@@ -14,11 +14,11 @@ class TokenPageObject extends BasePage {
   }
 
   get _primaryComponent() {
-    return By(TOKENS_TEST_COMPONENT);
+    return GetElement(TOKENS_TEST_COMPONENT);
   }
 
   get _pageButton() {
-    return By(HOMEPAGE_TOKEN_BUTTON);
+    return GetElement(HOMEPAGE_TOKEN_BUTTON);
   }
 }
 

--- a/apps/fluent-tester/src/E2E/common/BasePage.ts
+++ b/apps/fluent-tester/src/E2E/common/BasePage.ts
@@ -116,6 +116,7 @@ export class BasePage {
 
   /* Waits for the test page to load. If the test page doesn't load before the timeout, it causes the test to fail. */
   async waitForPageDisplayed(timeout?: number): Promise<void> {
+    await browser.pause(2000);
     await browser.waitUntil(async () => await this.isPageLoaded(), {
       timeout: timeout ?? this.waitForPageTimeout,
       timeoutMsg: this._pageName + ' did not render correctly. Please see /errorShots for more information.',

--- a/apps/fluent-tester/src/E2E/common/BasePage.ts
+++ b/apps/fluent-tester/src/E2E/common/BasePage.ts
@@ -219,7 +219,8 @@ export class BasePage {
     return windowHandles.length > 1;
   }
 
-  async GetFirstScrollViewButtonChild() {
+  static async GetFirstScrollViewButtonChild() {
+    console.log('\nRunning static logic.\n')
     const ScrollViewer = await GetElement('SCROLLVIEW_TEST_ID');
     const TestChildren = await ScrollViewer.$$('//*');
     const reg = new RegExp('Homepage_[a-zA-Z]*_Button');
@@ -288,7 +289,7 @@ export class BasePage {
   }
 
   get _firstTestPageButton() {
-    return this.GetFirstScrollViewButtonChild();
+    return BasePage.GetFirstScrollViewButtonChild();
   }
 
   /****************** Error Messages ******************/

--- a/apps/fluent-tester/src/E2E/common/BasePage.ts
+++ b/apps/fluent-tester/src/E2E/common/BasePage.ts
@@ -219,19 +219,19 @@ export class BasePage {
     return windowHandles.length > 1;
   }
 
-  // async SetFirstScrollViewButtonChild() {
-  //   const TestChildren = await (await this._testPageButtonScrollViewer).$$('//*');
-  //   const reg = new RegExp('Homepage_[a-zA-Z]*_Button');
+  async SetFirstScrollViewButtonChild() {
+    const TestChildren = await (await this._testPageButtonScrollViewer).$$('//*');
+    const reg = new RegExp('Homepage_[a-zA-Z]*_Button');
 
-  //   for (const child of TestChildren) {
-  //     const autoId = await child.getAttribute('AutomationId');
-  //     if (autoId && autoId !== 'SCROLLVIEW_TEST_ID' && autoId.match(reg)) {
-  //       return await child;
-  //     }
-  //   }
+    for (const child of TestChildren) {
+      const autoId = await child.getAttribute('AutomationId');
+      if (autoId && autoId !== 'SCROLLVIEW_TEST_ID' && autoId.match(reg)) {
+        return await child;
+      }
+    }
 
-  //   return null;
-  // }
+    return null;
+  }
 
   /*****************************************/
   /**************** Getters ****************/
@@ -285,8 +285,7 @@ export class BasePage {
   }
 
   get _firstTestPageButton() {
-    //return this.SetFirstScrollViewButtonChild();
-    return GetElement('Homepage_ActivityIndicator_Button');
+    return this.SetFirstScrollViewButtonChild();
   }
 
   /****************** Error Messages ******************/

--- a/apps/fluent-tester/src/E2E/common/BasePage.ts
+++ b/apps/fluent-tester/src/E2E/common/BasePage.ts
@@ -186,6 +186,9 @@ export class BasePage {
           "'s main test element. Please see Pipeline artifacts for more debugging information.",
       },
     );
+
+    // We have this extra scroll here to ensure the whole component is visible.
+    await FocusButton.addValue(scrollDownKeys);
   }
 
   /* A method that allows the caller to pass in a condition. A wrapper for waitUntil(). Once testing becomes more extensive,

--- a/apps/fluent-tester/src/E2E/common/BasePage.ts
+++ b/apps/fluent-tester/src/E2E/common/BasePage.ts
@@ -99,7 +99,7 @@ export class BasePage {
             return await (await this._pageButton).isDisplayed();
           },
           {
-            timeout: this.waitForPageTimeout,
+            timeout: this.waitForUIEvent,
             timeoutMsg:
               'Could not scroll to the ' +
               this._pageName +
@@ -116,7 +116,7 @@ export class BasePage {
             return await (await this._pageButton).isDisplayed();
           },
           {
-            timeout: this.waitForPageTimeout,
+            timeout: this.waitForUIEvent,
             timeoutMsg:
               'Could not scroll to the ' + this._pageName + "'s Button. Please see Pipeline artifacts for more debugging information.",
           },
@@ -139,7 +139,7 @@ export class BasePage {
   async waitForPageDisplayed(timeout?: number): Promise<void> {
     await browser.pause(2000);
     await browser.waitUntil(async () => await this.isPageLoaded(), {
-      timeout: timeout ?? this.waitForPageTimeout,
+      timeout: timeout ?? this.waitForUIEvent,
       timeoutMsg: this._pageName + ' did not render correctly. Please see /errorShots for more information.',
       interval: 1500,
     });
@@ -148,7 +148,7 @@ export class BasePage {
   /* Waits for the test page's button to be displayed. If the button doesn't load before the timeout, it causes the test to fail. */
   async waitForButtonDisplayed(timeout?: number): Promise<void> {
     await browser.waitUntil(async () => await this.isButtonInView(), {
-      timeout: timeout ?? this.waitForPageTimeout,
+      timeout: timeout ?? this.waitForUIEvent,
       timeoutMsg: 'Could not find the button to navigate to ' + this._pageName + '. Please see /errorShots for more information.',
       interval: 1500,
     });
@@ -157,7 +157,7 @@ export class BasePage {
   /* Waits for the primary UI test element to be displayed. If the element doesn't load before the timeout, it causes the test to fail. */
   async waitForPrimaryElementDisplayed(timeout?: number): Promise<void> {
     await browser.waitUntil(async () => await (await this._primaryComponent).isDisplayed(), {
-      timeout: timeout ?? this.waitForPageTimeout,
+      timeout: timeout ?? this.waitForUIEvent,
       timeoutMsg:
         'The primary UI element for testing did not display correctly. Please see /errorShots of the first failed test for more information.',
       interval: 1500,
@@ -179,7 +179,7 @@ export class BasePage {
         return await (await this._primaryComponent).isDisplayed();
       },
       {
-        timeout: this.waitForPageTimeout,
+        timeout: 30000,
         timeoutMsg:
           'Could not scroll to the ' +
           this._pageName +
@@ -195,7 +195,7 @@ export class BasePage {
    * this will allow cleaner code within all the Page Objects. */
   async waitForCondition(condition?: () => Promise<boolean>, errorMsg?: string, timeout?: number): Promise<void> {
     await browser.waitUntil(async () => await condition(), {
-      timeout: timeout ?? this.waitForPageTimeout,
+      timeout: timeout ?? this.waitForUIEvent,
       timeoutMsg: errorMsg ?? 'Error. Please see /errorShots and logs for more information.',
       interval: 1000,
     });
@@ -308,6 +308,6 @@ export class BasePage {
     return 'An assert popped up. ' + this.ERRORMESSAGE_SUFFIX;
   }
 
-  // Default timeout to wait until page is displayed (10s)
-  waitForPageTimeout: number = 15000;
+  // Default timeout to wait until page is displayed (20s)
+  waitForUIEvent: number = 20000;
 }

--- a/apps/fluent-tester/src/E2E/common/BasePage.ts
+++ b/apps/fluent-tester/src/E2E/common/BasePage.ts
@@ -15,7 +15,7 @@ export async function GetElement(identifier: string): Promise<WebdriverIO.Elemen
   await browser.waitUntil(
     async () => {
       Element = await By(identifier);
-      return await Element.isDisplayed();
+      return await Element.isExisting();
     },
     {
       timeoutMsg: 'Could not find the element with identifier = ' + identifier,

--- a/apps/fluent-tester/src/E2E/common/BasePage.ts
+++ b/apps/fluent-tester/src/E2E/common/BasePage.ts
@@ -94,8 +94,7 @@ export class BasePage {
         const scrollDownKeys = [Keys.PAGE_DOWN];
         await browser.waitUntil(
           async () => {
-            const firstTestPageButton = await browser.getFirstTestPageButton();
-            await firstTestPageButton.addValue(scrollDownKeys);
+            await (await this._firstTestPageButton).addValue(scrollDownKeys);
             scrollDownKeys.push(Keys.PAGE_DOWN);
             return await (await this._pageButton).isDisplayed();
           },
@@ -220,6 +219,21 @@ export class BasePage {
     return windowHandles.length > 1;
   }
 
+  async SetFirstScrollViewButtonChild() {
+    console.log('\nRunning static logic.\n');
+    const TestChildren = await (await this._testPageButtonScrollViewer).$$('//*');
+    const reg = new RegExp('Homepage_[a-zA-Z]*_Button');
+
+    for (const child of TestChildren) {
+      const autoId = await child.getAttribute('AutomationId');
+      if (autoId && autoId !== 'SCROLLVIEW_TEST_ID' && autoId.match(reg)) {
+        return await child;
+      }
+    }
+
+    return null;
+  }
+
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
@@ -269,6 +283,10 @@ export class BasePage {
   // The scrollviewer containing the body of each test page
   get _testElementScrollViewer() {
     return GetElement('ScrollViewAreaForComponents');
+  }
+
+  get _firstTestPageButton() {
+    return this.SetFirstScrollViewButtonChild();
   }
 
   /****************** Error Messages ******************/

--- a/apps/fluent-tester/src/E2E/common/BasePage.ts
+++ b/apps/fluent-tester/src/E2E/common/BasePage.ts
@@ -165,8 +165,10 @@ export class BasePage {
   }
 
   /* Scrolls to the primary UI test element until it is displayed. */
-  async scrollToTestElement(): Promise<void> {
-    if (await (await this._primaryComponent).isDisplayed()) {
+  async scrollToTestElement(component?: WebdriverIO.Element): Promise<void> {
+    const ComponentToScrollTo = component ?? (await this._primaryComponent);
+
+    if (await ComponentToScrollTo.isDisplayed()) {
       return;
     }
 
@@ -176,7 +178,7 @@ export class BasePage {
       async () => {
         await FocusButton.addValue(scrollDownKeys);
         scrollDownKeys.push(Keys.PAGE_DOWN);
-        return await (await this._primaryComponent).isDisplayed();
+        return await ComponentToScrollTo.isDisplayed();
       },
       {
         timeout: 30000,

--- a/apps/fluent-tester/src/E2E/common/BasePage.ts
+++ b/apps/fluent-tester/src/E2E/common/BasePage.ts
@@ -94,7 +94,8 @@ export class BasePage {
         const scrollDownKeys = [Keys.PAGE_DOWN];
         await browser.waitUntil(
           async () => {
-            await (await this._firstTestPageButton).addValue(scrollDownKeys);
+            const firstTestPageButton = await browser.getFirstTestPageButton();
+            await firstTestPageButton.addValue(scrollDownKeys);
             scrollDownKeys.push(Keys.PAGE_DOWN);
             return await (await this._pageButton).isDisplayed();
           },
@@ -219,21 +220,6 @@ export class BasePage {
     return windowHandles.length > 1;
   }
 
-  async SetFirstScrollViewButtonChild() {
-    console.log('\nRunning static logic.\n');
-    const TestChildren = await (await this._testPageButtonScrollViewer).$$('//*');
-    const reg = new RegExp('Homepage_[a-zA-Z]*_Button');
-
-    for (const child of TestChildren) {
-      const autoId = await child.getAttribute('AutomationId');
-      if (autoId && autoId !== 'SCROLLVIEW_TEST_ID' && autoId.match(reg)) {
-        return await child;
-      }
-    }
-
-    return null;
-  }
-
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
@@ -283,10 +269,6 @@ export class BasePage {
   // The scrollviewer containing the body of each test page
   get _testElementScrollViewer() {
     return GetElement('ScrollViewAreaForComponents');
-  }
-
-  get _firstTestPageButton() {
-    return this.SetFirstScrollViewButtonChild();
   }
 
   /****************** Error Messages ******************/

--- a/apps/fluent-tester/src/E2E/common/BasePage.ts
+++ b/apps/fluent-tester/src/E2E/common/BasePage.ts
@@ -137,11 +137,9 @@ export class BasePage {
 
   /* Waits for the test page to load. If the test page doesn't load before the timeout, it causes the test to fail. */
   async waitForPageDisplayed(timeout?: number): Promise<void> {
-    await browser.pause(2000);
     await browser.waitUntil(async () => await this.isPageLoaded(), {
       timeout: timeout ?? this.waitForUIEvent,
       timeoutMsg: this._pageName + ' did not render correctly. Please see /errorShots for more information.',
-      interval: 1500,
     });
   }
 
@@ -150,7 +148,6 @@ export class BasePage {
     await browser.waitUntil(async () => await this.isButtonInView(), {
       timeout: timeout ?? this.waitForUIEvent,
       timeoutMsg: 'Could not find the button to navigate to ' + this._pageName + '. Please see /errorShots for more information.',
-      interval: 1500,
     });
   }
 
@@ -160,7 +157,6 @@ export class BasePage {
       timeout: timeout ?? this.waitForUIEvent,
       timeoutMsg:
         'The primary UI element for testing did not display correctly. Please see /errorShots of the first failed test for more information.',
-      interval: 1500,
     });
   }
 
@@ -199,7 +195,6 @@ export class BasePage {
     await browser.waitUntil(async () => await condition(), {
       timeout: timeout ?? this.waitForUIEvent,
       timeoutMsg: errorMsg ?? 'Error. Please see /errorShots and logs for more information.',
-      interval: 1000,
     });
   }
 

--- a/apps/fluent-tester/src/E2E/common/BasePage.ts
+++ b/apps/fluent-tester/src/E2E/common/BasePage.ts
@@ -219,20 +219,19 @@ export class BasePage {
     return windowHandles.length > 1;
   }
 
-  async SetFirstScrollViewButtonChild() {
-    console.log('\nRunning static logic.\n');
-    const TestChildren = await (await this._testPageButtonScrollViewer).$$('//*');
-    const reg = new RegExp('Homepage_[a-zA-Z]*_Button');
+  // async SetFirstScrollViewButtonChild() {
+  //   const TestChildren = await (await this._testPageButtonScrollViewer).$$('//*');
+  //   const reg = new RegExp('Homepage_[a-zA-Z]*_Button');
 
-    for (const child of TestChildren) {
-      const autoId = await child.getAttribute('AutomationId');
-      if (autoId && autoId !== 'SCROLLVIEW_TEST_ID' && autoId.match(reg)) {
-        return await child;
-      }
-    }
+  //   for (const child of TestChildren) {
+  //     const autoId = await child.getAttribute('AutomationId');
+  //     if (autoId && autoId !== 'SCROLLVIEW_TEST_ID' && autoId.match(reg)) {
+  //       return await child;
+  //     }
+  //   }
 
-    return null;
-  }
+  //   return null;
+  // }
 
   /*****************************************/
   /**************** Getters ****************/
@@ -286,7 +285,8 @@ export class BasePage {
   }
 
   get _firstTestPageButton() {
-    return this.SetFirstScrollViewButtonChild();
+    //return this.SetFirstScrollViewButtonChild();
+    return GetElement('Homepage_ActivityIndicator_Button');
   }
 
   /****************** Error Messages ******************/

--- a/apps/fluent-tester/src/E2E/common/BasePage.ts
+++ b/apps/fluent-tester/src/E2E/common/BasePage.ts
@@ -90,7 +90,7 @@ export class BasePage {
     }
 
     switch (platform) {
-      case Platform.Win32:
+      case Platform.Win32: {
         const scrollDownKeys = [Keys.PAGE_DOWN];
         await browser.waitUntil(
           async () => {
@@ -107,8 +107,9 @@ export class BasePage {
           },
         );
         break;
+      }
 
-      case Platform.iOS:
+      case Platform.iOS: {
         await browser.waitUntil(
           async () => {
             await driver.execute('mobile: scroll', { direction: 'down' });
@@ -121,6 +122,7 @@ export class BasePage {
           },
         );
         break;
+      }
 
       case Platform.macOS:
         // Not needed for macOS. It automatically scrolls

--- a/apps/fluent-tester/src/E2E/common/BasePage.ts
+++ b/apps/fluent-tester/src/E2E/common/BasePage.ts
@@ -15,7 +15,7 @@ export async function GetElement(identifier: string): Promise<WebdriverIO.Elemen
   await browser.waitUntil(
     async () => {
       Element = await By(identifier);
-      return await Element.isExisting();
+      return await Element.isDisplayed();
     },
     {
       timeoutMsg: 'Could not find the element with identifier = ' + identifier,

--- a/apps/fluent-tester/src/E2E/common/BasePage.ts
+++ b/apps/fluent-tester/src/E2E/common/BasePage.ts
@@ -74,11 +74,13 @@ export class BasePage {
 
     switch (platform) {
       case Platform.Win32:
-        // eslint-disable-next-line no-case-declarations
-        const ScrollViewer = await By('SCROLLVIEW_TEST_ID');
         await browser.waitUntil(
           async () => {
-            await driver.touchScroll(COMPONENT_SCROLL_COORDINATES.x, COMPONENT_SCROLL_COORDINATES.y, ScrollViewer.elementId);
+            await driver.touchScroll(
+              COMPONENT_SCROLL_COORDINATES.x,
+              COMPONENT_SCROLL_COORDINATES.y,
+              await this._testPageButtonScrollViewer.elementId,
+            );
             return await TestPageButton.isDisplayed();
           },
           {
@@ -151,11 +153,13 @@ export class BasePage {
       return;
     }
 
-    // Scroll until element is displayed
-    const ScrollViewerID = await By('ScrollViewAreaForComponents').elementId;
     await browser.waitUntil(
       async () => {
-        await driver.touchScroll(COMPONENT_SCROLL_COORDINATES.x, COMPONENT_SCROLL_COORDINATES.y, ScrollViewerID);
+        await driver.touchScroll(
+          COMPONENT_SCROLL_COORDINATES.x,
+          COMPONENT_SCROLL_COORDINATES.y,
+          await this._testElementScrollViewer.elementId,
+        );
         return await PrimaryComponent.isDisplayed();
       },
       {
@@ -167,7 +171,7 @@ export class BasePage {
       },
     );
 
-    await driver.touchScroll(COMPONENT_SCROLL_COORDINATES.x, COMPONENT_SCROLL_COORDINATES.y, ScrollViewerID);
+    await driver.touchScroll(COMPONENT_SCROLL_COORDINATES.x, COMPONENT_SCROLL_COORDINATES.y, await this._testElementScrollViewer.elementId);
   }
 
   /* A method that allows the caller to pass in a condition. A wrapper for waitUntil(). Once testing becomes more extensive,
@@ -237,6 +241,16 @@ export class BasePage {
   // Returns the name of the test page. Useful for error messages (see above).
   get _pageName(): string {
     return DUMMY_CHAR;
+  }
+
+  // The scrollviewer containing the list of buttons to navigate to each test page
+  get _testPageButtonScrollViewer() {
+    return By('SCROLLVIEW_TEST_ID');
+  }
+
+  // The scrollviewer containing the body of each test page
+  get _testElementScrollViewer() {
+    return By('ScrollViewAreaForComponents');
   }
 
   /****************** Error Messages ******************/

--- a/apps/fluent-tester/src/E2E/common/BasePage.ts
+++ b/apps/fluent-tester/src/E2E/common/BasePage.ts
@@ -219,18 +219,15 @@ export class BasePage {
     return windowHandles.length > 1;
   }
 
-  static async GetFirstScrollViewButtonChild() {
-    console.log('\nRunning static logic.\n')
-    const ScrollViewer = await GetElement('SCROLLVIEW_TEST_ID');
-    const TestChildren = await ScrollViewer.$$('//*');
+  async SetFirstScrollViewButtonChild() {
+    console.log('\nRunning static logic.\n');
+    const TestChildren = await (await this._testPageButtonScrollViewer).$$('//*');
     const reg = new RegExp('Homepage_[a-zA-Z]*_Button');
 
-    for await (const child of TestChildren) {
+    for (const child of TestChildren) {
       const autoId = await child.getAttribute('AutomationId');
-      if (autoId && autoId !== 'SCROLLVIEW_TEST_ID') {
-        if (autoId.match(reg)) {
-          return await child;
-        }
+      if (autoId && autoId !== 'SCROLLVIEW_TEST_ID' && autoId.match(reg)) {
+        return await child;
       }
     }
 
@@ -289,7 +286,7 @@ export class BasePage {
   }
 
   get _firstTestPageButton() {
-    return BasePage.GetFirstScrollViewButtonChild();
+    return this.SetFirstScrollViewButtonChild();
   }
 
   /****************** Error Messages ******************/

--- a/apps/fluent-tester/src/E2E/common/NativeTesting/pages/NativeTestingPageObject.win.ts
+++ b/apps/fluent-tester/src/E2E/common/NativeTesting/pages/NativeTestingPageObject.win.ts
@@ -1,4 +1,4 @@
-import { BasePage, By } from '../../../common/BasePage';
+import { BasePage, GetElement } from '../../../common/BasePage';
 
 const ScrollViewTestId = 'SCROLLVIEW_TEST_ID';
 
@@ -13,14 +13,14 @@ class NativeTestingPageObject extends BasePage {
   }
 
   async doesScrollViewParentExist(): Promise<boolean> {
-    return await this._scrollViewParent.isExisting();
+    return await (await this._scrollViewParent).isExisting();
   }
 
   /* Validate the Children of the ScrollView stay intact. The children are the buttons that
    * navigate to each test page. Also, validate these children exist with the proper testId format */
   async validateScrollViewChildren(): Promise<boolean> {
     // Gets all the children
-    const testChildren = await this._scrollViewParent.$$('//*');
+    const testChildren = await (await this._scrollViewParent).$$('//*');
     let foundValidButton = false;
 
     // Ensure the testID (maps 1:1 to automationId) properties of the button children match the defined testing format
@@ -44,7 +44,7 @@ class NativeTestingPageObject extends BasePage {
   }
 
   get _scrollViewParent() {
-    return By(ScrollViewTestId);
+    return GetElement(ScrollViewTestId);
   }
 }
 

--- a/apps/fluent-tester/src/E2E/common/NativeTesting/pages/NativeTestingPageObject.win.ts
+++ b/apps/fluent-tester/src/E2E/common/NativeTesting/pages/NativeTestingPageObject.win.ts
@@ -5,7 +5,7 @@ const ScrollViewTestId = 'SCROLLVIEW_TEST_ID';
 class NativeTestingPageObject extends BasePage {
   async waitForScrollViewDisplayed(timeout?: number): Promise<void> {
     await browser.waitUntil(async () => await this.doesScrollViewParentExist(), {
-      timeout: timeout ?? this.waitForPageTimeout,
+      timeout: timeout ?? this.waitForUIEvent,
       timeoutMsg:
         'For testing purposes we require that the root view contains a non-empty, immutable ScrollView of buttons that navigate to test pages.',
       interval: 1000,

--- a/apps/fluent-tester/src/E2E/common/NavigateAppPage.ts
+++ b/apps/fluent-tester/src/E2E/common/NavigateAppPage.ts
@@ -28,123 +28,123 @@ import { HOMEPAGE_TOKEN_BUTTON } from '../../TestComponents/Tokens/consts';
 import { HOMEPAGE_TABS_BUTTON } from '../../TestComponents/Tabs/consts';
 import { HOMEPAGE_THEME_BUTTON } from '../../TestComponents/Theme/consts';
 import { BASE_TESTPAGE } from '../../TestComponents/Common/consts';
-import { By, BasePage } from './BasePage';
+import { GetElement, BasePage } from './BasePage';
 
 class NavigateAppPage extends BasePage {
   async clickAndGoToActivityIndicatorPage() {
-    await this.activityIndicatorPage.click();
+    await (await this.activityIndicatorPage).click();
   }
 
   async clickAndGoToAvatarPage() {
-    await this.avatarPage.click();
+    await (await this.avatarPage).click();
   }
 
   async clickAndGoToBadgePage() {
-    await this.badgePage.click();
+    await (await this.badgePage).click();
   }
 
   async clickAndGoToButtonPage() {
-    await this.buttonPage.click();
+    await (await this.buttonPage).click();
   }
 
   async clickAndGoToCalloutPage() {
-    await this.calloutPage.click();
+    await (await this.calloutPage).click();
   }
 
   async clickAndGoToCheckboxPage() {
-    await this.checkboxPage.click();
+    await (await this.checkboxPage).click();
   }
 
   async clickAndGoToCheckboxExperimentalPage() {
-    await this.checkboxExperimentalPage.click();
+    await (await this.checkboxExperimentalPage).click();
   }
 
   async clickAndGoToContextualMenuPage() {
-    await this.contextualMenuPage.click();
+    await (await this.contextualMenuPage).click();
   }
 
   async clickAndGoToFocusTrapZonePage() {
-    await this.focusTrapZonePage.click();
+    await (await this.focusTrapZonePage).click();
   }
 
   async clickAndGoToFocusZonePage() {
-    await this.focusZonePage.click();
+    await (await this.focusZonePage).click();
   }
 
   async clickAndGoToIconPage() {
-    await this.iconPage.click();
+    await (await this.iconPage).click();
   }
 
   async clickAndGoToLinkPage() {
-    await this.linkPage.click();
+    await (await this.linkPage).click();
   }
 
   async clickAndGoToMenuPage() {
-    await this.menuPage.click();
+    await (await this.menuPage).click();
   }
 
   async clickAndGoToMenuButtonPage() {
-    await this.menuButtonPage.click();
+    await (await this.menuButtonPage).click();
   }
 
   async clickAndGoToExperimentalMenuButtonPage() {
-    await this.menuButtonExperimentalPage.click();
+    await (await this.menuButtonExperimentalPage).click();
   }
 
   async clickAndGoToPersonaPage() {
-    await this.personaPage.click();
+    await (await this.personaPage).click();
   }
 
   async clickAndGoToPersonaCoinPage() {
-    await this.personaCoinPage.click();
+    await (await this.personaCoinPage).click();
   }
 
   async clickAndGoToPressablePage() {
-    await this.pressablePage.click();
+    await (await this.pressablePage).click();
   }
 
   async clickAndGoToRadioGroupPage() {
-    await this.radioGroupPage.click();
+    await (await this.radioGroupPage).click();
   }
 
   async clickAndGoToSeparatorPage() {
-    await this.separatorPage.click();
+    await (await this.separatorPage).click();
   }
 
   async clickAndGoToShimmerPage() {
-    await this.shimmerPage.click();
+    await (await this.shimmerPage).click();
   }
 
   async clickAndGoToSvgPage() {
-    await this.svgPage.click();
+    await (await this.svgPage).click();
   }
 
   async clickAndGoToSwitchPage() {
-    await this.switchPage.click();
+    await (await this.switchPage).click();
   }
 
   async clickAndGoToTextPage() {
-    await this.textPage.click();
+    await (await this.textPage).click();
   }
 
   async clickAndGoToExperimentalTextPage() {
-    await this.textExperimentalPage.click();
+    await (await this.textExperimentalPage).click();
   }
 
   async clickAndGoToTabsPage() {
-    await this.tabsPage.click();
+    await (await this.tabsPage).click();
   }
 
   async clickAndGoToThemePage() {
-    await this.themePage.click();
+    await (await this.themePage).click();
   }
 
   async clickAndGoToTokensPage() {
-    await this.tokensPage.click();
+    await (await this.tokensPage).click();
   }
 
   async clickAndGoToExperimentalTabsPage() {
-    await this.experimentalTabsPage.click();
+    await (await this.experimentalTabsPage).click();
   }
 
   /*
@@ -152,123 +152,123 @@ class NavigateAppPage extends BasePage {
    */
 
   get _testPage() {
-    return By(BASE_TESTPAGE);
+    return GetElement(BASE_TESTPAGE);
   }
 
   private get activityIndicatorPage() {
-    return By(HOMEPAGE_ACTIVITY_INDICATOR_BUTTON);
+    return GetElement(HOMEPAGE_ACTIVITY_INDICATOR_BUTTON);
   }
 
   private get avatarPage() {
-    return By(HOMEPAGE_AVATAR_BUTTON);
+    return GetElement(HOMEPAGE_AVATAR_BUTTON);
   }
 
   private get badgePage() {
-    return By(HOMEPAGE_BADGE_BUTTON);
+    return GetElement(HOMEPAGE_BADGE_BUTTON);
   }
 
   private get buttonPage() {
-    return By(HOMEPAGE_BUTTON_BUTTON);
+    return GetElement(HOMEPAGE_BUTTON_BUTTON);
   }
 
   private get calloutPage() {
-    return By(HOMEPAGE_CALLOUT_BUTTON);
+    return GetElement(HOMEPAGE_CALLOUT_BUTTON);
   }
 
   private get checkboxPage() {
-    return By(HOMEPAGE_CHECKBOX_BUTTON);
+    return GetElement(HOMEPAGE_CHECKBOX_BUTTON);
   }
 
   private get checkboxExperimentalPage() {
-    return By(HOMEPAGE_CHECKBOX_EXPERIMENTAL_BUTTON);
+    return GetElement(HOMEPAGE_CHECKBOX_EXPERIMENTAL_BUTTON);
   }
 
   private get contextualMenuPage() {
-    return By(HOMEPAGE_CONTEXTUALMENU_BUTTON);
+    return GetElement(HOMEPAGE_CONTEXTUALMENU_BUTTON);
   }
 
   private get focusTrapZonePage() {
-    return By(HOMEPAGE_FOCUSTRAPZONE_BUTTON);
+    return GetElement(HOMEPAGE_FOCUSTRAPZONE_BUTTON);
   }
 
   private get focusZonePage() {
-    return By(HOMEPAGE_FOCUSZONE_BUTTON);
+    return GetElement(HOMEPAGE_FOCUSZONE_BUTTON);
   }
 
   private get iconPage() {
-    return By(HOMEPAGE_ICON_BUTTON);
+    return GetElement(HOMEPAGE_ICON_BUTTON);
   }
 
   private get linkPage() {
-    return By(HOMEPAGE_LINK_BUTTON);
+    return GetElement(HOMEPAGE_LINK_BUTTON);
   }
 
   private get menuPage() {
-    return By(HOMEPAGE_MENU_BUTTON);
+    return GetElement(HOMEPAGE_MENU_BUTTON);
   }
 
   private get menuButtonPage() {
-    return By(HOMEPAGE_MENUBUTTON_BUTTON);
+    return GetElement(HOMEPAGE_MENUBUTTON_BUTTON);
   }
 
   private get menuButtonExperimentalPage() {
-    return By(HOMEPAGE_EXPERIMENTAL_MENU_BUTTON);
+    return GetElement(HOMEPAGE_EXPERIMENTAL_MENU_BUTTON);
   }
 
   private get personaPage() {
-    return By(HOMEPAGE_PERSONA_BUTTON);
+    return GetElement(HOMEPAGE_PERSONA_BUTTON);
   }
 
   private get personaCoinPage() {
-    return By(HOMEPAGE_PERSONACOIN_BUTTON);
+    return GetElement(HOMEPAGE_PERSONACOIN_BUTTON);
   }
 
   private get pressablePage() {
-    return By(HOMEPAGE_PRESSABLE_BUTTON);
+    return GetElement(HOMEPAGE_PRESSABLE_BUTTON);
   }
 
   private get radioGroupPage() {
-    return By(HOMEPAGE_RADIOGROUP_BUTTON);
+    return GetElement(HOMEPAGE_RADIOGROUP_BUTTON);
   }
 
   private get separatorPage() {
-    return By(HOMEPAGE_SEPARATOR_BUTTON);
+    return GetElement(HOMEPAGE_SEPARATOR_BUTTON);
   }
 
   private get shimmerPage() {
-    return By(HOMEPAGE_SHIMMER_BUTTON);
+    return GetElement(HOMEPAGE_SHIMMER_BUTTON);
   }
 
   private get svgPage() {
-    return By(HOMEPAGE_SVG_BUTTON);
+    return GetElement(HOMEPAGE_SVG_BUTTON);
   }
 
   private get switchPage() {
-    return By(HOMEPAGE_SWITCH_BUTTON);
+    return GetElement(HOMEPAGE_SWITCH_BUTTON);
   }
 
   private get textPage() {
-    return By(HOMEPAGE_TEXT_BUTTON);
+    return GetElement(HOMEPAGE_TEXT_BUTTON);
   }
 
   private get textExperimentalPage() {
-    return By(HOMEPAGE_EXPERIMENTAL_TEXT_BUTTON);
+    return GetElement(HOMEPAGE_EXPERIMENTAL_TEXT_BUTTON);
   }
 
   private get tabsPage() {
-    return By(HOMEPAGE_TABS_BUTTON);
+    return GetElement(HOMEPAGE_TABS_BUTTON);
   }
 
   private get themePage() {
-    return By(HOMEPAGE_THEME_BUTTON);
+    return GetElement(HOMEPAGE_THEME_BUTTON);
   }
 
   private get tokensPage() {
-    return By(HOMEPAGE_TOKEN_BUTTON);
+    return GetElement(HOMEPAGE_TOKEN_BUTTON);
   }
 
   private get experimentalTabsPage() {
-    return By(HOMEPAGE_EXPERIMENTAL_TABS_BUTTON);
+    return GetElement(HOMEPAGE_EXPERIMENTAL_TABS_BUTTON);
   }
 }
 

--- a/apps/fluent-tester/src/E2E/common/consts.ts
+++ b/apps/fluent-tester/src/E2E/common/consts.ts
@@ -1,4 +1,4 @@
-/* Accessibility Role Control Types - https://docs.microsoft.com/en-us/windows/win32/winauto/uiauto-controltype-ids */
+/* Accessibility Role Control Types - https =//docs.microsoft.com/en-us/windows/win32/winauto/uiauto-controltype-ids */
 export const BUTTON_A11Y_ROLE = 'ControlType.Button';
 export const CALLOUT_A11Y_ROLE = 'ControlType.Group';
 export const CHECKBOX_A11Y_ROLE = 'ControlType.CheckBox';
@@ -18,11 +18,64 @@ export const PAGE_TIMEOUT = 15000;
 
 /* Keyboard Key Constants */
 export const enum Keys {
-  Up_Arrow = 'ArrowUp',
-  Right_Arrow = 'ArrowRight',
-  Down_Arrow = 'ArrowDown',
-  Left_Arrow = 'ArrowLeft',
-  Spacebar = ' ',
-  Enter = 'Enter',
-  Escape = 'Escape',
+  NULL = '\uE000',
+  CANCEL = '\uE001', // ^break
+  HELP = '\uE002',
+  BACK_SPACE = '\uE003',
+  TAB = '\uE004',
+  CLEAR = '\uE005',
+  RETURN = '\uE006',
+  ENTER = '\uE007',
+  SHIFT = '\uE008',
+  CONTROL = '\uE009',
+  ALT = '\uE00A',
+  PAUSE = '\uE00B',
+  ESCAPE = '\uE00C',
+  SPACE = '\uE00D',
+  PAGE_UP = '\uE00E',
+  PAGE_DOWN = '\uE00F',
+  END = '\uE010',
+  HOME = '\uE011',
+  ARROW_LEFT = '\uE012',
+  LEFT = '\uE012',
+  ARROW_UP = '\uE013',
+  UP = '\uE013',
+  ARROW_RIGHT = '\uE014',
+  RIGHT = '\uE014',
+  ARROW_DOWN = '\uE015',
+  DOWN = '\uE015',
+  INSERT = '\uE016',
+  DELETE = '\uE017',
+  SEMICOLON = '\uE018',
+  EQUALS = '\uE019',
+
+  NUMPAD0 = '\uE01A', // number pad keys
+  NUMPAD1 = '\uE01B',
+  NUMPAD2 = '\uE01C',
+  NUMPAD3 = '\uE01D',
+  NUMPAD4 = '\uE01E',
+  NUMPAD5 = '\uE01F',
+  NUMPAD6 = '\uE020',
+  NUMPAD7 = '\uE021',
+  NUMPAD8 = '\uE022',
+  NUMPAD9 = '\uE023',
+  MULTIPLY = '\uE024',
+  ADD = '\uE025',
+  SEPARATOR = '\uE026',
+  SUBTRACT = '\uE027',
+  DECIMAL = '\uE028',
+  DIVIDE = '\uE029',
+
+  F1 = '\uE031', // function keys
+  F2 = '\uE032',
+  F3 = '\uE033',
+  F4 = '\uE034',
+  F5 = '\uE035',
+  F6 = '\uE036',
+  F7 = '\uE037',
+  F8 = '\uE038',
+  F9 = '\uE039',
+  F10 = '\uE03A',
+  F11 = '\uE03B',
+  F12 = '\uE03C',
 }

--- a/apps/fluent-tester/src/TestComponents/Test.tsx
+++ b/apps/fluent-tester/src/TestComponents/Test.tsx
@@ -6,6 +6,7 @@ import { stackStyle } from './Common/styles';
 import { useTheme } from '@fluentui-react-native/theme-types';
 import Svg, { G, Path, SvgProps } from 'react-native-svg';
 import { SvgIconProps } from '@fluentui-react-native/icon';
+import { Button } from '@fluentui-react-native/experimental-button';
 
 export type TestSection = {
   name: string;
@@ -70,6 +71,9 @@ const styles = StyleSheet.create({
   status: {
     fontWeight: 'normal',
   },
+  e2eFocusButton: {
+    opacity: 0.1,
+  },
 });
 
 export const Test = (props: TestProps): React.ReactElement<Record<string, never>> => {
@@ -112,6 +116,9 @@ export const Test = (props: TestProps): React.ReactElement<Record<string, never>
         <Text style={styles.name} variant="heroSemibold">
           {props.name}
         </Text>
+        <Button testID="Focus_Button" style={styles.e2eFocusButton}>
+          E2E Testing Button
+        </Button>
         {props.spec && <Link url={props.spec} content="SPEC" />}
       </View>
       <Separator />

--- a/apps/fluent-tester/wdio.conf.ios.js
+++ b/apps/fluent-tester/wdio.conf.ios.js
@@ -28,7 +28,7 @@ exports.config = {
    */
 
   logLevel: 'info', // Level of logging verbosity: trace | debug | info | warn | error | silent
-  bail: 0, // If you only want to run your tests until a specific amount of tests have failed use bail (default is 0 - don't bail, run all tests).
+  bail: 1, // If you only want to run your tests until a specific amount of tests have failed use bail (default is 0 - don't bail, run all tests).
   waitforTimeout: defaultWaitForTimeout, // Default timeout for all waitForXXX commands.
   connectionRetryTimeout: defaultConnectionRetryTimeout, // Timeout for any WebDriver request to a driver or grid.
   connectionRetryCount: 3, // Maximum count of request retries to the Selenium server.

--- a/apps/fluent-tester/wdio.conf.ios.js
+++ b/apps/fluent-tester/wdio.conf.ios.js
@@ -6,7 +6,7 @@ const jasmineDefaultTimeout = 60000; // 60 seconds for Jasmine test timeout
 
 exports.config = {
   runner: 'local', // Where should your test be launched
-  specs: [['src/E2E/**/specs/*.ios.ts']],
+  specs: ['src/E2E/**/specs/*.ios.ts'],
   exclude: [],
 
   maxInstances: 30,

--- a/apps/fluent-tester/wdio.conf.ios.js
+++ b/apps/fluent-tester/wdio.conf.ios.js
@@ -6,8 +6,8 @@ const jasmineDefaultTimeout = 60000; // 60 seconds for Jasmine test timeout
 
 exports.config = {
   runner: 'local', // Where should your test be launched
-  specs: ['src/E2E/**/specs/*.ios.ts'],
-  exclude: [ ],
+  specs: [['src/E2E/**/specs/*.ios.ts']],
+  exclude: [],
 
   maxInstances: 30,
   capabilities: [

--- a/apps/fluent-tester/wdio.conf.macos.js
+++ b/apps/fluent-tester/wdio.conf.macos.js
@@ -28,7 +28,7 @@ exports.config = {
    */
 
   logLevel: 'info', // Level of logging verbosity: trace | debug | info | warn | error | silent
-  bail: 0, // If you only want to run your tests until a specific amount of tests have failed use bail (default is 0 - don't bail, run all tests).
+  bail: 1, // If you only want to run your tests until a specific amount of tests have failed use bail (default is 0 - don't bail, run all tests).
   waitforTimeout: defaultWaitForTimeout, // Default timeout for all waitForXXX commands.
   connectionRetryTimeout: defaultConnectionRetryTimeout, // Timeout for any WebDriver request to a driver or grid.
   connectionRetryCount: 3, // Maximum count of request retries to the Selenium server.

--- a/apps/fluent-tester/wdio.conf.macos.js
+++ b/apps/fluent-tester/wdio.conf.macos.js
@@ -6,7 +6,7 @@ const jasmineDefaultTimeout = 60000; // 60 seconds for Jasmine test timeout
 
 exports.config = {
   runner: 'local', // Where should your test be launched
-  specs: ['src/E2E/**/specs/*.macos.ts'],
+  specs: [['src/E2E/**/specs/*.macos.ts']],
   exclude: [
     /* 'path/to/excluded/files' */
   ],

--- a/apps/fluent-tester/wdio.conf.windows.js
+++ b/apps/fluent-tester/wdio.conf.windows.js
@@ -9,19 +9,21 @@ exports.config = {
   /* UWP controls are a subset of the Win32 controls. Only some work on our UWP test app,
   so we must specify which ones we want to test here. */
   specs: [
-    'src/E2E/ActivityIndicator/specs/*.win.ts',
-    'src/E2E/Button/specs/*.win.ts',
-    'src/E2E/Callout/specs/*.win.ts',
-    'src/E2E/Checkbox/specs/*.windows.ts', // See spec file for more information
-    'src/E2E/Link/specs/*.win.ts',
-    'src/E2E/PersonaCoin/specs/*.win.ts',
-    'src/E2E/Pressable/specs/*.win.ts',
-    'src/E2E/Separator/specs/*.win.ts',
-    'src/E2E/Tabs/specs/*.windows.ts', // See spec file for more information
-    'src/E2E/Text/specs/*.win.ts',
-    'src/E2E/TextExperimental/specs/*.win.ts',
-    'src/E2E/Theme/specs/*.win.ts',
-    'src/E2E/Tokens/specs/*.win.ts',
+    [
+      'src/E2E/ActivityIndicator/specs/*.win.ts',
+      'src/E2E/Button/specs/*.win.ts',
+      'src/E2E/Callout/specs/*.win.ts',
+      'src/E2E/Checkbox/specs/*.windows.ts', // See spec file for more information
+      'src/E2E/Link/specs/*.win.ts',
+      'src/E2E/PersonaCoin/specs/*.win.ts',
+      'src/E2E/Pressable/specs/*.win.ts',
+      'src/E2E/Separator/specs/*.win.ts',
+      'src/E2E/Tabs/specs/*.windows.ts', // See spec file for more information
+      'src/E2E/Text/specs/*.win.ts',
+      'src/E2E/TextExperimental/specs/*.win.ts',
+      'src/E2E/Theme/specs/*.win.ts',
+      'src/E2E/Tokens/specs/*.win.ts',
+    ],
   ],
   exclude: [
     /* 'path/to/excluded/files' */

--- a/apps/fluent-tester/wdio.conf.windows.js
+++ b/apps/fluent-tester/wdio.conf.windows.js
@@ -47,7 +47,7 @@ exports.config = {
    */
 
   logLevel: 'info', // Level of logging verbosity: trace | debug | info | warn | error | silent
-  bail: 0, // If you only want to run your tests until a specific amount of tests have failed use bail (default is 0 - don't bail, run all tests).
+  bail: 1, // If you only want to run your tests until a specific amount of tests have failed use bail (default is 0 - don't bail, run all tests).
   waitforTimeout: defaultWaitForTimeout, // Default timeout for all waitForXXX commands.
   connectionRetryTimeout: defaultConnectionRetryTimeout, // Timeout for any WebDriver request to a driver or grid.
   connectionRetryCount: 3, // Maximum count of request retries to the Selenium server.

--- a/apps/win32/wdio.conf.js
+++ b/apps/win32/wdio.conf.js
@@ -15,9 +15,6 @@ exports.config = {
   exclude: [
     '../fluent-tester/src/E2E/Menu/specs/*.win.ts',
     '../fluent-tester/src/E2E/ButtonExperimental/specs/*.win.ts',
-    '../fluent-tester/src/E2E/CheckboxExperimental/specs/*.win.ts',
-    '../fluent-tester/src/E2E/MenuButtonExperimental/specs/*.win.ts',
-    '../fluent-tester/src/E2E/RadioGroupExperimental/specs/*.win.ts',
     '../fluent-tester/src/E2E/TabsExperimental/specs/*.win.ts',
     '../fluent-tester/src/E2E/TextExperimental/specs/*.win.ts',
     '../fluent-tester/src/E2E/Text/specs/*.win.ts',

--- a/apps/win32/wdio.conf.js
+++ b/apps/win32/wdio.conf.js
@@ -12,11 +12,7 @@ const jasmineDefaultTimeout = 60000; // 60 seconds for Jasmine test timeout
 exports.config = {
   runner: 'local', // Where should your test be launched
   specs: [['../fluent-tester/src/E2E/**/specs/*.win.ts']],
-  exclude: [
-    '../fluent-tester/src/E2E/Menu/specs/*.win.ts',
-    '../fluent-tester/src/E2E/ButtonExperimental/specs/*.win.ts',
-    '../fluent-tester/src/E2E/Switch/specs/*.win.ts',
-  ],
+  exclude: ['../fluent-tester/src/E2E/ButtonExperimental/specs/*.win.ts', '../fluent-tester/src/E2E/Switch/specs/*.win.ts'],
 
   capabilities: [
     {

--- a/apps/win32/wdio.conf.js
+++ b/apps/win32/wdio.conf.js
@@ -146,7 +146,7 @@ exports.config = {
    * Function to be executed after a test (in Mocha/Jasmine).
    */
   afterTest: async function (test, context, results) {
-    console.log('\n\n\n\n Test Case: ' + test.description + '.      Test Result: ' + results.passed + ' \n\n\n\n');
+    console.log('\n\n Test Case: ' + test.description + '.      Test Result: ' + results.passed + ' \n\n');
     // if test passed, ignore, else take and save screenshot. Unless it's the first test that boots the app,
     // it may be useful to have a screenshot of the app on load.
     if (results.passed) {

--- a/apps/win32/wdio.conf.js
+++ b/apps/win32/wdio.conf.js
@@ -108,7 +108,7 @@ exports.config = {
    * @param {Array.<String>} specs List of spec file paths that are to be run
    */
   before: async function () {
-    //await browser.maximizeWindow();
+    await browser.maximizeWindow();
   },
   /**
    * Runs before a WebdriverIO command gets executed.
@@ -126,7 +126,7 @@ exports.config = {
   /**
    * Function to be executed before a test (in Mocha/Jasmine) starts.
    */
-  // beforeTest: function (test, context) => {
+  // beforeTest: function (test, context) {
   // },
   /**
    * Hook that gets executed _before_ a hook within the suite starts (e.g. runs before calling

--- a/apps/win32/wdio.conf.js
+++ b/apps/win32/wdio.conf.js
@@ -36,7 +36,7 @@ exports.config = {
    ** ===============================================================================================
    */
 
-  logLevel: 'info', // Level of logging verbosity: trace | debug | info | warn | error | silent
+  logLevel: 'debug', // Level of logging verbosity: trace | debug | info | warn | error | silent
   bail: 0, // If you only want to run your tests until a specific amount of tests have failed use bail (default is 0 - don't bail, run all tests).
   waitforTimeout: defaultWaitForTimeout, // Default timeout for all waitForXXX commands.
   connectionRetryTimeout: defaultConnectionRetryTimeout, // Timeout for any WebDriver request to a driver or grid.

--- a/apps/win32/wdio.conf.js
+++ b/apps/win32/wdio.conf.js
@@ -15,6 +15,7 @@ exports.config = {
   exclude: [
     '../fluent-tester/src/E2E/Menu/specs/*.win.ts',
     '../fluent-tester/src/E2E/ButtonExperimental/specs/*.win.ts',
+    '../fluent-tester/src/E2E/Switch/specs/*.win.ts',
     '../fluent-tester/src/E2E/TabsExperimental/specs/*.win.ts',
     '../fluent-tester/src/E2E/TextExperimental/specs/*.win.ts',
     '../fluent-tester/src/E2E/Text/specs/*.win.ts',

--- a/apps/win32/wdio.conf.js
+++ b/apps/win32/wdio.conf.js
@@ -12,7 +12,7 @@ const jasmineDefaultTimeout = 60000; // 60 seconds for Jasmine test timeout
 exports.config = {
   runner: 'local', // Where should your test be launched
   specs: [['../fluent-tester/src/E2E/**/specs/*.win.ts']],
-  exclude: ['../fluent-tester/src/E2E/Shimmer/specs/*.win.ts'],
+  exclude: ['../fluent-tester/src/E2E/Menu/specs/*.win.ts', '../fluent-tester/src/E2E/ButtonExperimental/specs/*.win.ts'],
 
   capabilities: [
     {

--- a/apps/win32/wdio.conf.js
+++ b/apps/win32/wdio.conf.js
@@ -13,10 +13,8 @@ exports.config = {
   runner: 'local', // Where should your test be launched
   specs: [['../fluent-tester/src/E2E/**/specs/*.win.ts']],
   exclude: [
-    '../fluent-tester/src/E2E/Menu/specs/*.win.ts',
     '../fluent-tester/src/E2E/ButtonExperimental/specs/*.win.ts',
     '../fluent-tester/src/E2E/Switch/specs/*.win.ts',
-    '../fluent-tester/src/E2E/TabsExperimental/specs/*.win.ts',
     '../fluent-tester/src/E2E/TextExperimental/specs/*.win.ts',
     '../fluent-tester/src/E2E/Text/specs/*.win.ts',
   ],
@@ -129,17 +127,25 @@ exports.config = {
    * @param {Object} suite suite details
    */
   // beforeSuite: function (suite) {
+  //   console.log('\n\n\n\n\n\n IN BEFORESUITE \n\n\n\n\n\n\n\n\n');
   // },
   /**
    * Function to be executed before a test (in Mocha/Jasmine) starts.
    */
-  // beforeTest: function (test, context) {
-  // },
+  beforeTest: async (test) => {
+    // get current test title and clean it, to use it as file name
+    const fileName = encodeURIComponent(test.description.replace(/\s+/g, '-'));
+
+    // build file path
+    const filePath = './errorShots/before_' + fileName + '.png';
+    await browser.saveScreenshot(filePath);
+  },
   /**
    * Hook that gets executed _before_ a hook within the suite starts (e.g. runs before calling
    * beforeEach in Mocha)
    */
   // beforeHook: function (test, context) {
+  //   console.log('\n\n\n\n Before Hook - test: ' + JSON.stringify(test) + '. And context: ' + JSON.stringify(context), +'\n\n');
   // },
   /**
    * Hook that gets executed _after_ a hook within the suite starts (e.g. runs after calling

--- a/apps/win32/wdio.conf.js
+++ b/apps/win32/wdio.conf.js
@@ -109,6 +109,34 @@ exports.config = {
    */
   before: async function () {
     await browser.maximizeWindow();
+
+    // Find the ScrollViewer containing the test page buttons
+    var testPageButtonScrollViewer = null;
+    await browser.waitUntil(
+      async () => {
+        testPageButtonScrollViewer = await $('~SCROLLVIEW_TEST_ID');
+        return await testPageButtonScrollViewer.isExisting();
+      },
+      {
+        timeoutMsg: 'Could not find the element with identifier = ' + identifier,
+      },
+    );
+
+    const testPageButtons = await testPageButtonScrollViewer.$$('//*');
+    const reg = new RegExp('Homepage_[a-zA-Z]*_Button');
+
+    var firstTestPageButton = null;
+    for (const child of testPageButtons) {
+      const autoId = await child.getAttribute('AutomationId');
+      if (autoId && autoId !== 'SCROLLVIEW_TEST_ID' && autoId.match(reg)) {
+        firstTestPageButton = await child;
+        break;
+      }
+    }
+
+    await browser.addCommand('getFirstTestPageButton', async function () {
+      return firstTestPageButton;
+    });
   },
   /**
    * Runs before a WebdriverIO command gets executed.

--- a/apps/win32/wdio.conf.js
+++ b/apps/win32/wdio.conf.js
@@ -11,7 +11,7 @@ const jasmineDefaultTimeout = 60000; // 60 seconds for Jasmine test timeout
 
 exports.config = {
   runner: 'local', // Where should your test be launched
-  specs: [['../fluent-tester/src/E2E/Avatar/specs/*.win.ts']],
+  specs: [['../fluent-tester/src/E2E/**/specs/*.win.ts']],
   exclude: ['../fluent-tester/src/E2E/ButtonExperimental/specs/*.win.ts'],
 
   capabilities: [
@@ -37,7 +37,7 @@ exports.config = {
   waitforTimeout: defaultWaitForTimeout, // Default timeout for all waitForXXX commands.
   connectionRetryTimeout: defaultConnectionRetryTimeout, // Timeout for any WebDriver request to a driver or grid.
   connectionRetryCount: 3, // Maximum count of request retries to the Selenium server.
-  specFileRetries: 1, // The number of times to retry the entire spec file when it fails as a whole.
+  specFileRetries: 3, // The number of times to retry the entire spec file when it fails as a whole.
 
   port: 4723, // default appium port
   services: [

--- a/apps/win32/wdio.conf.js
+++ b/apps/win32/wdio.conf.js
@@ -20,6 +20,7 @@ exports.config = {
     '../fluent-tester/src/E2E/RadioGroupExperimental/specs/*.win.ts',
     '../fluent-tester/src/E2E/TabsExperimental/specs/*.win.ts',
     '../fluent-tester/src/E2E/TextExperimental/specs/*.win.ts',
+    '../fluent-tester/src/E2E/Text/specs/*.win.ts',
   ],
 
   capabilities: [

--- a/apps/win32/wdio.conf.js
+++ b/apps/win32/wdio.conf.js
@@ -12,7 +12,7 @@ const jasmineDefaultTimeout = 60000; // 60 seconds for Jasmine test timeout
 exports.config = {
   runner: 'local', // Where should your test be launched
   specs: [['../fluent-tester/src/E2E/**/specs/*.win.ts']],
-  exclude: ['../fluent-tester/src/E2E/ButtonExperimental/specs/*.win.ts'],
+  exclude: [],
 
   capabilities: [
     {

--- a/apps/win32/wdio.conf.js
+++ b/apps/win32/wdio.conf.js
@@ -12,7 +12,7 @@ const jasmineDefaultTimeout = 60000; // 60 seconds for Jasmine test timeout
 exports.config = {
   runner: 'local', // Where should your test be launched
   specs: [['../fluent-tester/src/E2E/**/specs/*.win.ts']],
-  exclude: [],
+  exclude: ['../fluent-tester/src/E2E/ButtonExperimental/specs/*.win.ts'],
 
   capabilities: [
     {

--- a/apps/win32/wdio.conf.js
+++ b/apps/win32/wdio.conf.js
@@ -11,7 +11,7 @@ const jasmineDefaultTimeout = 60000; // 60 seconds for Jasmine test timeout
 
 exports.config = {
   runner: 'local', // Where should your test be launched
-  specs: [['../fluent-tester/src/E2E/**/specs/*.win.ts']],
+  specs: [['../fluent-tester/src/E2E/Theme/specs/*.win.ts']],
   exclude: [],
 
   capabilities: [
@@ -108,7 +108,7 @@ exports.config = {
    * @param {Array.<String>} specs List of spec file paths that are to be run
    */
   before: async function () {
-    await browser.maximizeWindow();
+    //await browser.maximizeWindow();
   },
   /**
    * Runs before a WebdriverIO command gets executed.
@@ -122,19 +122,17 @@ exports.config = {
    * @param {Object} suite suite details
    */
   // beforeSuite: function (suite) {
-  //   console.log('\n\n\n\n\n\n IN BEFORESUITE \n\n\n\n\n\n\n\n\n');
   // },
   /**
    * Function to be executed before a test (in Mocha/Jasmine) starts.
    */
-  // beforeTest: async (test) => {
+  // beforeTest: function (test, context) => {
   // },
   /**
    * Hook that gets executed _before_ a hook within the suite starts (e.g. runs before calling
    * beforeEach in Mocha)
    */
   // beforeHook: function (test, context) {
-  //   console.log('\n\n\n\n Before Hook - test: ' + JSON.stringify(test) + '. And context: ' + JSON.stringify(context), +'\n\n');
   // },
   /**
    * Hook that gets executed _after_ a hook within the suite starts (e.g. runs after calling
@@ -146,7 +144,8 @@ exports.config = {
    * Function to be executed after a test (in Mocha/Jasmine).
    */
   afterTest: async function (test, context, results) {
-    console.log('\n\n Test Case: ' + test.description + '.      Test Result: ' + results.passed + ' \n\n');
+    console.log('\n\n Test Case: ' + test.description + '.      Test Result: ' + results.passed ? 'Passed' : 'Failed' + ' \n\n');
+
     // if test passed, ignore, else take and save screenshot. Unless it's the first test that boots the app,
     // it may be useful to have a screenshot of the app on load.
     if (results.passed) {

--- a/apps/win32/wdio.conf.js
+++ b/apps/win32/wdio.conf.js
@@ -127,14 +127,8 @@ exports.config = {
   /**
    * Function to be executed before a test (in Mocha/Jasmine) starts.
    */
-  beforeTest: async (test) => {
-    // get current test title and clean it, to use it as file name
-    const fileName = encodeURIComponent(test.description.replace(/\s+/g, '-'));
-
-    // build file path
-    const filePath = './errorShots/before_' + fileName + '.png';
-    await browser.saveScreenshot(filePath);
-  },
+  // beforeTest: async (test) => {
+  // },
   /**
    * Hook that gets executed _before_ a hook within the suite starts (e.g. runs before calling
    * beforeEach in Mocha)
@@ -152,6 +146,7 @@ exports.config = {
    * Function to be executed after a test (in Mocha/Jasmine).
    */
   afterTest: async function (test, context, results) {
+    console.log('\n\n\n\n Test Case: ' + test.description + '.      Test Result: ' + results.passed + ' \n\n\n\n');
     // if test passed, ignore, else take and save screenshot. Unless it's the first test that boots the app,
     // it may be useful to have a screenshot of the app on load.
     if (results.passed) {

--- a/apps/win32/wdio.conf.js
+++ b/apps/win32/wdio.conf.js
@@ -33,7 +33,7 @@ exports.config = {
    */
 
   logLevel: 'debug', // Level of logging verbosity: trace | debug | info | warn | error | silent
-  bail: 0, // If you only want to run your tests until a specific amount of tests have failed use bail (default is 0 - don't bail, run all tests).
+  bail: 1, // If you only want to run your tests until a specific amount of tests have failed use bail (default is 0 - don't bail, run all tests).
   waitforTimeout: defaultWaitForTimeout, // Default timeout for all waitForXXX commands.
   connectionRetryTimeout: defaultConnectionRetryTimeout, // Timeout for any WebDriver request to a driver or grid.
   connectionRetryCount: 3, // Maximum count of request retries to the Selenium server.

--- a/apps/win32/wdio.conf.js
+++ b/apps/win32/wdio.conf.js
@@ -12,7 +12,15 @@ const jasmineDefaultTimeout = 60000; // 60 seconds for Jasmine test timeout
 exports.config = {
   runner: 'local', // Where should your test be launched
   specs: [['../fluent-tester/src/E2E/**/specs/*.win.ts']],
-  exclude: ['../fluent-tester/src/E2E/Menu/specs/*.win.ts', '../fluent-tester/src/E2E/ButtonExperimental/specs/*.win.ts'],
+  exclude: [
+    '../fluent-tester/src/E2E/Menu/specs/*.win.ts',
+    '../fluent-tester/src/E2E/ButtonExperimental/specs/*.win.ts',
+    '../fluent-tester/src/E2E/CheckboxExperimental/specs/*.win.ts',
+    '../fluent-tester/src/E2E/MenuButtonExperimental/specs/*.win.ts',
+    '../fluent-tester/src/E2E/RadioGroupExperimental/specs/*.win.ts',
+    '../fluent-tester/src/E2E/TabsExperimental/specs/*.win.ts',
+    '../fluent-tester/src/E2E/TextExperimental/specs/*.win.ts',
+  ],
 
   capabilities: [
     {

--- a/apps/win32/wdio.conf.js
+++ b/apps/win32/wdio.conf.js
@@ -11,7 +11,7 @@ const jasmineDefaultTimeout = 60000; // 60 seconds for Jasmine test timeout
 
 exports.config = {
   runner: 'local', // Where should your test be launched
-  specs: ['../fluent-tester/src/E2E/**/specs/*.win.ts'],
+  specs: [['../fluent-tester/src/E2E/**/specs/*.win.ts']],
   exclude: ['../fluent-tester/src/E2E/Shimmer/specs/*.win.ts'],
 
   capabilities: [

--- a/apps/win32/wdio.conf.js
+++ b/apps/win32/wdio.conf.js
@@ -12,7 +12,7 @@ const jasmineDefaultTimeout = 60000; // 60 seconds for Jasmine test timeout
 exports.config = {
   runner: 'local', // Where should your test be launched
   specs: [['../fluent-tester/src/E2E/**/specs/*.win.ts']],
-  exclude: ['../fluent-tester/src/E2E/ButtonExperimental/specs/*.win.ts', '../fluent-tester/src/E2E/Switch/specs/*.win.ts'],
+  exclude: [],
 
   capabilities: [
     {

--- a/apps/win32/wdio.conf.js
+++ b/apps/win32/wdio.conf.js
@@ -109,34 +109,6 @@ exports.config = {
    */
   before: async function () {
     await browser.maximizeWindow();
-
-    // Find the ScrollViewer containing the test page buttons
-    var testPageButtonScrollViewer = null;
-    await browser.waitUntil(
-      async () => {
-        testPageButtonScrollViewer = await $('~SCROLLVIEW_TEST_ID');
-        return await testPageButtonScrollViewer.isExisting();
-      },
-      {
-        timeoutMsg: 'Could not find the element with identifier = ' + identifier,
-      },
-    );
-
-    const testPageButtons = await testPageButtonScrollViewer.$$('//*');
-    const reg = new RegExp('Homepage_[a-zA-Z]*_Button');
-
-    var firstTestPageButton = null;
-    for (const child of testPageButtons) {
-      const autoId = await child.getAttribute('AutomationId');
-      if (autoId && autoId !== 'SCROLLVIEW_TEST_ID' && autoId.match(reg)) {
-        firstTestPageButton = await child;
-        break;
-      }
-    }
-
-    await browser.addCommand('getFirstTestPageButton', async function () {
-      return firstTestPageButton;
-    });
   },
   /**
    * Runs before a WebdriverIO command gets executed.

--- a/apps/win32/wdio.conf.js
+++ b/apps/win32/wdio.conf.js
@@ -11,7 +11,7 @@ const jasmineDefaultTimeout = 60000; // 60 seconds for Jasmine test timeout
 
 exports.config = {
   runner: 'local', // Where should your test be launched
-  specs: [['../fluent-tester/src/E2E/**/specs/*.win.ts']],
+  specs: [['../fluent-tester/src/E2E/Avatar/specs/*.win.ts']],
   exclude: ['../fluent-tester/src/E2E/ButtonExperimental/specs/*.win.ts'],
 
   capabilities: [
@@ -37,7 +37,7 @@ exports.config = {
   waitforTimeout: defaultWaitForTimeout, // Default timeout for all waitForXXX commands.
   connectionRetryTimeout: defaultConnectionRetryTimeout, // Timeout for any WebDriver request to a driver or grid.
   connectionRetryCount: 3, // Maximum count of request retries to the Selenium server.
-  specFileRetries: 3, // The number of times to retry the entire spec file when it fails as a whole.
+  specFileRetries: 1, // The number of times to retry the entire spec file when it fails as a whole.
 
   port: 4723, // default appium port
   services: [

--- a/apps/win32/wdio.conf.js
+++ b/apps/win32/wdio.conf.js
@@ -11,7 +11,7 @@ const jasmineDefaultTimeout = 60000; // 60 seconds for Jasmine test timeout
 
 exports.config = {
   runner: 'local', // Where should your test be launched
-  specs: [['../fluent-tester/src/E2E/Theme/specs/*.win.ts']],
+  specs: [['../fluent-tester/src/E2E/**/specs/*.win.ts']],
   exclude: [],
 
   capabilities: [

--- a/apps/win32/wdio.conf.js
+++ b/apps/win32/wdio.conf.js
@@ -144,7 +144,8 @@ exports.config = {
    * Function to be executed after a test (in Mocha/Jasmine).
    */
   afterTest: async function (test, context, results) {
-    console.log('\n\n Test Case: ' + test.description + '.      Test Result: ' + results.passed ? 'Passed' : 'Failed' + ' \n\n');
+    const resultString = results.passed ? 'Passed' : 'Failed';
+    console.log('\n\n Test Case: ' + test.description + '.      Test Result: ' + resultString + ' \n\n');
 
     // if test passed, ignore, else take and save screenshot. Unless it's the first test that boots the app,
     // it may be useful to have a screenshot of the app on load.

--- a/apps/win32/wdio.conf.js
+++ b/apps/win32/wdio.conf.js
@@ -13,10 +13,9 @@ exports.config = {
   runner: 'local', // Where should your test be launched
   specs: [['../fluent-tester/src/E2E/**/specs/*.win.ts']],
   exclude: [
+    '../fluent-tester/src/E2E/Menu/specs/*.win.ts',
     '../fluent-tester/src/E2E/ButtonExperimental/specs/*.win.ts',
     '../fluent-tester/src/E2E/Switch/specs/*.win.ts',
-    '../fluent-tester/src/E2E/TextExperimental/specs/*.win.ts',
-    '../fluent-tester/src/E2E/Text/specs/*.win.ts',
   ],
 
   capabilities: [

--- a/change/@fluentui-react-native-tester-625345f7-4878-4ea6-a4fc-b4640e4a7ed0.json
+++ b/change/@fluentui-react-native-tester-625345f7-4878-4ea6-a4fc-b4640e4a7ed0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Removing E2E test for CI testing purposes",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "safreibe@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-tester-8e7acf13-163e-4927-bd49-4f15864db38f.json
+++ b/change/@fluentui-react-native-tester-8e7acf13-163e-4927-bd49-4f15864db38f.json
@@ -1,0 +1,6 @@
+{
+  "type": "minor",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "safreibe@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-win32-15b8ca28-3c28-4b7e-b3bf-f44ddc3f6b19.json
+++ b/change/@fluentui-react-native-tester-win32-15b8ca28-3c28-4b7e-b3bf-f44ddc3f6b19.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Make E2E Win32 tests run sequentually",
+  "packageName": "@fluentui-react-native/tester-win32",
+  "email": "safreibe@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This PR accomplishes a couple things. Most notably, E2E tests grouped in the same suite run sequentially - meaning the app doesn't have to teardown/bootup after each spec file. This **significantly** improves the performance of FURNs E2E testing by cutting down the runtime significantly.

Previous Runtime v. Current Runtime
Win32:
MacOS:
iOS:
Windows:


Additionally, this PR improves the logic for scrolling. Previously, we were using an API called `touchScroll`, which uses touch to scroll. This API was very finnicky and caused flaky tests. Now, we're using PageDown to scroll. To accomplish this, we have to put keyboard focus in the area we want to scroll. To do this, I added a button at the top of each test page so we can easily focus in whenever we need to scroll.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
