### PR TITLE
Shadow: Move layout props to outer/inner view as needed

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Shadow/ShadowWithDifferentPropsTestSection.tsx
+++ b/apps/fluent-tester/src/TestComponents/Shadow/ShadowWithDifferentPropsTestSection.tsx
@@ -39,6 +39,10 @@ const getThemedStyles = themedStyleSheet((t: Theme) => {
       borderWidth: 2,
       borderColor: 'black',
     },
+    offsetTestProps: { start: 10 },
+    alignItemsTestProps: { alignItems: 'flex-start' },
+    flexDirectionTestProps: { flexDirection: 'row' },
+    flexWrapTestProps: { flexWrap: 'wrap' },
   };
 });
 
@@ -81,6 +85,26 @@ export const ShadowWithDifferentPropsTestSection: React.FunctionComponent = () =
             )}
           >
             <Text variant="bodySemibold">borderWidth: 2</Text>
+          </View>
+        </Shadow>
+        <Shadow shadowToken={theme.shadows.shadow16}>
+          <View style={mergeStyles(themedStyles.defaultShadowTestBoxProps, themedStyles.offsetTestProps)}>
+            <Text variant="bodySemibold">start: 10</Text>
+          </View>
+        </Shadow>
+        <Shadow shadowToken={theme.shadows.shadow16}>
+          <View style={mergeStyles(themedStyles.defaultShadowTestBoxProps, themedStyles.alignItemsTestProps)}>
+            <Text variant="bodySemibold">alignItems: flex-start</Text>
+          </View>
+        </Shadow>
+        <Shadow shadowToken={theme.shadows.shadow16}>
+          <View style={mergeStyles(themedStyles.defaultShadowTestBoxProps, themedStyles.flexDirectionTestProps)}>
+            <Text variant="bodySemibold">flexDirection: row</Text>
+          </View>
+        </Shadow>
+        <Shadow shadowToken={theme.shadows.shadow16}>
+          <View style={mergeStyles(themedStyles.defaultShadowTestBoxProps, themedStyles.flexWrapTestProps)}>
+            <Text variant="bodySemibold">flexWrap: wrap</Text>
           </View>
         </Shadow>
       </View>

--- a/change/@fluentui-react-native-button-86f2ae3d-4ab5-4522-86b2-d0997017fd90.json
+++ b/change/@fluentui-react-native-button-86f2ae3d-4ab5-4522-86b2-d0997017fd90.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update tests after considering layout props",
+  "packageName": "@fluentui-react-native/button",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-shadow-f5d9c298-8f05-47f7-b288-d47a4d44c117.json
+++ b/change/@fluentui-react-native-experimental-shadow-f5d9c298-8f05-47f7-b288-d47a4d44c117.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Get Shadow working with layout props",
+  "packageName": "@fluentui-react-native/experimental-shadow",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-notification-b8945a70-66d4-4cc6-a136-3581ea07778f.json
+++ b/change/@fluentui-react-native-notification-b8945a70-66d4-4cc6-a136-3581ea07778f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update tests after considering layout props",
+  "packageName": "@fluentui-react-native/notification",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-747bc08c-8d21-4701-98ee-6ecd5b3b8df3.json
+++ b/change/@fluentui-react-native-tester-747bc08c-8d21-4701-98ee-6ecd5b3b8df3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Get Shadow working with layout props",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Button/src/FAB/__snapshots__/FAB.test.tsx.snap
+++ b/packages/components/Button/src/FAB/__snapshots__/FAB.test.tsx.snap
@@ -67,14 +67,15 @@ exports[`Default FAB (iOS) 1`] = `
 <View
   style={
     Object {
-      "alignItems": "center",
       "alignSelf": "flex-start",
       "backgroundColor": "#0078d4",
       "borderColor": "#005a9e",
       "borderRadius": 9999,
+      "bottom": undefined,
       "display": "flex",
-      "flexDirection": "row",
+      "end": undefined,
       "justifyContent": "center",
+      "left": undefined,
       "margin": undefined,
       "marginBottom": undefined,
       "marginEnd": undefined,
@@ -86,6 +87,7 @@ exports[`Default FAB (iOS) 1`] = `
       "marginVertical": undefined,
       "minHeight": 56,
       "minWidth": 56,
