### PR TITLE
Badge office color fix

### DIFF
--- a/change/@fluentui-react-native-badge-398f851c-3a45-4f10-8d72-59c0409880f2.json
+++ b/change/@fluentui-react-native-badge-398f851c-3a45-4f10-8d72-59c0409880f2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed Badge tint-severe colors",
+  "packageName": "@fluentui-react-native/badge",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Badge/src/BadgeColorTokens.ts
+++ b/packages/components/Badge/src/BadgeColorTokens.ts
@@ -100,11 +100,11 @@ export const defaultBadgeColorTokens: TokenSettings<BadgeTokens> = (t: Theme) =>
         ...getTintColorProps(
           {
             backgroundColor: globalTokens.color.darkOrange.tint60,
-            color: globalTokens.color.office.shade10,
-            borderColor: globalTokens.color.office.tint50,
+            color: globalTokens.color.darkOrange.shade10,
+            borderColor: globalTokens.color.darkOrange.tint50,
             backgroundColorDark: globalTokens.color.orange.shade40,
-            colorDark: globalTokens.color.office.tint40,
-            borderColorDark: globalTokens.color.office.shade40,
+            colorDark: globalTokens.color.darkOrange.tint40,
+            borderColorDark: globalTokens.color.darkOrange.shade40,
           },
           t,
         ),


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [X] macOS
- [ ] win32 (Office)
- [X] windows
- [X] android

### Description of changes
Mobile tokens don't have an Office brand, so the Badge currently has runtime issues (hang) when trying to render on mobile.
I had to change tokens from Office colors to darkOrange (as web does).

### Verification
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="107" alt="image" src="https://user-images.githubusercontent.com/11574680/197238088-1571474b-606a-487c-9b44-505decb115e9.png"> | <img width="109" alt="image" src="https://user-images.githubusercontent.com/11574680/197238118-494ff37e-6338-4e77-bb1f-2b8e2f9a5852.png">|

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
