### PR TITLE
Fixed bug with colors for Presence badge on Mac

### DIFF
--- a/change/@fluentui-react-native-badge-c347b792-0600-44c4-b1bf-ce85781cfb67.json
+++ b/change/@fluentui-react-native-badge-c347b792-0600-44c4-b1bf-ce85781cfb67.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix bug with colors on Mac for PresenceBadge",
+  "packageName": "@fluentui-react-native/badge",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Badge/src/PresenceBadge/PresenceBadgeTokens.macos.ts
+++ b/packages/components/Badge/src/PresenceBadge/PresenceBadgeTokens.macos.ts
@@ -36,4 +36,23 @@ export const defaultPresenceBadgeTokens: TokenSettings<PresenceBadgeTokens> = ()
       height: 28,
       borderWidth: 2,
     },
+    available: getBadgeColor('lightGreen'),
+    away: getBadgeColor('marigold'),
+    awayOutOfOffice: getBadgeColor('berry'),
+    busy: getBadgeColor('red'),
+    blocked: getBadgeColor('red'),
+    unknown: getBadgeColor('red'),
+    offline: {
+      iconColor: globalTokens.color.grey[38],
+    },
+    outOfOffice: getBadgeColor('berry'),
   } as PresenceBadgeTokens);
+
+function getBadgeColor(color: string) {
+  return {
+    iconColor: globalTokens.color[color].primary,
+    outOfOffice: {
+      iconColor: globalTokens.color[color].primary,
+    },
+  };
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
Added colors of PresenceBadge for macOS
Also, I need a condition how to check high contrast on Mac

### Verification
Needs check

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
