### PR TITLE
Set theme to 'Office' as default for win32 tester

### DIFF
--- a/apps/fluent-tester/src/theme/CustomThemes.ts
+++ b/apps/fluent-tester/src/theme/CustomThemes.ts
@@ -32,7 +32,7 @@ export const lightnessOptions = [
 ];
 
 export class TesterThemeReference extends ThemeReference {
-  private _themeName: ThemeNames = 'Default';
+  private _themeName: ThemeNames = Platform.OS === ('win32' as any) ? 'Office' : 'Default';
   private _brand: OfficeBrand = 'Default';
 
   private options: ThemeOptions;

--- a/change/@fluentui-react-native-tester-4fc512db-45c8-4457-acb3-4a8114b0e2c1.json
+++ b/change/@fluentui-react-native-tester-4fc512db-45c8-4457-acb3-4a8114b0e2c1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Set default theme to Office for win32",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Since this causes a lot of confusion and misalignment of what's seen in the tester vs. what will show up in products, setting the default of the theme picker to "Office" for win32 so that the tester boots straight into "What will partners see".

### Verification

Booted tester in win32, it starts on "Office".

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
