### PR TITLE
Add an example of how spacing tokens can be used in FURN

### DIFF
--- a/change/@fluentui-react-native-notification-a46a5b1a-c802-4b11-90a3-d8b1ba6dc388.json
+++ b/change/@fluentui-react-native-notification-a46a5b1a-c802-4b11-90a3-d8b1ba6dc388.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add spacing tokens to Notification",
+  "packageName": "@fluentui-react-native/notification",
+  "email": "adgleitm@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Notification/src/NotificationTokens.ios.ts
+++ b/packages/components/Notification/src/NotificationTokens.ios.ts
@@ -104,8 +104,8 @@ export const defaultNotificationTokens: TokenSettings<NotificationTokens, Theme>
     fontSize: 15,
     fontWeight: '400',
     minHeight: 52,
-    padding: 16,
-    paddingVertical: 12,
+    padding: t.spacing.m,
+    paddingVertical: t.spacing.s,
     shadowToken: notificationShadowStyle,
     isBar: {
       borderRadius: 0,

--- a/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
+++ b/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`Notification component tests Notification default 1`] = `
         "flexWrap": undefined,
         "justifyContent": "space-between",
         "minHeight": 52,
-        "padding": 16,
+        "padding": "16px",
         "paddingBottom": undefined,
         "paddingEnd": undefined,
         "paddingHorizontal": undefined,
@@ -86,7 +86,7 @@ exports[`Notification component tests Notification default 1`] = `
         "paddingRight": undefined,
         "paddingStart": undefined,
         "paddingTop": undefined,
-        "paddingVertical": 12,
+        "paddingVertical": undefined,
         "shadowColor": "#000000",
         "shadowOffset": Object {
           "height": 0,


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This adds an example of how spacing tokens can be used in FURN. The tokens were chosen such that their iOS values line up with the original hard-coded values.

### Verification

Notification looks the same on the test page.

| Before | After |
|-|-|
| ![Screen Shot 2022-10-19 at 2 37 16 PM](https://user-images.githubusercontent.com/717674/196809963-18f90b69-c00a-49cc-a7b8-e39052b0c710.png) | ![Screen Shot 2022-10-19 at 2 37 43 PM](https://user-images.githubusercontent.com/717674/196809994-48e38397-ce29-44f6-a9c6-2d4f66cb36a4.png) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
