### PR TITLE
macOS: Fix callout bug

### DIFF
--- a/change/@fluentui-react-native-callout-449646ed-c703-496b-9060-fe027f9948e2.json
+++ b/change/@fluentui-react-native-callout-449646ed-c703-496b-9060-fe027f9948e2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix callout bug",
+  "packageName": "@fluentui-react-native/callout",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Callout/macos/Callout.swift
+++ b/packages/components/Callout/macos/Callout.swift
@@ -43,6 +43,13 @@ class CalloutView: RCTView, CalloutWindowLifeCycleDelegate {
 	convenience init(bridge: RCTBridge) {
 		self.init()
 		self.bridge = bridge
+
+		// Listens for mouse clicks in the main menu bar while callout is shown
+		NotificationCenter.default.addObserver(
+			self,
+			selector: #selector(menuDidBeginTracking),
+			name: NSMenu.didBeginTrackingNotification,
+			object: nil)
 	}
 
 	override func viewDidMoveToWindow() {
@@ -328,6 +335,11 @@ class CalloutView: RCTView, CalloutWindowLifeCycleDelegate {
 			let event: [AnyHashable: Any] = ["target": reactTag]
 			onDismiss(event)
 		}
+	}
+
+	// The app's main menu bar is active while callout is shown, dismiss.
+	@objc private func menuDidBeginTracking() {
+		self.dismissCallout()
 	}
 
 	// MARK: Private variables


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

We should dismiss callout when the app's main menu bar becomes first responder / callout becomes inactive.

### Verification

Local testing

Before: 

https://user-images.githubusercontent.com/67026167/194952516-e2d77056-6292-48e3-bbc0-c6bc78b7be73.mov

After:

https://user-images.githubusercontent.com/67026167/194952563-e7c84287-9f2c-4ccd-a903-1448f4570167.mov


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
