### PR TITLE
[Dropdown] Add pressable state handling

### DIFF
--- a/packages/experimental/Dropdown/src/Dropdown/Dropdown.tsx
+++ b/packages/experimental/Dropdown/src/Dropdown/Dropdown.tsx
@@ -34,18 +34,17 @@ const dropdownTokens = buildUseTokens<DropdownTokens>((t: Theme) => ({
 const dropdownState: (keyof DropdownTokens)[] = ['hovered', 'focused', 'pressed'];
 
 const Dropdown = compressible<DropdownProps, DropdownTokens>((props: DropdownProps, useTokens: UseTokens<DropdownTokens>) => {
-  const pressableState = useAsPressable(props);
+  const pressable = useAsPressable(props);
   const theme = useFluentTheme();
   const [tokens, tokenCache] = useTokens(theme);
-  const [mergedTokens] = applyTokenLayers(tokens, dropdownState, tokenCache, (layer) => pressableState.state[layer]);
+  const [mergedTokens] = applyTokenLayers(tokens, dropdownState, tokenCache, (layer) => pressable.state[layer]);
 
   const onButtonClick = React.useCallback(() => {}, []); //eslint-disable-line
   const buttonProps: ButtonProps = React.useMemo(
     () => ({
-      ...pressableState.props,
       onClick: onButtonClick,
     }),
-    [onButtonClick, pressableState],
+    [onButtonClick],
   );
   const CustButton = React.useMemo(
     () =>
@@ -78,7 +77,7 @@ const Dropdown = compressible<DropdownProps, DropdownTokens>((props: DropdownPro
     />
   );
 
-  const RootSlot = useSlot<IViewProps>(View, props);
+  const RootSlot = useSlot<IViewProps>(View, pressable.props);
   const ButtonSlot = useSlot<ButtonProps>(CustButton, buttonProps);
   const ExpandIconSlot = useSlot<SvgProps>(Svg, expandIconProps);
 

--- a/packages/experimental/Dropdown/src/Dropdown/Dropdown.tsx
+++ b/packages/experimental/Dropdown/src/Dropdown/Dropdown.tsx
@@ -20,11 +20,14 @@ import { dropdownName, DropdownProps, DropdownTokens } from './Dropdown.types';
 // Change later for win32
 const dropdownTokens = buildUseTokens<DropdownTokens>((t: Theme) => ({
   buttonBorder: t.colors.neutralStroke1,
+  expandIconColor: 'red',
   hovered: {
     buttonBorder: t.colors.neutralStroke1Hover,
+    expandIconColor: 'pink',
   },
   pressed: {
     buttonBorder: t.colors.neutralStrokeAccessible,
+    expandIconColor: 'blue',
   },
 }));
 
@@ -34,14 +37,15 @@ const Dropdown = compressible<DropdownProps, DropdownTokens>((props: DropdownPro
   const pressableState = useAsPressable(props);
   const theme = useFluentTheme();
   const [tokens, tokenCache] = useTokens(theme);
-  const [mergedTokens] = applyTokenLayers(tokens, dropdownState, tokenCache, (layer) => pressableState[layer]);
+  const [mergedTokens] = applyTokenLayers(tokens, dropdownState, tokenCache, (layer) => pressableState.state[layer]);
 
   const onButtonClick = React.useCallback(() => {}, []); //eslint-disable-line
   const buttonProps: ButtonProps = React.useMemo(
     () => ({
+      ...pressableState.props,
       onClick: onButtonClick,
     }),
-    [onButtonClick],
+    [onButtonClick, pressableState],
   );
   const CustButton = React.useMemo(
     () =>
@@ -65,10 +69,13 @@ const Dropdown = compressible<DropdownProps, DropdownTokens>((props: DropdownPro
       viewBox: '0 0 16 16',
       fill: 'none',
     }),
-    [mergedTokens.expandIconColor],
+    [mergedTokens],
   );
   const expandIconPath = (
-    <Path d="M3.14645 5.64645C3.34171 5.45118 3.65829 5.45118 3.85355 5.64645L8 9.79289L12.1464 5.64645C12.3417 5.45118 12.6583 5.45118 12.8536 5.64645C13.0488 5.84171 13.0488 6.15829 12.8536 6.35355L8.35355 10.8536C8.15829 11.0488 7.84171 11.0488 7.64645 10.8536L3.14645 6.35355C2.95118 6.15829 2.95118 5.84171 3.14645 5.64645Z" />
+    <Path
+      fill="currentColor"
+      d="M3.14645 5.64645C3.34171 5.45118 3.65829 5.45118 3.85355 5.64645L8 9.79289L12.1464 5.64645C12.3417 5.45118 12.6583 5.45118 12.8536 5.64645C13.0488 5.84171 13.0488 6.15829 12.8536 6.35355L8.35355 10.8536C8.15829 11.0488 7.84171 11.0488 7.64645 10.8536L3.14645 6.35355C2.95118 6.15829 2.95118 5.84171 3.14645 5.64645Z"
+    />
   );
 
   const RootSlot = useSlot<IViewProps>(View, props);

--- a/packages/experimental/Dropdown/src/Dropdown/Dropdown.tsx
+++ b/packages/experimental/Dropdown/src/Dropdown/Dropdown.tsx
@@ -1,13 +1,41 @@
 /** @jsx withSlots */
 import { IViewProps } from '@fluentui-react-native/adapters';
 import { ButtonV1 as Button, ButtonProps } from '@fluentui-react-native/button';
-import { buildUseTokens, compressible, useSlot, UseTokens, withSlots } from '@fluentui-react-native/framework';
+import {
+  applyTokenLayers,
+  buildUseTokens,
+  compressible,
+  Theme,
+  useFluentTheme,
+  useSlot,
+  UseTokens,
+  withSlots,
+} from '@fluentui-react-native/framework';
+import { useAsPressable } from '@fluentui-react-native/interactive-hooks';
 import React from 'react';
 import { View } from 'react-native';
 import { Path, Svg, SvgProps } from 'react-native-svg';
 import { dropdownName, DropdownProps, DropdownTokens } from './Dropdown.types';
 
-const Dropdown = compressible<DropdownProps, DropdownTokens>((props: DropdownProps, _useTokens: UseTokens<DropdownTokens>) => {
+// Change later for win32
+const dropdownTokens = buildUseTokens<DropdownTokens>((t: Theme) => ({
+  buttonBorder: t.colors.neutralStroke1,
+  hovered: {
+    buttonBorder: t.colors.neutralStroke1Hover,
+  },
+  pressed: {
+    buttonBorder: t.colors.neutralStrokeAccessible,
+  },
+}));
+
+const dropdownState: (keyof DropdownTokens)[] = ['hovered', 'focused', 'pressed'];
+
+const Dropdown = compressible<DropdownProps, DropdownTokens>((props: DropdownProps, useTokens: UseTokens<DropdownTokens>) => {
+  const pressableState = useAsPressable(props);
+  const theme = useFluentTheme();
+  const [tokens, tokenCache] = useTokens(theme);
+  const [mergedTokens] = applyTokenLayers(tokens, dropdownState, tokenCache, (layer) => pressableState[layer]);
+
   const onButtonClick = React.useCallback(() => {}, []); //eslint-disable-line
   const buttonProps: ButtonProps = React.useMemo(
     () => ({
@@ -15,22 +43,36 @@ const Dropdown = compressible<DropdownProps, DropdownTokens>((props: DropdownPro
     }),
     [onButtonClick],
   );
+  const CustButton = React.useMemo(
+    () =>
+      Button.customize({
+        borderColor: tokens.buttonBorder,
+        hovered: {
+          borderColor: tokens.hovered.buttonBorder,
+        },
+        pressed: {
+          borderColor: tokens.pressed.buttonBorder,
+        },
+      }),
+    [tokens],
+  );
 
   const expandIconProps: SvgProps = React.useMemo(
     () => ({
+      color: mergedTokens.expandIconColor,
       width: '16',
       height: '16',
       viewBox: '0 0 16 16',
       fill: 'none',
     }),
-    [],
+    [mergedTokens.expandIconColor],
   );
   const expandIconPath = (
     <Path d="M3.14645 5.64645C3.34171 5.45118 3.65829 5.45118 3.85355 5.64645L8 9.79289L12.1464 5.64645C12.3417 5.45118 12.6583 5.45118 12.8536 5.64645C13.0488 5.84171 13.0488 6.15829 12.8536 6.35355L8.35355 10.8536C8.15829 11.0488 7.84171 11.0488 7.64645 10.8536L3.14645 6.35355C2.95118 6.15829 2.95118 5.84171 3.14645 5.64645Z" />
   );
 
   const RootSlot = useSlot<IViewProps>(View, props);
-  const ButtonSlot = useSlot<ButtonProps>(Button, buttonProps);
+  const ButtonSlot = useSlot<ButtonProps>(CustButton, buttonProps);
   const ExpandIconSlot = useSlot<SvgProps>(Svg, expandIconProps);
 
   return (_final: DropdownProps, ..._children: React.ReactNode[]) => {
@@ -43,7 +85,7 @@ const Dropdown = compressible<DropdownProps, DropdownTokens>((props: DropdownPro
       </RootSlot>
     );
   };
-}, buildUseTokens<DropdownTokens>({}));
+}, dropdownTokens);
 Dropdown.displayName = dropdownName;
 
 export { Dropdown };

--- a/packages/experimental/Dropdown/src/Dropdown/Dropdown.types.ts
+++ b/packages/experimental/Dropdown/src/Dropdown/Dropdown.types.ts
@@ -1,9 +1,19 @@
+import type { ColorValue } from 'react-native';
 import type { IViewProps } from '@fluentui-react-native/adapters';
 import { IPressableHooks, IWithPressableOptions } from '@fluentui-react-native/interactive-hooks';
 
 export const dropdownName = 'Dropdown';
 
-export interface DropdownTokens {}
+export interface DropdownTokens {
+  buttonBackground?: ColorValue;
+  buttonBorder?: ColorValue;
+  buttonText?: ColorValue;
+  expandIconColor?: ColorValue;
+
+  focused?: DropdownTokens;
+  hovered?: DropdownTokens;
+  pressed?: DropdownTokens;
+}
 
 export interface DropdownProps extends IWithPressableOptions<IViewProps> {}
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

PR right now is serving as example on how to handle Pressable state in compressible

@lenahong
@saadnajmi (in case I'm using the wrong hook)

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
