### PR TITLE
Use Xcode 14.0.1 in ADO

### DIFF
--- a/.ado/scripts/xcode_select_current_version.sh
+++ b/.ado/scripts/xcode_select_current_version.sh
@@ -3,7 +3,7 @@
 if [ -n "$XCODE_PATH_OVERRIDE" ]; then # If someone calls this with the XCODE_PATH_OVERRIDE variable set to a path to a developer dir, use it instead
     XCODE_PATH="$XCODE_PATH_OVERRIDE"
 else
-    XCODE_PATH='/Applications/Xcode_13.4.app/Contents/Developer'
+    XCODE_PATH='/Applications/Xcode_14.0.1.app/Contents/Developer'
 fi
 
 echo "Running command: sudo xcode-select --switch $XCODE_PATH"

--- a/.ado/templates/apple-yarn-build.yml
+++ b/.ado/templates/apple-yarn-build.yml
@@ -11,7 +11,7 @@ steps:
 
   - bash: |
       echo "Pre boot simulator"
-      UDID=$(xcrun simctl create test-iphone com.apple.CoreSimulator.SimDeviceType.iPhone-12 iOS15.5)
+      UDID=$(xcrun simctl create test-iphone com.apple.CoreSimulator.SimDeviceType.iPhone-12 iOS16.0)
       xcrun simctl boot $UDID
     workingDirectory: apps/fluent-tester
     condition: and(succeeded(), eq('${{ parameters.platform }}', 'ios'))

--- a/apps/fluent-tester/wdio.conf.ios.js
+++ b/apps/fluent-tester/wdio.conf.ios.js
@@ -15,7 +15,7 @@ exports.config = {
       maxInstances: 1, // Maximum number of total parallel running workers.
       platformName: 'iOS',
       'appium:platformVersion': '16.0',
-      'appium:deviceName': 'iPhone 14',
+      'appium:deviceName': 'iPhone 13',
       'appium:automationName': 'XCUITest',
       'appium:bundleId': 'com.microsoft.ReactTestApp',
     },

--- a/apps/fluent-tester/wdio.conf.ios.js
+++ b/apps/fluent-tester/wdio.conf.ios.js
@@ -14,8 +14,8 @@ exports.config = {
     {
       maxInstances: 1, // Maximum number of total parallel running workers.
       platformName: 'iOS',
-      'appium:platformVersion': '15.5',
-      'appium:deviceName': 'iPhone 13',
+      'appium:platformVersion': '16.0',
+      'appium:deviceName': 'iPhone 14',
       'appium:automationName': 'XCUITest',
       'appium:bundleId': 'com.microsoft.ReactTestApp',
     },

--- a/change/@fluentui-react-native-tester-db65fa64-4f6e-4d49-88b5-93df813dc504.json
+++ b/change/@fluentui-react-native-tester-db65fa64-4f6e-4d49-88b5-93df813dc504.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Use iOS 16.0 simulator",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "adgleitm@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Use Xcode 14.0.1 in our ADO CI loops.

This is the new default version of Xcode as well as the latest version available on the App Store at the time of writing.
