### PR TITLE
Port partner repo FocusZone testing to FURN

### DIFF
--- a/apps/fluent-tester/src/E2E/FocusZone/pages/FocusZonePageObject.ts
+++ b/apps/fluent-tester/src/E2E/FocusZone/pages/FocusZonePageObject.ts
@@ -4,6 +4,7 @@ import {
   FOCUSZONE_CIRCLE_NAV_SWITCH,
   FOCUSZONE_DEFAULT_TABBABLE_SWITCH,
   FOCUSZONE_DIRECTION_ID,
+  FOCUSZONE_DIRECTION_PICKER,
   FOCUSZONE_DISABLED_SWITCH,
   FOCUSZONE_GRID_AFTER,
   FOCUSZONE_GRID_BEFORE,
@@ -62,7 +63,9 @@ class FocusZonePageObject extends BasePage {
     let switchElement: WebdriverIO.Element;
     switch (option) {
       case GridFocusZoneOption.SetDirection:
-        await (await this._getGridFocusZoneRadioButton(arg)).click();
+        await (await this._directionPicker).click();
+        await browser.waitUntil(async () => await (await this._getGridFocusZoneMenuOption(arg)).isDisplayed());
+        await (await this._getGridFocusZoneMenuOption(arg)).click();
         return;
       case GridFocusZoneOption.Set2DNavigation:
         switchElement = await this._twoDimSwitch;
@@ -105,7 +108,7 @@ class FocusZonePageObject extends BasePage {
     }
   }
 
-  private async _getGridFocusZoneRadioButton(direction: FocusZoneDirection) {
+  private async _getGridFocusZoneMenuOption(direction: FocusZoneDirection) {
     return await By(FOCUSZONE_DIRECTION_ID(direction));
   }
 
@@ -124,10 +127,12 @@ class FocusZonePageObject extends BasePage {
     return By(FOCUSZONE_TEST_COMPONENT);
   }
 
-  // FocusZone grid
-
   get _pageButton() {
     return By(HOMEPAGE_FOCUSZONE_BUTTON);
+  }
+
+  get _directionPicker() {
+    return By(FOCUSZONE_DIRECTION_PICKER);
   }
 
   get _twoDimSwitch() {

--- a/apps/fluent-tester/src/E2E/FocusZone/pages/FocusZonePageObject.ts
+++ b/apps/fluent-tester/src/E2E/FocusZone/pages/FocusZonePageObject.ts
@@ -1,12 +1,112 @@
-import { FOCUSZONE_TESTPAGE, FOCUSZONE_TEST_COMPONENT, HOMEPAGE_FOCUSZONE_BUTTON } from '../../../TestComponents/FocusZone/consts';
+import { FocusZoneDirection } from '@fluentui/react-native';
+import { Attribute, AttributeValue, Keys } from '../../common/consts';
+import {
+  FOCUSZONE_CIRCLE_NAV_SWITCH,
+  FOCUSZONE_DEFAULT_TABBABLE_SWITCH,
+  FOCUSZONE_DIRECTION_ID,
+  FOCUSZONE_DISABLED_SWITCH,
+  FOCUSZONE_GRID_AFTER,
+  FOCUSZONE_GRID_BEFORE,
+  FOCUSZONE_GRID_BUTTON,
+  FOCUSZONE_TESTPAGE,
+  FOCUSZONE_TEST_COMPONENT,
+  FOCUSZONE_TWO_DIM_SWITCH,
+  HOMEPAGE_FOCUSZONE_BUTTON,
+} from '../../../TestComponents/FocusZone/consts';
 import { BasePage, By } from '../../common/BasePage';
 
+export const enum GridFocusZoneOption {
+  SetDirection = 0,
+  Set2DNavigation,
+  SetCircularNavigation,
+  UseDefaultTabbableElement,
+  Disable,
+}
+
+export const enum GridButtonSelector {
+  Before = 0,
+  One,
+  Two,
+  Three,
+  Four,
+  Five,
+  Six,
+  Seven,
+  Eight,
+  Nine,
+  After,
+}
+
+type BooleanGridFocusZoneOption =
+  | GridFocusZoneOption.UseDefaultTabbableElement
+  | GridFocusZoneOption.Set2DNavigation
+  | GridFocusZoneOption.SetCircularNavigation
+  | GridFocusZoneOption.Disable;
+
 class FocusZonePageObject extends BasePage {
-  // OVERRIDE: We use isExisting() here instead of isDisplayed() because FocusZone does not have any UI to it, it's simply
-  // a wrapper that adds keyboard focus functionality
   async waitForPrimaryElementDisplayed(timeout?: number): Promise<void> {
     const errorMsg = 'The FocusZone UI Element did not load correctly. Please see logs.';
-    await this.waitForCondition(async () => await this._primaryComponent.isExisting(), errorMsg, timeout);
+    await this.waitForCondition(async () => await this._primaryComponent.isDisplayed(), errorMsg, timeout);
+  }
+
+  async resetTest() {
+    await this.configureGridFocusZone(GridFocusZoneOption.SetDirection, 'bidirectional');
+    await this.configureGridFocusZone(GridFocusZoneOption.Set2DNavigation, false);
+    await this.configureGridFocusZone(GridFocusZoneOption.SetCircularNavigation, false);
+    await this.configureGridFocusZone(GridFocusZoneOption.Disable, false);
+  }
+
+  async configureGridFocusZone(option: GridFocusZoneOption.SetDirection, direction: FocusZoneDirection);
+  async configureGridFocusZone(option: BooleanGridFocusZoneOption, value: boolean);
+  async configureGridFocusZone(option: GridFocusZoneOption, arg: any): Promise<void> {
+    let switchElement: WebdriverIO.Element;
+    switch (option) {
+      case GridFocusZoneOption.SetDirection:
+        await (await this._getGridFocusZoneRadioButton(arg)).click();
+        return;
+      case GridFocusZoneOption.Set2DNavigation:
+        switchElement = await this._twoDimSwitch;
+        break;
+      case GridFocusZoneOption.SetCircularNavigation:
+        switchElement = await this._circleNavSwitch;
+        break;
+      case GridFocusZoneOption.UseDefaultTabbableElement:
+        switchElement = await this._defaultTabbableElementSwitch;
+        break;
+      case GridFocusZoneOption.Disable:
+        switchElement = await this._disabledSwitch;
+        break;
+      default:
+    }
+    const switchValue = await switchElement.isSelected();
+    if (switchValue !== arg) {
+      await switchElement.click();
+    }
+  }
+
+  async sendKeys(selector: GridButtonSelector, keys: Keys[]): Promise<void> {
+    const btn = await this._getGridButton(selector);
+    await btn.addValue(keys);
+  }
+
+  async gridButtonIsFocused(selector: GridButtonSelector): Promise<boolean> {
+    const btn = await this._getGridButton(selector);
+    return (await this.getElementAttribute(btn, Attribute.IsFocused)) === AttributeValue.true;
+  }
+
+  private async _getGridButton(selector: GridButtonSelector): Promise<WebdriverIO.Element> {
+    switch (selector) {
+      case GridButtonSelector.Before:
+        return await this._gridBeforeButton;
+      case GridButtonSelector.After:
+        return await this._gridAfterButton;
+      default:
+        return await By(FOCUSZONE_GRID_BUTTON(selector));
+    }
+  }
+
+  private async _getGridFocusZoneRadioButton(direction: FocusZoneDirection) {
+    return await By(FOCUSZONE_DIRECTION_ID(direction));
   }
 
   /*****************************************/
@@ -24,8 +124,34 @@ class FocusZonePageObject extends BasePage {
     return By(FOCUSZONE_TEST_COMPONENT);
   }
 
+  // FocusZone grid
+
   get _pageButton() {
     return By(HOMEPAGE_FOCUSZONE_BUTTON);
+  }
+
+  get _twoDimSwitch() {
+    return By(FOCUSZONE_TWO_DIM_SWITCH);
+  }
+
+  get _disabledSwitch() {
+    return By(FOCUSZONE_DISABLED_SWITCH);
+  }
+
+  get _circleNavSwitch() {
+    return By(FOCUSZONE_CIRCLE_NAV_SWITCH);
+  }
+
+  get _defaultTabbableElementSwitch() {
+    return By(FOCUSZONE_DEFAULT_TABBABLE_SWITCH);
+  }
+
+  get _gridBeforeButton() {
+    return By(FOCUSZONE_GRID_BEFORE);
+  }
+
+  get _gridAfterButton() {
+    return By(FOCUSZONE_GRID_AFTER);
   }
 }
 

--- a/apps/fluent-tester/src/E2E/FocusZone/specs/FocusZone.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/FocusZone/specs/FocusZone.spec.win.ts
@@ -32,7 +32,7 @@ describe('FocusZone Testing Initialization', function () {
  * */
 describe('FocusZone Functional Testing', () => {
   beforeEach(async () => {
-    // await FocusZonePageObject.scrollToTestElement();
+    await FocusZonePageObject.scrollToTestElement();
     await FocusZonePageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
     await FocusZonePageObject.resetTest();
   });

--- a/apps/fluent-tester/src/E2E/FocusZone/specs/FocusZone.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/FocusZone/specs/FocusZone.spec.win.ts
@@ -115,13 +115,17 @@ describe('FocusZone Functional Testing', () => {
     await expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
   });
 
-  it('Navigates focuszone with circular navigation on - switches focus correctly', async () => {
+  it("Navigates focuszone with circular navigation off - doesn't switch focus", async () => {
     await FocusZonePageObject.sendKeys(GridButtonSelector.One, [Keys.ARROW_LEFT]);
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.One)).toBeTruthy();
 
     await FocusZonePageObject.sendKeys(GridButtonSelector.Nine, [Keys.ARROW_RIGHT]);
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Nine)).toBeTruthy();
 
+    await expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
+  });
+
+  it('Navigates focuszone with circular navigation on - switches focus correctly', async () => {
     await FocusZonePageObject.configureGridFocusZone(GridFocusZoneOption.SetCircularNavigation, true);
 
     await FocusZonePageObject.sendKeys(GridButtonSelector.One, [Keys.ARROW_LEFT]);
@@ -161,6 +165,11 @@ describe('FocusZone Functional Testing', () => {
 
     await FocusZonePageObject.sendKeys(GridButtonSelector.After, [Keys.SHIFT, Keys.TAB]);
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Nine)).toBeTruthy();
+
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Nine, [Keys.SHIFT, Keys.TAB]);
+    await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Before)).toBeTruthy();
+
+    await expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
   });
 
   it('Tabs in and out of the FocusZone with a defaultTabbableElement set - switches focus correctly', async () => {
@@ -174,6 +183,16 @@ describe('FocusZone Functional Testing', () => {
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.After)).toBeTruthy();
 
     await FocusZonePageObject.sendKeys(GridButtonSelector.After, [Keys.SHIFT, Keys.TAB]);
+    await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Four)).toBeTruthy();
+
+    // Key to another button, tab out, and tab back in to make sure the default tabbable element is still the first to be tabbed to
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Four, [Keys.ARROW_RIGHT]);
+    await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Five)).toBeTruthy();
+
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Five, [Keys.SHIFT, Keys.TAB]);
+    await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Before)).toBeTruthy();
+
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Before, [Keys.TAB]);
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Four)).toBeTruthy();
 
     await expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);

