### PR TITLE
 Use iOS shadow tokens from pipeline

### DIFF
--- a/change/@fluentui-react-native-apple-theme-12115355-9d10-46a7-9584-9ec9549c5500.json
+++ b/change/@fluentui-react-native-apple-theme-12115355-9d10-46a7-9584-9ec9549c5500.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove hardcoded tokens, use shadow tokens from pipeline",
+  "packageName": "@fluentui-react-native/apple-theme",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/theming/apple-theme/package.json
+++ b/packages/theming/apple-theme/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@fluentui-react-native/default-theme": ">=0.16.2 <1.0.0",
-    "@fluentui-react-native/design-tokens-ios": "^0.19.0",
+    "@fluentui-react-native/design-tokens-ios": "^0.23.0",
     "@fluentui-react-native/design-tokens-macos": "^0.13.0",
     "@fluentui-react-native/memo-cache": "^1.1.7",
     "@fluentui-react-native/theme": ">=0.7.4 <1.0.0",

--- a/packages/theming/apple-theme/src/appleShadows.ios.ts
+++ b/packages/theming/apple-theme/src/appleShadows.ios.ts
@@ -1,0 +1,10 @@
+import { ThemeShadowDefinition } from '@fluentui-react-native/theme-types';
+import { getCurrentAppearance } from '@fluentui-react-native/theming-utils';
+import { Appearance } from 'react-native';
+import { createiOSShadowAliasTokens } from './createiOSAliasTokens';
+
+export function iOSShadows(): ThemeShadowDefinition {
+  const appearance = Appearance.getColorScheme();
+  const mode = getCurrentAppearance(appearance, 'light');
+  return createiOSShadowAliasTokens(mode);
+}

--- a/packages/theming/apple-theme/src/appleTheme.ios.ts
+++ b/packages/theming/apple-theme/src/appleTheme.ios.ts
@@ -1,6 +1,7 @@
 import { Theme, Spacing } from '@fluentui-react-native/theme-types';
 import { paletteFromAppleColors } from './appleColors.ios';
 import { appleTypography } from './appleTypography.ios';
+import { iOSShadows } from './appleShadows.ios';
 
 function appleSpacing(): Spacing {
   return { s2: '4px', s1: '8px', m: '16px', l1: '20px', l2: '32px' };
@@ -121,62 +122,10 @@ const appleComponents = {
   },
 };
 
