### PR TITLE
chore: bump `@rnx-kit/cli` to 0.14.8

### DIFF
--- a/apps/fluent-tester/metro.config.js
+++ b/apps/fluent-tester/metro.config.js
@@ -6,8 +6,10 @@
  */
 
 const path = require('path');
-const { defaultWatchFolders, exclusionList } = require('@rnx-kit/metro-config');
+const { defaultWatchFolders, exclusionList, resolveUniqueModule } = require('@rnx-kit/metro-config');
 const { getDefaultConfig } = require('metro-config');
+
+const [reactIs, reactIsExcludePattern] = resolveUniqueModule('react-is');
 
 const blockList = exclusionList([
   /node_modules\/.*\/node_modules\/react-native\/.*/,
@@ -31,6 +33,8 @@ const blockList = exclusionList([
 
   // Exclude build output directory
   /.*\/apps\/fluent-tester\/dist\/.*/,
+
+  reactIsExcludePattern,
 ]);
 
 module.exports = (async () => {
@@ -44,6 +48,9 @@ module.exports = (async () => {
       sourceExts: [...sourceExts, 'svg'],
       blacklistRE: blockList,
       blockList,
+      extraNodeModules: {
+        'react-is': reactIs,
+      },
     },
     transformer: {
       // This transformer selects between the regular transformer and svg transformer depending on the file type

--- a/apps/fluent-tester/package.json
+++ b/apps/fluent-tester/package.json
@@ -16,7 +16,7 @@
     "android": "react-native run-android",
     "build": "fluentui-scripts build",
     "bundle": "react-native rnx-bundle --dev false",
-    "bundle:android": "react-native rnx-bundle --dev false --platform android --assets-dest dist/res",
+    "bundle:android": "react-native rnx-bundle --dev false --platform android",
     "bundle:ios": "react-native rnx-bundle --dev false --platform ios",
     "bundle:macos": "react-native rnx-bundle --dev false --platform macos",
     "bundle:windows": "react-native rnx-bundle --dev false --platform windows",
@@ -128,6 +128,7 @@
       {
         "id": "main",
         "entryFile": "index.js",
+        "assetsDest": "dist",
         "targets": [
           "android",
           "ios",
@@ -140,7 +141,26 @@
         "detectDuplicateDependencies": {
           "throwOnError": false
         },
-        "typescriptValidation": false
+        "typescriptValidation": false,
+        "platforms": {
+          "android": {
+            "bundleOutput": "dist/index.android.bundle",
+            "sourcemapOutput": "dist/index.android.bundle.map",
+            "assetsDest": "dist/res"
+          },
+          "ios": {
+            "bundleOutput": "dist/index.ios.jsbundle",
+            "sourcemapOutput": "dist/index.ios.jsbundle.map"
+          },
+          "macos": {
+            "bundleOutput": "dist/index.macos.jsbundle",
+            "sourcemapOutput": "dist/index.macos.jsbundle.map"
+          },
+          "windows": {
+            "bundleOutput": "dist/index.windows.bundle",
+            "sourcemapOutput": "dist/index.windows.bundle.map"
+          }
+        }
       }
     ],
     "capabilities": [

--- a/apps/fluent-tester/package.json
+++ b/apps/fluent-tester/package.json
@@ -16,7 +16,7 @@
     "android": "react-native run-android",
     "build": "fluentui-scripts build",
     "bundle": "react-native rnx-bundle --dev false",
-    "bundle:android": "react-native rnx-bundle --dev false --platform android --assets-path dist/res",
+    "bundle:android": "react-native rnx-bundle --dev false --platform android --assets-dest dist/res",
     "bundle:ios": "react-native rnx-bundle --dev false --platform ios",
     "bundle:macos": "react-native rnx-bundle --dev false --platform macos",
     "bundle:windows": "react-native rnx-bundle --dev false --platform windows",
@@ -90,8 +90,8 @@
     "@babel/runtime": "^7.8.0",
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/scripts": "^0.1.1",
-    "@rnx-kit/cli": "^0.9.57",
-    "@rnx-kit/metro-config": "^1.2.26",
+    "@rnx-kit/cli": "^0.14.8",
+    "@rnx-kit/metro-config": "^1.3.1",
     "@types/jasmine": "3.5.10",
     "@types/react": "^17.0.2",
     "@types/react-native": "^0.68.0",
@@ -124,22 +124,25 @@
   "rnx-kit": {
     "reactNativeVersion": "^0.68",
     "kitType": "app",
-    "bundle": {
-      "targets": [
-        "android",
-        "ios",
-        "macos",
-        "windows"
-      ],
-      "entryPath": "index.js",
-      "detectCyclicDependencies": {
-        "throwOnError": true
-      },
-      "detectDuplicateDependencies": {
-        "throwOnError": false
-      },
-      "typescriptValidation": false
-    },
+    "bundle": [
+      {
+        "id": "main",
+        "entryFile": "index.js",
+        "targets": [
+          "android",
+          "ios",
+          "macos",
+          "windows"
+        ],
+        "detectCyclicDependencies": {
+          "throwOnError": true
+        },
+        "detectDuplicateDependencies": {
+          "throwOnError": false
+        },
+        "typescriptValidation": false
+      }
+    ],
     "capabilities": [
       "core-android",
       "core-ios",

--- a/apps/win32/package.json
+++ b/apps/win32/package.json
@@ -75,6 +75,9 @@
       {
         "id": "main",
         "entryFile": "index.js",
+        "bundleOutput": "dist/index.win32.bundle",
+        "sourcemapOutput": "dist/index.win32.bundle.map",
+        "assetsDest": "dist",
         "targets": [
           "win32"
         ],

--- a/apps/win32/package.json
+++ b/apps/win32/package.json
@@ -42,8 +42,8 @@
     "@fluentui-react-native/scripts": "^0.1.1",
     "@office-iss/react-native-win32": ">=0.68.0 <0.68.6",
     "@office-iss/rex-win32": "0.68.15-devmain.15717.10000",
-    "@rnx-kit/cli": "^0.9.57",
-    "@rnx-kit/metro-config": "^1.2.26",
+    "@rnx-kit/cli": "^0.14.8",
+    "@rnx-kit/metro-config": "^1.3.1",
     "@types/jasmine": "3.5.10",
     "@types/react": "^17.0.2",
     "@types/react-native": "^0.68.0",
@@ -71,19 +71,22 @@
   "rnx-kit": {
     "reactNativeVersion": "0.68",
     "kitType": "app",
-    "bundle": {
-      "targets": [
-        "win32"
-      ],
-      "entryPath": "index.js",
-      "detectCyclicDependencies": {
-        "throwOnError": true
-      },
-      "detectDuplicateDependencies": {
-        "throwOnError": false
-      },
-      "typescriptValidation": false
-    },
+    "bundle": [
+      {
+        "id": "main",
+        "entryFile": "index.js",
+        "targets": [
+          "win32"
+        ],
+        "detectCyclicDependencies": {
+          "throwOnError": true
+        },
+        "detectDuplicateDependencies": {
+          "throwOnError": false
+        },
+        "typescriptValidation": false
+      }
+    ],
     "capabilities": [
       "core",
       "react",

--- a/change/@fluentui-react-native-tester-3c094a55-c66c-4e1a-8d5b-4dbde3039b17.json
+++ b/change/@fluentui-react-native-tester-3c094a55-c66c-4e1a-8d5b-4dbde3039b17.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: bump `@rnx-kit/cli` to 0.14.8",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-tester-win32-48abd40c-4671-436f-89a2-5607c6c0f840.json
+++ b/change/@fluentui-react-native-tester-win32-48abd40c-4671-436f-89a2-5607c6c0f840.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: bump `@rnx-kit/cli` to 0.14.8",
+  "packageName": "@fluentui-react-native/tester-win32",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1422,6 +1422,16 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
+"@esbuild/android-arm@0.15.10":
+  version "0.15.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.15.10.tgz#a5f9432eb221afc243c321058ef25fe899886892"
+  integrity sha512-FNONeQPy/ox+5NBkcSbYJxoXj9GWu8gVGJTVmUyoOCKQFDTrHVKgNSzChdNt0I8Aj/iKcsDf2r9BFwv+FSNUXg==
+
+"@esbuild/linux-loong64@0.15.10":
+  version "0.15.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.15.10.tgz#78a42897c2cf8db9fd5f1811f7590393b77774c7"
+  integrity sha512-w0Ou3Z83LOYEkwaui2M8VwIp+nLi/NA60lBLMvaJ+vXVMcsARYdEzLNE7RSm4+lSg4zq4d7fAVuzk7PNQ5JFgg==
+
 "@eslint/eslintrc@^1.3.2":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.3.2.tgz#58b69582f3b7271d8fa67fe5251767a5b38ea356"
@@ -2548,35 +2558,39 @@
   dependencies:
     babel-plugin-const-enum "^1.0.0"
 
-"@rnx-kit/cli@^0.9.57":
-  version "0.9.58"
-  resolved "https://registry.yarnpkg.com/@rnx-kit/cli/-/cli-0.9.58.tgz#1590b002e5efa89bc54a908105d458b2b548ea00"
-  integrity sha512-IJziNWSUjxnLcQ0l0ZnJGMv/acdFqCEm9YrqyymfsIIhDRsKpIKhcZkL+orkunzJhC16a00ikgNEFd+AWWME3w==
+"@rnx-kit/cli@^0.14.8":
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/@rnx-kit/cli/-/cli-0.14.8.tgz#021f1da095e780f50389b5a1fe0e6cabe275bce6"
+  integrity sha512-+63pAQEtWLjdtIMbGX1weJPwd2kTC5kIFjQ0b2Lu5jHg6AYwvrweqW+SWEDI304VERpvm7T2uKMTSyacOAjD3w==
   dependencies:
-    "@rnx-kit/config" "^0.4.21"
+    "@rnx-kit/config" "^0.5.2"
     "@rnx-kit/console" "^1.0.11"
-    "@rnx-kit/dep-check" "^1.9.5"
+    "@rnx-kit/dep-check" "^1.12.23"
     "@rnx-kit/metro-plugin-cyclic-dependencies-detector" "^1.0.21"
-    "@rnx-kit/metro-plugin-duplicates-checker" "^1.2.15"
+    "@rnx-kit/metro-plugin-duplicates-checker" "^2.0.0"
     "@rnx-kit/metro-serializer" "^1.0.11"
-    "@rnx-kit/metro-serializer-esbuild" "^0.0.23"
-    "@rnx-kit/metro-service" "^1.1.13"
+    "@rnx-kit/metro-serializer-esbuild" "^0.1.0"
+    "@rnx-kit/metro-service" "^3.0.2"
     "@rnx-kit/third-party-notices" "^1.2.13"
-    "@rnx-kit/tools-language" "^1.2.6"
-    "@rnx-kit/tools-node" "^1.2.6"
-    "@rnx-kit/tools-react-native" "^1.0.10"
+    "@rnx-kit/tools-language" "^1.3.0"
+    "@rnx-kit/tools-node" "^1.2.7"
+    "@rnx-kit/tools-react-native" "^1.2.0"
     "@rnx-kit/typescript-react-native-resolver" "^0.2.0"
     "@rnx-kit/typescript-service" "^1.5.3"
     chalk "^4.1.0"
+    find-up "^5.0.0"
+    fs-extra "^10.0.0"
+    ora "^5.4.1"
+    qrcode "^1.5.0"
     readline "^1.3.0"
 
-"@rnx-kit/config@^0.4.21":
-  version "0.4.24"
-  resolved "https://registry.yarnpkg.com/@rnx-kit/config/-/config-0.4.24.tgz#b69b52cdbca9a0fa43a2b89e5587facdfac3b16b"
-  integrity sha512-XlhDncZ09PPLi4tm6JTA5h7iS4EI+WCdcMF/j19CRbmuEnuYmT/DcU+IWhKZN3+sObz6OtYFjZ3+o1kKMBIXIA==
+"@rnx-kit/config@^0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@rnx-kit/config/-/config-0.5.2.tgz#21c148289beb932bfeacc4c63165064aea4b16c4"
+  integrity sha512-ESq5FRxLaUU5BEkEwHEehHihH4LwdIDP33GMhwZwbXZ8WNMzdyWHCJWIVTpB1ulAmdoF1uaew1AadeUTg/ZPvQ==
   dependencies:
     "@rnx-kit/console" "^1.0.11"
-    cosmiconfig "^7.0.0"
+    "@rnx-kit/tools-node" "^1.2.7"
     lodash "^4.17.21"
     semver "^7.0.0"
 
@@ -2587,7 +2601,7 @@
   dependencies:
     chalk "^4.1.0"
 
-"@rnx-kit/dep-check@^1.10.1", "@rnx-kit/dep-check@^1.9.5":
+"@rnx-kit/dep-check@^1.10.1", "@rnx-kit/dep-check@^1.12.23":
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/@rnx-kit/dep-check/-/dep-check-1.13.0.tgz#9f3780a17e512131c724f0120dbf6efa202e6d29"
   integrity sha512-fisE8pssSCh57tCbhv8LqdF3h9RPj4AZXvQTbWEPw7SiVPhmP525sKXw39RyEU0iSkJwgjLO3ZH2T76dbIxRHQ==
@@ -2612,7 +2626,7 @@
     "@babel/preset-typescript" "^7.0.0"
     find-up "^5.0.0"
 
-"@rnx-kit/metro-config@^1.2.26":
+"@rnx-kit/metro-config@^1.3.1":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@rnx-kit/metro-config/-/metro-config-1.3.1.tgz#c31cc5411cdd579a470bad03c465a080069e42bd"
   integrity sha512-HB4zApKYmaduyxgDVKpmjk5yuwFhSTUB2yrhCWsV98N27UK7v8Z3eI2gESKYkozuNXPUfcJKORdwjqwfiefNPg==
@@ -2630,22 +2644,24 @@
     "@rnx-kit/console" "^1.0.11"
     "@rnx-kit/tools-node" "^1.2.7"
 
-"@rnx-kit/metro-plugin-duplicates-checker@^1.2.15":
-  version "1.2.16"
-  resolved "https://registry.yarnpkg.com/@rnx-kit/metro-plugin-duplicates-checker/-/metro-plugin-duplicates-checker-1.2.16.tgz#5e20e17e53ed6ca5a613978be325abf1bc826905"
-  integrity sha512-fcXQbmDA7es7aSqZH0whVXyoPGgA7yy8I8193K18TRCHF6U1LoK/ZnjHAaHTzrcyq2NhrpwkDWwFoDTCFjYWjw==
+"@rnx-kit/metro-plugin-duplicates-checker@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@rnx-kit/metro-plugin-duplicates-checker/-/metro-plugin-duplicates-checker-2.0.0.tgz#8e596b92a6af69f3dac5b98e551eb7f55efdc223"
+  integrity sha512-9jt7k5YD3svExq5mVqHWWhi5iGTXlNOnwu5NC01WaSeKPW2oC+9IgT6Wi6iA5egdNKch+SogPTdLgYeWekH9Tw==
   dependencies:
     "@rnx-kit/console" "^1.0.11"
     "@rnx-kit/tools-node" "^1.2.7"
 
-"@rnx-kit/metro-serializer-esbuild@^0.0.23":
-  version "0.0.23"
-  resolved "https://registry.yarnpkg.com/@rnx-kit/metro-serializer-esbuild/-/metro-serializer-esbuild-0.0.23.tgz#34fe890341d9b62a78144c0008fd31ece58391c9"
-  integrity sha512-uRiIjZo0kvJImQYhwcCl445X3JVJsLHMFg8QdLZOufSpO685QDXuwrJi2cKOrfzHD4IX26nZhbwULcPNb8buEg==
+"@rnx-kit/metro-serializer-esbuild@^0.1.0":
+  version "0.1.14"
+  resolved "https://registry.yarnpkg.com/@rnx-kit/metro-serializer-esbuild/-/metro-serializer-esbuild-0.1.14.tgz#d47744b255ae74b59310c295f7c0d4b261f7568e"
+  integrity sha512-x/pBYhbWx+QBulyalZ4pl2QpGAa1gjREmIYA7+YwrO2XlMI/31IWi8TIv3/3JI+Vg7sQC0fLdbgsqraMugdW6Q==
   dependencies:
     "@rnx-kit/console" "^1.0.11"
-    esbuild "^0.13.4"
-    esbuild-plugin-lodash "^1.1.0"
+    "@rnx-kit/tools-node" "^1.3.0"
+    esbuild "^0.15.0"
+    esbuild-plugin-lodash "^1.2.0"
+    fast-glob "^3.2.7"
     semver "^7.0.0"
 
 "@rnx-kit/metro-serializer@^1.0.11":
@@ -2655,15 +2671,13 @@
   dependencies:
     semver "^7.0.0"
 
-"@rnx-kit/metro-service@^1.1.13":
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/@rnx-kit/metro-service/-/metro-service-1.1.14.tgz#756ba456b2c0f1a0a8f781aa6c8dab3260cd8817"
-  integrity sha512-K0UhuOjthYQ5zDGOwO0YSa9Jil5NBwv0fK1zUW7cB6CkOUJI8R8Ukc9mVQ3Se749nrSN0uLjMGQ57QBH5yNmRw==
+"@rnx-kit/metro-service@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@rnx-kit/metro-service/-/metro-service-3.0.2.tgz#b43c4f92cdb657cff8db9bf1b0b71a97d03394df"
+  integrity sha512-HiZmwKa0ZYcVNg0gvpTwKYMO0it11zNlFSkaVAFXb0ucXLDeM/6BZg3DV96D4L6C22mnci7PeN8SNAHTlt11xQ==
   dependencies:
     "@rnx-kit/tools-language" "^1.2.6"
     chalk "^4.1.0"
-    cp-file "^9.1.0"
-    make-dir "^3.1.0"
 
 "@rnx-kit/third-party-notices@^1.2.13":
   version "1.2.16"
@@ -2675,12 +2689,12 @@
     spdx-expression-parse "^3.0.1"
     yargs "^16.0.0"
 
-"@rnx-kit/tools-language@^1.2.6":
+"@rnx-kit/tools-language@^1.2.6", "@rnx-kit/tools-language@^1.3.0":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@rnx-kit/tools-language/-/tools-language-1.3.1.tgz#7ab040becedd1426fbc58b0d6f8161df6d949add"
   integrity sha512-PI5ouRAAT1UavccKw0c/Ufe/jubenU/6TWSphpGK4XdJ4/gV8gz9KOrALbSPrVCr0exrAaqf5p9QyBiPIFpriw==
 
-"@rnx-kit/tools-node@^1.2.6", "@rnx-kit/tools-node@^1.2.7", "@rnx-kit/tools-node@^1.3.0":
+"@rnx-kit/tools-node@^1.2.7", "@rnx-kit/tools-node@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@rnx-kit/tools-node/-/tools-node-1.3.0.tgz#8eb7a513ad9d2bba625cc9b1c5e9b033bb09045c"
   integrity sha512-aUlKjcETkS3p6y2va4iFSpgUQ1QbzwxV54EgurGsJZ6FVv64LBc2FzgEVEVZ9IFwT/aVlc7JK4foC2LhT4rc5Q==
@@ -2690,7 +2704,7 @@
     pkg-dir "^5.0.0"
     pkg-up "^3.1.0"
 
-"@rnx-kit/tools-react-native@^1.0.10", "@rnx-kit/tools-react-native@^1.2.0":
+"@rnx-kit/tools-react-native@^1.2.0":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@rnx-kit/tools-react-native/-/tools-react-native-1.2.2.tgz#18cdcdccff08e454d082f6a2a4d915c5fcd4ee05"
   integrity sha512-KG/pW+8Ct+AC54QC2iUtB4HRAZn4eDvNOGPsm3jBUR5pAebaiO0c8z62AAczI+uW3P+Aqxgmfz4Mz97JVkq86g==
@@ -5920,16 +5934,6 @@ cosmiconfig@^7.0.0, cosmiconfig@^7.0.1:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
-cp-file@^9.1.0:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/cp-file/-/cp-file-9.1.0.tgz#e98e30db72d57d47b5b1d444deb70d05e5684921"
-  integrity sha512-3scnzFj/94eb7y4wyXRWwvzLFaQp87yyfTnChIjlfYrVqp5lVO3E2hIJMeQIltUT0K2ZAB3An1qXcBmwGyvuwA==
-  dependencies:
-    graceful-fs "^4.1.2"
-    make-dir "^3.0.0"
-    nested-error-stacks "^2.0.0"
-    p-event "^4.1.0"
-
 crc-32@^1.2.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.2.tgz#3cad35a934b8bf71f25ca524b6da51fb7eace2ff"
@@ -6364,6 +6368,11 @@ diff@^5.0.0:
   resolved "https://registry.yarnpkg.com/diff/-/diff-5.1.0.tgz#bc52d298c5ea8df9194800224445ed43ffc87e40"
   integrity sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==
 
+dijkstrajs@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/dijkstrajs/-/dijkstrajs-1.0.2.tgz#2e48c0d3b825462afe75ab4ad5e829c8ece36257"
+  integrity sha512-QV6PMaHTCNmKSeP6QoXhVTw9snc9VD8MulTT0Bd99Pacp4SS1cjcrYPgBPmibqKVtMJJfqC6XvOXgPMEEPH/fg==
+
 dir-glob@^2.0.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.2.2.tgz#fa09f0694153c8918b18ba0deafae94769fc50c4"
@@ -6542,6 +6551,11 @@ enabled@2.0.x:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/enabled/-/enabled-2.0.0.tgz#f9dd92ec2d6f4bbc0d5d1e64e21d61cd4665e7c2"
   integrity sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==
+
+encode-utf8@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/encode-utf8/-/encode-utf8-1.0.3.tgz#f30fdd31da07fb596f281beb2f6b027851994cda"
+  integrity sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==
 
 encodeurl@~1.0.2:
   version "1.0.2"
@@ -6749,118 +6763,138 @@ es6-weak-map@^2.0.1:
     es6-iterator "^2.0.3"
     es6-symbol "^3.1.1"
 
-esbuild-android-arm64@0.13.15:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.13.15.tgz#3fc3ff0bab76fe35dd237476b5d2b32bb20a3d44"
-  integrity sha512-m602nft/XXeO8YQPUDVoHfjyRVPdPgjyyXOxZ44MK/agewFFkPa8tUo6lAzSWh5Ui5PB4KR9UIFTSBKh/RrCmg==
+esbuild-android-64@0.15.10:
+  version "0.15.10"
+  resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.15.10.tgz#8a59a84acbf2eca96996cadc35642cf055c494f0"
+  integrity sha512-UI7krF8OYO1N7JYTgLT9ML5j4+45ra3amLZKx7LO3lmLt1Ibn8t3aZbX5Pu4BjWiqDuJ3m/hsvhPhK/5Y/YpnA==
 
-esbuild-darwin-64@0.13.15:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.13.15.tgz#8e9169c16baf444eacec60d09b24d11b255a8e72"
-  integrity sha512-ihOQRGs2yyp7t5bArCwnvn2Atr6X4axqPpEdCFPVp7iUj4cVSdisgvEKdNR7yH3JDjW6aQDw40iQFoTqejqxvQ==
+esbuild-android-arm64@0.15.10:
+  version "0.15.10"
+  resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.15.10.tgz#f453851dc1d8c5409a38cf7613a33852faf4915d"
+  integrity sha512-EOt55D6xBk5O05AK8brXUbZmoFj4chM8u3riGflLa6ziEoVvNjRdD7Cnp82NHQGfSHgYR06XsPI8/sMuA/cUwg==
 
-esbuild-darwin-arm64@0.13.15:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.15.tgz#1b07f893b632114f805e188ddfca41b2b778229a"
-  integrity sha512-i1FZssTVxUqNlJ6cBTj5YQj4imWy3m49RZRnHhLpefFIh0To05ow9DTrXROTE1urGTQCloFUXTX8QfGJy1P8dQ==
+esbuild-darwin-64@0.15.10:
+  version "0.15.10"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.15.10.tgz#778bd29c8186ff47b176c8af58c08cf0fb8e6b86"
+  integrity sha512-hbDJugTicqIm+WKZgp208d7FcXcaK8j2c0l+fqSJ3d2AzQAfjEYDRM3Z2oMeqSJ9uFxyj/muSACLdix7oTstRA==
 
-esbuild-freebsd-64@0.13.15:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.15.tgz#0b8b7eca1690c8ec94c75680c38c07269c1f4a85"
-  integrity sha512-G3dLBXUI6lC6Z09/x+WtXBXbOYQZ0E8TDBqvn7aMaOCzryJs8LyVXKY4CPnHFXZAbSwkCbqiPuSQ1+HhrNk7EA==
+esbuild-darwin-arm64@0.15.10:
+  version "0.15.10"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.10.tgz#b30bbefb46dc3c5d4708b0435e52f6456578d6df"
+  integrity sha512-M1t5+Kj4IgSbYmunf2BB6EKLkWUq+XlqaFRiGOk8bmBapu9bCDrxjf4kUnWn59Dka3I27EiuHBKd1rSO4osLFQ==
 
-esbuild-freebsd-arm64@0.13.15:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.15.tgz#2e1a6c696bfdcd20a99578b76350b41db1934e52"
-  integrity sha512-KJx0fzEDf1uhNOZQStV4ujg30WlnwqUASaGSFPhznLM/bbheu9HhqZ6mJJZM32lkyfGJikw0jg7v3S0oAvtvQQ==
+esbuild-freebsd-64@0.15.10:
+  version "0.15.10"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.10.tgz#ab301c5f6ded5110dbdd611140bef1a7c2e99236"
+  integrity sha512-KMBFMa7C8oc97nqDdoZwtDBX7gfpolkk6Bcmj6YFMrtCMVgoU/x2DI1p74DmYl7CSS6Ppa3xgemrLrr5IjIn0w==
 
-esbuild-linux-32@0.13.15:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.13.15.tgz#6fd39f36fc66dd45b6b5f515728c7bbebc342a69"
-  integrity sha512-ZvTBPk0YWCLMCXiFmD5EUtB30zIPvC5Itxz0mdTu/xZBbbHJftQgLWY49wEPSn2T/TxahYCRDWun5smRa0Tu+g==
+esbuild-freebsd-arm64@0.15.10:
+  version "0.15.10"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.10.tgz#a5b09b867a6ff49110f52343b6f12265db63d43f"
+  integrity sha512-m2KNbuCX13yQqLlbSojFMHpewbn8wW5uDS6DxRpmaZKzyq8Dbsku6hHvh2U+BcLwWY4mpgXzFUoENEf7IcioGg==
 
-esbuild-linux-64@0.13.15:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.13.15.tgz#9cb8e4bcd7574e67946e4ee5f1f1e12386bb6dd3"
-  integrity sha512-eCKzkNSLywNeQTRBxJRQ0jxRCl2YWdMB3+PkWFo2BBQYC5mISLIVIjThNtn6HUNqua1pnvgP5xX0nHbZbPj5oA==
+esbuild-linux-32@0.15.10:
+  version "0.15.10"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.15.10.tgz#5282fe9915641caf9c8070e4ba2c3e16d358f837"
+  integrity sha512-guXrwSYFAvNkuQ39FNeV4sNkNms1bLlA5vF1H0cazZBOLdLFIny6BhT+TUbK/hdByMQhtWQ5jI9VAmPKbVPu1w==
 
-esbuild-linux-arm64@0.13.15:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.15.tgz#3891aa3704ec579a1b92d2a586122e5b6a2bfba1"
-  integrity sha512-bYpuUlN6qYU9slzr/ltyLTR9YTBS7qUDymO8SV7kjeNext61OdmqFAzuVZom+OLW1HPHseBfJ/JfdSlx8oTUoA==
+esbuild-linux-64@0.15.10:
+  version "0.15.10"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.15.10.tgz#f3726e85a00149580cb19f8abfabcbb96f5d52bb"
+  integrity sha512-jd8XfaSJeucMpD63YNMO1JCrdJhckHWcMv6O233bL4l6ogQKQOxBYSRP/XLWP+6kVTu0obXovuckJDcA0DKtQA==
 
-esbuild-linux-arm@0.13.15:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.13.15.tgz#8a00e99e6a0c6c9a6b7f334841364d8a2b4aecfe"
-  integrity sha512-wUHttDi/ol0tD8ZgUMDH8Ef7IbDX+/UsWJOXaAyTdkT7Yy9ZBqPg8bgB/Dn3CZ9SBpNieozrPRHm0BGww7W/jA==
+esbuild-linux-arm64@0.15.10:
+  version "0.15.10"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.10.tgz#2f0056e9d5286edb0185b56655caa8c574d8dbe7"
+  integrity sha512-GByBi4fgkvZFTHFDYNftu1DQ1GzR23jws0oWyCfhnI7eMOe+wgwWrc78dbNk709Ivdr/evefm2PJiUBMiusS1A==
 
-esbuild-linux-mips64le@0.13.15:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.15.tgz#36b07cc47c3d21e48db3bb1f4d9ef8f46aead4f7"
-  integrity sha512-KlVjIG828uFPyJkO/8gKwy9RbXhCEUeFsCGOJBepUlpa7G8/SeZgncUEz/tOOUJTcWMTmFMtdd3GElGyAtbSWg==
+esbuild-linux-arm@0.15.10:
+  version "0.15.10"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.15.10.tgz#40a9270da3c8ffa32cf72e24a79883e323dff08d"
+  integrity sha512-6N8vThLL/Lysy9y4Ex8XoLQAlbZKUyExCWyayGi2KgTBelKpPgj6RZnUaKri0dHNPGgReJriKVU6+KDGQwn10A==
 
-esbuild-linux-ppc64le@0.13.15:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.15.tgz#f7e6bba40b9a11eb9dcae5b01550ea04670edad2"
-  integrity sha512-h6gYF+OsaqEuBjeesTBtUPw0bmiDu7eAeuc2OEH9S6mV9/jPhPdhOWzdeshb0BskRZxPhxPOjqZ+/OqLcxQwEQ==
+esbuild-linux-mips64le@0.15.10:
+  version "0.15.10"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.10.tgz#90ce1c4ee0202edb4ac69807dea77f7e5804abc4"
+  integrity sha512-BxP+LbaGVGIdQNJUNF7qpYjEGWb0YyHVSKqYKrn+pTwH/SiHUxFyJYSP3pqkku61olQiSBnSmWZ+YUpj78Tw7Q==
 
-esbuild-netbsd-64@0.13.15:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.15.tgz#a2fedc549c2b629d580a732d840712b08d440038"
-  integrity sha512-3+yE9emwoevLMyvu+iR3rsa+Xwhie7ZEHMGDQ6dkqP/ndFzRHkobHUKTe+NCApSqG5ce2z4rFu+NX/UHnxlh3w==
+esbuild-linux-ppc64le@0.15.10:
+  version "0.15.10"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.10.tgz#782837ae7bd5b279178106c9dd801755a21fabdf"
+  integrity sha512-LoSQCd6498PmninNgqd/BR7z3Bsk/mabImBWuQ4wQgmQEeanzWd5BQU2aNi9mBURCLgyheuZS6Xhrw5luw3OkQ==
 
-esbuild-openbsd-64@0.13.15:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.15.tgz#b22c0e5806d3a1fbf0325872037f885306b05cd7"
-  integrity sha512-wTfvtwYJYAFL1fSs8yHIdf5GEE4NkbtbXtjLWjM3Cw8mmQKqsg8kTiqJ9NJQe5NX/5Qlo7Xd9r1yKMMkHllp5g==
+esbuild-linux-riscv64@0.15.10:
+  version "0.15.10"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.10.tgz#d7420d806ece5174f24f4634303146f915ab4207"
+  integrity sha512-Lrl9Cr2YROvPV4wmZ1/g48httE8z/5SCiXIyebiB5N8VT7pX3t6meI7TQVHw/wQpqP/AF4SksDuFImPTM7Z32Q==
 
-esbuild-plugin-lodash@^1.1.0:
+esbuild-linux-s390x@0.15.10:
+  version "0.15.10"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.10.tgz#21fdf0cb3494a7fb520a71934e4dffce67fe47be"
+  integrity sha512-ReP+6q3eLVVP2lpRrvl5EodKX7EZ1bS1/z5j6hsluAlZP5aHhk6ghT6Cq3IANvvDdscMMCB4QEbI+AjtvoOFpA==
+
+esbuild-netbsd-64@0.15.10:
+  version "0.15.10"
+  resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.10.tgz#6c06b3107e3df53de381e6299184d4597db0440f"
+  integrity sha512-iGDYtJCMCqldMskQ4eIV+QSS/CuT7xyy9i2/FjpKvxAuCzrESZXiA1L64YNj6/afuzfBe9i8m/uDkFHy257hTw==
+
+esbuild-openbsd-64@0.15.10:
+  version "0.15.10"
+  resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.10.tgz#4daef5f5d8e74bbda53b65160029445d582570cf"
+  integrity sha512-ftMMIwHWrnrYnvuJQRJs/Smlcb28F9ICGde/P3FUTCgDDM0N7WA0o9uOR38f5Xe2/OhNCgkjNeb7QeaE3cyWkQ==
+
+esbuild-plugin-lodash@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/esbuild-plugin-lodash/-/esbuild-plugin-lodash-1.2.0.tgz#6395b64cbb9b23a1bee3e37fbbdd98c50bd0b53a"
   integrity sha512-8CyR67Z/VMvcJ4ABYYSaR2hhioeuoFVII1IsyPb6AwAKN57VQW8jFXyY27OwH4FGU3h3OVwwQ/GVNbo+RgpTGA==
 
-esbuild-sunos-64@0.13.15:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.13.15.tgz#d0b6454a88375ee8d3964daeff55c85c91c7cef4"
-  integrity sha512-lbivT9Bx3t1iWWrSnGyBP9ODriEvWDRiweAs69vI+miJoeKwHWOComSRukttbuzjZ8r1q0mQJ8Z7yUsDJ3hKdw==
+esbuild-sunos-64@0.15.10:
+  version "0.15.10"
+  resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.15.10.tgz#5fe7bef267a02f322fd249a8214d0274937388a7"
+  integrity sha512-mf7hBL9Uo2gcy2r3rUFMjVpTaGpFJJE5QTDDqUFf1632FxteYANffDZmKbqX0PfeQ2XjUDE604IcE7OJeoHiyg==
 
-esbuild-windows-32@0.13.15:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.13.15.tgz#c96d0b9bbb52f3303322582ef8e4847c5ad375a7"
-  integrity sha512-fDMEf2g3SsJ599MBr50cY5ve5lP1wyVwTe6aLJsM01KtxyKkB4UT+fc5MXQFn3RLrAIAZOG+tHC+yXObpSn7Nw==
+esbuild-windows-32@0.15.10:
+  version "0.15.10"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.15.10.tgz#48e3dde25ab0135579a288b30ab6ddef6d1f0b28"
+  integrity sha512-ttFVo+Cg8b5+qHmZHbEc8Vl17kCleHhLzgT8X04y8zudEApo0PxPg9Mz8Z2cKH1bCYlve1XL8LkyXGFjtUYeGg==
 
-esbuild-windows-64@0.13.15:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.13.15.tgz#1f79cb9b1e1bb02fb25cd414cb90d4ea2892c294"
-  integrity sha512-9aMsPRGDWCd3bGjUIKG/ZOJPKsiztlxl/Q3C1XDswO6eNX/Jtwu4M+jb6YDH9hRSUflQWX0XKAfWzgy5Wk54JQ==
+esbuild-windows-64@0.15.10:
+  version "0.15.10"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.15.10.tgz#387a9515bef3fee502d277a5d0a2db49a4ecda05"
+  integrity sha512-2H0gdsyHi5x+8lbng3hLbxDWR7mKHWh5BXZGKVG830KUmXOOWFE2YKJ4tHRkejRduOGDrBvHBriYsGtmTv3ntA==
 
-esbuild-windows-arm64@0.13.15:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.15.tgz#482173070810df22a752c686509c370c3be3b3c3"
-  integrity sha512-zzvyCVVpbwQQATaf3IG8mu1IwGEiDxKkYUdA4FpoCHi1KtPa13jeScYDjlW0Qh+ebWzpKfR2ZwvqAQkSWNcKjA==
+esbuild-windows-arm64@0.15.10:
+  version "0.15.10"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.10.tgz#5a6fcf2fa49e895949bf5495cf088ab1b43ae879"
+  integrity sha512-S+th4F+F8VLsHLR0zrUcG+Et4hx0RKgK1eyHc08kztmLOES8BWwMiaGdoW9hiXuzznXQ0I/Fg904MNbr11Nktw==
 
-esbuild@^0.13.4:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.13.15.tgz#db56a88166ee373f87dbb2d8798ff449e0450cdf"
-  integrity sha512-raCxt02HBKv8RJxE8vkTSCXGIyKHdEdGfUmiYb8wnabnaEmHzyW7DCHb5tEN0xU8ryqg5xw54mcwnYkC4x3AIw==
+esbuild@^0.15.0:
+  version "0.15.10"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.15.10.tgz#85c2f8446e9b1fe04fae68daceacba033eedbd42"
+  integrity sha512-N7wBhfJ/E5fzn/SpNgX+oW2RLRjwaL8Y0ezqNqhjD6w0H2p0rDuEz2FKZqpqLnO8DCaWumKe8dsC/ljvVSSxng==
   optionalDependencies:
-    esbuild-android-arm64 "0.13.15"
-    esbuild-darwin-64 "0.13.15"
-    esbuild-darwin-arm64 "0.13.15"
-    esbuild-freebsd-64 "0.13.15"
-    esbuild-freebsd-arm64 "0.13.15"
-    esbuild-linux-32 "0.13.15"
-    esbuild-linux-64 "0.13.15"
-    esbuild-linux-arm "0.13.15"
-    esbuild-linux-arm64 "0.13.15"
-    esbuild-linux-mips64le "0.13.15"
-    esbuild-linux-ppc64le "0.13.15"
-    esbuild-netbsd-64 "0.13.15"
-    esbuild-openbsd-64 "0.13.15"
-    esbuild-sunos-64 "0.13.15"
-    esbuild-windows-32 "0.13.15"
-    esbuild-windows-64 "0.13.15"
-    esbuild-windows-arm64 "0.13.15"
+    "@esbuild/android-arm" "0.15.10"
+    "@esbuild/linux-loong64" "0.15.10"
+    esbuild-android-64 "0.15.10"
+    esbuild-android-arm64 "0.15.10"
+    esbuild-darwin-64 "0.15.10"
+    esbuild-darwin-arm64 "0.15.10"
+    esbuild-freebsd-64 "0.15.10"
+    esbuild-freebsd-arm64 "0.15.10"
+    esbuild-linux-32 "0.15.10"
+    esbuild-linux-64 "0.15.10"
+    esbuild-linux-arm "0.15.10"
+    esbuild-linux-arm64 "0.15.10"
+    esbuild-linux-mips64le "0.15.10"
+    esbuild-linux-ppc64le "0.15.10"
+    esbuild-linux-riscv64 "0.15.10"
+    esbuild-linux-s390x "0.15.10"
+    esbuild-netbsd-64 "0.15.10"
+    esbuild-openbsd-64 "0.15.10"
+    esbuild-sunos-64 "0.15.10"
+    esbuild-windows-32 "0.15.10"
+    esbuild-windows-64 "0.15.10"
+    esbuild-windows-arm64 "0.15.10"
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -10105,7 +10139,7 @@ make-dir@^2.0.0, make-dir@^2.1.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
-make-dir@^3.0.0, make-dir@^3.1.0:
+make-dir@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
@@ -10822,11 +10856,6 @@ neo-async@^2.5.0:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-nested-error-stacks@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/nested-error-stacks/-/nested-error-stacks-2.1.1.tgz#26c8a3cee6cc05fbcf1e333cd2fc3e003326c0b5"
-  integrity sha512-9iN1ka/9zmX1ZvLV9ewJYEk9h7RyRRtqdK0woXcqohu8EWIerfPUjYJPg0ULy0UqP7cslmdGc8xKDJcojlKiaw==
-
 next-tick@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
@@ -11274,13 +11303,6 @@ p-defer@^1.0.0:
   resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"
   integrity sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==
 
-p-event@^4.1.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/p-event/-/p-event-4.2.0.tgz#af4b049c8acd91ae81083ebd1e6f5cae2044c1b5"
-  integrity sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==
-  dependencies:
-    p-timeout "^3.1.0"
-
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
@@ -11340,13 +11362,6 @@ p-profiler@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/p-profiler/-/p-profiler-0.2.1.tgz#853b5e6b482c5d376e5e2bb1e94bd09c0e715983"
   integrity sha512-/XDER5u19OrAJ283ofIgw9hsLSoyQnjzki+tmn42vdppHOfo8PgivSSZfwaiyRAzLC2h02+Q+MKiIuuSve+7nw==
-
-p-timeout@^3.1.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.2.0.tgz#c7e17abc971d2a7962ef83626b35d635acf23dfe"
-  integrity sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
-  dependencies:
-    p-finally "^1.0.0"
 
 p-try@^2.0.0:
   version "2.2.0"
@@ -11684,6 +11699,11 @@ pngjs@^3.0.0, pngjs@^3.3.3:
   resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-3.4.0.tgz#99ca7d725965fb655814eaf65f38f12bbdbf555f"
   integrity sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==
 
+pngjs@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-5.0.0.tgz#e79dd2b215767fd9c04561c01236df960bce7fbb"
+  integrity sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==
+
 portscanner@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/portscanner/-/portscanner-2.2.0.tgz#6059189b3efa0965c9d96a56b958eb9508411cf1"
@@ -11854,6 +11874,16 @@ puppeteer-core@^13.1.3:
     tar-fs "2.1.1"
     unbzip2-stream "1.4.3"
     ws "8.5.0"
+
+qrcode@^1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/qrcode/-/qrcode-1.5.1.tgz#0103f97317409f7bc91772ef30793a54cd59f0cb"
+  integrity sha512-nS8NJ1Z3md8uTjKtP+SGGhfqmTCs5flU/xR623oI0JX+Wepz9R8UrRVCTBTJm3qGw3rH6jJ6MUHjkDx15cxSSg==
+  dependencies:
+    dijkstrajs "^1.0.1"
+    encode-utf8 "^1.0.3"
+    pngjs "^5.0.0"
+    yargs "^15.3.1"
 
 qs@6.10.3:
   version "6.10.3"


### PR DESCRIPTION
### Platforms Impacted

- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Bump `@rnx-kit/cli` to 0.14.8 and updated configuration.

### Verification

```
cd apps/fluent-tester
yarn bundle
```

### Pull request checklist

This PR has considered (when applicable):

- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