--- a/apps/fluent-tester/src/E2E/FocusZone/specs/FocusZone.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/FocusZone/specs/FocusZone.spec.win.ts
@@ -38,13 +38,67 @@ describe('FocusZone Functional Testing', () => {
   });
 
   it('Navigate bidirectional focuszone by arrow keys - switches focus correctly', async () => {
-    // move to 1 with right arrow
+    // move to 2 with right arrow
     await FocusZonePageObject.sendKeys(GridButtonSelector.One, [Keys.Right_Arrow]);
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Two)).toBeTruthy();
 
-    // move to 2 with down arrow
+    // move to 3 with down arrow
     await FocusZonePageObject.sendKeys(GridButtonSelector.Two, [Keys.Down_Arrow]);
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Three)).toBeTruthy();
+
+    await expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
+  });
+
+  it('Navigate horizontal focuszone by arrow keys - switches focus correctly', async () => {
+    await FocusZonePageObject.configureGridFocusZone(GridFocusZoneOption.SetDirection, 'horizontal');
+    // move to 2 with right arrow
+    await FocusZonePageObject.sendKeys(GridButtonSelector.One, [Keys.Right_Arrow]);
+    await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Two)).toBeTruthy();
+
+    // down arrow shouldn't move focus
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Two, [Keys.Down_Arrow]);
+    await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Two)).toBeTruthy();
+
+    // left arrow goes back
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Four, [Keys.Left_Arrow]);
+    await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Three)).toBeTruthy();
+
+    await expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
+  });
+
+  it('Navigates vertical focuszone by arrow keys - switches focus correctly', async () => {
+    await FocusZonePageObject.configureGridFocusZone(GridFocusZoneOption.SetDirection, 'vertical');
+
+    // move to 2 with down arrow
+    await FocusZonePageObject.sendKeys(GridButtonSelector.One, [Keys.Down_Arrow]);
+    await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Two)).toBeTruthy();
+
+    // right arrow shouldn't move focus
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Two, [Keys.Right_Arrow]);
+    await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Two)).toBeTruthy();
+
+    // up arrow goes back
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Four, [Keys.Up_Arrow]);
+    await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Three)).toBeTruthy();
+
+    await expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
+  });
+
+  it("Navigates none-direction focuszone by arrow keys - doesn't switch focus", async () => {
+    await FocusZonePageObject.configureGridFocusZone(GridFocusZoneOption.SetDirection, 'none');
+
+    // none of these key commands should move
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Two, [Keys.Down_Arrow]);
+    await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Two)).toBeTruthy();
+
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Two, [Keys.Up_Arrow]);
+    await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Two)).toBeTruthy();
+
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Two, [Keys.Left_Arrow]);
+    await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Two)).toBeTruthy();
+
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Two, [Keys.Right_Arrow]);
+    await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Two)).toBeTruthy();
 
     await expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
   });
@@ -57,6 +111,43 @@ describe('FocusZone Functional Testing', () => {
 
     await FocusZonePageObject.sendKeys(GridButtonSelector.Four, [Keys.Right_Arrow]);
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Five)).toBeTruthy();
+
+    await expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
+  });
+
+  it('Navigates focuszone with circular navigation on - switches focus correctly', async () => {
+    await FocusZonePageObject.sendKeys(GridButtonSelector.One, [Keys.Left_Arrow]);
+    await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.One)).toBeTruthy();
+
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Nine, [Keys.Right_Arrow]);
+    await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Nine)).toBeTruthy();
+
+    await FocusZonePageObject.configureGridFocusZone(GridFocusZoneOption.SetCircularNavigation, true);
+
+    await FocusZonePageObject.sendKeys(GridButtonSelector.One, [Keys.Left_Arrow]);
+    await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Nine)).toBeTruthy();
+
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Nine, [Keys.Right_Arrow]);
+    await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.One)).toBeTruthy();
+
+    await expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
+  });
+
+  it("Navigates disabled focuszone by arrow keys - doesn't switch focus", async () => {
+    await FocusZonePageObject.configureGridFocusZone(GridFocusZoneOption.Disable, true);
+
+    // none of these key commands should move
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Two, [Keys.Down_Arrow]);
+    await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Two)).toBeTruthy();
+
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Two, [Keys.Up_Arrow]);
+    await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Two)).toBeTruthy();
+
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Two, [Keys.Left_Arrow]);
+    await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Two)).toBeTruthy();
+
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Two, [Keys.Right_Arrow]);
+    await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Two)).toBeTruthy();
 
     await expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
   });

--- a/apps/fluent-tester/src/E2E/FocusZone/specs/FocusZone.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/FocusZone/specs/FocusZone.spec.win.ts
@@ -39,11 +39,11 @@ describe('FocusZone Functional Testing', () => {
 
   it('Navigate bidirectional focuszone by arrow keys - switches focus correctly', async () => {
     // move to 2 with right arrow
-    await FocusZonePageObject.sendKeys(GridButtonSelector.One, [Keys.Right_Arrow]);
+    await FocusZonePageObject.sendKeys(GridButtonSelector.One, [Keys.ARROW_RIGHT]);
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Two)).toBeTruthy();
 
     // move to 3 with down arrow
-    await FocusZonePageObject.sendKeys(GridButtonSelector.Two, [Keys.Down_Arrow]);
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Two, [Keys.ARROW_DOWN]);
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Three)).toBeTruthy();
 
     await expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