+      "right": undefined,
       "shadowColor": "#000000",
       "shadowOffset": Object {
         "height": 0,
@@ -93,6 +95,8 @@ exports[`Default FAB (iOS) 1`] = `
       },
       "shadowOpacity": 0.12,
       "shadowRadius": 1,
+      "start": undefined,
+      "top": undefined,
       "width": undefined,
     }
   }
@@ -136,6 +140,7 @@ exports[`Default FAB (iOS) 1`] = `
         "borderWidth": undefined,
         "display": "flex",
         "flexDirection": "row",
+        "flexWrap": undefined,
         "justifyContent": "center",
         "minHeight": 56,
         "minWidth": 56,

--- a/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
+++ b/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
@@ -7,9 +7,11 @@ exports[`Notification component tests Notification default 1`] = `
       "backgroundColor": "#EBF3FC",
       "borderColor": "transparent",
       "borderRadius": 12,
+      "bottom": undefined,
+      "end": undefined,
       "flex": 1,
-      "flexDirection": "row",
       "justifyContent": "space-between",
+      "left": undefined,
       "margin": undefined,
       "marginBottom": undefined,
       "marginEnd": undefined,
@@ -20,6 +22,7 @@ exports[`Notification component tests Notification default 1`] = `
       "marginTop": undefined,
       "marginVertical": undefined,
       "minHeight": 52,
+      "right": undefined,
       "shadowColor": "#000000",
       "shadowOffset": Object {
         "height": 8,
@@ -27,6 +30,8 @@ exports[`Notification component tests Notification default 1`] = `
       },
       "shadowOpacity": 0.14,
       "shadowRadius": 8,
+      "start": undefined,
+      "top": undefined,
     }
   }
 >
@@ -43,6 +48,7 @@ exports[`Notification component tests Notification default 1`] = `
     onStartShouldSetResponder={[Function]}
     style={
       Object {
+        "alignItems": undefined,
         "backgroundColor": "#EBF3FC",
         "borderBottomWidth": undefined,
         "borderColor": "transparent",
@@ -55,6 +61,7 @@ exports[`Notification component tests Notification default 1`] = `
         "borderWidth": 1,
         "flex": 1,
         "flexDirection": "row",
+        "flexWrap": undefined,
         "justifyContent": "space-between",
         "minHeight": 52,
         "padding": 16,

--- a/packages/experimental/Shadow/src/Shadow.tsx
+++ b/packages/experimental/Shadow/src/Shadow.tsx
@@ -66,6 +66,18 @@ function getStylePropsForShadowViewsWorker(childStyleProps: ViewStyle = {}, shad
     paddingTop,
     paddingVertical,
 
+    alignItems,
+
+    flexWrap,
+    flexDirection,
+
+    start,
+    end,
+    left,
+    right,
+    top,
+    bottom,
+
     ...restOfChildStyleProps
   } = childStyleProps;
 
@@ -85,6 +97,7 @@ function getStylePropsForShadowViewsWorker(childStyleProps: ViewStyle = {}, shad
         borderStartWidth,
         borderTopWidth,
         borderWidth,
+
         padding,
         paddingBottom,
         paddingEnd,
@@ -94,6 +107,12 @@ function getStylePropsForShadowViewsWorker(childStyleProps: ViewStyle = {}, shad
         paddingStart,
         paddingTop,
         paddingVertical,
+
+        alignItems,
+
+        flexWrap,
+        flexDirection,
+
         ...shadowTokenStyleSet.key,
         ...restOfChildStyleProps,
       },
@@ -109,6 +128,14 @@ function getStylePropsForShadowViewsWorker(childStyleProps: ViewStyle = {}, shad
         marginStart,
         marginTop,
         marginVertical,
+
+        start,
+        end,
+        left,
+        right,
+        top,
+        bottom,
+
         ...shadowTokenStyleSet.ambient,
         ...restOfChildStyleProps,
       },

--- a/packages/experimental/Shadow/src/__tests__/__snapshots__/Shadow.test.tsx.snap
+++ b/packages/experimental/Shadow/src/__tests__/__snapshots__/Shadow.test.tsx.snap
@@ -5,6 +5,9 @@ exports[`Shadow component tests Brand shadow (depth=2) 1`] = `
   style={
     Object {
       "backgroundColor": "red",
+      "bottom": undefined,
+      "end": undefined,
+      "left": undefined,
       "margin": undefined,
       "marginBottom": undefined,
       "marginEnd": undefined,
@@ -14,6 +17,7 @@ exports[`Shadow component tests Brand shadow (depth=2) 1`] = `
       "marginStart": undefined,
       "marginTop": undefined,
       "marginVertical": undefined,
+      "right": undefined,
       "shadowColor": "#000000",
       "shadowOffset": Object {
         "height": 0,
@@ -21,12 +25,15 @@ exports[`Shadow component tests Brand shadow (depth=2) 1`] = `
       },
       "shadowOpacity": 0.3,
       "shadowRadius": 1,
+      "start": undefined,
+      "top": undefined,
     }
   }
 >
   <View
     style={
       Object {
+        "alignItems": undefined,
         "backgroundColor": "red",
         "borderBottomWidth": undefined,
         "borderEndWidth": undefined,
@@ -35,6 +42,8 @@ exports[`Shadow component tests Brand shadow (depth=2) 1`] = `
         "borderStartWidth": undefined,
         "borderTopWidth": undefined,
         "borderWidth": undefined,
+        "flexDirection": undefined,
+        "flexWrap": undefined,
         "padding": undefined,
         "paddingBottom": undefined,
         "paddingEnd": undefined,
@@ -66,6 +75,9 @@ exports[`Shadow component tests Brand shadow (depth=4) 1`] = `
   style={
     Object {
       "backgroundColor": "red",
+      "bottom": undefined,
+      "end": undefined,
+      "left": undefined,
       "margin": undefined,
       "marginBottom": undefined,
       "marginEnd": undefined,
@@ -75,6 +87,7 @@ exports[`Shadow component tests Brand shadow (depth=4) 1`] = `
       "marginStart": undefined,
       "marginTop": undefined,
       "marginVertical": undefined,
+      "right": undefined,
       "shadowColor": "#000000",
       "shadowOffset": Object {
         "height": 0,
@@ -82,12 +95,15 @@ exports[`Shadow component tests Brand shadow (depth=4) 1`] = `
       },
       "shadowOpacity": 0.3,
       "shadowRadius": 1,
+      "start": undefined,
+      "top": undefined,
     }
   }
 >
   <View
     style={
       Object {
+        "alignItems": undefined,
         "backgroundColor": "red",
         "borderBottomWidth": undefined,
         "borderEndWidth": undefined,
@@ -96,6 +112,8 @@ exports[`Shadow component tests Brand shadow (depth=4) 1`] = `
         "borderStartWidth": undefined,
         "borderTopWidth": undefined,
         "borderWidth": undefined,
+        "flexDirection": undefined,
+        "flexWrap": undefined,
         "padding": undefined,
         "paddingBottom": undefined,
         "paddingEnd": undefined,
@@ -127,6 +145,9 @@ exports[`Shadow component tests Brand shadow (depth=8) 1`] = `
   style={
     Object {
       "backgroundColor": "red",
+      "bottom": undefined,
+      "end": undefined,
+      "left": undefined,
       "margin": undefined,
       "marginBottom": undefined,
       "marginEnd": undefined,
@@ -136,6 +157,7 @@ exports[`Shadow component tests Brand shadow (depth=8) 1`] = `
       "marginStart": undefined,
       "marginTop": undefined,
       "marginVertical": undefined,
+      "right": undefined,
       "shadowColor": "#000000",
       "shadowOffset": Object {
         "height": 0,
@@ -143,12 +165,15 @@ exports[`Shadow component tests Brand shadow (depth=8) 1`] = `
       },
       "shadowOpacity": 0.3,
       "shadowRadius": 1,
+      "start": undefined,
+      "top": undefined,
     }
   }
 >
   <View
     style={
       Object {
+        "alignItems": undefined,
         "backgroundColor": "red",
         "borderBottomWidth": undefined,
         "borderEndWidth": undefined,
@@ -157,6 +182,8 @@ exports[`Shadow component tests Brand shadow (depth=8) 1`] = `
         "borderStartWidth": undefined,
         "borderTopWidth": undefined,
         "borderWidth": undefined,
+        "flexDirection": undefined,
+        "flexWrap": undefined,
         "padding": undefined,
         "paddingBottom": undefined,
         "paddingEnd": undefined,
@@ -188,6 +215,9 @@ exports[`Shadow component tests Brand shadow (depth=16) 1`] = `
   style={
     Object {
       "backgroundColor": "red",
+      "bottom": undefined,
+      "end": undefined,
+      "left": undefined,
       "margin": undefined,
       "marginBottom": undefined,
       "marginEnd": undefined,
@@ -197,6 +227,7 @@ exports[`Shadow component tests Brand shadow (depth=16) 1`] = `
       "marginStart": undefined,
       "marginTop": undefined,
       "marginVertical": undefined,
+      "right": undefined,
       "shadowColor": "#000000",
       "shadowOffset": Object {
         "height": 0,
@@ -204,12 +235,15 @@ exports[`Shadow component tests Brand shadow (depth=16) 1`] = `
       },
       "shadowOpacity": 0.3,
       "shadowRadius": 1,
+      "start": undefined,
+      "top": undefined,
     }
   }
 >
   <View
     style={
       Object {
+        "alignItems": undefined,
         "backgroundColor": "red",
         "borderBottomWidth": undefined,
         "borderEndWidth": undefined,
@@ -218,6 +252,8 @@ exports[`Shadow component tests Brand shadow (depth=16) 1`] = `
         "borderStartWidth": undefined,
         "borderTopWidth": undefined,
         "borderWidth": undefined,
+        "flexDirection": undefined,
+        "flexWrap": undefined,
         "padding": undefined,
         "paddingBottom": undefined,
         "paddingEnd": undefined,
@@ -249,6 +285,9 @@ exports[`Shadow component tests Brand shadow (depth=28) 1`] = `
   style={
     Object {
       "backgroundColor": "red",
+      "bottom": undefined,
+      "end": undefined,
+      "left": undefined,
       "margin": undefined,
       "marginBottom": undefined,
       "marginEnd": undefined,
@@ -258,6 +297,7 @@ exports[`Shadow component tests Brand shadow (depth=28) 1`] = `
       "marginStart": undefined,
       "marginTop": undefined,
       "marginVertical": undefined,
+      "right": undefined,
       "shadowColor": "#000000",
       "shadowOffset": Object {
         "height": 0,
@@ -265,12 +305,15 @@ exports[`Shadow component tests Brand shadow (depth=28) 1`] = `
       },
       "shadowOpacity": 0.3,
       "shadowRadius": 4,
+      "start": undefined,
+      "top": undefined,
     }
   }
 >
   <View
     style={
       Object {
+        "alignItems": undefined,
         "backgroundColor": "red",
         "borderBottomWidth": undefined,
         "borderEndWidth": undefined,
@@ -279,6 +322,8 @@ exports[`Shadow component tests Brand shadow (depth=28) 1`] = `
         "borderStartWidth": undefined,
         "borderTopWidth": undefined,
         "borderWidth": undefined,
+        "flexDirection": undefined,
+        "flexWrap": undefined,
         "padding": undefined,
         "paddingBottom": undefined,
         "paddingEnd": undefined,
@@ -310,6 +355,9 @@ exports[`Shadow component tests Brand shadow (depth=64) 1`] = `
   style={
     Object {
       "backgroundColor": "red",
+      "bottom": undefined,
+      "end": undefined,
+      "left": undefined,
       "margin": undefined,
       "marginBottom": undefined,
       "marginEnd": undefined,
@@ -319,6 +367,7 @@ exports[`Shadow component tests Brand shadow (depth=64) 1`] = `
       "marginStart": undefined,
       "marginTop": undefined,
       "marginVertical": undefined,
+      "right": undefined,
       "shadowColor": "#000000",
       "shadowOffset": Object {
         "height": 0,
@@ -326,12 +375,15 @@ exports[`Shadow component tests Brand shadow (depth=64) 1`] = `
       },
       "shadowOpacity": 0.3,
       "shadowRadius": 4,
+      "start": undefined,
+      "top": undefined,
     }
   }
 >
   <View
     style={
       Object {
+        "alignItems": undefined,
         "backgroundColor": "red",
         "borderBottomWidth": undefined,
         "borderEndWidth": undefined,
@@ -340,6 +392,8 @@ exports[`Shadow component tests Brand shadow (depth=64) 1`] = `
         "borderStartWidth": undefined,
         "borderTopWidth": undefined,
         "borderWidth": undefined,
+        "flexDirection": undefined,
+        "flexWrap": undefined,
         "padding": undefined,
         "paddingBottom": undefined,
         "paddingEnd": undefined,
@@ -371,6 +425,9 @@ exports[`Shadow component tests Pressable that has a shadow 1`] = `
   style={
     Object {
       "backgroundColor": "red",
+      "bottom": undefined,
+      "end": undefined,
+      "left": undefined,
       "margin": undefined,
       "marginBottom": undefined,
       "marginEnd": undefined,
@@ -380,6 +437,7 @@ exports[`Shadow component tests Pressable that has a shadow 1`] = `
       "marginStart": undefined,
       "marginTop": undefined,
       "marginVertical": undefined,
+      "right": undefined,
       "shadowColor": "#000000",
       "shadowOffset": Object {
         "height": 0,
@@ -387,6 +445,8 @@ exports[`Shadow component tests Pressable that has a shadow 1`] = `
       },
       "shadowOpacity": 0.12,
       "shadowRadius": 1,
+      "start": undefined,
+      "top": undefined,
     }
   }
 >
@@ -404,6 +464,7 @@ exports[`Shadow component tests Pressable that has a shadow 1`] = `
     onStartShouldSetResponder={[Function]}
     style={
       Object {
+        "alignItems": undefined,
         "backgroundColor": "red",
         "borderBottomWidth": undefined,
         "borderEndWidth": undefined,
@@ -412,6 +473,8 @@ exports[`Shadow component tests Pressable that has a shadow 1`] = `
         "borderStartWidth": undefined,
         "borderTopWidth": undefined,
         "borderWidth": undefined,
+        "flexDirection": undefined,
+        "flexWrap": undefined,
         "padding": undefined,
         "paddingBottom": undefined,
         "paddingEnd": undefined,
@@ -439,6 +502,9 @@ exports[`Shadow component tests Shadow (depth=2) 1`] = `
   style={
     Object {
       "backgroundColor": "red",
+      "bottom": undefined,
+      "end": undefined,
+      "left": undefined,
       "margin": undefined,
       "marginBottom": undefined,
       "marginEnd": undefined,
@@ -448,6 +514,7 @@ exports[`Shadow component tests Shadow (depth=2) 1`] = `
       "marginStart": undefined,
       "marginTop": undefined,
       "marginVertical": undefined,
+      "right": undefined,
       "shadowColor": "#000000",
       "shadowOffset": Object {
         "height": 0,
@@ -455,12 +522,15 @@ exports[`Shadow component tests Shadow (depth=2) 1`] = `
       },
       "shadowOpacity": 0.12,
       "shadowRadius": 1,
+      "start": undefined,
+      "top": undefined,
     }
   }
 >
   <View
     style={
       Object {
+        "alignItems": undefined,
         "backgroundColor": "red",
         "borderBottomWidth": undefined,
         "borderEndWidth": undefined,
@@ -469,6 +539,8 @@ exports[`Shadow component tests Shadow (depth=2) 1`] = `
         "borderStartWidth": undefined,
         "borderTopWidth": undefined,
         "borderWidth": undefined,
+        "flexDirection": undefined,
+        "flexWrap": undefined,
         "padding": undefined,
         "paddingBottom": undefined,
         "paddingEnd": undefined,
@@ -500,6 +572,9 @@ exports[`Shadow component tests Shadow (depth=4) 1`] = `
   style={
     Object {
       "backgroundColor": "red",
+      "bottom": undefined,
+      "end": undefined,
+      "left": undefined,
       "margin": undefined,
       "marginBottom": undefined,
       "marginEnd": undefined,
@@ -509,6 +584,7 @@ exports[`Shadow component tests Shadow (depth=4) 1`] = `
       "marginStart": undefined,
       "marginTop": undefined,
       "marginVertical": undefined,
+      "right": undefined,
       "shadowColor": "#000000",
       "shadowOffset": Object {
         "height": 0,
@@ -516,12 +592,15 @@ exports[`Shadow component tests Shadow (depth=4) 1`] = `
       },
       "shadowOpacity": 0.12,
       "shadowRadius": 1,
+      "start": undefined,
+      "top": undefined,
     }
   }
 >
   <View
     style={
       Object {
+        "alignItems": undefined,
         "backgroundColor": "red",
         "borderBottomWidth": undefined,
         "borderEndWidth": undefined,
@@ -530,6 +609,8 @@ exports[`Shadow component tests Shadow (depth=4) 1`] = `
         "borderStartWidth": undefined,
         "borderTopWidth": undefined,
         "borderWidth": undefined,
+        "flexDirection": undefined,
+        "flexWrap": undefined,
         "padding": undefined,
         "paddingBottom": undefined,
         "paddingEnd": undefined,
@@ -561,6 +642,9 @@ exports[`Shadow component tests Shadow (depth=8) 1`] = `
   style={
     Object {
       "backgroundColor": "red",
+      "bottom": undefined,
+      "end": undefined,
+      "left": undefined,
       "margin": undefined,
       "marginBottom": undefined,
       "marginEnd": undefined,
@@ -570,6 +654,7 @@ exports[`Shadow component tests Shadow (depth=8) 1`] = `
       "marginStart": undefined,
       "marginTop": undefined,
       "marginVertical": undefined,
+      "right": undefined,
       "shadowColor": "#000000",
       "shadowOffset": Object {
         "height": 0,
@@ -577,12 +662,15 @@ exports[`Shadow component tests Shadow (depth=8) 1`] = `
       },
       "shadowOpacity": 0.12,
       "shadowRadius": 1,
+      "start": undefined,
+      "top": undefined,
     }
   }
 >
   <View
     style={
       Object {
+        "alignItems": undefined,
         "backgroundColor": "red",
         "borderBottomWidth": undefined,
         "borderEndWidth": undefined,
@@ -591,6 +679,8 @@ exports[`Shadow component tests Shadow (depth=8) 1`] = `
         "borderStartWidth": undefined,
         "borderTopWidth": undefined,
         "borderWidth": undefined,
+        "flexDirection": undefined,
+        "flexWrap": undefined,
         "padding": undefined,
         "paddingBottom": undefined,
         "paddingEnd": undefined,
@@ -622,6 +712,9 @@ exports[`Shadow component tests Shadow (depth=16) 1`] = `
   style={
     Object {
       "backgroundColor": "red",
+      "bottom": undefined,
+      "end": undefined,
+      "left": undefined,
       "margin": undefined,
       "marginBottom": undefined,
       "marginEnd": undefined,
@@ -631,6 +724,7 @@ exports[`Shadow component tests Shadow (depth=16) 1`] = `
       "marginStart": undefined,
       "marginTop": undefined,
       "marginVertical": undefined,
+      "right": undefined,
       "shadowColor": "#000000",
       "shadowOffset": Object {
         "height": 0,
@@ -638,12 +732,15 @@ exports[`Shadow component tests Shadow (depth=16) 1`] = `
       },
       "shadowOpacity": 0.12,
       "shadowRadius": 1,
+      "start": undefined,
+      "top": undefined,
     }
   }
 >
   <View
     style={
       Object {
+        "alignItems": undefined,
         "backgroundColor": "red",
         "borderBottomWidth": undefined,
         "borderEndWidth": undefined,
@@ -652,6 +749,8 @@ exports[`Shadow component tests Shadow (depth=16) 1`] = `
         "borderStartWidth": undefined,
         "borderTopWidth": undefined,
         "borderWidth": undefined,
+        "flexDirection": undefined,
+        "flexWrap": undefined,
         "padding": undefined,
         "paddingBottom": undefined,
         "paddingEnd": undefined,
@@ -683,6 +782,9 @@ exports[`Shadow component tests Shadow (depth=28) 1`] = `
   style={
     Object {
       "backgroundColor": "red",
+      "bottom": undefined,
+      "end": undefined,
+      "left": undefined,
       "margin": undefined,
       "marginBottom": undefined,
       "marginEnd": undefined,
@@ -692,6 +794,7 @@ exports[`Shadow component tests Shadow (depth=28) 1`] = `
       "marginStart": undefined,
       "marginTop": undefined,
       "marginVertical": undefined,
+      "right": undefined,
       "shadowColor": "#000000",
       "shadowOffset": Object {
         "height": 0,
@@ -699,12 +802,15 @@ exports[`Shadow component tests Shadow (depth=28) 1`] = `
       },
       "shadowOpacity": 0.2,
       "shadowRadius": 4,
+      "start": undefined,
+      "top": undefined,
     }
   }
 >
   <View
     style={
       Object {
+        "alignItems": undefined,
         "backgroundColor": "red",
         "borderBottomWidth": undefined,
         "borderEndWidth": undefined,
@@ -713,6 +819,8 @@ exports[`Shadow component tests Shadow (depth=28) 1`] = `
         "borderStartWidth": undefined,
         "borderTopWidth": undefined,
         "borderWidth": undefined,
+        "flexDirection": undefined,
+        "flexWrap": undefined,
         "padding": undefined,
         "paddingBottom": undefined,
         "paddingEnd": undefined,
@@ -744,6 +852,9 @@ exports[`Shadow component tests Shadow (depth=64) 1`] = `
   style={
     Object {
       "backgroundColor": "red",
+      "bottom": undefined,
+      "end": undefined,
+      "left": undefined,
       "margin": undefined,
       "marginBottom": undefined,
       "marginEnd": undefined,
@@ -753,6 +864,7 @@ exports[`Shadow component tests Shadow (depth=64) 1`] = `
       "marginStart": undefined,
       "marginTop": undefined,
       "marginVertical": undefined,
+      "right": undefined,
       "shadowColor": "#000000",
       "shadowOffset": Object {
         "height": 0,
@@ -760,12 +872,15 @@ exports[`Shadow component tests Shadow (depth=64) 1`] = `
       },
       "shadowOpacity": 0.2,
       "shadowRadius": 4,
+      "start": undefined,
+      "top": undefined,
     }
   }
 >
   <View
     style={
       Object {
+        "alignItems": undefined,
         "backgroundColor": "red",
         "borderBottomWidth": undefined,
         "borderEndWidth": undefined,
@@ -774,6 +889,8 @@ exports[`Shadow component tests Shadow (depth=64) 1`] = `
         "borderStartWidth": undefined,
         "borderTopWidth": undefined,
         "borderWidth": undefined,
+        "flexDirection": undefined,
+        "flexWrap": undefined,
         "padding": undefined,
         "paddingBottom": undefined,
         "paddingEnd": undefined,
@@ -806,6 +923,9 @@ exports[`Shadow component tests Shadow on a child with border radius 1`] = `
     Object {
       "backgroundColor": "red",
       "borderRadius": 2,
+      "bottom": undefined,
+      "end": undefined,
+      "left": undefined,
       "margin": undefined,
       "marginBottom": undefined,
       "marginEnd": undefined,
@@ -815,6 +935,7 @@ exports[`Shadow component tests Shadow on a child with border radius 1`] = `
       "marginStart": undefined,
       "marginTop": undefined,
       "marginVertical": undefined,
+      "right": undefined,
       "shadowColor": "#000000",
       "shadowOffset": Object {
         "height": 0,
@@ -822,12 +943,15 @@ exports[`Shadow component tests Shadow on a child with border radius 1`] = `
       },
       "shadowOpacity": 0.12,
       "shadowRadius": 1,
+      "start": undefined,
+      "top": undefined,
     }
   }
 >
   <View
     style={
       Object {
+        "alignItems": undefined,
         "backgroundColor": "red",
         "borderBottomWidth": undefined,
         "borderEndWidth": undefined,
@@ -837,6 +961,8 @@ exports[`Shadow component tests Shadow on a child with border radius 1`] = `
         "borderStartWidth": undefined,
         "borderTopWidth": undefined,
         "borderWidth": undefined,
+        "flexDirection": undefined,
+        "flexWrap": undefined,
         "padding": undefined,
         "paddingBottom": undefined,
         "paddingEnd": undefined,
@@ -868,6 +994,9 @@ exports[`Shadow component tests Shadow on a child with border width 1`] = `
   style={
     Object {
       "backgroundColor": "red",
+      "bottom": undefined,
+      "end": undefined,
+      "left": undefined,
       "margin": undefined,
       "marginBottom": undefined,
       "marginEnd": undefined,
@@ -877,6 +1006,7 @@ exports[`Shadow component tests Shadow on a child with border width 1`] = `
       "marginStart": undefined,
       "marginTop": undefined,
       "marginVertical": undefined,
+      "right": undefined,
       "shadowColor": "#000000",
       "shadowOffset": Object {
         "height": 0,
@@ -884,12 +1014,15 @@ exports[`Shadow component tests Shadow on a child with border width 1`] = `
       },
       "shadowOpacity": 0.12,
       "shadowRadius": 1,
+      "start": undefined,
+      "top": undefined,
     }
   }
 >
   <View
     style={
       Object {
+        "alignItems": undefined,
         "backgroundColor": "red",
         "borderBottomWidth": undefined,
         "borderEndWidth": undefined,
@@ -898,6 +1031,8 @@ exports[`Shadow component tests Shadow on a child with border width 1`] = `
         "borderStartWidth": undefined,
         "borderTopWidth": undefined,
         "borderWidth": 2,
+        "flexDirection": undefined,
+        "flexWrap": undefined,
         "padding": undefined,
         "paddingBottom": undefined,
         "paddingEnd": undefined,
@@ -929,6 +1064,9 @@ exports[`Shadow component tests Shadow on a child with margin and padding 1`] = 
   style={
     Object {
       "backgroundColor": "red",
+      "bottom": undefined,
+      "end": undefined,
+      "left": undefined,
       "margin": 2,
       "marginBottom": undefined,
       "marginEnd": undefined,
@@ -938,6 +1076,7 @@ exports[`Shadow component tests Shadow on a child with margin and padding 1`] = 
       "marginStart": undefined,
       "marginTop": undefined,
       "marginVertical": undefined,
+      "right": undefined,
       "shadowColor": "#000000",
       "shadowOffset": Object {
         "height": 0,
@@ -945,12 +1084,15 @@ exports[`Shadow component tests Shadow on a child with margin and padding 1`] = 
       },
       "shadowOpacity": 0.12,
       "shadowRadius": 1,
+      "start": undefined,
+      "top": undefined,
     }
   }
 >
   <View
     style={
       Object {
+        "alignItems": undefined,
         "backgroundColor": "red",
         "borderBottomWidth": undefined,
         "borderEndWidth": undefined,
@@ -959,6 +1101,8 @@ exports[`Shadow component tests Shadow on a child with margin and padding 1`] = 
         "borderStartWidth": undefined,
         "borderTopWidth": undefined,
         "borderWidth": undefined,
+        "flexDirection": undefined,
+        "flexWrap": undefined,
         "padding": 2,
         "paddingBottom": undefined,
         "paddingEnd": undefined,


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Tested some style props that can be set on the child View of a Shadow component. Not every possible prop was tested, just the ones that were identified as needing extra consideration. By default, style props on the child of the Shadow will get set on both the inner and outer view of the Shadow. For any props that resulted in unexpected behavior with this default, I determined which view (inner or outer) the prop should be set on that would result in the correct behavior and added a test for it.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="1093" alt="before" src="https://user-images.githubusercontent.com/78454019/192855186-c7e0fffd-a014-46be-b808-539ee0da825a.png"> | <img width="1059" alt="after" src="https://user-images.githubusercontent.com/78454019/192855230-de18cf5c-1a15-4e3c-9bf6-2a6ee35ba9fd.png"> |

Notes:
- There are some props that don't really need to be set on both inner and outer views (ex. borderColor will only be visible on the inner view), but if it didn't make a difference visually I would just leave it. Not sure if there’s any kind of negative impact to having unnecessary props
- I am less confident with the flexbox props ([summary of all of them here](https://reactnative.dev/docs/flexbox)) - I don’t fully understand why some of these needed to be set only on the inner view while others could be set on both (ex. alignItems needed to be set on the inner View, but alignSelf and alignContent seemed to be fine getting set on both).

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
