### PR TITLE
Implemented label subtexts in RadioGroups

### DIFF
--- a/apps/fluent-tester/src/TestComponents/RadioGroupExperimental/RadioGroupExperimentalTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/RadioGroupExperimental/RadioGroupExperimentalTest.tsx
@@ -3,6 +3,7 @@ import { RADIO_GROUP_EXPERIMENTAL_TESTPAGE } from './consts';
 import { DefaultRadioGroup } from './DefaultRadioGroup';
 import { RequiredRadioGroup } from './RequiredRadioGroup';
 import { DisabledRadioGroup } from './DisabledRadioGroup';
+import { SubtextRadioGroup } from './SubtextRadioGroup';
 import { Test, TestSection, PlatformStatus } from '../Test';
 
 const radioGroupExperimentalSections: TestSection[] = [
@@ -20,6 +21,11 @@ const radioGroupExperimentalSections: TestSection[] = [
     name: 'Required RadioGroup',
     testID: RADIO_GROUP_EXPERIMENTAL_TESTPAGE,
     component: RequiredRadioGroup,
+  },
+  {
+    name: 'RadioGroup with Label Subtext',
+    testID: RADIO_GROUP_EXPERIMENTAL_TESTPAGE,
+    component: SubtextRadioGroup,
   },
 ];
 

