### PR TITLE
[Notification] Fix error "Text strings must be rendered within a <Text> component" when title text is empty

### DIFF
--- a/change/@fluentui-react-native-notification-18fb3425-2c79-4126-8c6e-c8958659c32a.json
+++ b/change/@fluentui-react-native-notification-18fb3425-2c79-4126-8c6e-c8958659c32a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix error when title string is empty",
+  "packageName": "@fluentui-react-native/notification",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Notification/src/Notification.tsx
+++ b/packages/components/Notification/src/Notification.tsx
@@ -79,7 +79,7 @@ export const Notification = compose<NotificationType>({
           <Slots.root {...mergedProps}>
             {icon && <Slots.icon {...iconProps} accessible={false} />}
             <Slots.contentContainer accessible={true}>
-              {title && <Slots.title>{title}</Slots.title>}
+              {title ? <Slots.title>{title}</Slots.title> : null}
               <Slots.message style={messageStyle}>{children}</Slots.message>
             </Slots.contentContainer>
             {onActionPress && <Slots.action {...notificationButtonProps} />}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Noticed that the app would error out if I removed everything in the title text box. 

From https://reactjs.org/docs/conditional-rendering.html: "returning a falsy expression will still cause the element after && to be skipped but will return the falsy expression"

So in the line  `{title && <Slots.title>{title}</Slots.title>}`, if title is an empty string (which is a falsy expression) we would return an empty string, which would cause the error because then we have a string that isn't wrapped in a Text component. We want to return null or undefined or false.

This error wasn't popping up when toggling the "show title" button to be off because we were passing in undefined into the title prop, not an empty string. This would make the expression evaluate as undefined, which was okay.


### Verification

(ignore the first red box that comes up in this video, have a bug filed for that too)

https://user-images.githubusercontent.com/78454019/196296934-4407640c-c8cb-4b38-996c-2d61d7b39b1e.mov

https://user-images.githubusercontent.com/78454019/196296948-c67e3407-1750-4573-9666-0ef59f700ce0.mov


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
