### PR TITLE
FocusZone (macOS): Calculate distance from origin

### DIFF
--- a/.ado/markdown-link-check-config.json
+++ b/.ado/markdown-link-check-config.json
@@ -1,7 +1,8 @@
 {
   "ignorePatterns": [
     {
-      "pattern": "^https://badge.fury.io/js/%40fluentui%2Freact-native"
+      "pattern": "^https://badge.fury.io/js/%40fluentui%2Freact-native",
+      "pattern": "https://cla.opensource.microsoft.com"
     }
   ],
   "timeout": "5s",

--- a/.ado/markdown-link-check-config.json
+++ b/.ado/markdown-link-check-config.json
@@ -1,7 +1,9 @@
 {
   "ignorePatterns": [
     {
-      "pattern": "^https://badge.fury.io/js/%40fluentui%2Freact-native",
+      "pattern": "^https://badge.fury.io/js/%40fluentui%2Freact-native"
+    },
+    {
       "pattern": "https://cla.opensource.microsoft.com"
     }
   ],

--- a/apps/fluent-tester/src/TestComponents/FocusZone/FocusZoneTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/FocusZone/FocusZoneTest.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { View, ScrollView } from 'react-native';
-import { FocusZone, FocusZoneDirection, Text } from '@fluentui/react-native';
+import { View, ScrollView, Pressable } from 'react-native';
+import { FocusZone, FocusZoneDirection, Text, useOnPressWithFocus } from '@fluentui/react-native';
 import { ButtonV1 as Button } from '@fluentui-react-native/button';
 import { Checkbox, CheckboxProps } from '@fluentui-react-native/experimental-checkbox';
 import { Test, TestSection, PlatformStatus } from '../Test';
@@ -87,6 +87,50 @@ const FocusZoneNoProps: React.FunctionComponent = () => {
   );
 };
 
+const TinyBox = () => {
+  const ref = React.useRef<View>();
+  const onPress = useOnPressWithFocus(ref, null);
+
+  return <Pressable focusable style={focusZoneTestStyles.smallBoxStyle} ref={ref} onPress={onPress} />;
+};
+
+const WideBox = () => {
+  const ref = React.useRef<View>();
+  const onPress = useOnPressWithFocus(ref, null);
+
+  return <Pressable focusable style={focusZoneTestStyles.wideBoxStyle} ref={ref} onPress={onPress} />;
+};
+
+const TinyText = () => {
+  return (
+    <Text selectable style={focusZoneTestStyles.smallBoxStyle}>
+      Hi
+    </Text>
+  );
+};
+
+const WideText = () => {
+  return (
+    <Text selectable style={focusZoneTestStyles.wideBoxStyle}>
+      Hello world
+    </Text>
+  );
+};
+
+const DifferentSizesTest: React.FunctionComponent = () => {
+  return (
+    <FocusZone focusZoneDirection="bidirectional">
+      <View style={focusZoneTestStyles.dashedBorder}>
+        <WideBox />
+        <TinyBox />
+        <WideBox />
+        <TinyText />
+        <WideText />
+      </View>
+    </FocusZone>
+  );
+};
+
 const NestedFocusZone: React.FunctionComponent = () => {
   return (
     <FocusZoneListWrapper>
@@ -131,6 +175,10 @@ const focusZoneSections: TestSection[] = [
   {
     name: 'FocusZone with no props',
     component: FocusZoneNoProps,
+  },
+  {
+    name: 'Different Sized Children',
+    component: DifferentSizesTest,
   },
   {
     name: 'Nested FocusZone',

--- a/apps/fluent-tester/src/TestComponents/FocusZone/styles.ts
+++ b/apps/fluent-tester/src/TestComponents/FocusZone/styles.ts
@@ -43,6 +43,18 @@ export const focusZoneTestStyles = StyleSheet.create({
     marginHorizontal: 20,
     marginBottom: 100,
   },
+  smallBoxStyle: {
+    width: 20,
+    height: 20,
+    backgroundColor: 'lightgrey',
+    margin: 5,
+  },
+  wideBoxStyle: {
+    width: 150,
+    height: 20,
+    backgroundColor: 'lightgrey',
+    margin: 5,
+  },
 });
 
 export const GridButton = Button.compose({

--- a/change/@fluentui-react-native-focus-zone-5951beaa-ac23-48e9-97ef-aeb7e1a12830.json
+++ b/change/@fluentui-react-native-focus-zone-5951beaa-ac23-48e9-97ef-aeb7e1a12830.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "FocusZone (macOS): Calculate distance from origin",
+  "packageName": "@fluentui-react-native/focus-zone",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-ae12c1e7-f116-4d02-90e9-458e42c4cdcc.json
+++ b/change/@fluentui-react-native-tester-ae12c1e7-f116-4d02-90e9-458e42c4cdcc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "FocusZone (macOS): Calculate distance from origin",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/FocusZone/macos/RCTFocusZone.m
+++ b/packages/components/FocusZone/macos/RCTFocusZone.m
@@ -25,14 +25,9 @@ static inline CGFloat GetDistanceBetweenPoints(NSPoint point1, NSPoint point2)
 	return sqrt(delta.x * delta.x + delta.y * delta.y);
 }
 
-static inline NSPoint GetCenterOfRect(NSRect rect)
+static inline CGFloat GetDistanceBetweenOriginsOfRects(NSRect rect1, NSRect rect2)
 {
-	return NSMakePoint(NSMidX(rect), NSMidY(rect));
-}
-
-static inline CGFloat GetDistanceBetweenCentersOfRects(NSRect rect1, NSRect rect2)
-{
-	return GetDistanceBetweenPoints(GetCenterOfRect(rect1), GetCenterOfRect(rect2));
+	return GetDistanceBetweenPoints(rect1.origin, rect2.origin);
 }
 
 static inline CGFloat GetMinDistanceBetweenRectVerticesAndPoint(NSRect rect, NSPoint point)
@@ -275,7 +270,7 @@ static BOOL ShouldSkipFocusZone(NSView *view)
 
 		if (!skip)
 		{
-			CGFloat distance = GetDistanceBetweenCentersOfRects(firstResponderRect, candidateRect);
+			CGFloat distance = GetDistanceBetweenOriginsOfRects(firstResponderRect, candidateRect);
 			
 			// If there are other candidate views inside the same ScrollView as the firstResponder,
 			// prefer those views over other views outside the scrollview, even if they are closer.


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

FocusZone on macOS tries to calculate the closet view in a certain direction whenever you try to move focus with arrow keys. Currently, it was calculating the distance between the _center_ of two Views, rather than their origins. This is incorrect, it should be using each View's origin instead. This matches what macOS does natively (see https://cocoadev.github.io/KeyViewLoopGuidelines/). The discrepancy led to a bug where focus would move to the wrong view if the children of a FocusZone varied in size drastically. 

### Verification

Before:
Notice the small boxes are skipped
![Screen Recording 2022-10-20 at 8 50 58 AM](https://user-images.githubusercontent.com/6722175/196998214-c4d6f7b4-f395-410d-8c52-96e4afa9ab93.gif)


After:
All Views get focus
![Screen Recording 2022-10-20 at 8 51 39 AM](https://user-images.githubusercontent.com/6722175/196998191-253a4fbb-9e57-48b4-8861-43e080a2f027.gif)




I also quickly tested RadioGroup and ContextualMenu to make sure they still behaved properly for the simple scenario of moving focus between Radios / Menu items.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [x] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
