### PR TITLE
Modifier key fix

### DIFF
--- a/change/@fluentui-react-native-interactive-hooks-49b39837-d70e-409c-8e83-ce21bd68fcbf.json
+++ b/change/@fluentui-react-native-interactive-hooks-49b39837-d70e-409c-8e83-ce21bd68fcbf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added check for modifier key",
+  "packageName": "@fluentui-react-native/interactive-hooks",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/utils/interactive-hooks/src/isModifierKey.ts
+++ b/packages/utils/interactive-hooks/src/isModifierKey.ts
@@ -1,0 +1,18 @@
+/**
+ * Verifies if nativeEvent contains modifier key.
+ * @param nativeEvent
+ * @returns `true` if one or more of modifier keys are `true`
+ */
+export const isModifierKey = (nativeEvent: any): boolean => {
+  return (
+    nativeEvent &&
+    (nativeEvent.alt ||
+      nativeEvent.altKey ||
+      nativeEvent.ctrl ||
+      nativeEvent.ctrlKey ||
+      nativeEvent.meta ||
+      nativeEvent.metaKey ||
+      nativeEvent.shift ||
+      nativeEvent.shiftKey)
+  );
+};

--- a/packages/utils/interactive-hooks/src/useKeyProps.macos.ts
+++ b/packages/utils/interactive-hooks/src/useKeyProps.macos.ts
@@ -1,6 +1,7 @@
 import { KeyCallback, KeyPressProps } from './useKeyProps';
 import { KeyPressEvent } from './Pressability/CoreEventTypes';
 import { memoize } from '@fluentui-react-native/memo-cache';
+import { isModifierKey } from './isModifierKey';
 import * as React from 'react';
 
 /**
@@ -26,7 +27,7 @@ export function useKeyCallback(userCallback?: KeyCallback, ...keys: string[]) {
 
 function getKeyCallbackWorker(userCallback?: KeyCallback, ...keys: string[]) {
   const onKeyEvent = (args: KeyPressEvent) => {
-    if (userCallback !== undefined && (keys === undefined || keys.includes(args.nativeEvent.key))) {
+    if (userCallback !== undefined && !isModifierKey(args.nativeEvent) && (keys === undefined || keys.includes(args.nativeEvent.key))) {
       userCallback(args);
       args.stopPropagation();
     }

--- a/packages/utils/interactive-hooks/src/useKeyProps.win32.ts
+++ b/packages/utils/interactive-hooks/src/useKeyProps.win32.ts
@@ -26,7 +26,7 @@ export function useKeyCallback(userCallback?: KeyCallback, ...keys: string[]) {
 
 export function getKeyCallbackWorker(userCallback?: KeyCallback, ...keys: string[]) {
   const onKeyEvent = (args: KeyPressEvent) => {
-    if (userCallback !== undefined && (keys === undefined || keys.includes(args.nativeEvent.key))) {
+    if (userCallback !== undefined && !isModifierKey(args.nativeEvent) && (keys === undefined || keys.includes(args.nativeEvent.key))) {
       userCallback(args);
       args.stopPropagation();
     }
@@ -80,3 +80,22 @@ export const useKeyProps = memoize(getKeyUpPropsWorker);
 
 /** Exposes the behavior of useKeyProps for the current platform as a boolean */
 export const preferKeyDownForKeyEvents = false;
+
+/**
+ * Verifies if nativeEvent contains modifier key.
+ * @param nativeEvent
+ * @returns `true` if one or more of modifier keys are `true`
+ */
+export const isModifierKey = (nativeEvent: any): boolean => {
+  return (
+    nativeEvent &&
+    (nativeEvent.alt ||
+      nativeEvent.altKey ||
+      nativeEvent.ctrl ||
+      nativeEvent.ctrlKey ||
+      nativeEvent.meta ||
+      nativeEvent.metaKey ||
+      nativeEvent.shift ||
+      nativeEvent.shiftKey)
+  );
+};

--- a/packages/utils/interactive-hooks/src/useKeyProps.win32.ts
+++ b/packages/utils/interactive-hooks/src/useKeyProps.win32.ts
@@ -1,6 +1,7 @@
 import { KeyCallback, KeyPressProps } from './useKeyProps';
 import { KeyPressEvent } from './Pressability/CoreEventTypes';
 import { memoize } from '@fluentui-react-native/memo-cache';
