### PR TITLE
Initial Android Shadow Implementation

### DIFF
--- a/apps/fluent-tester/src/testPages.ts
+++ b/apps/fluent-tester/src/testPages.ts
@@ -211,7 +211,7 @@ export const tests: TestDescription[] = [
     name: 'Shadow',
     component: ShadowTest,
     testPage: HOMEPAGE_SHADOW_BUTTON,
-    platforms: ['ios', 'macos', 'win32'],
+    platforms: ['android', 'ios', 'macos', 'win32'],
   },
   {
     name: 'Shimmer',

--- a/change/@fluentui-react-native-experimental-shadow-488741b8-5f88-49ea-8b96-1ea89d52fab7.json
+++ b/change/@fluentui-react-native-experimental-shadow-488741b8-5f88-49ea-8b96-1ea89d52fab7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Initial Android Shadow Implementation",
+  "packageName": "@fluentui-react-native/experimental-shadow",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-fbe2d3a0-09bc-4343-abb3-6ad9656e56d5.json
+++ b/change/@fluentui-react-native-tester-fbe2d3a0-09bc-4343-abb3-6ad9656e56d5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Initial Android Shadow Implementation",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Shadow/src/Shadow.tsx
+++ b/packages/experimental/Shadow/src/Shadow.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { View, ViewStyle } from 'react-native';
+import { Platform, View, ViewStyle } from 'react-native';
 import { ShadowProps, shadowName } from './Shadow.types';
 import { mergeProps, stagedComponent } from '@fluentui-react-native/framework';
 import { getShadowTokenStyleSet } from './shadowStyle';
@@ -8,7 +8,13 @@ import { ShadowToken } from '@fluentui-react-native/theme-types';
 
 export const Shadow = stagedComponent((props: ShadowProps) => {
   return (final: ShadowProps, children: React.ReactNode) => {
-    if (!props.shadowToken) {
+    /**
+     * Don't render additional views if we don't need to.
+     * On Android, we still want the extra outer view to constrain a ripple that
+     * may be present in the inner view, due to the following bug:
+     * https://stackoverflow.com/questions/63048178/ripple-effect-leaking-at-corners-as-if-pressable-button-has-a-borderradius
+     **/
+    if (!props.shadowToken && Platform.OS !== 'android') {
       return <>{children}</>;
     }
 
@@ -113,7 +119,7 @@ function getStylePropsForShadowViewsWorker(childStyleProps: ViewStyle = {}, shad
         flexWrap,
         flexDirection,
 
-        ...shadowTokenStyleSet.key,
+        ...shadowTokenStyleSet.ambient,
         ...restOfChildStyleProps,
       },
     },
@@ -136,7 +142,7 @@ function getStylePropsForShadowViewsWorker(childStyleProps: ViewStyle = {}, shad
         top,
         bottom,
 
-        ...shadowTokenStyleSet.ambient,
+        ...shadowTokenStyleSet.key,
         ...restOfChildStyleProps,
       },
     },

--- a/packages/experimental/Shadow/src/shadowStyle.android.ts
+++ b/packages/experimental/Shadow/src/shadowStyle.android.ts
@@ -1,0 +1,25 @@
+import { memoize } from '@fluentui-react-native/framework';
+import { ShadowToken } from '@fluentui-react-native/theme-types';
+
+/**
+ * For Android, we do not set two independent shadows on two views.
+ * Instead, the `elevation` prop takes care of synthesizing a key and ambient
+ * shadow together with it's own depth ramp. The `blur` token of our key shadow roughly
+ * matches the elevation value. See the following:
+ * https://material.io/design/environment/light-shadows.html#light
+ * https://github.com/microsoft/apple-ux-guide/blob/gh-pages/Shadows.md
+ *
+ * We still however, want to have two views in our heirarchy so that the "ambient" shadow
+ * constrains the Android Ripple's borders due to the following bug:
+ * https://stackoverflow.com/questions/63048178/ripple-effect-leaking-at-corners-as-if-pressable-button-has-a-borderradius
+ */
+export const getShadowTokenStyleSet = memoize(getShadowTokenStyleSetWorker);
+
+function getShadowTokenStyleSetWorker(shadowToken: ShadowToken) {
+  return {
+    key: {
+      elevation: shadowToken?.key?.blur,
+    },
+    ambient: {},
+  };
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [x] android

### Description of changes

This PR adds the initial implementation of Fluent shadows for Android. This is done by just mapping the key shadow's blur to the Android elevation prop. 

I also intended this PR to do the "margin extraction / ripple constraining" logic that #2103 needs, but will probably factor that out. 

### Verification

Shadow test page on Android works, and notification component has shadows

<img width="515" alt="Screenshot 2022-10-14 at 11 59 37 AM" src="https://user-images.githubusercontent.com/6722175/195942354-91cc12e7-5d3c-429f-bef3-78269fb30f1f.png">
<img width="515" alt="Screenshot 2022-10-14 at 11 41 50 AM" src="https://user-images.githubusercontent.com/6722175/195942360-671f72f4-581d-4969-8c0a-fa6c3aecd792.png">


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