@@ -52,15 +52,15 @@ describe('FocusZone Functional Testing', () => {
   it('Navigate horizontal focuszone by arrow keys - switches focus correctly', async () => {
     await FocusZonePageObject.configureGridFocusZone(GridFocusZoneOption.SetDirection, 'horizontal');
     // move to 2 with right arrow
-    await FocusZonePageObject.sendKeys(GridButtonSelector.One, [Keys.Right_Arrow]);
+    await FocusZonePageObject.sendKeys(GridButtonSelector.One, [Keys.ARROW_RIGHT]);
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Two)).toBeTruthy();
 
     // down arrow shouldn't move focus
-    await FocusZonePageObject.sendKeys(GridButtonSelector.Two, [Keys.Down_Arrow]);
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Two, [Keys.ARROW_DOWN]);
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Two)).toBeTruthy();
 
     // left arrow goes back
-    await FocusZonePageObject.sendKeys(GridButtonSelector.Four, [Keys.Left_Arrow]);
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Four, [Keys.ARROW_LEFT]);
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Three)).toBeTruthy();
 
     await expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
@@ -70,15 +70,15 @@ describe('FocusZone Functional Testing', () => {
     await FocusZonePageObject.configureGridFocusZone(GridFocusZoneOption.SetDirection, 'vertical');
 
     // move to 2 with down arrow
-    await FocusZonePageObject.sendKeys(GridButtonSelector.One, [Keys.Down_Arrow]);
+    await FocusZonePageObject.sendKeys(GridButtonSelector.One, [Keys.ARROW_DOWN]);
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Two)).toBeTruthy();
 
     // right arrow shouldn't move focus
-    await FocusZonePageObject.sendKeys(GridButtonSelector.Two, [Keys.Right_Arrow]);
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Two, [Keys.ARROW_RIGHT]);
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Two)).toBeTruthy();
 
     // up arrow goes back
-    await FocusZonePageObject.sendKeys(GridButtonSelector.Four, [Keys.Up_Arrow]);
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Four, [Keys.ARROW_UP]);
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Three)).toBeTruthy();
 
     await expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
@@ -88,16 +88,16 @@ describe('FocusZone Functional Testing', () => {
     await FocusZonePageObject.configureGridFocusZone(GridFocusZoneOption.SetDirection, 'none');
 
     // none of these key commands should move
-    await FocusZonePageObject.sendKeys(GridButtonSelector.Two, [Keys.Down_Arrow]);
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Two, [Keys.ARROW_DOWN]);
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Two)).toBeTruthy();
 
-    await FocusZonePageObject.sendKeys(GridButtonSelector.Two, [Keys.Up_Arrow]);
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Two, [Keys.ARROW_UP]);
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Two)).toBeTruthy();
 
-    await FocusZonePageObject.sendKeys(GridButtonSelector.Two, [Keys.Left_Arrow]);
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Two, [Keys.ARROW_LEFT]);
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Two)).toBeTruthy();
 
-    await FocusZonePageObject.sendKeys(GridButtonSelector.Two, [Keys.Right_Arrow]);
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Two, [Keys.ARROW_RIGHT]);
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Two)).toBeTruthy();
 
     await expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
@@ -106,28 +106,28 @@ describe('FocusZone Functional Testing', () => {
   it('Navigates bi-directional focuszone with 2d navigation - switches focus correctly', async () => {
     await FocusZonePageObject.configureGridFocusZone(GridFocusZoneOption.Set2DNavigation, true);
 
-    await FocusZonePageObject.sendKeys(GridButtonSelector.One, [Keys.Down_Arrow]);
+    await FocusZonePageObject.sendKeys(GridButtonSelector.One, [Keys.ARROW_DOWN]);
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Four)).toBeTruthy();
 
-    await FocusZonePageObject.sendKeys(GridButtonSelector.Four, [Keys.Right_Arrow]);
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Four, [Keys.ARROW_RIGHT]);
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Five)).toBeTruthy();
 
     await expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
   });
 
   it('Navigates focuszone with circular navigation on - switches focus correctly', async () => {
-    await FocusZonePageObject.sendKeys(GridButtonSelector.One, [Keys.Left_Arrow]);
+    await FocusZonePageObject.sendKeys(GridButtonSelector.One, [Keys.ARROW_LEFT]);
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.One)).toBeTruthy();
 
-    await FocusZonePageObject.sendKeys(GridButtonSelector.Nine, [Keys.Right_Arrow]);
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Nine, [Keys.ARROW_RIGHT]);
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Nine)).toBeTruthy();
 
     await FocusZonePageObject.configureGridFocusZone(GridFocusZoneOption.SetCircularNavigation, true);
 
-    await FocusZonePageObject.sendKeys(GridButtonSelector.One, [Keys.Left_Arrow]);
+    await FocusZonePageObject.sendKeys(GridButtonSelector.One, [Keys.ARROW_LEFT]);
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Nine)).toBeTruthy();
 
-    await FocusZonePageObject.sendKeys(GridButtonSelector.Nine, [Keys.Right_Arrow]);
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Nine, [Keys.ARROW_RIGHT]);
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.One)).toBeTruthy();
 
     await expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
@@ -137,29 +137,29 @@ describe('FocusZone Functional Testing', () => {
     await FocusZonePageObject.configureGridFocusZone(GridFocusZoneOption.Disable, true);
 
     // none of these key commands should move
-    await FocusZonePageObject.sendKeys(GridButtonSelector.Two, [Keys.Down_Arrow]);
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Two, [Keys.ARROW_DOWN]);
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Two)).toBeTruthy();
 
-    await FocusZonePageObject.sendKeys(GridButtonSelector.Two, [Keys.Up_Arrow]);
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Two, [Keys.ARROW_UP]);
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Two)).toBeTruthy();
 
-    await FocusZonePageObject.sendKeys(GridButtonSelector.Two, [Keys.Left_Arrow]);
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Two, [Keys.ARROW_LEFT]);
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Two)).toBeTruthy();
 
-    await FocusZonePageObject.sendKeys(GridButtonSelector.Two, [Keys.Right_Arrow]);
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Two, [Keys.ARROW_RIGHT]);
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Two)).toBeTruthy();
 
     await expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
   });
 
   it('Tabs in and out of the FocusZone - switches focus correctly', async () => {
-    await FocusZonePageObject.sendKeys(GridButtonSelector.Before, [Keys.Tab]);
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Before, [Keys.TAB]);
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.One)).toBeTruthy();
 
-    await FocusZonePageObject.sendKeys(GridButtonSelector.One, [Keys.Tab]);
+    await FocusZonePageObject.sendKeys(GridButtonSelector.One, [Keys.TAB]);
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.After)).toBeTruthy();
 
-    await FocusZonePageObject.sendKeys(GridButtonSelector.After, [Keys.Shift, Keys.Tab]);
+    await FocusZonePageObject.sendKeys(GridButtonSelector.After, [Keys.SHIFT, Keys.TAB]);
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Nine)).toBeTruthy();
   });
 
@@ -167,13 +167,13 @@ describe('FocusZone Functional Testing', () => {
     // This sets the defaultTabbableElement prop of the FocusZone to be grid button #4. Whenever a user tabs into the zone, button 4 should always be the first to be selected.
     await FocusZonePageObject.configureGridFocusZone(GridFocusZoneOption.UseDefaultTabbableElement, true);
 
-    await FocusZonePageObject.sendKeys(GridButtonSelector.Before, [Keys.Tab]);
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Before, [Keys.TAB]);
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Four)).toBeTruthy();
 
-    await FocusZonePageObject.sendKeys(GridButtonSelector.Four, [Keys.Tab]);
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Four, [Keys.TAB]);
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.After)).toBeTruthy();
 
-    await FocusZonePageObject.sendKeys(GridButtonSelector.After, [Keys.Shift, Keys.Tab]);
+    await FocusZonePageObject.sendKeys(GridButtonSelector.After, [Keys.SHIFT, Keys.TAB]);
     await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Four)).toBeTruthy();
 
     await expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);

