### PR TITLE
Remove unnecessary scroll logic to component buttons on Win32

### DIFF
--- a/apps/fluent-tester/src/E2E/ActivityIndicator/specs/ActivityIndicator.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/ActivityIndicator/specs/ActivityIndicator.spec.ios.ts
@@ -1,7 +1,7 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import ActivityIndicatorPageObject from '../pages/ActivityIndicatorPageObject';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
+import { MobilePlatform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Activity Indicator Testing Initialization', function () {
@@ -11,7 +11,7 @@ describe('Activity Indicator Testing Initialization', function () {
   });
 
   it('Click and navigate to Activity Indicator test page', async () => {
-    await ActivityIndicatorPageObject.mobileScrollToComponentButton(Platform.iOS);
+    await ActivityIndicatorPageObject.mobileScrollToComponentButton(MobilePlatform.iOS);
     await ActivityIndicatorPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/ActivityIndicator/specs/ActivityIndicator.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/ActivityIndicator/specs/ActivityIndicator.spec.ios.ts
@@ -11,7 +11,7 @@ describe('Activity Indicator Testing Initialization', function () {
   });
 
   it('Click and navigate to Activity Indicator test page', async () => {
-    await ActivityIndicatorPageObject.scrollToComponentButton(Platform.iOS);
+    await ActivityIndicatorPageObject.mobileScrollToComponentButton(Platform.iOS);
     await ActivityIndicatorPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/ActivityIndicator/specs/ActivityIndicator.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/ActivityIndicator/specs/ActivityIndicator.spec.win.ts
@@ -1,7 +1,6 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import ActivityIndicatorPageObject from '../pages/ActivityIndicatorPageObject';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Activity Indicator Testing Initialization', function () {
@@ -11,8 +10,6 @@ describe('Activity Indicator Testing Initialization', function () {
   });
 
   it('Click and navigate to Activity Indicator test page', async () => {
-    await ActivityIndicatorPageObject.scrollToComponentButton(Platform.Win32);
-
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToActivityIndicatorPage();
     await ActivityIndicatorPageObject.waitForPageDisplayed(PAGE_TIMEOUT);

--- a/apps/fluent-tester/src/E2E/ActivityIndicator/specs/ActivityIndicator.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/ActivityIndicator/specs/ActivityIndicator.spec.win.ts
@@ -12,7 +12,6 @@ describe('Activity Indicator Testing Initialization', function () {
 
   it('Click and navigate to Activity Indicator test page', async () => {
     await ActivityIndicatorPageObject.scrollToComponentButton(Platform.Win32);
-    await ActivityIndicatorPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToActivityIndicatorPage();

--- a/apps/fluent-tester/src/E2E/Avatar/specs/Avatar.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/Avatar/specs/Avatar.spec.ios.ts
@@ -1,7 +1,7 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import AvatarPageObject from '../pages/AvatarPageObject';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
+import { MobilePlatform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Avatar Testing Initialization', function () {
@@ -11,7 +11,7 @@ describe('Avatar Testing Initialization', function () {
   });
 
   it('Click and navigate to Avatar test page', async () => {
-    await AvatarPageObject.mobileScrollToComponentButton(Platform.iOS);
+    await AvatarPageObject.mobileScrollToComponentButton(MobilePlatform.iOS);
     await AvatarPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/Avatar/specs/Avatar.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/Avatar/specs/Avatar.spec.ios.ts
@@ -11,7 +11,7 @@ describe('Avatar Testing Initialization', function () {
   });
 
   it('Click and navigate to Avatar test page', async () => {
-    await AvatarPageObject.scrollToComponentButton(Platform.iOS);
+    await AvatarPageObject.mobileScrollToComponentButton(Platform.iOS);
     await AvatarPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/Avatar/specs/Avatar.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Avatar/specs/Avatar.spec.win.ts
@@ -11,7 +11,6 @@ import {
   ACCESSIBILITY_ROLE_IMAGE,
   ACCESSIBILITY_ROLE_LINK,
 } from '../../../TestComponents/Avatar/consts';
-import { Platform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Avatar Testing Initialization', function () {
@@ -21,9 +20,6 @@ describe('Avatar Testing Initialization', function () {
   });
 
   it('Click and navigate to Avatar test page', async () => {
-    /* Scroll to component test page button in scrollview if not already visible*/
-    await AvatarPageObject.scrollToComponentButton(Platform.Win32);
-
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToAvatarPage();
     await AvatarPageObject.waitForPageDisplayed(PAGE_TIMEOUT);

--- a/apps/fluent-tester/src/E2E/Avatar/specs/Avatar.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Avatar/specs/Avatar.spec.win.ts
@@ -23,7 +23,6 @@ describe('Avatar Testing Initialization', function () {
   it('Click and navigate to Avatar test page', async () => {
     /* Scroll to component test page button in scrollview if not already visible*/
     await AvatarPageObject.scrollToComponentButton(Platform.Win32);
-    await AvatarPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToAvatarPage();

--- a/apps/fluent-tester/src/E2E/Badge/specs/Badge.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/Badge/specs/Badge.spec.ios.ts
@@ -1,7 +1,7 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import BasicBadgePageObject from '../pages/BasicBadgePageObject';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
+import { MobilePlatform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Badge Testing Initialization', function () {
@@ -11,7 +11,7 @@ describe('Badge Testing Initialization', function () {
   });
 
   it('Click and navigate to Badge test page', async () => {
-    await BasicBadgePageObject.mobileScrollToComponentButton(Platform.iOS);
+    await BasicBadgePageObject.mobileScrollToComponentButton(MobilePlatform.iOS);
     await BasicBadgePageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/Badge/specs/Badge.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/Badge/specs/Badge.spec.ios.ts
@@ -11,7 +11,7 @@ describe('Badge Testing Initialization', function () {
   });
 
   it('Click and navigate to Badge test page', async () => {
-    await BasicBadgePageObject.scrollToComponentButton(Platform.iOS);
+    await BasicBadgePageObject.mobileScrollToComponentButton(Platform.iOS);
     await BasicBadgePageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/Badge/specs/Badge.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Badge/specs/Badge.spec.win.ts
@@ -13,7 +13,6 @@ describe('Badge Testing Initialization', function () {
   it('Click and navigate to Badge test page', async () => {
     /* Scroll to component test page button in scrollview if not already visible*/
     await BasicBadgePageObject.scrollToComponentButton(Platform.Win32);
-    await BasicBadgePageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToBadgePage();

--- a/apps/fluent-tester/src/E2E/Badge/specs/Badge.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Badge/specs/Badge.spec.win.ts
@@ -1,7 +1,6 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import BasicBadgePageObject from '../pages/BasicBadgePageObject';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Badge Testing Initialization', function () {
@@ -11,9 +10,6 @@ describe('Badge Testing Initialization', function () {
   });
 
   it('Click and navigate to Badge test page', async () => {
-    /* Scroll to component test page button in scrollview if not already visible*/
-    await BasicBadgePageObject.scrollToComponentButton(Platform.Win32);
-
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToBadgePage();
     await BasicBadgePageObject.waitForPageDisplayed(PAGE_TIMEOUT);

--- a/apps/fluent-tester/src/E2E/Button/specs/Button.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/Button/specs/Button.spec.ios.ts
@@ -1,7 +1,7 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import ButtonPageObject from '../pages/ButtonPageObject';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
+import { MobilePlatform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Button Testing Initialization', function () {
@@ -11,7 +11,7 @@ describe('Button Testing Initialization', function () {
   });
 
   it('Click and navigate to Button test page', async () => {
-    await ButtonPageObject.mobileScrollToComponentButton(Platform.iOS);
+    await ButtonPageObject.mobileScrollToComponentButton(MobilePlatform.iOS);
     await ButtonPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/Button/specs/Button.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/Button/specs/Button.spec.ios.ts
@@ -11,7 +11,7 @@ describe('Button Testing Initialization', function () {
   });
 
   it('Click and navigate to Button test page', async () => {
-    await ButtonPageObject.scrollToComponentButton(Platform.iOS);
+    await ButtonPageObject.mobileScrollToComponentButton(Platform.iOS);
     await ButtonPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/Button/specs/Button.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Button/specs/Button.spec.win.ts
@@ -14,7 +14,6 @@ describe('Button Testing Initialization', function () {
   it('Click and navigate to Button test page', async () => {
     /* Scroll to component test page button in scrollview if not already visible*/
     await ButtonPageObject.scrollToComponentButton(Platform.Win32);
-    await ButtonPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToButtonPage();

--- a/apps/fluent-tester/src/E2E/Button/specs/Button.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Button/specs/Button.spec.win.ts
@@ -1,6 +1,6 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import ButtonPageObject, { ButtonSelector } from '../pages/ButtonPageObject';
-import { ComponentSelector, Platform } from '../../common/BasePage';
+import { ComponentSelector } from '../../common/BasePage';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT, BUTTON_A11Y_ROLE, Keys } from '../../common/consts';
 import { BUTTON_ACCESSIBILITY_LABEL_DEPRECATED, BUTTON_TEST_COMPONENT_LABEL_DEPRECATED } from '../../../TestComponents/Button/consts';
 
@@ -12,9 +12,6 @@ describe('Button Testing Initialization', function () {
   });
 
   it('Click and navigate to Button test page', async () => {
-    /* Scroll to component test page button in scrollview if not already visible*/
-    await ButtonPageObject.scrollToComponentButton(Platform.Win32);
-
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToButtonPage();
     await ButtonPageObject.waitForPageDisplayed(PAGE_TIMEOUT);

--- a/apps/fluent-tester/src/E2E/ButtonExperimental/specs/ButtonExperimental.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/ButtonExperimental/specs/ButtonExperimental.spec.win.ts
@@ -14,7 +14,6 @@ describe('Experimental Button Testing Initialization', function () {
   it('Click and navigate to Button test page', async () => {
     /* Scroll to component test page button in scrollview if not already visible*/
     await ButtonExperimentalPageObject.scrollToComponentButton(Platform.Win32);
-    await ButtonExperimentalPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToButtonPage();

--- a/apps/fluent-tester/src/E2E/ButtonExperimental/specs/ButtonExperimental.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/ButtonExperimental/specs/ButtonExperimental.spec.win.ts
@@ -1,6 +1,6 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import ButtonExperimentalPageObject, { ButtonSelector } from '../pages/ButtonExperimentalPageObject';
-import { ComponentSelector, Platform } from '../../common/BasePage';
+import { ComponentSelector } from '../../common/BasePage';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT, BUTTON_A11Y_ROLE, Keys } from '../../common/consts';
 import { BUTTON_ACCESSIBILITY_LABEL, BUTTON_TEST_COMPONENT_LABEL } from '../../../TestComponents/Button/consts';
 
@@ -12,9 +12,6 @@ describe('Experimental Button Testing Initialization', function () {
   });
 
   it('Click and navigate to Button test page', async () => {
-    /* Scroll to component test page button in scrollview if not already visible*/
-    await ButtonExperimentalPageObject.scrollToComponentButton(Platform.Win32);
-
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToButtonPage();
     await ButtonExperimentalPageObject.waitForPageDisplayed(PAGE_TIMEOUT);

--- a/apps/fluent-tester/src/E2E/Callout/specs/Callout.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Callout/specs/Callout.spec.win.ts
@@ -13,7 +13,6 @@ describe('Callout Testing Initialization', function () {
   it('Click and navigate to Callout test page', async () => {
     /* Scroll to component test page button in scrollview if not already visible*/
     await CalloutPageObject.scrollToComponentButton(Platform.Win32);
-    await CalloutPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToCalloutPage();

--- a/apps/fluent-tester/src/E2E/Callout/specs/Callout.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Callout/specs/Callout.spec.win.ts
@@ -1,7 +1,6 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import CalloutPageObject from '../pages/CalloutPageObject.win';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Callout Testing Initialization', function () {
@@ -11,9 +10,6 @@ describe('Callout Testing Initialization', function () {
   });
 
   it('Click and navigate to Callout test page', async () => {
-    /* Scroll to component test page button in scrollview if not already visible*/
-    await CalloutPageObject.scrollToComponentButton(Platform.Win32);
-
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToCalloutPage();
     await CalloutPageObject.waitForPageDisplayed(PAGE_TIMEOUT);

--- a/apps/fluent-tester/src/E2E/Checkbox/specs/Checkbox.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/Checkbox/specs/Checkbox.spec.ios.ts
@@ -1,7 +1,7 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import CheckboxPageObject from '../pages/CheckboxPageObject';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
+import { MobilePlatform } from '../../common/BasePage';
 
 describe('Checkbox Testing Initialization', () => {
   it('Wait for app load', async () => {
@@ -10,7 +10,7 @@ describe('Checkbox Testing Initialization', () => {
   });
 
   it('Click and navigate to Checkbox test page', async () => {
-    await CheckboxPageObject.mobileScrollToComponentButton(Platform.iOS);
+    await CheckboxPageObject.mobileScrollToComponentButton(MobilePlatform.iOS);
     await CheckboxPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/Checkbox/specs/Checkbox.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/Checkbox/specs/Checkbox.spec.ios.ts
@@ -10,7 +10,7 @@ describe('Checkbox Testing Initialization', () => {
   });
 
   it('Click and navigate to Checkbox test page', async () => {
-    await CheckboxPageObject.scrollToComponentButton(Platform.iOS);
+    await CheckboxPageObject.mobileScrollToComponentButton(Platform.iOS);
     await CheckboxPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/Checkbox/specs/Checkbox.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Checkbox/specs/Checkbox.spec.win.ts
@@ -13,7 +13,6 @@ describe('Checkbox Testing Initialization', () => {
   it('Click and navigate to Checkbox test page', async () => {
     /* Scroll to component test page button in scrollview if not already visible*/
     await CheckboxPageObject.scrollToComponentButton(Platform.Win32);
-    await CheckboxPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToCheckboxPage();

--- a/apps/fluent-tester/src/E2E/Checkbox/specs/Checkbox.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Checkbox/specs/Checkbox.spec.win.ts
@@ -1,6 +1,6 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import CheckboxPageObject, { CheckboxSelector } from '../pages/CheckboxPageObject';
-import { ComponentSelector, Platform } from '../../common/BasePage';
+import { ComponentSelector } from '../../common/BasePage';
 import { CHECKBOX_TEST_COMPONENT_LABEL, CHECKBOX_ACCESSIBILITY_LABEL } from '../../../TestComponents/Checkbox/consts';
 import { CHECKBOX_A11Y_ROLE, PAGE_TIMEOUT, BOOT_APP_TIMEOUT, Keys } from '../../common/consts';
 
@@ -11,9 +11,6 @@ describe('Checkbox Testing Initialization', () => {
   });
 
   it('Click and navigate to Checkbox test page', async () => {
-    /* Scroll to component test page button in scrollview if not already visible*/
-    await CheckboxPageObject.scrollToComponentButton(Platform.Win32);
-
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToCheckboxPage();
     await CheckboxPageObject.waitForPageDisplayed(PAGE_TIMEOUT);

--- a/apps/fluent-tester/src/E2E/Checkbox/specs/Checkbox.spec.windows.ts
+++ b/apps/fluent-tester/src/E2E/Checkbox/specs/Checkbox.spec.windows.ts
@@ -1,6 +1,6 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import CheckboxPageObject from '../pages/CheckboxPageObject';
-import { ComponentSelector, Platform } from '../../common/BasePage';
+import { ComponentSelector } from '../../common/BasePage';
 import { CHECKBOX_TEST_COMPONENT_LABEL, CHECKBOX_ACCESSIBILITY_LABEL } from '../../../TestComponents/Checkbox/consts';
 import { CHECKBOX_A11Y_ROLE, PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
 
@@ -11,10 +11,6 @@ describe('Checkbox Testing Initialization', () => {
   });
 
   it('Click and navigate to Checkbox test page', async () => {
-    /* Scroll to component test page button in scrollview if not already visible*/
-    await CheckboxPageObject.mobileScrollToComponentButton(Platform.Win32);
-    await CheckboxPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
-
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToCheckboxPage();
     await CheckboxPageObject.waitForPageDisplayed(PAGE_TIMEOUT);

--- a/apps/fluent-tester/src/E2E/Checkbox/specs/Checkbox.spec.windows.ts
+++ b/apps/fluent-tester/src/E2E/Checkbox/specs/Checkbox.spec.windows.ts
@@ -12,7 +12,7 @@ describe('Checkbox Testing Initialization', () => {
 
   it('Click and navigate to Checkbox test page', async () => {
     /* Scroll to component test page button in scrollview if not already visible*/
-    await CheckboxPageObject.scrollToComponentButton(Platform.Win32);
+    await CheckboxPageObject.mobileScrollToComponentButton(Platform.Win32);
     await CheckboxPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/CheckboxExperimental/specs/ExperimentalCheckbox.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/CheckboxExperimental/specs/ExperimentalCheckbox.spec.ios.ts
@@ -10,7 +10,7 @@ describe('Experimental Checkbox Testing Initialization', () => {
   });
 
   it('Click and navigate to Experimental Checkbox test page', async () => {
-    await ExperimentalCheckboxPageObject.scrollToComponentButton(Platform.iOS);
+    await ExperimentalCheckboxPageObject.mobileScrollToComponentButton(Platform.iOS);
     await ExperimentalCheckboxPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/CheckboxExperimental/specs/ExperimentalCheckbox.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/CheckboxExperimental/specs/ExperimentalCheckbox.spec.ios.ts
@@ -1,7 +1,7 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import ExperimentalCheckboxPageObject from '../pages/ExperimentalCheckboxPageObject';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
+import { MobilePlatform } from '../../common/BasePage';
 
 describe('Experimental Checkbox Testing Initialization', () => {
   it('Wait for app load', async () => {
@@ -10,7 +10,7 @@ describe('Experimental Checkbox Testing Initialization', () => {
   });
 
   it('Click and navigate to Experimental Checkbox test page', async () => {
-    await ExperimentalCheckboxPageObject.mobileScrollToComponentButton(Platform.iOS);
+    await ExperimentalCheckboxPageObject.mobileScrollToComponentButton(MobilePlatform.iOS);
     await ExperimentalCheckboxPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/CheckboxExperimental/specs/ExperimentalCheckbox.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/CheckboxExperimental/specs/ExperimentalCheckbox.spec.win.ts
@@ -16,7 +16,6 @@ describe('Experimental Checkbox Testing Initialization', () => {
   it('Click and navigate to Experimental Checkbox test page', async () => {
     /* Scroll to component test page button in scrollview if not already visible*/
     await ExperimentalCheckboxPageObject.scrollToComponentButton(Platform.Win32);
-    await ExperimentalCheckboxPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToCheckboxExperimentalPage();

--- a/apps/fluent-tester/src/E2E/CheckboxExperimental/specs/ExperimentalCheckbox.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/CheckboxExperimental/specs/ExperimentalCheckbox.spec.win.ts
@@ -1,6 +1,6 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import ExperimentalCheckboxPageObject, { ExperimentalCheckboxSelector } from '../pages/ExperimentalCheckboxPageObject';
-import { ComponentSelector, Platform } from '../../common/BasePage';
+import { ComponentSelector } from '../../common/BasePage';
 import {
   EXPERIMENTAL_CHECKBOX_TEST_COMPONENT_LABEL,
   EXPERIMENTAL_CHECKBOX_ACCESSIBILITY_LABEL,
@@ -14,9 +14,6 @@ describe('Experimental Checkbox Testing Initialization', () => {
   });
 
   it('Click and navigate to Experimental Checkbox test page', async () => {
-    /* Scroll to component test page button in scrollview if not already visible*/
-    await ExperimentalCheckboxPageObject.scrollToComponentButton(Platform.Win32);
-
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToCheckboxExperimentalPage();
     await ExperimentalCheckboxPageObject.waitForPageDisplayed(PAGE_TIMEOUT);

--- a/apps/fluent-tester/src/E2E/ContextualMenu/specs/ContextualMenu.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/ContextualMenu/specs/ContextualMenu.spec.win.ts
@@ -13,7 +13,6 @@ describe('ContextualMenu Testing Initialization', function () {
   it('Click and navigate to ContextualMenu test page', async () => {
     /* Scroll to component test page button in scrollview if not already visible*/
     await ContextualMenuPageObjectObject.scrollToComponentButton(Platform.Win32);
-    await ContextualMenuPageObjectObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToContextualMenuPage();

--- a/apps/fluent-tester/src/E2E/ContextualMenu/specs/ContextualMenu.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/ContextualMenu/specs/ContextualMenu.spec.win.ts
@@ -1,7 +1,6 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import ContextualMenuPageObjectObject, { ContextualMenuSelector } from '../pages/ContextualMenuPageObject.win';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT, Keys } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('ContextualMenu Testing Initialization', function () {
@@ -11,9 +10,6 @@ describe('ContextualMenu Testing Initialization', function () {
   });
 
   it('Click and navigate to ContextualMenu test page', async () => {
-    /* Scroll to component test page button in scrollview if not already visible*/
-    await ContextualMenuPageObjectObject.scrollToComponentButton(Platform.Win32);
-
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToContextualMenuPage();
     await ContextualMenuPageObjectObject.waitForPageDisplayed(PAGE_TIMEOUT);

--- a/apps/fluent-tester/src/E2E/FocusTrapZone/specs/FocusTrapZone.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/FocusTrapZone/specs/FocusTrapZone.spec.win.ts
@@ -13,7 +13,6 @@ describe('FocusTrapZone Testing Initialization', function () {
   it('Click and navigate to FocusTrapZone test page', async () => {
     /* Scroll to component test page button in scrollview if not already visible*/
     await FocusTrapZonePageObject.scrollToComponentButton(Platform.Win32);
-    await FocusTrapZonePageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToFocusTrapZonePage();

--- a/apps/fluent-tester/src/E2E/FocusTrapZone/specs/FocusTrapZone.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/FocusTrapZone/specs/FocusTrapZone.spec.win.ts
@@ -1,7 +1,6 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import FocusTrapZonePageObject from '../pages/FocusTrapZonePageObject.win';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('FocusTrapZone Testing Initialization', function () {
@@ -11,9 +10,6 @@ describe('FocusTrapZone Testing Initialization', function () {
   });
 
   it('Click and navigate to FocusTrapZone test page', async () => {
-    /* Scroll to component test page button in scrollview if not already visible*/
-    await FocusTrapZonePageObject.scrollToComponentButton(Platform.Win32);
-
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToFocusTrapZonePage();
     await FocusTrapZonePageObject.waitForPageDisplayed(PAGE_TIMEOUT);

--- a/apps/fluent-tester/src/E2E/FocusZone/specs/FocusZone.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/FocusZone/specs/FocusZone.spec.win.ts
@@ -1,7 +1,6 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import FocusZonePageObject, { GridButtonSelector, GridFocusZoneOption } from '../pages/FocusZonePageObject';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT, Keys } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('FocusZone Testing Initialization', function () {
@@ -11,9 +10,6 @@ describe('FocusZone Testing Initialization', function () {
   });
 
   it('Click and navigate to FocusZone test page', async () => {
-    /* Scroll to component test page button in scrollview if not already visible*/
-    await FocusZonePageObject.scrollToComponentButton(Platform.Win32);
-
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToFocusZonePage();
     await FocusZonePageObject.waitForPageDisplayed(PAGE_TIMEOUT);

--- a/apps/fluent-tester/src/E2E/FocusZone/specs/FocusZone.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/FocusZone/specs/FocusZone.spec.win.ts
@@ -13,7 +13,6 @@ describe('FocusZone Testing Initialization', function () {
   it('Click and navigate to FocusZone test page', async () => {
     /* Scroll to component test page button in scrollview if not already visible*/
     await FocusZonePageObject.scrollToComponentButton(Platform.Win32);
-    await FocusZonePageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToFocusZonePage();

--- a/apps/fluent-tester/src/E2E/Icon/specs/Icon.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/Icon/specs/Icon.spec.ios.ts
@@ -11,7 +11,7 @@ describe('Icon Testing Initialization', function () {
   });
 
   it('Click and navigate to Icon test page', async () => {
-    await IconPageObject.scrollToComponentButton(Platform.iOS);
+    await IconPageObject.mobileScrollToComponentButton(Platform.iOS);
     await IconPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/Icon/specs/Icon.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/Icon/specs/Icon.spec.ios.ts
@@ -1,7 +1,7 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import IconPageObject from '../pages/IconPageObject';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
+import { MobilePlatform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Icon Testing Initialization', function () {
@@ -11,7 +11,7 @@ describe('Icon Testing Initialization', function () {
   });
 
   it('Click and navigate to Icon test page', async () => {
-    await IconPageObject.mobileScrollToComponentButton(Platform.iOS);
+    await IconPageObject.mobileScrollToComponentButton(MobilePlatform.iOS);
     await IconPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/Icon/specs/Icon.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Icon/specs/Icon.spec.win.ts
@@ -1,7 +1,6 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import IconPageObject from '../pages/IconPageObject';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Icon Testing Initialization', function () {
@@ -11,9 +10,6 @@ describe('Icon Testing Initialization', function () {
   });
 
   it('Click and navigate to Icon test page', async () => {
-    /* Scroll to component test page button in scrollview if not already visible*/
-    await IconPageObject.scrollToComponentButton(Platform.Win32);
-
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToIconPage();
     await IconPageObject.waitForPageDisplayed(PAGE_TIMEOUT);

--- a/apps/fluent-tester/src/E2E/Icon/specs/Icon.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Icon/specs/Icon.spec.win.ts
@@ -13,7 +13,6 @@ describe('Icon Testing Initialization', function () {
   it('Click and navigate to Icon test page', async () => {
     /* Scroll to component test page button in scrollview if not already visible*/
     await IconPageObject.scrollToComponentButton(Platform.Win32);
-    await IconPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToIconPage();

--- a/apps/fluent-tester/src/E2E/Link/specs/Link.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/Link/specs/Link.spec.ios.ts
@@ -1,7 +1,7 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import LinkPageObject from '../pages/LinkPageObject';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
+import { MobilePlatform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Link Testing Initialization', function () {
@@ -11,7 +11,7 @@ describe('Link Testing Initialization', function () {
   });
 
   it('Click and navigate to Link test page', async () => {
-    await LinkPageObject.mobileScrollToComponentButton(Platform.iOS);
+    await LinkPageObject.mobileScrollToComponentButton(MobilePlatform.iOS);
     await LinkPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/Link/specs/Link.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/Link/specs/Link.spec.ios.ts
@@ -11,7 +11,7 @@ describe('Link Testing Initialization', function () {
   });
 
   it('Click and navigate to Link test page', async () => {
-    await LinkPageObject.scrollToComponentButton(Platform.iOS);
+    await LinkPageObject.mobileScrollToComponentButton(Platform.iOS);
     await LinkPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/Link/specs/Link.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Link/specs/Link.spec.win.ts
@@ -14,7 +14,6 @@ describe('Link Testing Initialization', function () {
   it('Click and navigate to Link test page', async () => {
     /* Scroll to component test page button in scrollview if not already visible*/
     await LinkPageObject.scrollToComponentButton(Platform.Win32);
-    await LinkPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToLinkPage();

--- a/apps/fluent-tester/src/E2E/Link/specs/Link.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Link/specs/Link.spec.win.ts
@@ -1,6 +1,6 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import LinkPageObject from '../pages/LinkPageObject';
-import { ComponentSelector, Platform } from '../../common/BasePage';
+import { ComponentSelector } from '../../common/BasePage';
 import { LINK_ACCESSIBILITY_LABEL } from '../../../TestComponents/Link/consts';
 import { LINK_A11Y_ROLE, PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
 
@@ -12,9 +12,6 @@ describe('Link Testing Initialization', function () {
   });
 
   it('Click and navigate to Link test page', async () => {
-    /* Scroll to component test page button in scrollview if not already visible*/
-    await LinkPageObject.scrollToComponentButton(Platform.Win32);
-
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToLinkPage();
     await LinkPageObject.waitForPageDisplayed(PAGE_TIMEOUT);

--- a/apps/fluent-tester/src/E2E/LinkExperimental/specs/Link.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/LinkExperimental/specs/Link.spec.win.ts
@@ -1,6 +1,6 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import ExperimentalLinkPageObject from '../pages/LinkPageObject';
-import { ComponentSelector, Platform } from '../../common/BasePage';
+import { ComponentSelector } from '../../common/BasePage';
 import { EXPERIMENTAL_LINK_ACCESSIBILITY_LABEL } from '../../../TestComponents/LinkExperimental/consts';
 import { LINK_A11Y_ROLE, PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
 
@@ -12,10 +12,6 @@ describe('Link Testing Initialization', function () {
   });
 
   it('Click and navigate to Link test page', async () => {
-    /* Scroll to component test page button in scrollview if not already visible*/
-    await ExperimentalLinkPageObject.scrollToComponentButton(Platform.Win32);
-    await ExperimentalLinkPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
-
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToLinkExperimentalPage();
     await ExperimentalLinkPageObject.waitForPageDisplayed(PAGE_TIMEOUT);

--- a/apps/fluent-tester/src/E2E/Menu/specs/Menu.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Menu/specs/Menu.spec.win.ts
@@ -2,7 +2,6 @@ import NavigateAppPage from '../../common/NavigateAppPage';
 import MenuPageObject, { MenuComponentSelector } from '../pages/MenuPageObject';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT, Keys, MENUITEM_A11Y_ROLE, ExpandCollapseState } from '../../common/consts';
 import { MENUITEM_TEST_LABEL } from '../../../TestComponents/Menu/consts';
-import { Platform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Menu Testing Initialization', function () {
@@ -12,9 +11,6 @@ describe('Menu Testing Initialization', function () {
   });
 
   it('Click and navigate to Menu test page', async () => {
-    /* Scroll to component test page button in scrollview if not already visible*/
-    await MenuPageObject.scrollToComponentButton(Platform.Win32);
-
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToMenuPage();
     await MenuPageObject.waitForPageDisplayed(PAGE_TIMEOUT);

--- a/apps/fluent-tester/src/E2E/Menu/specs/Menu.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Menu/specs/Menu.spec.win.ts
@@ -14,7 +14,6 @@ describe('Menu Testing Initialization', function () {
   it('Click and navigate to Menu test page', async () => {
     /* Scroll to component test page button in scrollview if not already visible*/
     await MenuPageObject.scrollToComponentButton(Platform.Win32);
-    await MenuPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToMenuPage();

--- a/apps/fluent-tester/src/E2E/MenuButton/specs/MenuButton.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/MenuButton/specs/MenuButton.spec.win.ts
@@ -14,7 +14,6 @@ describe('MenuButton Testing Initialization', function () {
   it('Click and navigate to MenuButton test page', async () => {
     /* Scroll to component test page button in scrollview if not already visible*/
     await MenuButtonPageObject.scrollToComponentButton(Platform.Win32);
-    await MenuButtonPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToMenuButtonPage();

--- a/apps/fluent-tester/src/E2E/MenuButton/specs/MenuButton.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/MenuButton/specs/MenuButton.spec.win.ts
@@ -2,7 +2,7 @@ import NavigateAppPage from '../../common/NavigateAppPage';
 import MenuButtonPageObject, { MenuButtonSelector } from '../pages/MenuButtonPageObject.win';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT, MENUBUTTON_A11Y_ROLE, Keys } from '../../common/consts';
 import { MENU_BUTTON_ACCESSIBILITY_LABEL, MENU_BUTTON_TEST_COMPONENT_LABEL } from '../../../TestComponents/MenuButton/consts';
-import { ComponentSelector, Platform } from '../../common/BasePage';
+import { ComponentSelector } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('MenuButton Testing Initialization', function () {
@@ -12,9 +12,6 @@ describe('MenuButton Testing Initialization', function () {
   });
 
   it('Click and navigate to MenuButton test page', async () => {
-    /* Scroll to component test page button in scrollview if not already visible*/
-    await MenuButtonPageObject.scrollToComponentButton(Platform.Win32);
-
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToMenuButtonPage();
     await MenuButtonPageObject.waitForPageDisplayed(PAGE_TIMEOUT);

--- a/apps/fluent-tester/src/E2E/MenuButtonExperimental/specs/ExperimentalMenuButton.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/MenuButtonExperimental/specs/ExperimentalMenuButton.spec.win.ts
@@ -17,7 +17,6 @@ describe('Experimental MenuButton Testing Initialization', function () {
   it('Click and navigate to Experimental MenuButton test page', async () => {
     /* Scroll to component test page button in scrollview if not already visible*/
     await ExperimentalMenuButtonPageObject.scrollToComponentButton(Platform.Win32);
-    await ExperimentalMenuButtonPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToExperimentalMenuButtonPage();

--- a/apps/fluent-tester/src/E2E/MenuButtonExperimental/specs/ExperimentalMenuButton.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/MenuButtonExperimental/specs/ExperimentalMenuButton.spec.win.ts
@@ -5,7 +5,7 @@ import {
   EXPERIMENTAL_MENU_BUTTON_ACCESSIBILITY_LABEL,
   EXPERIMENTAL_MENU_BUTTON_TEST_COMPONENT_LABEL,
 } from '../../../TestComponents/MenuButtonExperimental/consts';
-import { ComponentSelector, Platform } from '../../common/BasePage';
+import { ComponentSelector } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Experimental MenuButton Testing Initialization', function () {
@@ -15,9 +15,6 @@ describe('Experimental MenuButton Testing Initialization', function () {
   });
 
   it('Click and navigate to Experimental MenuButton test page', async () => {
-    /* Scroll to component test page button in scrollview if not already visible*/
-    await ExperimentalMenuButtonPageObject.scrollToComponentButton(Platform.Win32);
-
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToExperimentalMenuButtonPage();
     await ExperimentalMenuButtonPageObject.waitForPageDisplayed(PAGE_TIMEOUT);

--- a/apps/fluent-tester/src/E2E/Persona/specs/Persona.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/Persona/specs/Persona.spec.ios.ts
@@ -11,7 +11,7 @@ describe('Persona Testing Initialization', function () {
   });
 
   it('Click and navigate to Persona test page', async () => {
-    await PersonaPageObject.scrollToComponentButton(Platform.iOS);
+    await PersonaPageObject.mobileScrollToComponentButton(Platform.iOS);
     await PersonaPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/Persona/specs/Persona.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/Persona/specs/Persona.spec.ios.ts
@@ -1,7 +1,7 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import PersonaPageObject from '../pages/PersonaPageObject';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
+import { MobilePlatform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Persona Testing Initialization', function () {
@@ -11,7 +11,7 @@ describe('Persona Testing Initialization', function () {
   });
 
   it('Click and navigate to Persona test page', async () => {
-    await PersonaPageObject.mobileScrollToComponentButton(Platform.iOS);
+    await PersonaPageObject.mobileScrollToComponentButton(MobilePlatform.iOS);
     await PersonaPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/Persona/specs/Persona.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Persona/specs/Persona.spec.win.ts
@@ -13,7 +13,6 @@ describe('Persona Testing Initialization', function () {
   it('Click and navigate to Persona test page', async () => {
     /* Scroll to component test page button in scrollview if not already visible*/
     await PersonaPageObject.scrollToComponentButton(Platform.Win32);
-    await PersonaPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToPersonaPage();

--- a/apps/fluent-tester/src/E2E/Persona/specs/Persona.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Persona/specs/Persona.spec.win.ts
@@ -1,7 +1,6 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import PersonaPageObject from '../pages/PersonaPageObject';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Persona Testing Initialization', function () {
@@ -11,9 +10,6 @@ describe('Persona Testing Initialization', function () {
   });
 
   it('Click and navigate to Persona test page', async () => {
-    /* Scroll to component test page button in scrollview if not already visible*/
-    await PersonaPageObject.scrollToComponentButton(Platform.Win32);
-
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToPersonaPage();
     await PersonaPageObject.waitForPageDisplayed(PAGE_TIMEOUT);

--- a/apps/fluent-tester/src/E2E/PersonaCoin/specs/PersonaCoin.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/PersonaCoin/specs/PersonaCoin.spec.ios.ts
@@ -1,7 +1,7 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import PersonaCoinPageObject from '../pages/PersonaCoinPageObject';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
+import { MobilePlatform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('PersonaCoin Testing Initialization', function () {
@@ -11,7 +11,7 @@ describe('PersonaCoin Testing Initialization', function () {
   });
 
   it('Click and navigate to PersonaCoin test page', async () => {
-    await PersonaCoinPageObject.mobileScrollToComponentButton(Platform.iOS);
+    await PersonaCoinPageObject.mobileScrollToComponentButton(MobilePlatform.iOS);
     await PersonaCoinPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/PersonaCoin/specs/PersonaCoin.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/PersonaCoin/specs/PersonaCoin.spec.ios.ts
@@ -11,7 +11,7 @@ describe('PersonaCoin Testing Initialization', function () {
   });
 
   it('Click and navigate to PersonaCoin test page', async () => {
-    await PersonaCoinPageObject.scrollToComponentButton(Platform.iOS);
+    await PersonaCoinPageObject.mobileScrollToComponentButton(Platform.iOS);
     await PersonaCoinPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/PersonaCoin/specs/PersonaCoin.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/PersonaCoin/specs/PersonaCoin.spec.win.ts
@@ -13,7 +13,6 @@ describe('PersonaCoin Testing Initialization', function () {
   it('Click and navigate to PersonaCoin test page', async () => {
     /* Scroll to component test page button in scrollview if not already visible*/
     await PersonaCoinPageObject.scrollToComponentButton(Platform.Win32);
-    await PersonaCoinPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToPersonaCoinPage();

--- a/apps/fluent-tester/src/E2E/PersonaCoin/specs/PersonaCoin.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/PersonaCoin/specs/PersonaCoin.spec.win.ts
@@ -1,7 +1,6 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import PersonaCoinPageObject from '../pages/PersonaCoinPageObject';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('PersonaCoin Testing Initialization', function () {
@@ -11,9 +10,6 @@ describe('PersonaCoin Testing Initialization', function () {
   });
 
   it('Click and navigate to PersonaCoin test page', async () => {
-    /* Scroll to component test page button in scrollview if not already visible*/
-    await PersonaCoinPageObject.scrollToComponentButton(Platform.Win32);
-
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToPersonaCoinPage();
     await PersonaCoinPageObject.waitForPageDisplayed(PAGE_TIMEOUT);

--- a/apps/fluent-tester/src/E2E/Pressable/specs/Pressable.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/Pressable/specs/Pressable.spec.ios.ts
@@ -1,7 +1,7 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import PressablePageObject from '../pages/PressablePageObject';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
+import { MobilePlatform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Pressable Testing Initialization', function () {
@@ -11,7 +11,7 @@ describe('Pressable Testing Initialization', function () {
   });
 
   it('Click and navigate to Pressable test page', async () => {
-    await PressablePageObject.mobileScrollToComponentButton(Platform.iOS);
+    await PressablePageObject.mobileScrollToComponentButton(MobilePlatform.iOS);
     await PressablePageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/Pressable/specs/Pressable.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/Pressable/specs/Pressable.spec.ios.ts
@@ -11,7 +11,7 @@ describe('Pressable Testing Initialization', function () {
   });
 
   it('Click and navigate to Pressable test page', async () => {
-    await PressablePageObject.scrollToComponentButton(Platform.iOS);
+    await PressablePageObject.mobileScrollToComponentButton(Platform.iOS);
     await PressablePageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/Pressable/specs/Pressable.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Pressable/specs/Pressable.spec.win.ts
@@ -1,7 +1,6 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import PressablePageObject from '../pages/PressablePageObject';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Pressable Testing Initialization', function () {
@@ -11,9 +10,6 @@ describe('Pressable Testing Initialization', function () {
   });
 
   it('Click and navigate to Pressable test page', async () => {
-    /* Scroll to component test page button in scrollview if not already visible*/
-    await PressablePageObject.scrollToComponentButton(Platform.Win32);
-
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToPressablePage();
     await PressablePageObject.waitForPageDisplayed(PAGE_TIMEOUT);

--- a/apps/fluent-tester/src/E2E/Pressable/specs/Pressable.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Pressable/specs/Pressable.spec.win.ts
@@ -13,7 +13,6 @@ describe('Pressable Testing Initialization', function () {
   it('Click and navigate to Pressable test page', async () => {
     /* Scroll to component test page button in scrollview if not already visible*/
     await PressablePageObject.scrollToComponentButton(Platform.Win32);
-    await PressablePageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToPressablePage();

--- a/apps/fluent-tester/src/E2E/RadioGroup/specs/RadioGroup.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/RadioGroup/specs/RadioGroup.spec.win.ts
@@ -19,7 +19,6 @@ describe('RadioGroup/RadioButton Testing Initialization', function () {
   it('Click and navigate to RadioGroup test page', async () => {
     /* Scroll to component test page button in scrollview if not already visible*/
     await RadioGroupPageObject.scrollToComponentButton(Platform.Win32);
-    await RadioGroupPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToRadioGroupPage();

--- a/apps/fluent-tester/src/E2E/RadioGroup/specs/RadioGroup.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/RadioGroup/specs/RadioGroup.spec.win.ts
@@ -1,6 +1,6 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import RadioGroupPageObject, { RadioButtonSelector } from '../pages/RadioGroupPageObject';
-import { ComponentSelector, Platform } from '../../common/BasePage';
+import { ComponentSelector } from '../../common/BasePage';
 import { RADIOBUTTON_A11Y_ROLE, RADIOGROUP_A11Y_ROLE, PAGE_TIMEOUT, BOOT_APP_TIMEOUT, Keys } from '../../common/consts';
 import {
   RADIOGROUP_ACCESSIBILITY_LABEL,
@@ -17,9 +17,6 @@ describe('RadioGroup/RadioButton Testing Initialization', function () {
   });
 
   it('Click and navigate to RadioGroup test page', async () => {
-    /* Scroll to component test page button in scrollview if not already visible*/
-    await RadioGroupPageObject.scrollToComponentButton(Platform.Win32);
-
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToRadioGroupPage();
     await RadioGroupPageObject.waitForPageDisplayed(PAGE_TIMEOUT);

--- a/apps/fluent-tester/src/E2E/Separator/specs/Separator.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/Separator/specs/Separator.spec.ios.ts
@@ -1,7 +1,7 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import SeparatorPageObject from '../pages/SeparatorPageObject';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
+import { MobilePlatform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Separator Testing Initialization', function () {
@@ -11,7 +11,7 @@ describe('Separator Testing Initialization', function () {
   });
 
   it('Click and navigate to Separator test page', async () => {
-    await SeparatorPageObject.mobileScrollToComponentButton(Platform.iOS);
+    await SeparatorPageObject.mobileScrollToComponentButton(MobilePlatform.iOS);
     await SeparatorPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/Separator/specs/Separator.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/Separator/specs/Separator.spec.ios.ts
@@ -11,7 +11,7 @@ describe('Separator Testing Initialization', function () {
   });
 
   it('Click and navigate to Separator test page', async () => {
-    await SeparatorPageObject.scrollToComponentButton(Platform.iOS);
+    await SeparatorPageObject.mobileScrollToComponentButton(Platform.iOS);
     await SeparatorPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/Separator/specs/Separator.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Separator/specs/Separator.spec.win.ts
@@ -13,7 +13,6 @@ describe('Separator Testing Initialization', function () {
   it('Click and navigate to Separator test page', async () => {
     /* Scroll to component test page button in scrollview if not already visible*/
     await SeparatorPageObject.scrollToComponentButton(Platform.Win32);
-    await SeparatorPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToSeparatorPage();

--- a/apps/fluent-tester/src/E2E/Separator/specs/Separator.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Separator/specs/Separator.spec.win.ts
@@ -1,7 +1,6 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import SeparatorPageObject from '../pages/SeparatorPageObject';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Separator Testing Initialization', function () {
@@ -11,9 +10,6 @@ describe('Separator Testing Initialization', function () {
   });
 
   it('Click and navigate to Separator test page', async () => {
-    /* Scroll to component test page button in scrollview if not already visible*/
-    await SeparatorPageObject.scrollToComponentButton(Platform.Win32);
-
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToSeparatorPage();
     await SeparatorPageObject.waitForPageDisplayed(PAGE_TIMEOUT);

--- a/apps/fluent-tester/src/E2E/Shimmer/specs/Shimmer.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/Shimmer/specs/Shimmer.spec.ios.ts
@@ -1,7 +1,7 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import ShimmerPageObject from '../pages/ShimmerPageObject.win';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
+import { MobilePlatform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Shimmer Testing Initialization', function () {
@@ -11,7 +11,7 @@ describe('Shimmer Testing Initialization', function () {
   });
 
   it('Click and navigate to Shimmer test page', async () => {
-    await ShimmerPageObject.mobileScrollToComponentButton(Platform.iOS);
+    await ShimmerPageObject.mobileScrollToComponentButton(MobilePlatform.iOS);
     await ShimmerPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/Shimmer/specs/Shimmer.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/Shimmer/specs/Shimmer.spec.ios.ts
@@ -11,7 +11,7 @@ describe('Shimmer Testing Initialization', function () {
   });
 
   it('Click and navigate to Shimmer test page', async () => {
-    await ShimmerPageObject.scrollToComponentButton(Platform.iOS);
+    await ShimmerPageObject.mobileScrollToComponentButton(Platform.iOS);
     await ShimmerPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/Shimmer/specs/Shimmer.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Shimmer/specs/Shimmer.spec.win.ts
@@ -13,7 +13,6 @@ describe('Shimmer Testing Initialization', function () {
   it('Click and navigate to Shimmer test page', async () => {
     /* Scroll to component test page button in scrollview if not already visible*/
     await ShimmerPageObject.scrollToComponentButton(Platform.Win32);
-    await ShimmerPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToShimmerPage();

--- a/apps/fluent-tester/src/E2E/Shimmer/specs/Shimmer.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Shimmer/specs/Shimmer.spec.win.ts
@@ -1,7 +1,6 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import ShimmerPageObject from '../pages/ShimmerPageObject.win';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Shimmer Testing Initialization', function () {
@@ -11,9 +10,6 @@ describe('Shimmer Testing Initialization', function () {
   });
 
   it('Click and navigate to Shimmer test page', async () => {
-    /* Scroll to component test page button in scrollview if not already visible*/
-    await ShimmerPageObject.scrollToComponentButton(Platform.Win32);
-
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToShimmerPage();
     await ShimmerPageObject.waitForPageDisplayed(PAGE_TIMEOUT);

--- a/apps/fluent-tester/src/E2E/Svg/specs/Svg.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/Svg/specs/Svg.spec.ios.ts
@@ -11,7 +11,7 @@ describe('Svg Testing Initialization', function () {
   });
 
   it('Click and navigate to Svg test page', async () => {
-    await SvgPageObject.scrollToComponentButton(Platform.iOS);
+    await SvgPageObject.mobileScrollToComponentButton(Platform.iOS);
     await SvgPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/Svg/specs/Svg.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/Svg/specs/Svg.spec.ios.ts
@@ -1,7 +1,7 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import SvgPageObject from '../pages/SvgPageObject';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
+import { MobilePlatform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Svg Testing Initialization', function () {
@@ -11,7 +11,7 @@ describe('Svg Testing Initialization', function () {
   });
 
   it('Click and navigate to Svg test page', async () => {
-    await SvgPageObject.mobileScrollToComponentButton(Platform.iOS);
+    await SvgPageObject.mobileScrollToComponentButton(MobilePlatform.iOS);
     await SvgPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/Svg/specs/Svg.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Svg/specs/Svg.spec.win.ts
@@ -1,7 +1,6 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import SvgPageObject from '../pages/SvgPageObject';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Svg Testing Initialization', function () {
@@ -11,9 +10,6 @@ describe('Svg Testing Initialization', function () {
   });
 
   it('Click and navigate to Svg test page', async () => {
-    /* Scroll to component test page button in scrollview if not already visible*/
-    await SvgPageObject.scrollToComponentButton(Platform.Win32);
-
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToSvgPage();
     await SvgPageObject.waitForPageDisplayed(PAGE_TIMEOUT);

--- a/apps/fluent-tester/src/E2E/Svg/specs/Svg.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Svg/specs/Svg.spec.win.ts
@@ -13,7 +13,6 @@ describe('Svg Testing Initialization', function () {
   it('Click and navigate to Svg test page', async () => {
     /* Scroll to component test page button in scrollview if not already visible*/
     await SvgPageObject.scrollToComponentButton(Platform.Win32);
-    await SvgPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToSvgPage();

--- a/apps/fluent-tester/src/E2E/Switch/specs/Switch.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Switch/specs/Switch.spec.win.ts
@@ -1,7 +1,7 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import SwitchPageObject from '../pages/SwitchPageObject';
 import { SwitchComponentSelector } from '../pages/SwitchPageObject';
-import { ComponentSelector, Platform } from '../../common/BasePage';
+import { ComponentSelector } from '../../common/BasePage';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT, BUTTON_A11Y_ROLE, Keys } from '../../common/consts';
 import { SWITCH_TEST_COMPONENT_LABEL, SWITCH_ACCESSIBILITY_LABEL } from '../../../TestComponents/Switch/consts';
 
@@ -13,9 +13,6 @@ describe('Switch Testing Initialization', function () {
   });
 
   it('Click and navigate to Switch test page', async () => {
-    /* Scroll to component test page button in scrollview if not already visible*/
-    await SwitchPageObject.scrollToComponentButton(Platform.Win32);
-
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToSwitchPage();
     await SwitchPageObject.waitForPageDisplayed(PAGE_TIMEOUT);

--- a/apps/fluent-tester/src/E2E/Switch/specs/Switch.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Switch/specs/Switch.spec.win.ts
@@ -15,7 +15,6 @@ describe('Switch Testing Initialization', function () {
   it('Click and navigate to Switch test page', async () => {
     /* Scroll to component test page button in scrollview if not already visible*/
     await SwitchPageObject.scrollToComponentButton(Platform.Win32);
-    await SwitchPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToSwitchPage();

--- a/apps/fluent-tester/src/E2E/Tabs/specs/Tabs.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Tabs/specs/Tabs.spec.win.ts
@@ -13,7 +13,6 @@ describe('Tabs Testing Initialization', function () {
   it('Click and navigate to Tabs test page', async () => {
     /* Scroll to component test page button in scrollview if not already visible*/
     await TabsPageObject.scrollToComponentButton(Platform.Win32);
-    await TabsPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToTabsPage();

--- a/apps/fluent-tester/src/E2E/Tabs/specs/Tabs.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Tabs/specs/Tabs.spec.win.ts
@@ -1,7 +1,6 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import TabsPageObject, { TabItemSelector } from '../pages/TabsPageObject';
 import { TAB_A11Y_ROLE, BOOT_APP_TIMEOUT, PAGE_TIMEOUT, TABITEM_A11Y_ROLE, Keys } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Tabs Testing Initialization', function () {
@@ -11,9 +10,6 @@ describe('Tabs Testing Initialization', function () {
   });
 
   it('Click and navigate to Tabs test page', async () => {
-    /* Scroll to component test page button in scrollview if not already visible*/
-    await TabsPageObject.scrollToComponentButton(Platform.Win32);
-
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToTabsPage();
     await TabsPageObject.waitForPageDisplayed(PAGE_TIMEOUT);

--- a/apps/fluent-tester/src/E2E/Tabs/specs/Tabs.spec.windows.ts
+++ b/apps/fluent-tester/src/E2E/Tabs/specs/Tabs.spec.windows.ts
@@ -1,7 +1,6 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import TabsPageObject, { TabItemSelector } from '../pages/TabsPageObject';
 import { TAB_A11Y_ROLE, BOOT_APP_TIMEOUT, PAGE_TIMEOUT, TABITEM_A11Y_ROLE } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Tabs Testing Initialization', function () {
@@ -12,8 +11,6 @@ describe('Tabs Testing Initialization', function () {
 
   it('Click and navigate to Tabs test page', async () => {
     /* Scroll to component test page button in scrollview if not already visible*/
-    await TabsPageObject.mobileScrollToComponentButton(Platform.Win32);
-    await TabsPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToTabsPage();

--- a/apps/fluent-tester/src/E2E/Tabs/specs/Tabs.spec.windows.ts
+++ b/apps/fluent-tester/src/E2E/Tabs/specs/Tabs.spec.windows.ts
@@ -12,7 +12,7 @@ describe('Tabs Testing Initialization', function () {
 
   it('Click and navigate to Tabs test page', async () => {
     /* Scroll to component test page button in scrollview if not already visible*/
-    await TabsPageObject.scrollToComponentButton(Platform.Win32);
+    await TabsPageObject.mobileScrollToComponentButton(Platform.Win32);
     await TabsPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/TabsExperimental/specs/TabsExperimental.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/TabsExperimental/specs/TabsExperimental.spec.win.ts
@@ -1,7 +1,6 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import ExperimentalTabsPageObject from '../pages/ExperimentalTabsPageObject';
 import { TAB_A11Y_ROLE, TABITEM_A11Y_ROLE, BOOT_APP_TIMEOUT, PAGE_TIMEOUT } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Experimental Tabs Testing Initialization', function () {
@@ -11,9 +10,6 @@ describe('Experimental Tabs Testing Initialization', function () {
   });
 
   it('Click and navigate to Experimental Tabs test page', async () => {
-    /* Scroll to component test page button in scrollview if not already visible*/
-    await ExperimentalTabsPageObject.scrollToComponentButton(Platform.Win32);
-
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToExperimentalTabsPage();
     await ExperimentalTabsPageObject.waitForPageDisplayed(PAGE_TIMEOUT);

--- a/apps/fluent-tester/src/E2E/TabsExperimental/specs/TabsExperimental.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/TabsExperimental/specs/TabsExperimental.spec.win.ts
@@ -13,7 +13,6 @@ describe('Experimental Tabs Testing Initialization', function () {
   it('Click and navigate to Experimental Tabs test page', async () => {
     /* Scroll to component test page button in scrollview if not already visible*/
     await ExperimentalTabsPageObject.scrollToComponentButton(Platform.Win32);
-    await ExperimentalTabsPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToExperimentalTabsPage();

--- a/apps/fluent-tester/src/E2E/Text/specs/Text.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/Text/specs/Text.spec.ios.ts
@@ -1,7 +1,7 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import TextPageObject from '../pages/TextPageObject';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
+import { MobilePlatform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Text Testing Initialization', function () {
@@ -11,7 +11,7 @@ describe('Text Testing Initialization', function () {
   });
 
   it('Click and navigate to Text test page', async () => {
-    await TextPageObject.mobileScrollToComponentButton(Platform.iOS);
+    await TextPageObject.mobileScrollToComponentButton(MobilePlatform.iOS);
     await TextPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/Text/specs/Text.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/Text/specs/Text.spec.ios.ts
@@ -11,7 +11,7 @@ describe('Text Testing Initialization', function () {
   });
 
   it('Click and navigate to Text test page', async () => {
-    await TextPageObject.scrollToComponentButton(Platform.iOS);
+    await TextPageObject.mobileScrollToComponentButton(Platform.iOS);
     await TextPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/Text/specs/Text.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Text/specs/Text.spec.win.ts
@@ -1,6 +1,6 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import TextPageObject from '../pages/TextPageObject';
-import { ComponentSelector, Platform } from '../../common/BasePage';
+import { ComponentSelector } from '../../common/BasePage';
 import { TEXT_A11Y_ROLE, PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
 import { TEXT_ACCESSIBILITY_LABEL, TEXT_COMPONENT_CONTENT } from '../../../TestComponents/Text/consts';
 
@@ -12,9 +12,6 @@ describe('Text Testing Initialization', function () {
   });
 
   it('Click and navigate to Text test page', async () => {
-    /* Scroll to component test page button in scrollview if not already visible*/
-    await TextPageObject.scrollToComponentButton(Platform.Win32);
-
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToTextPage();
     await TextPageObject.waitForPageDisplayed(PAGE_TIMEOUT);

--- a/apps/fluent-tester/src/E2E/Text/specs/Text.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Text/specs/Text.spec.win.ts
@@ -14,7 +14,6 @@ describe('Text Testing Initialization', function () {
   it('Click and navigate to Text test page', async () => {
     /* Scroll to component test page button in scrollview if not already visible*/
     await TextPageObject.scrollToComponentButton(Platform.Win32);
-    await TextPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToTextPage();

--- a/apps/fluent-tester/src/E2E/TextExperimental/specs/ExperimentalText.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/TextExperimental/specs/ExperimentalText.spec.ios.ts
@@ -11,7 +11,7 @@ describe('Experimental Text Testing Initialization', function () {
   });
 
   it('Click and navigate to Experimental Text test page', async () => {
-    await ExperimentalTextPageObject.scrollToComponentButton(Platform.iOS);
+    await ExperimentalTextPageObject.mobileScrollToComponentButton(Platform.iOS);
     await ExperimentalTextPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/TextExperimental/specs/ExperimentalText.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/TextExperimental/specs/ExperimentalText.spec.ios.ts
@@ -1,7 +1,7 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import ExperimentalTextPageObject from '../pages/ExperimentalTextPageObject.win';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
+import { MobilePlatform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Experimental Text Testing Initialization', function () {
@@ -11,7 +11,7 @@ describe('Experimental Text Testing Initialization', function () {
   });
 
   it('Click and navigate to Experimental Text test page', async () => {
-    await ExperimentalTextPageObject.mobileScrollToComponentButton(Platform.iOS);
+    await ExperimentalTextPageObject.mobileScrollToComponentButton(MobilePlatform.iOS);
     await ExperimentalTextPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/TextExperimental/specs/ExperimentalText.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/TextExperimental/specs/ExperimentalText.spec.win.ts
@@ -13,7 +13,6 @@ describe('Experimental Text Testing Initialization', function () {
   it('Click and navigate to Experimental Text test page', async () => {
     /* Scroll to component test page button in scrollview if not already visible*/
     await ExperimentalTextPageObject.scrollToComponentButton(Platform.Win32);
-    await ExperimentalTextPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToExperimentalTextPage();

--- a/apps/fluent-tester/src/E2E/TextExperimental/specs/ExperimentalText.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/TextExperimental/specs/ExperimentalText.spec.win.ts
@@ -1,7 +1,6 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import ExperimentalTextPageObject from '../pages/ExperimentalTextPageObject.win';
 import { TEXT_A11Y_ROLE, PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Experimental Text Testing Initialization', function () {
@@ -11,9 +10,6 @@ describe('Experimental Text Testing Initialization', function () {
   });
 
   it('Click and navigate to Experimental Text test page', async () => {
-    /* Scroll to component test page button in scrollview if not already visible*/
-    await ExperimentalTextPageObject.scrollToComponentButton(Platform.Win32);
-
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToExperimentalTextPage();
     await ExperimentalTextPageObject.waitForPageDisplayed(PAGE_TIMEOUT);

--- a/apps/fluent-tester/src/E2E/Theme/specs/Theme.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/Theme/specs/Theme.spec.ios.ts
@@ -11,7 +11,7 @@ describe('Theme Testing Initialization', function () {
   });
 
   it('Click and navigate to Theme test page', async () => {
-    await ThemePageObject.scrollToComponentButton(Platform.iOS);
+    await ThemePageObject.mobileScrollToComponentButton(Platform.iOS);
     await ThemePageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/Theme/specs/Theme.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/Theme/specs/Theme.spec.ios.ts
@@ -1,7 +1,7 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import ThemePageObject from '../pages/ThemePageObject.win';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
+import { MobilePlatform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Theme Testing Initialization', function () {
@@ -11,7 +11,7 @@ describe('Theme Testing Initialization', function () {
   });
 
   it('Click and navigate to Theme test page', async () => {
-    await ThemePageObject.mobileScrollToComponentButton(Platform.iOS);
+    await ThemePageObject.mobileScrollToComponentButton(MobilePlatform.iOS);
     await ThemePageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/Theme/specs/Theme.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Theme/specs/Theme.spec.win.ts
@@ -1,7 +1,6 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import ThemePageObject from '../pages/ThemePageObject.win';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Theme Testing Initialization', function () {
@@ -11,8 +10,6 @@ describe('Theme Testing Initialization', function () {
   });
 
   it('Click and navigate to Theme test page', async () => {
-    await ThemePageObject.scrollToComponentButton(Platform.Win32);
-
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToThemePage();
     await ThemePageObject.waitForPageDisplayed(PAGE_TIMEOUT);

--- a/apps/fluent-tester/src/E2E/Theme/specs/Theme.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Theme/specs/Theme.spec.win.ts
@@ -12,7 +12,6 @@ describe('Theme Testing Initialization', function () {
 
   it('Click and navigate to Theme test page', async () => {
     await ThemePageObject.scrollToComponentButton(Platform.Win32);
-    await ThemePageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToThemePage();

--- a/apps/fluent-tester/src/E2E/Tokens/specs/Tokens.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/Tokens/specs/Tokens.spec.ios.ts
@@ -11,7 +11,7 @@ describe('Tokens Testing Initialization', function () {
   });
 
   it('Click and navigate to Tokens test page', async () => {
-    await TokenPageObject.scrollToComponentButton(Platform.iOS);
+    await TokenPageObject.mobileScrollToComponentButton(Platform.iOS);
     await TokenPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/Tokens/specs/Tokens.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/Tokens/specs/Tokens.spec.ios.ts
@@ -1,7 +1,7 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import TokenPageObject from '../pages/TokensPageObject.win';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
+import { MobilePlatform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Tokens Testing Initialization', function () {
@@ -11,7 +11,7 @@ describe('Tokens Testing Initialization', function () {
   });
 
   it('Click and navigate to Tokens test page', async () => {
-    await TokenPageObject.mobileScrollToComponentButton(Platform.iOS);
+    await TokenPageObject.mobileScrollToComponentButton(MobilePlatform.iOS);
     await TokenPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */

--- a/apps/fluent-tester/src/E2E/Tokens/specs/Tokens.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Tokens/specs/Tokens.spec.win.ts
@@ -13,7 +13,6 @@ describe('Tokens Testing Initialization', function () {
   it('Click and navigate to Tokens test page', async () => {
     /* Scroll to component test page button in scrollview if not already visible*/
     await TokenPageObject.scrollToComponentButton(Platform.Win32);
-    await TokenPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
 
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToTokensPage();

--- a/apps/fluent-tester/src/E2E/Tokens/specs/Tokens.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Tokens/specs/Tokens.spec.win.ts
@@ -1,7 +1,6 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import TokenPageObject from '../pages/TokensPageObject.win';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
-import { Platform } from '../../common/BasePage';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Tokens Testing Initialization', function () {
@@ -11,9 +10,6 @@ describe('Tokens Testing Initialization', function () {
   });
 
   it('Click and navigate to Tokens test page', async () => {
-    /* Scroll to component test page button in scrollview if not already visible*/
-    await TokenPageObject.scrollToComponentButton(Platform.Win32);
-
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToTokensPage();
     await TokenPageObject.waitForPageDisplayed(PAGE_TIMEOUT);

--- a/apps/fluent-tester/src/E2E/common/BasePage.ts
+++ b/apps/fluent-tester/src/E2E/common/BasePage.ts
@@ -194,21 +194,6 @@ export class BasePage {
     return windowHandles.length > 1;
   }
 
-  /* Finds the first test page button in the ScrollView */
-  async SetFirstScrollViewButtonChild() {
-    const TestChildren = await (await this._testPageButtonScrollViewer).$$('//*');
-    const reg = new RegExp('Homepage_[a-zA-Z]*_Button');
-
-    for (const child of TestChildren) {
-      const autoId = await child.getAttribute('AutomationId');
-      if (autoId && autoId !== TESTPAGE_BUTTONS_SCROLLVIEWER && autoId.match(reg)) {
-        return await child;
-      }
-    }
-
-    return null;
-  }
-
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
@@ -253,10 +238,6 @@ export class BasePage {
   // The scrollviewer containing the list of buttons to navigate to each test page
   get _testPageButtonScrollViewer() {
     return By(TESTPAGE_BUTTONS_SCROLLVIEWER);
-  }
-
-  get _firstTestPageButton() {
-    return this.SetFirstScrollViewButtonChild();
   }
 
   /****************** Error Messages ******************/

--- a/apps/fluent-tester/src/E2E/common/BasePage.ts
+++ b/apps/fluent-tester/src/E2E/common/BasePage.ts
@@ -82,21 +82,9 @@ export class BasePage {
       'Could not scroll to the ' + this._pageName + "'s Button. Please see Pipeline artifacts for more debugging information.";
 
     switch (platform) {
-      case Platform.Win32: {
-        const scrollDownKeys = [Keys.PAGE_DOWN];
-        await browser.waitUntil(
-          async () => {
-            await (await this._firstTestPageButton).addValue(scrollDownKeys);
-            scrollDownKeys.push(Keys.PAGE_DOWN);
-            return await (await this._pageButton).isDisplayed();
-          },
-          {
-            timeout: this.waitForUiEvent,
-            timeoutMsg: errorMsg,
-          },
-        );
+      case Platform.Win32:
+        // Not needed for Win32. Automatic scroll on click.
         break;
-      }
 
       case Platform.iOS: {
         await browser.waitUntil(

--- a/apps/fluent-tester/src/E2E/common/BasePage.ts
+++ b/apps/fluent-tester/src/E2E/common/BasePage.ts
@@ -18,12 +18,18 @@ export const enum ComponentSelector {
   Secondary, // this._secondaryComponent
 }
 
-export const enum Platform {
-  Win32 = 0,
-  iOS,
-  macOS,
+export const enum MobilePlatform {
+  iOS = 0,
   Android,
 }
+
+export const enum NativePlatform {
+  Win32 = 0,
+  Windows,
+  macOS,
+}
+
+export type Platform = MobilePlatform | NativePlatform;
 
 /****************************** IMPORTANT! PLEASE READ! **************************************************
  * Every component's page object extends this. We can assume each test page will interact with at least
@@ -74,7 +80,7 @@ export class BasePage {
   /* Scrolls until the desired test page's button is displayed. We use the scroll viewer UI element as the point to start scrolling.
    * We use a negative number as the Y-coordinate because that enables us to scroll downwards.
    * There are no need for win32 and macos cases, as the click command automatically scrolls the element into view. */
-  async mobileScrollToComponentButton(platform: Platform): Promise<void> {
+  async mobileScrollToComponentButton(platform: MobilePlatform): Promise<void> {
     if (await (await this._pageButton).isDisplayed()) {
       return;
     }
@@ -83,7 +89,7 @@ export class BasePage {
       'Could not scroll to the ' + this._pageName + "'s Button. Please see Pipeline artifacts for more debugging information.";
 
     switch (platform) {
-      case Platform.iOS: {
+      case MobilePlatform.iOS: {
         await browser.waitUntil(
           async () => {
             await driver.execute('mobile: scroll', { direction: 'down' });
@@ -97,7 +103,7 @@ export class BasePage {
         break;
       }
       default:
-      case Platform.Android:
+      case MobilePlatform.Android:
         // Todo
         break;
     }

--- a/apps/fluent-tester/src/E2E/common/BasePage.ts
+++ b/apps/fluent-tester/src/E2E/common/BasePage.ts
@@ -73,7 +73,7 @@ export class BasePage {
 
   /* Scrolls until the desired test page's button is displayed. We use the scroll viewer UI element as the point to start scrolling.
    * We use a negative number as the Y-coordinate because that enables us to scroll downwards */
-  async scrollToComponentButton(platform: Platform): Promise<void> {
+  async mobileScrollToComponentButton(platform: Platform): Promise<void> {
     if (await (await this._pageButton).isDisplayed()) {
       return;
     }
@@ -83,7 +83,8 @@ export class BasePage {
 
     switch (platform) {
       case Platform.Win32:
-        // Not needed for Win32. Automatic scroll on click.
+        // Not needed for Win32. It automatically scrolls.
+        // Scrolling is automatically done by sending a click command to the component button.
         break;
 
       case Platform.iOS: {

--- a/apps/fluent-tester/src/E2E/common/BasePage.ts
+++ b/apps/fluent-tester/src/E2E/common/BasePage.ts
@@ -72,7 +72,8 @@ export class BasePage {
   }
 
   /* Scrolls until the desired test page's button is displayed. We use the scroll viewer UI element as the point to start scrolling.
-   * We use a negative number as the Y-coordinate because that enables us to scroll downwards */
+   * We use a negative number as the Y-coordinate because that enables us to scroll downwards.
+   * There are no need for win32 and macos cases, as the click command automatically scrolls the element into view. */
   async mobileScrollToComponentButton(platform: Platform): Promise<void> {
     if (await (await this._pageButton).isDisplayed()) {
       return;
@@ -82,11 +83,6 @@ export class BasePage {
       'Could not scroll to the ' + this._pageName + "'s Button. Please see Pipeline artifacts for more debugging information.";
 
     switch (platform) {
-      case Platform.Win32:
-        // Not needed for Win32. It automatically scrolls.
-        // Scrolling is automatically done by sending a click command to the component button.
-        break;
-
       case Platform.iOS: {
         await browser.waitUntil(
           async () => {
@@ -100,11 +96,6 @@ export class BasePage {
         );
         break;
       }
-
-      case Platform.macOS:
-        // Not needed for macOS. It automatically scrolls
-        break;
-
       default:
       case Platform.Android:
         // Todo

--- a/change/@fluentui-react-native-tester-83c37bb6-6aa1-4b48-866a-d72414a031f4.json
+++ b/change/@fluentui-react-native-tester-83c37bb6-6aa1-4b48-866a-d72414a031f4.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Remove janky scroll logic for win32 component button",
+  "comment": "Remove unnecessary scroll logic within e2e tests",
   "packageName": "@fluentui-react-native/tester",
   "email": "winlarry@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-native-tester-83c37bb6-6aa1-4b48-866a-d72414a031f4.json
+++ b/change/@fluentui-react-native-tester-83c37bb6-6aa1-4b48-866a-d72414a031f4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove janky scroll logic for win32 component button",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

After moving away from touchScroll, current scroll behavior relies on focusing on a button in a scroll view and sending Page Down inputs until we see the element we want. While it works, this is a bit janky. 

For the sidebar of component buttons, we can simply click the buttons without having to scroll to them first, since the elementClick command will scroll the element into view for us. 

### Verification

Tested on win32 locally and within the pipeline. 

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
