### PR TITLE
Fix for iOS bug where switching light/dark mode was not updating the theme

### DIFF
--- a/change/@fluentui-react-native-apple-theme-d7c6278c-a1dd-41ed-ab03-80076e012ea2.json
+++ b/change/@fluentui-react-native-apple-theme-d7c6278c-a1dd-41ed-ab03-80076e012ea2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Initial fix for theme not getting updated when appearance changes",
+  "packageName": "@fluentui-react-native/apple-theme",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/theming/apple-theme/src/appleColors.ios.ts
+++ b/packages/theming/apple-theme/src/appleColors.ios.ts
@@ -212,8 +212,8 @@ function getFluentUIAppleDarkPalette(): ApplePalette {
 }
 
 /** Creates a palette of colors for the apple theme, using the appropriate FluentUI Apple Palette based on appearance */
-export function paletteFromAppleColors(isDark: boolean): ThemeColorDefinition {
-  const fluentApple = isDark ? getFluentUIAppleDarkPalette() : getFluentUIAppleLightPalette();
+export function paletteFromAppleColors(isLight: boolean): ThemeColorDefinition {
+  const fluentApple = isLight ? getFluentUIAppleLightPalette() : getFluentUIAppleDarkPalette();
 
   return {
     /* PaletteBackgroundColors & PaletteTextColors */

--- a/packages/theming/apple-theme/src/appleColors.ios.ts
+++ b/packages/theming/apple-theme/src/appleColors.ios.ts
@@ -212,8 +212,8 @@ function getFluentUIAppleDarkPalette(): ApplePalette {
 }
 
 /** Creates a palette of colors for the apple theme, using the appropriate FluentUI Apple Palette based on appearance */
-export function paletteFromAppleColors(isLight: boolean): ThemeColorDefinition {
-  const fluentApple = isLight ? getFluentUIAppleLightPalette() : getFluentUIAppleDarkPalette();
+export function paletteFromAppleColors(isLightMode: boolean): ThemeColorDefinition {
+  const fluentApple = isLightMode ? getFluentUIAppleLightPalette() : getFluentUIAppleDarkPalette();
 
   return {
     /* PaletteBackgroundColors & PaletteTextColors */

--- a/packages/theming/apple-theme/src/appleTheme.ios.ts
+++ b/packages/theming/apple-theme/src/appleTheme.ios.ts
@@ -131,20 +131,13 @@ const appleComponents = {
   },
 };
 
-export const BaseAppleLightThemeIOS: Theme = {
-  colors: paletteFromAppleColors(false),
-  typography: appleTypography(),
-  shadows: iOSShadows(),
-  spacing: appleSpacing(),
-  components: appleComponents,
-  host: { appearance: 'light' },
-};
-
-export const BaseAppleDarkThemeIOS: Theme = {
-  colors: paletteFromAppleColors(true),
-  typography: appleTypography(),
-  shadows: iOSShadows(),
-  spacing: appleSpacing(),
-  components: appleComponents,
-  host: { appearance: 'dark' },
-};
+export function getBaseAppleThemeIOS(isLightMode: boolean): Theme {
+  return {
+    colors: paletteFromAppleColors(isLightMode),
+    typography: appleTypography(),
+    shadows: iOSShadows(),
+    spacing: appleSpacing(),
+    components: appleComponents,
+    host: { appearance: isLightMode ? 'light' : 'dark' },
+  };
+}

--- a/packages/theming/apple-theme/src/createAppleTheme.ios.ts
+++ b/packages/theming/apple-theme/src/createAppleTheme.ios.ts
@@ -1,15 +1,12 @@
 import { ThemeReference } from '@fluentui-react-native/theme';
 import { Theme } from '@fluentui-react-native/theme-types';
 import { Appearance } from 'react-native';
-import { BaseAppleDarkThemeIOS, BaseAppleLightThemeIOS } from './appleTheme.ios';
+import { getBaseAppleThemeIOS } from './appleTheme.ios';
 
 export function createAppleTheme(): ThemeReference {
-  const baseAppleTheme = () => {
-    const current = Appearance.getColorScheme();
-    return current === 'light' ? BaseAppleLightThemeIOS : BaseAppleDarkThemeIOS;
-  };
-
-  const appleThemeReference = new ThemeReference({} as Theme, baseAppleTheme);
+  const appleThemeReference = new ThemeReference({} as Theme, () => {
+    return getBaseAppleThemeIOS(Appearance.getColorScheme() === 'light');
+  });
 
   Appearance.addChangeListener(() => {
     appleThemeReference.invalidate();

--- a/packages/theming/apple-theme/src/createAppleTheme.ios.ts
+++ b/packages/theming/apple-theme/src/createAppleTheme.ios.ts
@@ -5,7 +5,8 @@ import { getBaseAppleThemeIOS } from './appleTheme.ios';
 
 export function createAppleTheme(): ThemeReference {
   const appleThemeReference = new ThemeReference({} as Theme, () => {
-    return getBaseAppleThemeIOS(Appearance.getColorScheme() === 'light');
+    const isLightMode = Appearance.getColorScheme() === 'light';
+    return getBaseAppleThemeIOS(isLightMode);
   });
 
   Appearance.addChangeListener(() => {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

While adding in iOS Shadow Tokens, I noticed that the theme wasn't always getting updated when switching between light and dark mode. It would get updated only when refreshing the app. As a result I would see the light mode shadows in dark mode or vice versa.

After putting in some console.log statements I noticed that:
- the theme was getting invalidated at the right times
- createAppleTheme.iOS.ts/baseAppleTheme() was also getting called at the right times
- however, paletteFromAppleColors(), appleTypography(), etc. was not getting called when they should be

Replacing the BaseAppleLightThemeIOS/BaseAppleDarkThemeIOS with method calls (ex. with getBaseAppleLightThemeIOS/getBaseAppleDarkThemeIOS) fixed the problem. This is more similar to what macOS does as well. I'm actually not exactly sure why the previous code did not work (maybe the BaseAppleLightThemeIOS object was getting cached somehow?) - if anyone has any insight into why, I'd love to know.

I also went ahead and simplified the logic for light mode/dark mode to use the same method (i.e. getBaseAppleThemeIOS), which also simplified some of the logic in createAppleTheme.ios.ts. I changed the parameter in paletteFromAppleColors to be isLight instead of isDark for consistency.

### Verification

Checked that after making the change, console.log statements in paletteFromAppleColors/appleTypography were getting called as expected.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