--- a/apps/fluent-tester/src/E2E/FocusZone/specs/FocusZone.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/FocusZone/specs/FocusZone.spec.win.ts
@@ -1,7 +1,7 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
-import FocusZonePageObject from '../pages/FocusZonePageObject';
-import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
+import FocusZonePageObject, { GridButtonSelector, GridFocusZoneOption } from '../pages/FocusZonePageObject';
+import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT, Keys } from '../../common/consts';
+// import { Platform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('FocusZone Testing Initialization', function () {
@@ -12,7 +12,7 @@ describe('FocusZone Testing Initialization', function () {
 
   it('Click and navigate to FocusZone test page', async () => {
     /* Scroll to component test page button in scrollview if not already visible*/
-    await FocusZonePageObject.scrollToComponentButton(Platform.Win32);
+    // await FocusZonePageObject.scrollToComponentButton(Platform.Win32);
     await FocusZonePageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */
@@ -21,5 +21,70 @@ describe('FocusZone Testing Initialization', function () {
 
     await expect(await FocusZonePageObject.isPageLoaded()).toBeTruthy(FocusZonePageObject.ERRORMESSAGE_PAGELOAD);
     await expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+  });
+});
+
+/* FocusZone Functional Testing
+ *
+ * This test validates that keyboard navigation using both arrow keys and
+ * tab key works, even when modifying how the FocusZone functions.
+ *
+ * */
+describe('FocusZone Functional Testing', () => {
+  beforeEach(async () => {
+    // await FocusZonePageObject.scrollToTestElement();
+    await FocusZonePageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
+    await FocusZonePageObject.resetTest();
+  });
+
+  it('Navigate bidirectional focuszone by arrow keys - switches focus correctly', async () => {
+    // move to 1 with right arrow
+    await FocusZonePageObject.sendKeys(GridButtonSelector.One, [Keys.Right_Arrow]);
+    await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Two)).toBeTruthy();
+
+    // move to 2 with down arrow
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Two, [Keys.Down_Arrow]);
+    await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Three)).toBeTruthy();
+
+    await expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
+  });
+
+  it('Navigates bi-directional focuszone with 2d navigation - switches focus correctly', async () => {
+    await FocusZonePageObject.configureGridFocusZone(GridFocusZoneOption.Set2DNavigation, true);
+
+    await FocusZonePageObject.sendKeys(GridButtonSelector.One, [Keys.Down_Arrow]);
+    await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Four)).toBeTruthy();
+
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Four, [Keys.Right_Arrow]);
+    await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Five)).toBeTruthy();
+
+    await expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
+  });
+
+  it('Tabs in and out of the FocusZone - switches focus correctly', async () => {
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Before, [Keys.Tab]);
+    await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.One)).toBeTruthy();
+
+    await FocusZonePageObject.sendKeys(GridButtonSelector.One, [Keys.Tab]);
+    await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.After)).toBeTruthy();
+
+    await FocusZonePageObject.sendKeys(GridButtonSelector.After, [Keys.Shift, Keys.Tab]);
+    await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Nine)).toBeTruthy();
+  });
+
+  it('Tabs in and out of the FocusZone with a defaultTabbableElement set - switches focus correctly', async () => {
+    // This sets the defaultTabbableElement prop of the FocusZone to be grid button #4. Whenever a user tabs into the zone, button 4 should always be the first to be selected.
+    await FocusZonePageObject.configureGridFocusZone(GridFocusZoneOption.UseDefaultTabbableElement, true);
+
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Before, [Keys.Tab]);
+    await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Four)).toBeTruthy();
+
+    await FocusZonePageObject.sendKeys(GridButtonSelector.Four, [Keys.Tab]);
+    await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.After)).toBeTruthy();
+
+    await FocusZonePageObject.sendKeys(GridButtonSelector.After, [Keys.Shift, Keys.Tab]);
+    await expect(await FocusZonePageObject.gridButtonIsFocused(GridButtonSelector.Four)).toBeTruthy();
+
+    await expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
   });
 });

