### PR TITLE
[Menu] Add ability to pass own callbacks to child of MenuTrigger

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Menu/MenuTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Menu/MenuTest.tsx
@@ -17,6 +17,7 @@ import { Test, TestSection, PlatformStatus } from '../Test';
 import { TextV1 as Text } from '@fluentui-react-native/text';
 import { E2EMenuTest } from './E2EMenuTest';
 import { StyleSheet } from 'react-native';
+import { MenuTriggerHoverOverride, MenuTriggerOnClickOverride } from './MenuTriggerOverrides';
 
 const MenuDefault: React.FunctionComponent = () => {
   return (
@@ -266,6 +267,14 @@ const menuSections: TestSection[] = [
   {
     name: 'Menu Submenu',
     component: MenuSubMenu,
+  },
+  {
+    name: 'Menu Trigger onClick Override',
+    component: MenuTriggerOnClickOverride,
+  },
+  {
+    name: 'Menu Trigger Hover Override',
+    component: MenuTriggerHoverOverride,
   },
   {
     name: 'Menu Customized',

--- a/apps/fluent-tester/src/TestComponents/Menu/MenuTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Menu/MenuTest.tsx
@@ -17,7 +17,7 @@ import { Test, TestSection, PlatformStatus } from '../Test';
 import { TextV1 as Text } from '@fluentui-react-native/text';
 import { E2EMenuTest } from './E2EMenuTest';
 import { StyleSheet } from 'react-native';
-import { MenuTriggerHoverOverride, MenuTriggerOnClickOverride } from './MenuTriggerOverrides';
+import { MenuTriggerHoverCallback, MenuTriggerOnClickCallback } from './MenuTriggerCallbacks';
 
 const MenuDefault: React.FunctionComponent = () => {
   return (
@@ -270,11 +270,11 @@ const menuSections: TestSection[] = [
   },
   {
     name: 'Menu Trigger onClick Override',
-    component: MenuTriggerOnClickOverride,
+    component: MenuTriggerOnClickCallback,
   },
   {
     name: 'Menu Trigger Hover Override',
-    component: MenuTriggerHoverOverride,
+    component: MenuTriggerHoverCallback,
   },
   {
     name: 'Menu Customized',

--- a/apps/fluent-tester/src/TestComponents/Menu/MenuTriggerCallbacks.tsx
+++ b/apps/fluent-tester/src/TestComponents/Menu/MenuTriggerCallbacks.tsx
@@ -6,7 +6,7 @@ import { stackStyle } from '../Common/styles';
 import { ColorValue } from 'react-native';
 import Svg, { Path } from 'react-native-svg';
 
-export const MenuTriggerOnClickOverride: React.FunctionComponent = () => {
+export const MenuTriggerOnClickCallback: React.FunctionComponent = () => {
   const [counter, setCounter] = React.useState<number>(0);
   const onClick = React.useCallback(() => {
     setCounter(counter + 1);
@@ -30,7 +30,7 @@ export const MenuTriggerOnClickOverride: React.FunctionComponent = () => {
   );
 };
 
-export const MenuTriggerHoverOverride: React.FunctionComponent = () => {
+export const MenuTriggerHoverCallback: React.FunctionComponent = () => {
   const [iconColor, setIconColor] = React.useState<ColorValue>('red');
   const onHoverIn = React.useCallback(() => {
     setIconColor('blue');

--- a/apps/fluent-tester/src/TestComponents/Menu/MenuTriggerOverrides.tsx
+++ b/apps/fluent-tester/src/TestComponents/Menu/MenuTriggerOverrides.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import { ButtonV1 as Button } from '@fluentui/react-native';
+import { Menu, MenuItem, MenuTrigger, MenuPopover, MenuList } from '@fluentui-react-native/menu';
+import { Stack } from '@fluentui-react-native/stack';
+import { stackStyle } from '../Common/styles';
+import { ColorValue } from 'react-native';
+import Svg, { Path } from 'react-native-svg';
+
+export const MenuTriggerOnClickOverride: React.FunctionComponent = () => {
+  const [counter, setCounter] = React.useState<number>(0);
+  const onClick = React.useCallback(() => {
+    setCounter(counter + 1);
+  }, [counter, setCounter]);
+
+  return (
+    <Stack style={stackStyle}>
+      <Menu>
+        <MenuTrigger>
+          <Button onClick={onClick}>{'Click to increase counter: ' + counter}</Button>
+        </MenuTrigger>
+        <MenuPopover>
+          <MenuList>
+            <MenuItem>A plain MenuItem</MenuItem>
+            <MenuItem disabled>A second disabled plain MenuItem</MenuItem>
+            <MenuItem>A third plain MenuItem</MenuItem>
+          </MenuList>
+        </MenuPopover>
+      </Menu>
+    </Stack>
+  );
+};
+
+export const MenuTriggerHoverOverride: React.FunctionComponent = () => {
+  const [iconColor, setIconColor] = React.useState<ColorValue>('red');
+  const onHoverIn = React.useCallback(() => {
+    setIconColor('blue');
+  }, [setIconColor]);
+  const onHoverOut = React.useCallback(() => {
+    setIconColor('red');
+  }, [setIconColor]);
+  const chevron = (
+    <Svg width="12" height="16" viewBox="0 0 11 6" color={iconColor}>
+      <Path
+        fill="currentColor"
+        d="M0.646447 0.646447C0.841709 0.451184 1.15829 0.451184 1.35355 0.646447L5.5 4.79289L9.64645 0.646447C9.84171 0.451185 10.1583 0.451185 10.3536 0.646447C10.5488 0.841709 10.5488 1.15829 10.3536 1.35355L5.85355 5.85355C5.65829 6.04882 5.34171 6.04882 5.14645 5.85355L0.646447 1.35355C0.451184 1.15829 0.451184 0.841709 0.646447 0.646447Z"
+      />
+    </Svg>
+  );
+
+  return (
+    <Stack style={stackStyle}>
+      <Menu>
+        <MenuTrigger>
+          <Button onHoverIn={onHoverIn} onHoverOut={onHoverOut}>
+            Test
+            {chevron}
+          </Button>
+        </MenuTrigger>
+        <MenuPopover>
+          <MenuList>
+            <MenuItem>A plain MenuItem</MenuItem>
+            <MenuItem disabled>A second disabled plain MenuItem</MenuItem>
+            <MenuItem>A third plain MenuItem</MenuItem>
+          </MenuList>
+        </MenuPopover>
+      </Menu>
+    </Stack>
+  );
+};

--- a/change/@fluentui-react-native-menu-947d9505-c034-4009-b4f3-2ae90869791c.json
+++ b/change/@fluentui-react-native-menu-947d9505-c034-4009-b4f3-2ae90869791c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add ability to have additional callback for callbacks overridden by MenuTrigger",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-tester-98137646-1b2e-4e99-b90d-42e722878fbb.json
+++ b/change/@fluentui-react-native-tester-98137646-1b2e-4e99-b90d-42e722878fbb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add test case",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/MenuTrigger/MenuTrigger.tsx
+++ b/packages/components/Menu/src/MenuTrigger/MenuTrigger.tsx
@@ -4,6 +4,7 @@ import { menuTriggerName, MenuTriggerChildProps, MenuTriggerState } from './Menu
 import { useMenuTrigger } from './useMenuTrigger';
 import { AccessibilityActionEvent } from 'react-native';
 import { MenuTriggerProvider } from '../context/menuTriggerContext';
+import { InteractionEvent, isMouseEvent } from '@fluentui-react-native/interactive-hooks';
 
 export const MenuTrigger = stagedComponent((_props: React.PropsWithChildren<Record<never, any>>) => {
   const menuTrigger = useMenuTrigger();
@@ -31,23 +32,46 @@ MenuTrigger.displayName = menuTriggerName;
 
 const getRevisedProps = memoize(getRevisedPropsWorker);
 function getRevisedPropsWorker(state: MenuTriggerState, props: any): MenuTriggerChildProps {
-  const revisedProps = state.props;
+  const revisedProps = { ...state.props };
   if (props.accessibilityState) {
-    revisedProps.accessibilityState = { ...revisedProps.accessibilityState, ...props.accessibilityState };
+    revisedProps.accessibilityState = { ...state.props.accessibilityState, ...props.accessibilityState };
   }
 
   if (props.accessibilityActions) {
-    revisedProps.accessibilityActions = [...revisedProps.accessibilityActions, ...props.accessibilityActions];
+    revisedProps.accessibilityActions = [...state.props.accessibilityActions, ...props.accessibilityActions];
   }
 
   if (props.onAccessibilityAction) {
     revisedProps.onAccessibilityAction = (e: AccessibilityActionEvent) => {
-      revisedProps.onAccessibilityAction(e);
       props.onAccessibilityAction(e);
+      state.props.onAccessibilityAction(e);
     };
   }
 
-  return revisedProps;
+  if (props.onClick) {
+    revisedProps.onClick = (e: InteractionEvent) => {
+      props.onClick(e);
+      state.props.onClick(e);
+    };
+  }
+
+  let onHoverIn = undefined;
+  if (props.onHoverIn) {
+    onHoverIn = (e: InteractionEvent) => {
+      props.onHoverIn(e);
+      state.props.onHoverIn(isMouseEvent(e) && e);
+    };
+  }
+
+  let onHoverOut = undefined;
+  if (props.onHoverOut) {
+    onHoverOut = (e: InteractionEvent) => {
+      props.onHoverOut(e);
+      state.props.onHoverOut(isMouseEvent(e) && e);
+    };
+  }
+
+  return { ...revisedProps, onHoverIn, onHoverOut };
 }
 
 export default MenuTrigger;

--- a/packages/components/Menu/src/MenuTrigger/MenuTrigger.tsx
+++ b/packages/components/Menu/src/MenuTrigger/MenuTrigger.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import { memoize, stagedComponent } from '@fluentui-react-native/framework';
-import { menuTriggerName, MenuTriggerChildProps, MenuTriggerState } from './MenuTrigger.types';
+import { stagedComponent } from '@fluentui-react-native/framework';
+import { menuTriggerName } from './MenuTrigger.types';
 import { useMenuTrigger } from './useMenuTrigger';
-import { AccessibilityActionEvent } from 'react-native';
 import { MenuTriggerProvider } from '../context/menuTriggerContext';
-import { InteractionEvent, isMouseEvent } from '@fluentui-react-native/interactive-hooks';
+import { getRevisedProps } from './getRevisedProps';
 
 export const MenuTrigger = stagedComponent((_props: React.PropsWithChildren<Record<never, any>>) => {
   const menuTrigger = useMenuTrigger();
@@ -29,49 +28,5 @@ export const MenuTrigger = stagedComponent((_props: React.PropsWithChildren<Reco
   };
 });
 MenuTrigger.displayName = menuTriggerName;
-
-const getRevisedProps = memoize(getRevisedPropsWorker);
-function getRevisedPropsWorker(state: MenuTriggerState, props: any): MenuTriggerChildProps {
-  const revisedProps = { ...state.props };
-  if (props.accessibilityState) {
-    revisedProps.accessibilityState = { ...state.props.accessibilityState, ...props.accessibilityState };
-  }
-
-  if (props.accessibilityActions) {
-    revisedProps.accessibilityActions = [...state.props.accessibilityActions, ...props.accessibilityActions];
-  }
-
-  if (props.onAccessibilityAction) {
-    revisedProps.onAccessibilityAction = (e: AccessibilityActionEvent) => {
-      props.onAccessibilityAction(e);
-      state.props.onAccessibilityAction(e);
-    };
-  }
-
-  if (props.onClick) {
-    revisedProps.onClick = (e: InteractionEvent) => {
-      props.onClick(e);
-      state.props.onClick(e);
-    };
-  }
-
-  let onHoverIn = undefined;
-  if (props.onHoverIn) {
-    onHoverIn = (e: InteractionEvent) => {
-      props.onHoverIn(e);
-      state.props.onHoverIn(isMouseEvent(e) && e);
-    };
-  }
-
-  let onHoverOut = undefined;
-  if (props.onHoverOut) {
-    onHoverOut = (e: InteractionEvent) => {
-      props.onHoverOut(e);
-      state.props.onHoverOut(isMouseEvent(e) && e);
-    };
-  }
-
-  return { ...revisedProps, onHoverIn, onHoverOut };
-}
 
 export default MenuTrigger;

--- a/packages/components/Menu/src/MenuTrigger/getRevisedProps.ts
+++ b/packages/components/Menu/src/MenuTrigger/getRevisedProps.ts
@@ -1,0 +1,48 @@
+import { AccessibilityActionEvent } from 'react-native';
+import { memoize } from '@fluentui-react-native/framework';
+import { InteractionEvent, isMouseEvent } from '@fluentui-react-native/interactive-hooks';
+import { MenuTriggerChildProps, MenuTriggerState } from './MenuTrigger.types';
+
+export const getRevisedProps = memoize(getRevisedPropsWorker);
+function getRevisedPropsWorker(state: MenuTriggerState, props: any): MenuTriggerChildProps {
+  const revisedProps = { ...state.props };
+  if (props.accessibilityState) {
+    revisedProps.accessibilityState = { ...state.props.accessibilityState, ...props.accessibilityState };
+  }
+
+  if (props.accessibilityActions) {
+    revisedProps.accessibilityActions = [...state.props.accessibilityActions, ...props.accessibilityActions];
+  }
+
+  if (props.onAccessibilityAction) {
+    revisedProps.onAccessibilityAction = (e: AccessibilityActionEvent) => {
+      props.onAccessibilityAction(e);
+      state.props.onAccessibilityAction(e);
+    };
+  }
+
+  if (props.onClick) {
+    revisedProps.onClick = (e: InteractionEvent) => {
+      props.onClick(e);
+      state.props.onClick(e);
+    };
+  }
+
+  let onHoverIn = undefined;
+  if (props.onHoverIn) {
+    onHoverIn = (e: InteractionEvent) => {
+      props.onHoverIn(e);
+      state.props.onHoverIn(isMouseEvent(e) && e);
+    };
+  }
+
+  let onHoverOut = undefined;
+  if (props.onHoverOut) {
+    onHoverOut = (e: InteractionEvent) => {
+      props.onHoverOut(e);
+      state.props.onHoverOut(isMouseEvent(e) && e);
+    };
+  }
+
+  return { ...revisedProps, onHoverIn, onHoverOut };
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

The child of the MenuTrigger had several callbacks overwritten but did not expose a way to have an additional callback provided by the client. Any callbacks passed into the child of the MenuTrigger would not get called. This change fixes that by calling any callbacks that are passed in for onClick and onHoverFoo, which are directly overwritten by useMenuTrigger. Also fixes a bug where the functions were recursively calling themselves forever.

### Verification

Test cases were added to test that any passed in callbacks were properly called.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
