### PR TITLE
Make `Theme.spacing` read-only

### DIFF
--- a/change/@fluentui-react-native-theme-types-14405bdd-59ae-4f51-9a8e-5aabb0a873e0.json
+++ b/change/@fluentui-react-native-theme-types-14405bdd-59ae-4f51-9a8e-5aabb0a873e0.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Make `Theme.spacing` read-only",
+  "packageName": "@fluentui-react-native/theme-types",
+  "email": "adgleitm@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/theming/theme-types/src/Theme.types.ts
+++ b/packages/theming/theme-types/src/Theme.types.ts
@@ -25,7 +25,7 @@ export interface Theme {
     [key: string]: object; // eslint-disable-line @typescript-eslint/ban-types
   };
   shadows: ThemeShadowDefinition;
-  spacing: Spacing;
+  readonly spacing: Spacing;
   host: {
     // appearance of the theme, this corresponds to the react-native Appearance library values, though can be overwritten
     // dynamic refers to a theme that handles it's own appearance switching, such as one that uses the PlatformColor API


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

Make `Theme.spacing` read-only. Since spacing tokens are global, we really shouldn't be overriding them.

### Verification

Validated that `yarn build` still works, which means that `tsc` isn't complaining about any attempts to edit any `Theme`'s `spacing` prop.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