--- a/apps/fluent-tester/src/E2E/FocusZone/specs/FocusZone.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/FocusZone/specs/FocusZone.spec.win.ts
@@ -1,7 +1,7 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import FocusZonePageObject, { GridButtonSelector, GridFocusZoneOption } from '../pages/FocusZonePageObject';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT, Keys } from '../../common/consts';
-// import { Platform } from '../../common/BasePage';
+import { Platform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('FocusZone Testing Initialization', function () {
@@ -12,7 +12,7 @@ describe('FocusZone Testing Initialization', function () {
 
   it('Click and navigate to FocusZone test page', async () => {
     /* Scroll to component test page button in scrollview if not already visible*/
-    // await FocusZonePageObject.scrollToComponentButton(Platform.Win32);
+    await FocusZonePageObject.scrollToComponentButton(Platform.Win32);
     await FocusZonePageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/common/BasePage.ts
+++ b/apps/fluent-tester/src/E2E/common/BasePage.ts
@@ -1,5 +1,6 @@
 import { Keys } from './consts';
 import { TESTPAGE_BUTTONS_SCROLLVIEWER } from '../../TestComponents/Common/consts';
+import { Attribute } from './consts';
 
 const DUMMY_CHAR = '';
 export const COMPONENT_SCROLL_COORDINATES = { x: -0, y: -100 }; // These are the offsets. Y is negative because we want the touch to move up (and thus it scrolls down)
@@ -36,17 +37,17 @@ export class BasePage {
   /**************** UI Element Interaction Methods ******************/
   /******************************************************************/
   async getAccessibilityRole(): Promise<string> {
-    return await this._primaryComponent.getAttribute('ControlType');
+    return await this.getElementAttribute(await this._primaryComponent, Attribute.AccessibilityRole);
   }
 
   /* Gets the accessibility label of an UI element given the selector */
   async getAccessibilityLabel(componentSelector: ComponentSelector): Promise<string> {
     switch (componentSelector) {
       case ComponentSelector.Primary:
-        return await this._primaryComponent.getAttribute('Name');
+        return await this.getElementAttribute(await this._primaryComponent, Attribute.AccessibilityLabel);
 
       case ComponentSelector.Secondary:
-        return await this._secondaryComponent.getAttribute('Name');
+        return await this.getElementAttribute(await this._secondaryComponent, Attribute.AccessibilityLabel);
     }
   }
 
@@ -64,6 +65,10 @@ export class BasePage {
 
   async clickComponent(): Promise<void> {
     await this._primaryComponent.click();
+  }
+
+  async getElementAttribute(element: WebdriverIO.Element, attribute: Attribute) {
+    return await element.getAttribute(attribute);
   }
 
   /* Scrolls until the desired test page's button is displayed. We use the scroll viewer UI element as the point to start scrolling.

--- a/apps/fluent-tester/src/E2E/common/consts.ts
+++ b/apps/fluent-tester/src/E2E/common/consts.ts
@@ -16,6 +16,23 @@ export const TEXT_A11Y_ROLE = 'ControlType.Text';
 export const BOOT_APP_TIMEOUT = 60000;
 export const PAGE_TIMEOUT = 15000;
 
+export const enum Attribute {
+  AccessibilityLabel = 'Name',
+  AccessibilityRole = 'ControlType',
+  IsEnabled = 'IsEnabled',
+  IsFocused = 'HasKeyboardFocus',
+  IsRequiredForForm = 'IsRequiredForForm',
+  IsTogglePatternAvailable = 'IsTogglePatternAvailable',
+  ToggleState = 'Toggle.ToggleState',
+}
+
+export const enum AttributeValue {
+  on = '1',
+  off = '0',
+  true = 'True',
+  false = 'False',
+}
+
 /* Keyboard Key Constants */
 export const enum Keys {
   NULL = '\uE000',

--- a/apps/fluent-tester/src/TestComponents/Common/MenuPicker.tsx
+++ b/apps/fluent-tester/src/TestComponents/Common/MenuPicker.tsx
@@ -18,10 +18,11 @@ export interface MenuPickerProps {
   onChange?: (value: any, index?: number) => void;
   collection?: CollectionItem[];
   style?: any;
+  testID?: string;
 }
 
 export const MenuPicker: React.FunctionComponent<MenuPickerProps> = (props: MenuPickerProps) => {
-  const { prompt, selected, onChange, collection, style } = props;
+  const { prompt, selected, onChange, collection, style, testID } = props;
   let selectedItemKey;
 
   collection.forEach((item) => {
@@ -32,6 +33,7 @@ export const MenuPicker: React.FunctionComponent<MenuPickerProps> = (props: Menu
 
   return (
     <Picker
+      testID={testID}
       prompt={prompt}
       selectedValue={selectedItemKey}
       onValueChange={(value: string, index: number) => onChange(value, index)}

--- a/apps/fluent-tester/src/TestComponents/Common/MenuPicker.tsx
+++ b/apps/fluent-tester/src/TestComponents/Common/MenuPicker.tsx
@@ -9,6 +9,7 @@ import { Picker } from '@react-native-picker/picker';
 export interface CollectionItem<T = string> {
   label: string;
   value?: T;
+  testID?: string;
 }
 
 export interface MenuPickerProps {
@@ -37,7 +38,7 @@ export const MenuPicker: React.FunctionComponent<MenuPickerProps> = (props: Menu
       style={{ ...style }}
     >
       {collection.map((item, index) => (
-        <Picker.Item label={item.label} key={index} value={item.value} />
+        <Picker.Item label={item.label} key={index} value={item.value} testID={item.testID} />
       ))}
     </Picker>
   );

--- a/apps/fluent-tester/src/TestComponents/FocusZone/FocusZoneE2ETest.tsx
+++ b/apps/fluent-tester/src/TestComponents/FocusZone/FocusZoneE2ETest.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { View, Switch } from 'react-native';
-import { FocusZoneDirection, FocusZone, Text } from '@fluentui/react-native';
-import { RadioGroup, Radio } from '@fluentui-react-native/experimental-radio-group';
+import { View } from 'react-native';
+import { FocusZoneDirection, FocusZone, MenuButton, Text } from '@fluentui/react-native';
+import { Switch } from '@fluentui-react-native/switch';
 import { ButtonV1 as Button, ButtonProps } from '@fluentui-react-native/button';
 import { commonTestStyles } from '../Common/styles';
 import {
@@ -14,6 +14,7 @@ import {
   FOCUSZONE_GRID_BEFORE,
   FOCUSZONE_GRID_AFTER,
   FOCUSZONE_GRID_BUTTON,
+  FOCUSZONE_DIRECTION_PICKER,
 } from './consts';
 import { focusZoneTestStyles, GridButton } from './styles';
 
@@ -39,6 +40,7 @@ type GridOfButtonsProps = {
   gridHeight: number;
   tabRef?: React.RefObject<View>;
   tabbableIdx?: number;
+  e2etesting?: boolean;
 };
 
 export const GridOfButtons: React.FunctionComponent<GridOfButtonsProps> = (props: GridOfButtonsProps) => {
@@ -51,7 +53,7 @@ export const GridOfButtons: React.FunctionComponent<GridOfButtonsProps> = (props
               const gridIndex = heightIndex * props.gridWidth + widthIndex + 1;
               return (
                 <GridButton
-                  testID={FOCUSZONE_GRID_BUTTON(gridIndex)}
+                  testID={props.e2etesting ? FOCUSZONE_GRID_BUTTON(gridIndex) : undefined}
                   key={widthIndex}
                   style={focusZoneTestStyles.focusZoneButton}
                   componentRef={gridIndex === props.tabbableIdx ? props.tabRef : undefined}
@@ -66,23 +68,6 @@ export const GridOfButtons: React.FunctionComponent<GridOfButtonsProps> = (props
     </View>
   );
 };
-
-interface ISwitchWithLabelProps {
-  label: string;
-  value: boolean;
-  onValueChange: (value: boolean) => void;
-  testID?: string;
-}
-
-function SwitchWithLabel(props: ISwitchWithLabelProps): React.ReactElement {
-  const { label, value, onValueChange, testID } = props;
-  return (
-    <View style={commonTestStyles.switch}>
-      <Text>{label}</Text>
-      <Switch testID={testID} value={value} onValueChange={onValueChange} />
-    </View>
-  );
-}
 
 export const FocusZone2D: React.FunctionComponent = () => {
   const [is2DNav, set2dNav] = React.useState(false);
@@ -99,25 +84,29 @@ export const FocusZone2D: React.FunctionComponent = () => {
         <Text variant="subheaderSemibold" testID={FOCUSZONE_TEST_COMPONENT}>
           FocusZone Direction
         </Text>
-        {/* Usage of RadioGroup over MenuPicker is because MenuPicker, from my experimentation, doesn't support automation. */}
-        <RadioGroup style={focusZoneTestStyles.radioGroup} onChange={(dir) => setDirection(dir as FocusZoneDirection)} value={direction}>
-          {FocusZoneDirections.map((direction, i) => (
-            <Radio label={direction} value={direction} testID={FOCUSZONE_DIRECTION_ID(direction)} key={i} />
-          ))}
-        </RadioGroup>
-        <SwitchWithLabel testID={FOCUSZONE_TWO_DIM_SWITCH} label="2D Navigation" value={is2DNav} onValueChange={set2dNav} />
-        <SwitchWithLabel testID={FOCUSZONE_DISABLED_SWITCH} label="Disabled" value={isDisabled} onValueChange={setDisabled} />
-        <SwitchWithLabel
+        <MenuButton
+          testID={FOCUSZONE_DIRECTION_PICKER}
+          content={`Current direction: ${direction}`}
+          menuItems={FocusZoneDirections.map((dir) => ({
+            itemKey: dir,
+            text: dir,
+            testID: FOCUSZONE_DIRECTION_ID(dir),
+          }))}
+          onItemClick={(dir) => setDirection(dir as FocusZoneDirection)}
+        />
+        <Switch testID={FOCUSZONE_TWO_DIM_SWITCH} label="2D Navigation" checked={is2DNav} onChange={(_, checked) => set2dNav(checked)} />
+        <Switch testID={FOCUSZONE_DISABLED_SWITCH} label="Disabled" checked={isDisabled} onChange={(_, checked) => setDisabled(checked)} />
+        <Switch
           testID={FOCUSZONE_CIRCLE_NAV_SWITCH}
           label="Circular Navigation"
-          value={isCircularNav}
-          onValueChange={setIsCircularNav}
+          checked={isCircularNav}
+          onChange={(_, checked) => setIsCircularNav(checked)}
         />
-        <SwitchWithLabel
+        <Switch
           testID={FOCUSZONE_DEFAULT_TABBABLE_SWITCH}
           label="Use Default Tabbable Element"
-          value={useDeffaultTabbableElement}
-          onValueChange={setUseDeffaultTabbableElement}
+          checked={useDeffaultTabbableElement}
+          onChange={(_, checked) => setUseDeffaultTabbableElement(checked)}
         />
       </View>
 
@@ -129,7 +118,7 @@ export const FocusZone2D: React.FunctionComponent = () => {
           isCircularNavigation={isCircularNav}
           defaultTabbableElement={useDeffaultTabbableElement ? tabbableRef : undefined}
         >
-          <GridOfButtons gridWidth={3} gridHeight={3} tabRef={tabbableRef} tabbableIdx={4} />
+          <GridOfButtons gridWidth={3} gridHeight={3} tabRef={tabbableRef} tabbableIdx={4} e2etesting />
         </FocusZone>
       </FocusZoneListWrapper>
     </View>

--- a/apps/fluent-tester/src/TestComponents/FocusZone/FocusZoneE2ETest.tsx
+++ b/apps/fluent-tester/src/TestComponents/FocusZone/FocusZoneE2ETest.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import { View, Switch } from 'react-native';
+import { FocusZoneDirection, FocusZone, Text } from '@fluentui/react-native';
+import { RadioGroup, Radio } from '@fluentui-react-native/experimental-radio-group';
+import { ButtonV1 as Button, ButtonProps } from '@fluentui-react-native/button';
+import { commonTestStyles } from '../Common/styles';
+import {
+  FOCUSZONE_TEST_COMPONENT,
+  FOCUSZONE_DIRECTION_ID,
+  FOCUSZONE_TWO_DIM_SWITCH,
+  FOCUSZONE_DISABLED_SWITCH,
+  FOCUSZONE_CIRCLE_NAV_SWITCH,
+  FOCUSZONE_DEFAULT_TABBABLE_SWITCH,
+  FOCUSZONE_GRID_BEFORE,
+  FOCUSZONE_GRID_AFTER,
+  FOCUSZONE_GRID_BUTTON,
+} from './consts';
+import { focusZoneTestStyles, GridButton } from './styles';
+
+export const FocusZoneDirections: FocusZoneDirection[] = ['bidirectional', 'horizontal', 'vertical', 'none'];
+
+type FocusZoneListWrapperProps = {
+  beforeID?: string;
+  afterID?: string;
+};
+export const FocusZoneListWrapper: React.FunctionComponent<FocusZoneListWrapperProps> = ({ beforeID, afterID, children }) => {
+  const buttonProps: ButtonProps = { children: 'Click to Focus', style: focusZoneTestStyles.listWrapperButton };
+  return (
+    <>
+      <Button {...buttonProps} testID={beforeID} />
+      {children}
+      <Button {...buttonProps} testID={afterID} />
+    </>
+  );
+};
+
+type GridOfButtonsProps = {
+  gridWidth: number;
+  gridHeight: number;
+  tabRef?: React.RefObject<View>;
+  tabbableIdx?: number;
+};
+
+export const GridOfButtons: React.FunctionComponent<GridOfButtonsProps> = (props: GridOfButtonsProps) => {
+  return (
+    <View style={focusZoneTestStyles.dashedBorder}>
+      {[...Array(props.gridHeight)].map((_value, heightIndex: number) => {
+        return (
+          <View key={heightIndex} style={focusZoneTestStyles.focusZoneViewStyle}>
+            {[...Array(props.gridWidth)].map((_value, widthIndex: number) => {
+              const gridIndex = heightIndex * props.gridWidth + widthIndex + 1;
+              return (
+                <GridButton
+                  testID={FOCUSZONE_GRID_BUTTON(gridIndex)}
+                  key={widthIndex}
+                  style={focusZoneTestStyles.focusZoneButton}
+                  componentRef={gridIndex === props.tabbableIdx ? props.tabRef : undefined}
+                >
+                  <Text>{gridIndex}</Text>
+                </GridButton>
+              );
+            })}
+          </View>
+        );
+      })}
+    </View>
+  );
+};
+
+interface ISwitchWithLabelProps {
+  label: string;
+  value: boolean;
+  onValueChange: (value: boolean) => void;
+  testID?: string;
+}
+
+function SwitchWithLabel(props: ISwitchWithLabelProps): React.ReactElement {
+  const { label, value, onValueChange, testID } = props;
+  return (
+    <View style={commonTestStyles.switch}>
+      <Text>{label}</Text>
+      <Switch testID={testID} value={value} onValueChange={onValueChange} />
+    </View>
+  );
+}
+
+export const FocusZone2D: React.FunctionComponent = () => {
+  const [is2DNav, set2dNav] = React.useState(false);
+  const [isDisabled, setDisabled] = React.useState(false);
+  const [isCircularNav, setIsCircularNav] = React.useState(false);
+  const [useDeffaultTabbableElement, setUseDeffaultTabbableElement] = React.useState(false);
+  const [direction, setDirection] = React.useState<FocusZoneDirection>('bidirectional');
+
+  const tabbableRef = React.useRef(null);
+
+  return (
+    <View style={commonTestStyles.root}>
+      <View style={commonTestStyles.settings}>
+        <Text variant="subheaderSemibold" testID={FOCUSZONE_TEST_COMPONENT}>
+          FocusZone Direction
+        </Text>
+        {/* Usage of RadioGroup over MenuPicker is because MenuPicker, from my experimentation, doesn't support automation. */}
+        <RadioGroup style={focusZoneTestStyles.radioGroup} onChange={(dir) => setDirection(dir as FocusZoneDirection)} value={direction}>
+          {FocusZoneDirections.map((direction, i) => (
+            <Radio label={direction} value={direction} testID={FOCUSZONE_DIRECTION_ID(direction)} key={i} />
+          ))}
+        </RadioGroup>
+        <SwitchWithLabel testID={FOCUSZONE_TWO_DIM_SWITCH} label="2D Navigation" value={is2DNav} onValueChange={set2dNav} />
+        <SwitchWithLabel testID={FOCUSZONE_DISABLED_SWITCH} label="Disabled" value={isDisabled} onValueChange={setDisabled} />
+        <SwitchWithLabel
+          testID={FOCUSZONE_CIRCLE_NAV_SWITCH}
+          label="Circular Navigation"
+          value={isCircularNav}
+          onValueChange={setIsCircularNav}
+        />
+        <SwitchWithLabel
+          testID={FOCUSZONE_DEFAULT_TABBABLE_SWITCH}
+          label="Use Default Tabbable Element"
+          value={useDeffaultTabbableElement}
+          onValueChange={setUseDeffaultTabbableElement}
+        />
+      </View>
+
+      <FocusZoneListWrapper beforeID={FOCUSZONE_GRID_BEFORE} afterID={FOCUSZONE_GRID_AFTER}>
+        <FocusZone
+          disabled={isDisabled}
+          use2DNavigation={is2DNav}
+          focusZoneDirection={direction}
+          isCircularNavigation={isCircularNav}
+          defaultTabbableElement={useDeffaultTabbableElement ? tabbableRef : undefined}
+        >
+          <GridOfButtons gridWidth={3} gridHeight={3} tabRef={tabbableRef} tabbableIdx={4} />
+        </FocusZone>
+      </FocusZoneListWrapper>
+    </View>
+  );
+};

--- a/apps/fluent-tester/src/TestComponents/FocusZone/FocusZoneTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/FocusZone/FocusZoneTest.tsx
@@ -114,15 +114,11 @@ const focusZoneSections: TestSection[] = [
   {
     name: 'Common FocusZone Usage',
     component: CommonUsageFocusZone,
+    testID: FOCUSZONE_TESTPAGE,
   },
   {
     name: 'Directional FocusZone Usage',
     component: DirectionalFocusZone,
-  },
-  {
-    name: '2D Navigation',
-    component: FocusZone2D,
-    testID: FOCUSZONE_TESTPAGE,
   },
   {
     name: 'ScrollView inside FocusZone',
@@ -139,6 +135,10 @@ const focusZoneSections: TestSection[] = [
   {
     name: 'Nested FocusZone',
     component: NestedFocusZone,
+  },
+  {
+    name: '2D Navigation + E2E Testing',
+    component: FocusZone2D,
   },
 ];
 

--- a/apps/fluent-tester/src/TestComponents/FocusZone/FocusZoneTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/FocusZone/FocusZoneTest.tsx
@@ -4,7 +4,7 @@ import { FocusZone, Text, FocusZoneDirection } from '@fluentui/react-native';
 import { ButtonV1 as Button, ButtonProps } from '@fluentui-react-native/button';
 import { Checkbox, CheckboxProps } from '@fluentui-react-native/experimental-checkbox';
 import { Test, TestSection, PlatformStatus } from '../Test';
-import { FOCUSZONE_TESTPAGE } from './consts';
+import { FOCUSZONE_TESTPAGE, FOCUSZONE_GRID_BUTTON, FOCUSZONE_DIRECTION_ID } from './consts';
 import { focusZoneTestStyles, GridButton, SubheaderText } from './styles';
 import { commonTestStyles } from '../Common/styles';
 import { CollectionItem, MenuPicker } from '../Common/MenuPicker';
@@ -13,6 +13,7 @@ const FocusZoneDirections: FocusZoneDirection[] = ['bidirectional', 'horizontal'
 const directionCollection: CollectionItem<FocusZoneDirection>[] = FocusZoneDirections.map((x) => ({
   label: x,
   value: x,
+  testID: FOCUSZONE_DIRECTION_ID(x),
 }));
 
 const Checkboxes = (props: CheckboxProps) => {
@@ -103,34 +104,6 @@ const FocusZoneListWrapper = (props) => {
   );
 };
 
-const DirectionalFocusZone: React.FunctionComponent = () => {
-  const [direction, setDirection] = React.useState<FocusZoneDirection>('none');
-
-  return (
-    <>
-      <MenuPicker prompt="Direction" selected={direction} onChange={setDirection} collection={directionCollection} />
-      <FocusZone focusZoneDirection={direction}>
-        <Checkboxes />
-      </FocusZone>
-    </>
-  );
-};
-
-const CommonUsageFocusZone: React.FunctionComponent = () => {
-  return (
-    <FocusZoneListWrapper>
-      <FocusZone isCircularNavigation={true}>
-        <SubheaderText>FocusZone with Circular Navigation</SubheaderText>
-        <Checkboxes />
-      </FocusZone>
-      <FocusZone disabled={true}>
-        <SubheaderText>Disabled FocusZone</SubheaderText>
-        <Checkboxes />
-      </FocusZone>
-    </FocusZoneListWrapper>
-  );
-};
-
 type GridOfButtonsProps = {
   gridWidth: number;
   gridHeight: number;
@@ -145,7 +118,7 @@ const GridOfButtons: React.FunctionComponent<GridOfButtonsProps> = (props: GridO
             {[...Array(props.gridWidth)].map((_value, widthIndex: number) => {
               const gridIndex = heightIndex * props.gridWidth + widthIndex + 1;
               return (
-                <GridButton key={widthIndex} style={focusZoneTestStyles.focusZoneButton}>
+                <GridButton testId={FOCUSZONE_GRID_BUTTON(gridIndex)} key={widthIndex} style={focusZoneTestStyles.focusZoneButton}>
                   <Text>{gridIndex}</Text>
                 </GridButton>
               );
@@ -198,15 +171,6 @@ const FocusZone2D: React.FunctionComponent = () => {
 };
 
 const focusZoneSections: TestSection[] = [
-  {
-    name: 'Common FocusZone Usage',
-    component: CommonUsageFocusZone,
-  },
-  {
-    name: 'Directional FocusZone Usage',
-    testID: FOCUSZONE_TESTPAGE,
-    component: DirectionalFocusZone,
-  },
   {
     name: '2D Navigation',
     component: FocusZone2D,

--- a/apps/fluent-tester/src/TestComponents/FocusZone/FocusZoneTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/FocusZone/FocusZoneTest.tsx
@@ -1,26 +1,15 @@
 import * as React from 'react';
-import { View, Switch, ScrollView } from 'react-native';
-import { FocusZone, Text, FocusZoneDirection } from '@fluentui/react-native';
-import { ButtonV1 as Button, ButtonProps } from '@fluentui-react-native/button';
+import { View, ScrollView } from 'react-native';
+import { FocusZone, FocusZoneDirection, Text } from '@fluentui/react-native';
+import { ButtonV1 as Button } from '@fluentui-react-native/button';
 import { Checkbox, CheckboxProps } from '@fluentui-react-native/experimental-checkbox';
-import { RadioGroup, Radio } from '@fluentui-react-native/experimental-radio-group';
 import { Test, TestSection, PlatformStatus } from '../Test';
-import {
-  FOCUSZONE_CIRCLE_NAV_SWITCH,
-  FOCUSZONE_DEFAULT_TABBABLE_SWITCH,
-  FOCUSZONE_DIRECTION_ID,
-  FOCUSZONE_DISABLED_SWITCH,
-  FOCUSZONE_GRID_AFTER,
-  FOCUSZONE_GRID_BEFORE,
-  FOCUSZONE_GRID_BUTTON,
-  FOCUSZONE_TESTPAGE,
-  FOCUSZONE_TEST_COMPONENT,
-  FOCUSZONE_TWO_DIM_SWITCH,
-} from './consts';
-import { focusZoneTestStyles, GridButton } from './styles';
-import { commonTestStyles } from '../Common/styles';
+import { FOCUSZONE_TESTPAGE } from './consts';
+import { focusZoneTestStyles, SubheaderText } from './styles';
+import { FocusZone2D, FocusZoneDirections, FocusZoneListWrapper, GridOfButtons } from './FocusZoneE2ETest';
+import { MenuPicker, CollectionItem } from '../Common/MenuPicker';
 
-const FocusZoneDirections: FocusZoneDirection[] = ['bidirectional', 'horizontal', 'vertical', 'none'];
+const directionCollection: CollectionItem[] = FocusZoneDirections.map((dir) => ({ label: dir, value: dir }));
 
 const Checkboxes = (props: CheckboxProps) => {
   return (
@@ -29,6 +18,34 @@ const Checkboxes = (props: CheckboxProps) => {
       <Checkbox label="Option B" {...props} />
       <Checkbox label="Option C" {...props} />
     </View>
+  );
+};
+
+const DirectionalFocusZone: React.FunctionComponent = () => {
+  const [direction, setDirection] = React.useState<FocusZoneDirection>('none');
+
+  return (
+    <>
+      <MenuPicker prompt="Direction" selected={direction} onChange={setDirection} collection={directionCollection} />
+      <FocusZone focusZoneDirection={direction}>
+        <Checkboxes />
+      </FocusZone>
+    </>
+  );
+};
+
+const CommonUsageFocusZone: React.FunctionComponent = () => {
+  return (
+    <FocusZoneListWrapper>
+      <FocusZone isCircularNavigation={true}>
+        <SubheaderText>FocusZone with Circular Navigation</SubheaderText>
+        <Checkboxes />
+      </FocusZone>
+      <FocusZone disabled={true}>
+        <SubheaderText>Disabled FocusZone</SubheaderText>
+        <Checkboxes />
+      </FocusZone>
+    </FocusZoneListWrapper>
   );
 };
 
@@ -93,123 +110,15 @@ const NestedFocusZone: React.FunctionComponent = () => {
   );
 };
 
-type FocusZoneListWrapperProps = {
-  beforeID?: string;
-  afterID?: string;
-};
-const FocusZoneListWrapper: React.FunctionComponent<FocusZoneListWrapperProps> = ({ beforeID, afterID, children }) => {
-  const buttonProps: ButtonProps = { children: 'Click to Focus', style: focusZoneTestStyles.listWrapperButton };
-  return (
-    <>
-      <Button {...buttonProps} testID={beforeID} />
-      {children}
-      <Button {...buttonProps} testID={afterID} />
-    </>
-  );
-};
-
-type GridOfButtonsProps = {
-  gridWidth: number;
-  gridHeight: number;
-  tabRef?: React.RefObject<View>;
-};
-
-const GridOfButtons: React.FunctionComponent<GridOfButtonsProps> = (props: GridOfButtonsProps) => {
-  return (
-    <View style={focusZoneTestStyles.dashedBorder}>
-      {[...Array(props.gridHeight)].map((_value, heightIndex: number) => {
-        return (
-          <View key={heightIndex} style={focusZoneTestStyles.focusZoneViewStyle}>
-            {[...Array(props.gridWidth)].map((_value, widthIndex: number) => {
-              const gridIndex = heightIndex * props.gridWidth + widthIndex + 1;
-              return (
-                <GridButton
-                  testID={FOCUSZONE_GRID_BUTTON(gridIndex)}
-                  key={widthIndex}
-                  style={focusZoneTestStyles.focusZoneButton}
-                  componentRef={gridIndex === 4 ? props.tabRef : undefined}
-                >
-                  <Text>{gridIndex}</Text>
-                </GridButton>
-              );
-            })}
-          </View>
-        );
-      })}
-    </View>
-  );
-};
-
-interface ISwitchWithLabelProps {
-  label: string;
-  value: boolean;
-  onValueChange: (value: boolean) => void;
-  testID?: string;
-}
-
-function SwitchWithLabel(props: ISwitchWithLabelProps): React.ReactElement {
-  const { label, value, onValueChange, testID } = props;
-  return (
-    <View style={commonTestStyles.switch}>
-      <Text>{label}</Text>
-      <Switch testID={testID} value={value} onValueChange={onValueChange} />
-    </View>
-  );
-}
-
-const FocusZone2D: React.FunctionComponent = () => {
-  const [is2DNav, set2dNav] = React.useState(false);
-  const [isDisabled, setDisabled] = React.useState(false);
-  const [isCircularNav, setIsCircularNav] = React.useState(false);
-  const [useDeffaultTabbableElement, setUseDeffaultTabbableElement] = React.useState(false);
-  const [direction, setDirection] = React.useState<FocusZoneDirection>('bidirectional');
-
-  const tabbableRef = React.useRef(null);
-
-  return (
-    <View style={commonTestStyles.root}>
-      <View style={commonTestStyles.settings}>
-        <Text variant="subheaderSemibold" testID={FOCUSZONE_TEST_COMPONENT}>
-          FocusZone Direction
-        </Text>
-        {/* Usage of RadioGroup over MenuPicker is because MenuPicker, from my experimentation, doesn't support automation. */}
-        <RadioGroup style={focusZoneTestStyles.radioGroup} onChange={(dir) => setDirection(dir as FocusZoneDirection)} value={direction}>
-          {FocusZoneDirections.map((direction, i) => (
-            <Radio label={direction} value={direction} testID={FOCUSZONE_DIRECTION_ID(direction)} key={i} />
-          ))}
-        </RadioGroup>
-        <SwitchWithLabel testID={FOCUSZONE_TWO_DIM_SWITCH} label="2D Navigation" value={is2DNav} onValueChange={set2dNav} />
-        <SwitchWithLabel testID={FOCUSZONE_DISABLED_SWITCH} label="Disabled" value={isDisabled} onValueChange={setDisabled} />
-        <SwitchWithLabel
-          testID={FOCUSZONE_CIRCLE_NAV_SWITCH}
-          label="Circular Navigation"
-          value={isCircularNav}
-          onValueChange={setIsCircularNav}
-        />
-        <SwitchWithLabel
-          testID={FOCUSZONE_DEFAULT_TABBABLE_SWITCH}
-          label="Use Default Tabbable Element"
-          value={useDeffaultTabbableElement}
-          onValueChange={setUseDeffaultTabbableElement}
-        />
-      </View>
-
-      <FocusZoneListWrapper beforeID={FOCUSZONE_GRID_BEFORE} afterID={FOCUSZONE_GRID_AFTER}>
-        <FocusZone
-          disabled={isDisabled}
-          use2DNavigation={is2DNav}
-          focusZoneDirection={direction}
-          isCircularNavigation={isCircularNav}
-          defaultTabbableElement={useDeffaultTabbableElement ? tabbableRef : undefined}
-        >
-          <GridOfButtons gridWidth={3} gridHeight={3} tabRef={tabbableRef} />
-        </FocusZone>
-      </FocusZoneListWrapper>
-    </View>
-  );
-};
-
 const focusZoneSections: TestSection[] = [
+  {
+    name: 'Common FocusZone Usage',
+    component: CommonUsageFocusZone,
+  },
+  {
+    name: 'Directional FocusZone Usage',
+    component: DirectionalFocusZone,
+  },
   {
     name: '2D Navigation',
     component: FocusZone2D,

--- a/apps/fluent-tester/src/TestComponents/FocusZone/consts.ts
+++ b/apps/fluent-tester/src/TestComponents/FocusZone/consts.ts
@@ -9,11 +9,16 @@ export const FOCUSZONE_TEST_COMPONENT = 'FocusZone_Test_Component'; // A compone
 /* E2E Testing FocusZone 2 */
 export const FOCUSZONE_SECOND_TEST_COMPONENT = 'FocusZone_Second_Test_Component';
 
+/* FocusZone List Wrapper Buttons Keys */
+export const FOCUSZONE_GRID_BEFORE = 'FocusZone_Grid_Before';
+export const FOCUSZONE_GRID_AFTER = 'FocusZone_Grid_After';
+
 /* Grid Button Test IDs */
-export const FOCUSZONE_GRID_BUTTON = (idx: number) => `FocusZone_Grid_Button_${idx}`;
+export const FOCUSZONE_GRID_BUTTON = (idx: number) => `FocusZone_GridButton_${idx}`;
 
 export const FOCUSZONE_TWO_DIM_SWITCH = 'FocusZone_2D_Switch';
 export const FOCUSZONE_DISABLED_SWITCH = 'FocusZone_Disabled_Switch';
+export const FOCUSZONE_DEFAULT_TABBABLE_SWITCH = 'FocusZone_Default_Tabbable_Switch';
 export const FOCUSZONE_CIRCLE_NAV_SWITCH = 'FocusZone_Circular_Navigation_Switch';
 
 export const FOCUSZONE_DIRECTION_PICKER = 'FocusZone_Direction_Picker';

--- a/apps/fluent-tester/src/TestComponents/FocusZone/consts.ts
+++ b/apps/fluent-tester/src/TestComponents/FocusZone/consts.ts
@@ -1,3 +1,5 @@
+import { FocusZoneDirection } from '@fluentui/react-native';
+
 export const HOMEPAGE_FOCUSZONE_BUTTON = 'Homepage_FocusZone_Button';
 export const FOCUSZONE_TESTPAGE = 'FocusZone_TestPage';
 
@@ -6,3 +8,13 @@ export const FOCUSZONE_TEST_COMPONENT = 'FocusZone_Test_Component'; // A compone
 
 /* E2E Testing FocusZone 2 */
 export const FOCUSZONE_SECOND_TEST_COMPONENT = 'FocusZone_Second_Test_Component';
+
+/* Grid Button Test IDs */
+export const FOCUSZONE_GRID_BUTTON = (idx: number) => `FocusZone_Grid_Button_${idx}`;
+
+export const FOCUSZONE_TWO_DIM_SWITCH = 'FocusZone_2D_Switch';
+export const FOCUSZONE_DISABLED_SWITCH = 'FocusZone_Disabled_Switch';
+export const FOCUSZONE_CIRCLE_NAV_SWITCH = 'FocusZone_Circular_Navigation_Switch';
+
+export const FOCUSZONE_DIRECTION_PICKER = 'FocusZone_Direction_Picker';
+export const FOCUSZONE_DIRECTION_ID = (direction: FocusZoneDirection) => `FocusZone_Direction_Opt_${direction}`;

--- a/apps/fluent-tester/src/TestComponents/FocusZone/styles.ts
+++ b/apps/fluent-tester/src/TestComponents/FocusZone/styles.ts
@@ -27,6 +27,11 @@ export const focusZoneTestStyles = StyleSheet.create({
     borderWidth: 1,
     borderStyle: 'dashed',
   },
+  radioGroup: {
+    display: 'flex',
+    flexDirection: 'row',
+    fontSize: 12,
+  },
   scrollViewStyle: {
     height: 100,
     width: 300,

--- a/apps/win32/wdio.conf.js
+++ b/apps/win32/wdio.conf.js
@@ -35,8 +35,8 @@ exports.config = {
   bail: 0, // If you only want to run your tests until a specific amount of tests have failed use bail (default is 0 - don't bail, run all tests).
   waitforTimeout: defaultWaitForTimeout, // Default timeout for all waitForXXX commands.
   connectionRetryTimeout: defaultConnectionRetryTimeout, // Timeout for any WebDriver request to a driver or grid.
-  connectionRetryCount: 0, // Maximum count of request retries to the Selenium server.
-  specFileRetries: 0, // The number of times to retry the entire spec file when it fails as a whole.
+  connectionRetryCount: 3, // Maximum count of request retries to the Selenium server.
+  specFileRetries: 3, // The number of times to retry the entire spec file when it fails as a whole.
 
   port: 4723, // default appium port
   services: [

--- a/apps/win32/wdio.conf.js
+++ b/apps/win32/wdio.conf.js
@@ -13,7 +13,6 @@ exports.config = {
   runner: 'local', // Where should your test be launched
   specs: ['../fluent-tester/src/E2E/**/specs/*.win.ts'],
   exclude: ['../fluent-tester/src/E2E/Menu/specs/*.win.ts'],
-
   capabilities: [
     {
       maxInstances: 1, // Maximum number of total parallel running workers.
@@ -36,8 +35,8 @@ exports.config = {
   bail: 0, // If you only want to run your tests until a specific amount of tests have failed use bail (default is 0 - don't bail, run all tests).
   waitforTimeout: defaultWaitForTimeout, // Default timeout for all waitForXXX commands.
   connectionRetryTimeout: defaultConnectionRetryTimeout, // Timeout for any WebDriver request to a driver or grid.
-  connectionRetryCount: 3, // Maximum count of request retries to the Selenium server.
-  specFileRetries: 3, // The number of times to retry the entire spec file when it fails as a whole.
+  connectionRetryCount: 0, // Maximum count of request retries to the Selenium server.
+  specFileRetries: 0, // The number of times to retry the entire spec file when it fails as a whole.
 
   port: 4723, // default appium port
   services: [

--- a/change/@fluentui-react-native-tester-0c4ddaef-6664-45eb-8da8-7382f8b993f6.json
+++ b/change/@fluentui-react-native-tester-0c4ddaef-6664-45eb-8da8-7382f8b993f6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Port partner focuszone tests to FURN",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-win32-cf0ffbe6-2dd9-403a-bebc-c0c274c66e61.json
+++ b/change/@fluentui-react-native-tester-win32-cf0ffbe6-2dd9-403a-bebc-c0c274c66e61.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Port partner focuszone tests to FURN",
+  "packageName": "@fluentui-react-native/tester-win32",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Currently, the FocusZone component doesn't have extensive e2e testing on the win32 platform. 

For a separate task in the partner repo, I implemented some basic FocusZone testing to demonstrate how to write e2e tests with keyboard navigation. I figure these tests can be easily ported to FURN and provide some benefit in covering gaps in component e2e testing.

The changes in this PR include:

- Modifications to the FocusZone test page, including the removal of some sections where testing is covered by the 2D grid. 
- Implementation of FocusZonePageObject, mostly taken from a partner repo
- Porting of some methods in fabric-internal's BasePage to FURN's BasePage
- Addition of tests in the FocusZone spec from fabric-internal + some of my own that were easy to implement

### Verification

#### Before

No functional FocusZone Tests existed. Image of the testing page below:

![image](https://user-images.githubusercontent.com/15683103/194680052-349265a6-0300-4a89-9724-4d354f3db0f5.png)
#### After

Tests pass locally and by eye.
![image](https://user-images.githubusercontent.com/15683103/194678952-67654a77-eceb-44ee-919c-e6281b6191af.png)

Image of local run.

[Link to a video of the e2etests](https://youtu.be/wAZL4lAeeso)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