+import { isModifierKey } from './isModifierKey';
 import * as React from 'react';
 
 /**
@@ -80,22 +81,3 @@ export const useKeyProps = memoize(getKeyUpPropsWorker);
 
 /** Exposes the behavior of useKeyProps for the current platform as a boolean */
 export const preferKeyDownForKeyEvents = false;
-
-/**
- * Verifies if nativeEvent contains modifier key.
- * @param nativeEvent
- * @returns `true` if one or more of modifier keys are `true`
- */
-export const isModifierKey = (nativeEvent: any): boolean => {
-  return (
-    nativeEvent &&
-    (nativeEvent.alt ||
-      nativeEvent.altKey ||
-      nativeEvent.ctrl ||
-      nativeEvent.ctrlKey ||
-      nativeEvent.meta ||
-      nativeEvent.metaKey ||
-      nativeEvent.shift ||
-      nativeEvent.shiftKey)
-  );
-};

--- a/packages/utils/interactive-hooks/src/useKeyProps.windows.ts
+++ b/packages/utils/interactive-hooks/src/useKeyProps.windows.ts
@@ -26,7 +26,7 @@ export function useKeyCallback(userCallback?: KeyCallback, ...keys: string[]) {
 
 export function getKeyCallbackWorker(userCallback?: KeyCallback, ...keys: string[]) {
   const onKeyEvent = (args: KeyPressEvent) => {
-    if (userCallback !== undefined && (keys === undefined || keys.includes(args.nativeEvent.key))) {
+    if (userCallback !== undefined && !isModifierKey(args.nativeEvent) && (keys === undefined || keys.includes(args.nativeEvent.key))) {
       userCallback(args);
       args.stopPropagation();
     }
@@ -72,3 +72,22 @@ export const useKeyProps = memoize(getKeyUpPropsWorker);
 
 /** Exposes the behavior of useKeyProps for the current platform as a boolean */
 export const preferKeyDownForKeyEvents = false;
+
+/**
+ * Verifies if nativeEvent contains modifier key.
+ * @param nativeEvent
+ * @returns `true` if one or more of modifier keys are `true`
+ */
+export const isModifierKey = (nativeEvent: any): boolean => {
+  return (
+    nativeEvent &&
+    (nativeEvent.alt ||
+      nativeEvent.altKey ||
+      nativeEvent.ctrl ||
+      nativeEvent.ctrlKey ||
+      nativeEvent.meta ||
+      nativeEvent.metaKey ||
+      nativeEvent.shift ||
+      nativeEvent.shiftKey)
+  );
+};

--- a/packages/utils/interactive-hooks/src/useKeyProps.windows.ts
+++ b/packages/utils/interactive-hooks/src/useKeyProps.windows.ts
@@ -2,6 +2,7 @@ import { KeyCallback, KeyPressProps } from './useKeyProps';
 import { KeyPressEvent } from './Pressability/CoreEventTypes';
 import { memoize } from '@fluentui-react-native/memo-cache';
 import * as React from 'react';
+import { isModifierKey } from './isModifierKey';
 
 /**
  * Re-usable hook for an onKeyDown event.
@@ -72,22 +73,3 @@ export const useKeyProps = memoize(getKeyUpPropsWorker);
 
 /** Exposes the behavior of useKeyProps for the current platform as a boolean */
 export const preferKeyDownForKeyEvents = false;
-
-/**
- * Verifies if nativeEvent contains modifier key.
- * @param nativeEvent
- * @returns `true` if one or more of modifier keys are `true`
- */
-export const isModifierKey = (nativeEvent: any): boolean => {
-  return (
-    nativeEvent &&
-    (nativeEvent.alt ||
-      nativeEvent.altKey ||
-      nativeEvent.ctrl ||
-      nativeEvent.ctrlKey ||
-      nativeEvent.meta ||
-      nativeEvent.metaKey ||
-      nativeEvent.shift ||
-      nativeEvent.shiftKey)
-  );
-};


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [X] windows
- [ ] android

### Description of changes
There's bug with modifier keys in interactive-hooks package in useKeyProps.ts.
User can start/stop Narrator by pressing Ctrl + Windows + Enter.
If the focus is on FURN Button when user pressing those keys, the Button control will be unexpectedly invoked.
OnClick event would be invoked by pressing on any modifier key.

### Verification
Checked manually.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
