### PR TITLE
Issue with useButton when using an old haul polyfill

### DIFF
--- a/change/@fluentui-react-native-button-eb80cd9b-63f4-4959-801b-a2c27b876b9b.json
+++ b/change/@fluentui-react-native-button-eb80cd9b-63f4-4959-801b-a2c27b876b9b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix issue when using older haul object polyfill",
+  "packageName": "@fluentui-react-native/button",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Button/src/useButton.ts
+++ b/packages/components/Button/src/useButton.ts
@@ -22,7 +22,7 @@ export const useButton = (props: ButtonProps): ButtonInfo => {
        * Due to a bug in React Native, unconditionally passing this may cause unnecessary re-renders.
        * Therefore, let's only pass it in if it's defined to limit this issue.
        */
-      ...(isDisabled && { disabled: isDisabled }),
+      ...(isDisabled ? { disabled: isDisabled } : null),
       accessible: true,
       accessibilityRole: 'button',
       onAccessibilityTap: props.onAccessibilityTap || (!hasTogglePattern ? props.onClick : undefined),


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

Packages built using older versions of Haul include a polyfill for Object.assign which does not handle values of false, only objects and null.  This change fixes a case where false was getting passed into Object.assign.

This was a recent regression, so only got hit when bringing in a new version of FURN into fabric-internal.


### Verification

Made this change manually in node_modules of fabric-internal to be able to boot an SDX that wasn't booting without this change.
