### PR TITLE
[RadioGroup] Remove iOS/Android/web from list of platforms

### DIFF
--- a/apps/fluent-tester/src/testPages.ts
+++ b/apps/fluent-tester/src/testPages.ts
@@ -194,13 +194,13 @@ export const tests: TestDescription[] = [
     name: 'RadioGroup',
     component: RadioGroupTest,
     testPage: HOMEPAGE_RADIOGROUP_BUTTON,
-    platforms: ['android', 'ios', 'macos', 'web', 'win32'],
+    platforms: ['macos', 'win32'],
   },
   {
     name: 'RadioGroup (Experimental)',
     component: RadioGroupExperimentalTest,
     testPage: HOMEPAGE_RADIO_GROUP_EXPERIMENTAL_BUTTON,
-    platforms: ['android', 'ios', 'macos', 'web', 'win32'],
+    platforms: ['macos', 'win32'],
   },
   {
     name: 'Spacing Tokens',

--- a/change/@fluentui-react-native-tester-42674883-524b-4e45-b4d7-e7595bc5bd6f.json
+++ b/change/@fluentui-react-native-tester-42674883-524b-4e45-b4d7-e7595bc5bd6f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update platforms to just win32/macOS",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [x] android

### Description of changes

When opening the iOS test page for RadioGroup this error pops up:

<img width="730" alt="Screen Shot 2022-10-20 at 10 41 26 AM" src="https://user-images.githubusercontent.com/78454019/197021860-cd3273ad-d798-42bd-bfab-29cfa0b9c07f.png">

iOS FocusZone doesn't exist, so removing RadioGroup from the list of test pages.

### Verification

Confirmed that radio group/radio group (experimental) doesn't show up in the list of test pages

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