--- a/apps/fluent-tester/src/TestComponents/RadioGroupExperimental/SubtextRadioGroup.tsx
+++ b/apps/fluent-tester/src/TestComponents/RadioGroupExperimental/SubtextRadioGroup.tsx
@@ -11,10 +11,10 @@ export const SubtextRadioGroup: React.FunctionComponent = () => {
   return (
     <View>
       <RadioGroup label="Uncontrolled RadioGroup" defaultValue="X" onChange={onChange}>
-        <Radio label="Option W" value="W" accessibilityLabel="Test Accessibility Label" />
-        <Radio label="Option X" value="X" />
-        <Radio label="Option Y" value="C" />
-        <Radio label="Option Z" value="Z" />
+        <Radio label="Apple" subtext="This is a type of fruit" value="W" />
+        <Radio label="Pear" value="X" />
+        <Radio label="Banana" value="C" />
+        <Radio label="Orange" value="Z" />
       </RadioGroup>
     </View>
   );

--- a/apps/fluent-tester/src/TestComponents/RadioGroupExperimental/SubtextRadioGroup.tsx
+++ b/apps/fluent-tester/src/TestComponents/RadioGroupExperimental/SubtextRadioGroup.tsx
@@ -1,0 +1,21 @@
+import { RadioGroup, Radio } from '@fluentui-react-native/experimental-radio-group';
+import * as React from 'react';
+import { View } from 'react-native';
+
+export const SubtextRadioGroup: React.FunctionComponent = () => {
+  // Client's example onChange function
+  const onChange = (key: string) => {
+    console.log(key);
+  };
+
+  return (
+    <View>
+      <RadioGroup label="Uncontrolled RadioGroup" defaultValue="X" onChange={onChange}>
+        <Radio label="Option W" value="W" accessibilityLabel="Test Accessibility Label" />
+        <Radio label="Option X" value="X" />
+        <Radio label="Option Y" value="C" />
+        <Radio label="Option Z" value="Z" />
+      </RadioGroup>
+    </View>
+  );
+};

--- a/packages/experimental/RadioGroup/src/Radio/Radio.styling.ts
+++ b/packages/experimental/RadioGroup/src/Radio/Radio.styling.ts
@@ -1,7 +1,8 @@
 import { radioName, RadioTokens, RadioSlotProps, RadioProps } from './Radio.types';
-import { UseStylingOptions, buildProps } from '@fluentui-react-native/framework';
+import { Theme, UseStylingOptions, buildProps } from '@fluentui-react-native/framework';
 import { globalTokens } from '@fluentui-react-native/theme-tokens';
 import { defaultRadioTokens } from './RadioTokens';
+import { fontStyles } from '@fluentui-react-native/tokens';
 
 export const radioStates: (keyof RadioTokens)[] = ['focused', 'hovered', 'pressed', 'selected', 'disabled'];
 
@@ -13,7 +14,7 @@ export const stylingSettings: UseStylingOptions<RadioProps, RadioSlotProps, Radi
       (tokens: RadioTokens) => ({
         style: {
           display: 'flex',
-          alignItems: 'center',
+          alignItems: 'flex-start',
           flexDirection: 'row',
           minHeight: 20,
           marginTop: 0,
@@ -56,12 +57,35 @@ export const stylingSettings: UseStylingOptions<RadioProps, RadioSlotProps, Radi
       }),
       ['radioInnerCircleSize', 'radioVisibility', 'radioFill'],
     ),
+    content: buildProps(
+      () => ({
+        style: {
+          display: 'flex',
+          alignItems: 'flex-start',
+          flexDirection: 'column',
+        },
+      }),
+      [],
+    ),
     label: buildProps(
-      (tokens: RadioTokens) => ({
+      (tokens: RadioTokens, theme: Theme) => ({
         variant: tokens.variant,
         style: {
           marginTop: 2,
           color: tokens.color,
+          ...fontStyles.from(tokens, theme),
+        },
+      }),
+      ['color', ...fontStyles.keys],
+    ),
+    subtext: buildProps(
+      (tokens: RadioTokens) => ({
+        variant: tokens.variant,
+        style: {
+          marginTop: globalTokens.spacing.xxs,
+          marginRight: globalTokens.spacing.xxs,
+          color: tokens.color,
+          fontSize: tokens.subtextSize,
         },
       }),
       ['color'],

--- a/packages/experimental/RadioGroup/src/Radio/Radio.tsx
+++ b/packages/experimental/RadioGroup/src/Radio/Radio.tsx
@@ -27,7 +27,9 @@ export const Radio = compose<RadioType>({
     root: View,
     button: View,
     innerCircle: View,
+    content: View,
     label: Text,
+    subtext: Text,
   },
   filters: {
     button: filterViewProps,
@@ -39,14 +41,21 @@ export const Radio = compose<RadioType>({
 
     // now return the handler for finishing render
     return (final: RadioProps) => {
-      const { label, ...mergedProps } = mergeProps(radio.props, final);
+      const { label, subtext, ...mergedProps } = mergeProps(radio.props, final);
+
+      const labelComponent = (
+        <Slots.content>
+          <Slots.label>{label}</Slots.label>
+          {!!subtext && <Slots.subtext>{subtext}</Slots.subtext>}
+        </Slots.content>
+      );
 
       return (
         <Slots.root {...mergedProps}>
           <Slots.button>
             <Slots.innerCircle />
           </Slots.button>
-          <Slots.label>{label}</Slots.label>
+          {labelComponent}
         </Slots.root>
       );
     };

--- a/packages/experimental/RadioGroup/src/Radio/Radio.types.ts
+++ b/packages/experimental/RadioGroup/src/Radio/Radio.types.ts
@@ -39,6 +39,11 @@ export interface RadioTokens extends FontTokens, IColorTokens, IForegroundColorT
   radioBorderWidth?: number;
 
   /**
+   * Border width of Radio
+   */
+  subtextSize?: number;
+
+  /**
    * States that can be applied to a Radio
    */
   selected?: RadioTokens;
@@ -53,6 +58,11 @@ export interface RadioProps extends IPressableProps {
    * The text string for the option
    */
   label: string;
+
+  /**
+   * Label subtext for the option
+   */
+  subtext?: string;
 
   /**
    * A unique key-identifier for each option
@@ -82,7 +92,9 @@ export interface RadioSlotProps {
   root: IViewProps;
   button: IViewProps;
   innerCircle: IViewProps;
+  content: IViewProps;
   label: TextProps;
+  subtext?: TextProps;
 }
 
 export interface RadioType {

--- a/packages/experimental/RadioGroup/src/Radio/RadioTokens.ts
+++ b/packages/experimental/RadioGroup/src/Radio/RadioTokens.ts
@@ -16,6 +16,7 @@ export const defaultRadioTokens: TokenSettings<RadioTokens, Theme> = (t: Theme) 
     color: t.colors.neutralForeground3,
     radioSize: 20,
     radioInnerCircleSize: 10,
+    subtextSize: globalTokens.font.size[200],
     disabled: {
       // Unchecked, Disabled
       radioBorder: t.colors.neutralForegroundDisabled,

--- a/packages/experimental/RadioGroup/src/Radio/useRadio.ts
+++ b/packages/experimental/RadioGroup/src/Radio/useRadio.ts
@@ -11,6 +11,7 @@ export const useRadio = (props: RadioProps): RadioState => {
   const defaultComponentRef = React.useRef(null);
   const {
     label,
+    subtext,
     value,
     disabled,
     accessibilityActions,
@@ -82,12 +83,13 @@ export const useRadio = (props: RadioProps): RadioState => {
     props: {
       value,
       label,
+      subtext,
       ...rest,
       ref: buttonRef,
       ...pressable.props,
       accessible: true,
       accessibilityRole: 'radio',
-      accessibilityLabel: accessibilityLabel ?? label,
+      accessibilityLabel: accessibilityLabel ?? (subtext ? label + subtext : label),
       accessibilityState: getAccessibilityState(state.disabled, state.selected, accessibilityState),
       accessibilityActions: accessibilityActionsProp,
       accessibilityPositionInSet: accessibilityPositionInSet ?? selectedInfo.buttonKeys.findIndex((x) => x == value) + 1,


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Implemented a new prop for label subtexts in Radio. 

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/30990970/192691465-17bfcedb-ec6a-4154-bc36-b132f6e95b47.png) | ![image](https://user-images.githubusercontent.com/30990970/192692198-f1ef6b9c-de78-4cab-adb8-d5b06f1ebf47.png) |

### Pull request checklist

This PR has considered (when applicable):
- [] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