-// mocked out
-const iOSShadows = {
-  shadow2: {
-    ambient: { x: 0, y: 0, blur: 2, color: '#0000001f' },
-    key: { x: 0, y: 1, blur: 2, color: '#00000024' },
-  },
-  shadow4: {
-    ambient: { x: 0, y: 0, blur: 2, color: '#0000001f' },
-    key: { x: 0, y: 2, blur: 4, color: '#00000024' },
-  },
-  shadow8: {
-    ambient: { x: 0, y: 0, blur: 2, color: '#0000001f' },
-    key: { x: 0, y: 4, blur: 8, color: '#00000024' },
-  },
-  shadow16: {
-    ambient: { x: 0, y: 0, blur: 2, color: '#0000001f' },
-    key: { x: 0, y: 8, blur: 16, color: '#00000024' },
-  },
-  shadow28: {
-    ambient: { x: 0, y: 0, blur: 8, color: '#00000033' },
-    key: { x: 0, y: 14, blur: 28, color: '#0000003d' },
-  },
-  shadow64: {
-    ambient: { x: 0, y: 0, blur: 8, color: '#00000033' },
-    key: { x: 0, y: 32, blur: 64, color: '#0000003d' },
-  },
-  shadow2brand: {
-    ambient: { x: 0, y: 0, blur: 2, color: '#0000004d' },
-    key: { x: 0, y: 1, blur: 2, color: '#00000040' },
-  },
-  shadow4brand: {
-    ambient: { x: 0, y: 0, blur: 2, color: '#0000004d' },
-    key: { x: 0, y: 2, blur: 4, color: '#00000040' },
-  },
-  shadow8brand: {
-    ambient: { x: 0, y: 0, blur: 2, color: '#0000004d' },
-    key: { x: 0, y: 4, blur: 8, color: '#00000040' },
-  },
-  shadow16brand: {
-    ambient: { x: 0, y: 0, blur: 2, color: '#0000004d' },
-    key: { x: 0, y: 8, blur: 16, color: '#00000040' },
-  },
-  shadow28brand: {
-    ambient: { x: 0, y: 0, blur: 8, color: '#0000004d' },
-    key: { x: 0, y: 14, blur: 28, color: '#00000040' },
-  },
-  shadow64brand: {
-    ambient: { x: 0, y: 0, blur: 8, color: '#0000004d' },
-    key: { x: 0, y: 32, blur: 64, color: '#00000040' },
-  },
-};
-
 export const BaseAppleLightThemeIOS: Theme = {
   colors: paletteFromAppleColors(false),
   typography: appleTypography(),
-  shadows: iOSShadows,
+  shadows: iOSShadows(),
   spacing: appleSpacing(),
   components: appleComponents,
   host: { appearance: 'light' },
@@ -185,7 +134,7 @@ export const BaseAppleLightThemeIOS: Theme = {
 export const BaseAppleDarkThemeIOS: Theme = {
   colors: paletteFromAppleColors(true),
   typography: appleTypography(),
-  shadows: iOSShadows,
+  shadows: iOSShadows(),
   spacing: appleSpacing(),
   components: appleComponents,
   host: { appearance: 'dark' },

--- a/packages/theming/apple-theme/src/createiOSAliasTokens.ts
+++ b/packages/theming/apple-theme/src/createiOSAliasTokens.ts
@@ -1,0 +1,12 @@
+import { getiOSShadowTokens } from './getiOSTokens';
+import { AppearanceOptions } from '@fluentui-react-native/theme-types';
+import { mapPipelineToShadow } from '@fluentui-react-native/theming-utils';
+import { memoize } from '@fluentui-react-native/memo-cache';
+import { ThemeShadowDefinition } from '@fluentui-react-native/theme-types/lib/Shadow.types';
+
+function createiOSShadowAliasTokensWorker(mode: AppearanceOptions): ThemeShadowDefinition {
+  const aliasTokens = getiOSShadowTokens(mode);
+  return mapPipelineToShadow(aliasTokens);
+}
+
+export const createiOSShadowAliasTokens = memoize(createiOSShadowAliasTokensWorker);

--- a/packages/theming/apple-theme/src/getiOSTokens.ts
+++ b/packages/theming/apple-theme/src/getiOSTokens.ts
@@ -1,0 +1,16 @@
+import iOSLightShadowTokens from '@fluentui-react-native/design-tokens-ios/light/tokens-shadow.json';
+import iOSDarkShadowTokens from '@fluentui-react-native/design-tokens-ios/dark/tokens-shadow.json';
+import { AppearanceOptions } from '@fluentui-react-native/theme-types';
+import { assertNever } from 'assert-never';
+
+export function getiOSShadowTokens(mode: AppearanceOptions) {
+  if (mode === 'light') {
+    return iOSLightShadowTokens.shadow;
+  } else if (mode === 'dark') {
+    return iOSDarkShadowTokens.shadow;
+  } else if (mode === 'highContrast') {
+    throw new Error('highContrast is not a valid AppearanceOptions on iOS');
+  } else {
+    assertNever(mode);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1452,10 +1452,10 @@
   resolved "https://registry.yarnpkg.com/@fluentui-react-native/design-tokens-android/-/design-tokens-android-0.17.0.tgz#55ed03b2639907f26103c5e9eb5eec46086a310e"
   integrity sha512-PPwXUuuKJ7eM5AEp16ceLM/CHfUi0Ltq9gDU5TZ9X6P0vW/B1IkLk6eFgtoiFdSmbQT+EoO5s3v2EUwhJ0z1ew==
 
-"@fluentui-react-native/design-tokens-ios@^0.19.0":
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/@fluentui-react-native/design-tokens-ios/-/design-tokens-ios-0.19.0.tgz#8c084af9080e93705239bc8b353da55bbbb507aa"
-  integrity sha512-Kvf3plp5eXN9S6mHK8SeDNhg2XukciVBm7rU954wgIYCePSif9/zixhH/OSSOE9HcYGyXzthRY6KDuu1KJDVCA==
+"@fluentui-react-native/design-tokens-ios@^0.23.0":
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/@fluentui-react-native/design-tokens-ios/-/design-tokens-ios-0.23.0.tgz#059b66c48fc1e236869187ccee1e39157c1a864a"
+  integrity sha512-03kPPV0z9hPRvzurUKwXa2as7Cv2PzGbw7xQAagSznoE6dl4r92Z67hlxzBpL5XlSfTvB3LlVhy6Pw5vX45wGw==
 
 "@fluentui-react-native/design-tokens-macos@^0.13.0":
   version "0.13.0"


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

iOS shadow tokens were added to the token pipeline (PR here https://github.com/microsoft/fluentui-design-tokens/pull/21)
This PR replaces the current hardcoded tokens in FURN with the tokens from the pipeline, following the same format as the macOS shadow tokens.

Out of scope for this PR:
- dark mode will be finished in a future PR. There seems to be a bug with dark mode in iOS where the theme doesn't get updated when we switch between light/dark mode, so unless the tester is refreshed sometimes the light mode shadows will be shown in dark mode or vice versa. Also to be done in another PR: the background of the tester in dark mode iOS is black, and shadows don't show up on a black background. 
- high contrast mode: there currently isn't a way to detect high contrast mode changes in RN-iOS. There is future work planned in react-native-macos to be able to respond to changes in high contrast mode, getting high contrast mode in for shadow tokens will be done when that work is complete.

### Verification

Only tested light mode. Dark mode will be tested/finished in another PR due to the reasons above.
No visual changes to light mode, since the hardcoded tokens were based off the actual token values

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
