### PR TITLE
Re-enable and rewrite parts of menu e2etest

### DIFF
--- a/apps/fluent-tester/src/E2E/Menu/pages/MenuPageObject.ts
+++ b/apps/fluent-tester/src/E2E/Menu/pages/MenuPageObject.ts
@@ -9,6 +9,7 @@ import {
   ExpandCollapseState,
 } from '../../../TestComponents/Menu/consts';
 import { BasePage, By } from '../../common/BasePage';
+import { Keys } from '../../common/consts';
 
 /* This enum gives the spec file an EASY way to interact with SPECIFIC UI elements on the page.
  * The spec file should import this enum and use it when wanting to interact with different elements on the page. */
@@ -41,16 +42,7 @@ class MenuPageObject extends BasePage {
   }
 
   async getMenuItemAccessibilityLabel(componentSelector: MenuComponentSelector): Promise<string> {
-    switch (componentSelector) {
-      case MenuComponentSelector.PrimaryComponent:
-        return await this._primaryComponent.getAttribute('Name');
-
-      case MenuComponentSelector.SecondaryComponent:
-        return await this._secondaryComponent.getAttribute('Name');
-
-      case MenuComponentSelector.TertiaryComponent:
-        return await this._tertiaryComponent.getAttribute('Name');
-    }
+    return await (await this.getMenuComponentSelector(componentSelector)).getAttribute('Name');
   }
 
   async getMenuAccessibilityRole(): Promise<string> {
@@ -68,14 +60,24 @@ class MenuPageObject extends BasePage {
 
   /* Returns the correct WebDriverIO element from the Button Selector */
   async getMenuComponentSelector(menuComponentSelector?: MenuComponentSelector): Promise<WebdriverIO.Element> {
-    if (menuComponentSelector == MenuComponentSelector.PrimaryComponent) {
-      return await this._primaryComponent;
+    switch (menuComponentSelector) {
+      case MenuComponentSelector.PrimaryComponent:
+        return await this._primaryComponent;
+      case MenuComponentSelector.SecondaryComponent:
+        return await this._secondaryComponent;
+      case MenuComponentSelector.TertiaryComponent:
+        return await this._tertiaryComponent;
+      default:
+        return await this._primaryComponent;
     }
-    return await this._primaryComponent;
   }
 
   async resetTest() {
-    await (await this._defocusButton).click();
+    // Both escape on the menu trigger to hard dismiss menu and click defocus to reset focus
+    if (await this.menuIsExpanded()) {
+      await this.sendKey(MenuComponentSelector.PrimaryComponent, Keys.ESCAPE);
+      await (await this._defocusButton).click();
+    }
   }
 
   /*****************************************/

--- a/apps/fluent-tester/src/E2E/Menu/pages/MenuPageObject.ts
+++ b/apps/fluent-tester/src/E2E/Menu/pages/MenuPageObject.ts
@@ -6,10 +6,9 @@ import {
   MENUITEM_TEST_COMPONENT,
   MENUPOPOVER_TEST_COMPONENT,
   MENU_DEFOCUS_BUTTON,
-  ExpandCollapseState,
 } from '../../../TestComponents/Menu/consts';
 import { BasePage, By } from '../../common/BasePage';
-import { Keys } from '../../common/consts';
+import { Keys, ExpandCollapseState, Attribute } from '../../common/consts';
 
 /* This enum gives the spec file an EASY way to interact with SPECIFIC UI elements on the page.
  * The spec file should import this enum and use it when wanting to interact with different elements on the page. */
@@ -38,19 +37,19 @@ class MenuPageObject extends BasePage {
   }
 
   async getMenuExpandCollapseState(): Promise<ExpandCollapseState> {
-    return (await (await this._primaryComponent).getAttribute('ExpandCollapse.ExpandCollapseState')) as ExpandCollapseState;
+    return (await this.getElementAttribute(await this._primaryComponent, Attribute.ExpandCollapseState)) as ExpandCollapseState;
   }
 
   async getMenuItemAccessibilityLabel(componentSelector: MenuComponentSelector): Promise<string> {
-    return await (await this.getMenuComponentSelector(componentSelector)).getAttribute('Name');
+    return await this.getElementAttribute(await this.getMenuComponentSelector(componentSelector), Attribute.AccessibilityLabel);
   }
 
   async getMenuAccessibilityRole(): Promise<string> {
-    return await By(MENUPOPOVER_TEST_COMPONENT).getAttribute('ControlType');
+    return await this.getElementAttribute(await By(MENUPOPOVER_TEST_COMPONENT), Attribute.AccessibilityRole);
   }
 
   async getMenuItemAccessibilityRole(): Promise<string> {
-    return await this._secondaryComponent.getAttribute('ControlType');
+    return await this.getElementAttribute(await this._secondaryComponent, Attribute.AccessibilityRole);
   }
 
   /* Sends a Keyboarding command on a specific UI element */
@@ -61,8 +60,6 @@ class MenuPageObject extends BasePage {
   /* Returns the correct WebDriverIO element from the Button Selector */
   async getMenuComponentSelector(menuComponentSelector?: MenuComponentSelector): Promise<WebdriverIO.Element> {
     switch (menuComponentSelector) {
-      case MenuComponentSelector.PrimaryComponent:
-        return await this._primaryComponent;
       case MenuComponentSelector.SecondaryComponent:
         return await this._secondaryComponent;
       case MenuComponentSelector.TertiaryComponent:

--- a/apps/fluent-tester/src/E2E/Menu/pages/MenuPageObject.ts
+++ b/apps/fluent-tester/src/E2E/Menu/pages/MenuPageObject.ts
@@ -6,6 +6,7 @@ import {
   MENUITEM_TEST_COMPONENT,
   MENUPOPOVER_TEST_COMPONENT,
   MENU_DEFOCUS_BUTTON,
+  ExpandCollapseState,
 } from '../../../TestComponents/Menu/consts';
 import { BasePage, By } from '../../common/BasePage';
 
@@ -32,9 +33,11 @@ class MenuPageObject extends BasePage {
   }
 
   async menuIsExpanded(): Promise<boolean> {
-    const expandCollapseState = await (await this._primaryComponent).getAttribute('ExpandCollapse.ExpandCollapseState');
-    const menuItemIsDisplayed = await (await this._secondaryComponent).isDisplayed();
-    return expandCollapseState === 'Expanded' && menuItemIsDisplayed;
+    return await (await this._secondaryComponent).isDisplayed();
+  }
+
+  async getMenuExpandCollapseState(): Promise<ExpandCollapseState> {
+    return (await (await this._primaryComponent).getAttribute('ExpandCollapse.ExpandCollapseState')) as ExpandCollapseState;
   }
 
   async getMenuItemAccessibilityLabel(componentSelector: MenuComponentSelector): Promise<string> {

--- a/apps/fluent-tester/src/E2E/Menu/pages/MenuPageObject.ts
+++ b/apps/fluent-tester/src/E2E/Menu/pages/MenuPageObject.ts
@@ -3,10 +3,9 @@ import {
   MENUTRIGGER_TEST_COMPONENT,
   MENUITEM_NO_A11Y_LABEL_COMPONENT,
   HOMEPAGE_MENU_BUTTON,
-  MENU_ON_OPEN,
-  MENU_ON_CLOSE,
   MENUITEM_TEST_COMPONENT,
   MENUPOPOVER_TEST_COMPONENT,
+  MENU_DEFOCUS_BUTTON,
 } from '../../../TestComponents/Menu/consts';
 import { BasePage, By } from '../../common/BasePage';
 
@@ -23,25 +22,19 @@ class MenuPageObject extends BasePage {
   /**************** UI Element Interaction Methods ******************/
   /******************************************************************/
   async didMenuOpen(): Promise<boolean> {
-    const callbackText = await By(MENU_ON_OPEN);
-    await browser.waitUntil(async () => await callbackText.isDisplayed(), {
+    await browser.waitUntil(async () => await this.menuIsExpanded(), {
       timeout: this.waitForUiEvent,
       timeoutMsg: 'The Menu did not open.',
       interval: 1000,
     });
 
-    return await callbackText.isDisplayed();
+    return await this.menuIsExpanded();
   }
 
-  async didMenuClose(): Promise<boolean> {
-    const callbackText = await By(MENU_ON_CLOSE);
-    await browser.waitUntil(async () => await callbackText.isDisplayed(), {
-      timeout: this.waitForUiEvent,
-      timeoutMsg: 'The Menu did not close.',
-      interval: 1000,
-    });
-
-    return await callbackText.isDisplayed();
+  async menuIsExpanded(): Promise<boolean> {
+    const expandState = await (await this._primaryComponent).getAttribute('ExpandCollapse.ExpandCollapseState');
+    console.log(expandState);
+    return expandState === 'Expanded';
   }
 
   async getMenuItemAccessibilityLabel(componentSelector: MenuComponentSelector): Promise<string> {
@@ -78,6 +71,10 @@ class MenuPageObject extends BasePage {
     return await this._primaryComponent;
   }
 
+  async resetTest() {
+    await (await this._defocusButton).click();
+  }
+
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
@@ -103,6 +100,10 @@ class MenuPageObject extends BasePage {
 
   get _pageButton() {
     return By(HOMEPAGE_MENU_BUTTON);
+  }
+
+  get _defocusButton() {
+    return By(MENU_DEFOCUS_BUTTON);
   }
 }
 

--- a/apps/fluent-tester/src/E2E/Menu/pages/MenuPageObject.ts
+++ b/apps/fluent-tester/src/E2E/Menu/pages/MenuPageObject.ts
@@ -32,9 +32,9 @@ class MenuPageObject extends BasePage {
   }
 
   async menuIsExpanded(): Promise<boolean> {
-    const expandState = await (await this._primaryComponent).getAttribute('ExpandCollapse.ExpandCollapseState');
-    console.log(expandState);
-    return expandState === 'Expanded';
+    const expandCollapseState = await (await this._primaryComponent).getAttribute('ExpandCollapse.ExpandCollapseState');
+    const menuItemIsDisplayed = await (await this._secondaryComponent).isDisplayed();
+    return expandCollapseState === 'Expanded' && menuItemIsDisplayed;
   }
 
   async getMenuItemAccessibilityLabel(componentSelector: MenuComponentSelector): Promise<string> {

--- a/apps/fluent-tester/src/E2E/Menu/specs/Menu.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Menu/specs/Menu.spec.win.ts
@@ -1,7 +1,7 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import MenuPageObject, { MenuComponentSelector } from '../pages/MenuPageObject';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT, Keys, MENUITEM_A11Y_ROLE } from '../../common/consts';
-import { MENUITEM_TEST_LABEL } from '../../../TestComponents/Menu/consts';
+import { ExpandCollapseState, MENUITEM_TEST_LABEL } from '../../../TestComponents/Menu/consts';
 import { Platform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
@@ -29,6 +29,7 @@ describe('Menu Accessibility Testing', () => {
   beforeEach(async () => {
     await MenuPageObject.scrollToTestElement();
     await MenuPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
+    await MenuPageObject.resetTest();
   });
 
   it('Menu - Validate accessibilityRole of menu item is correct', async () => {
@@ -40,6 +41,12 @@ describe('Menu Accessibility Testing', () => {
   it('Menu - Do not set accessibilityLabel -> Default to MenuItem label', async () => {
     await MenuPageObject.clickComponent();
     await expect(await MenuPageObject.getMenuItemAccessibilityLabel(MenuComponentSelector.TertiaryComponent)).toEqual(MENUITEM_TEST_LABEL);
+    await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
+  });
+
+  it('Menu - Click menu -> ExpandCollapseState correctly changes', async () => {
+    await MenuPageObject.clickComponent();
+    await expect(await MenuPageObject.getMenuExpandCollapseState()).toEqual(ExpandCollapseState.EXPANDED);
     await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
   });
 });

--- a/apps/fluent-tester/src/E2E/Menu/specs/Menu.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Menu/specs/Menu.spec.win.ts
@@ -1,7 +1,7 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import MenuPageObject, { MenuComponentSelector } from '../pages/MenuPageObject';
-import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT, Keys, MENUITEM_A11Y_ROLE } from '../../common/consts';
-import { ExpandCollapseState, MENUITEM_TEST_LABEL } from '../../../TestComponents/Menu/consts';
+import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT, Keys, MENUITEM_A11Y_ROLE, ExpandCollapseState } from '../../common/consts';
+import { MENUITEM_TEST_LABEL } from '../../../TestComponents/Menu/consts';
 import { Platform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open

--- a/apps/fluent-tester/src/E2E/Menu/specs/Menu.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Menu/specs/Menu.spec.win.ts
@@ -37,14 +37,6 @@ describe('Menu Accessibility Testing', () => {
     await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
   });
 
-  // TestID for Callouts aren't propagating, so this test is failing. Commenting out and creating task to investigate
-  // it('Menu - Validate accessibilityRole of menu is correct', async () => {
-  //   await expect(await MenuPageObject.didMenuOpen()).toBeTruthy();
-
-  //   await expect(await MenuPageObject.getMenuAccessibilityRole()).toEqual(MENU_A11Y_ROLE);
-  //   await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
-  // });
-
   it('Menu - Do not set accessibilityLabel -> Default to MenuItem label', async () => {
     await MenuPageObject.clickComponent();
     await expect(await MenuPageObject.getMenuItemAccessibilityLabel(MenuComponentSelector.TertiaryComponent)).toEqual(MENUITEM_TEST_LABEL);
@@ -57,6 +49,7 @@ describe('Menu Functional Testing', () => {
   beforeEach(async () => {
     await MenuPageObject.scrollToTestElement();
     await MenuPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
+    await MenuPageObject.resetTest();
   });
 
   it('Validate OnOpenChange() callback was fired -> Click', async () => {
@@ -73,7 +66,7 @@ describe('Menu Functional Testing', () => {
 
   it('Validate OnOpenChange() callback was fired -> Type "SPACE"', async () => {
     await MenuPageObject.sendKey(MenuComponentSelector.PrimaryComponent, Keys.SPACE);
-    await expect(await MenuPageObject.didMenuClose()).toBeTruthy();
+    await expect(await MenuPageObject.didMenuOpen()).toBeTruthy();
     await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
   });
 });

--- a/apps/fluent-tester/src/E2E/common/consts.ts
+++ b/apps/fluent-tester/src/E2E/common/consts.ts
@@ -19,6 +19,7 @@ export const PAGE_TIMEOUT = 15000;
 export const enum Attribute {
   AccessibilityLabel = 'Name',
   AccessibilityRole = 'ControlType',
+  ExpandCollapseState = 'ExpandCollapse.ExpandCollapseState',
   IsEnabled = 'IsEnabled',
   IsFocused = 'HasKeyboardFocus',
   IsRequiredForForm = 'IsRequiredForForm',
@@ -95,4 +96,9 @@ export const enum Keys {
   F10 = '\uE03A',
   F11 = '\uE03B',
   F12 = '\uE03C',
+}
+
+export const enum ExpandCollapseState {
+  EXPANDED = 'Expanded',
+  COLLAPSED = 'Collapsed',
 }

--- a/apps/fluent-tester/src/TestComponents/Menu/consts.ts
+++ b/apps/fluent-tester/src/TestComponents/Menu/consts.ts
@@ -16,8 +16,3 @@ export const MENU_ON_OPEN = 'Menu_On_Open'; // For testing the open functionalit
 export const MENU_ON_CLOSE = 'Menu_On_Close'; // For testing the open functionality of Menu
 
 export const MENU_DEFOCUS_BUTTON = 'Menu_Defocus_Button'; // Used to move focus away from menu button
-
-export const enum ExpandCollapseState {
-  EXPANDED = 'Expanded',
-  COLLAPSED = 'Collapsed',
-}

--- a/apps/fluent-tester/src/TestComponents/Menu/consts.ts
+++ b/apps/fluent-tester/src/TestComponents/Menu/consts.ts
@@ -16,3 +16,8 @@ export const MENU_ON_OPEN = 'Menu_On_Open'; // For testing the open functionalit
 export const MENU_ON_CLOSE = 'Menu_On_Close'; // For testing the open functionality of Menu
 
 export const MENU_DEFOCUS_BUTTON = 'Menu_Defocus_Button'; // Used to move focus away from menu button
+
+export const enum ExpandCollapseState {
+  EXPANDED = 'Expanded',
+  COLLAPSED = 'Collapsed',
+}

--- a/apps/win32/wdio.conf.js
+++ b/apps/win32/wdio.conf.js
@@ -12,7 +12,8 @@ const jasmineDefaultTimeout = 60000; // 60 seconds for Jasmine test timeout
 exports.config = {
   runner: 'local', // Where should your test be launched
   specs: ['../fluent-tester/src/E2E/**/specs/*.win.ts'],
-  exclude: ['../fluent-tester/src/E2E/Menu/specs/*.win.ts'],
+  exclude: [],
+
   capabilities: [
     {
       maxInstances: 1, // Maximum number of total parallel running workers.

--- a/change/@fluentui-react-native-tester-1e317d91-7176-42e7-9fce-35596f7a064f.json
+++ b/change/@fluentui-react-native-tester-1e317d91-7176-42e7-9fce-35596f7a064f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Re-enable and rewrite parts of menu e2etest",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-win32-8a79840e-6338-4a44-b533-0770c172e58b.json
+++ b/change/@fluentui-react-native-tester-win32-8a79840e-6338-4a44-b533-0770c172e58b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Re-enable and rewrite parts of menu e2etest",
+  "packageName": "@fluentui-react-native/tester-win32",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
E2E testing for the Menu component was disabled until now due to the spec failing in the pipeline. 

This PR re-enables the Menu tests and fixes the logic errors within the test spec which caused failures in CI. 

### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

- Removed the spec file from the list of excluded specs in the wdio config.
- Use getAttribute('ExpandCollapse.ExpandCollapseState') on primary component to check if menu is open rather than the value of a text component controlled by the menu

### Verification

2 / 3 functional tests were failing before. Now they all pass.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/15683103/194973634-77116aae-f7d8-46b5-8fa9-7c861c37aca9.png) | ![image](https://user-images.githubusercontent.com/15683103/194973267-694e2249-d031-4316-9117-d066aefd234b.png) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
