### PR TITLE
Fixed Keyboard Tabbing Over Disabled RadioGroup and Radio

### DIFF
--- a/change/@fluentui-react-native-experimental-radio-group-74b06f94-939d-4410-b125-504a977fdf73.json
+++ b/change/@fluentui-react-native-experimental-radio-group-74b06f94-939d-4410-b125-504a977fdf73.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "added check that default value is not set if disabled",
+  "packageName": "@fluentui-react-native/experimental-radio-group",
+  "email": "gulnazsayed@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/RadioGroup/src/Radio/useRadio.ts
+++ b/packages/experimental/RadioGroup/src/Radio/useRadio.ts
@@ -30,11 +30,14 @@ export const useRadio = (props: RadioProps): RadioInfo => {
     ...rest
   } = props;
 
+  const mergeDisabled = radioGroupContext.disabled || disabled;
+
   const buttonRef = useViewCommandFocus(componentRef);
 
   /* We don't want to call the user's onChange multiple times on the same selection. */
   const changeSelection = React.useCallback(() => {
     if (value !== radioGroupContext.value) {
+      // && !mergeDisabled
       radioGroupContext.onChange && radioGroupContext.onChange(value);
       radioGroupContext.updateSelectedButtonRef && componentRef && radioGroupContext.updateSelectedButtonRef(componentRef);
     }
@@ -44,7 +47,7 @@ export const useRadio = (props: RadioProps): RadioInfo => {
     element in a RadioGroup. Since the componentRef isn't generated until after initial render,
     we must update it once here. */
   React.useEffect(() => {
-    if (value === radioGroupContext.value) {
+    if (value === radioGroupContext.value && !mergeDisabled) {
       radioGroupContext.updateSelectedButtonRef && componentRef && radioGroupContext.updateSelectedButtonRef(componentRef);
     }
   }, []);
@@ -78,8 +81,8 @@ export const useRadio = (props: RadioProps): RadioInfo => {
 
   const state = {
     ...pressable.state,
-    selected: radioGroupContext.value === props.value,
-    disabled: radioGroupContext.disabled || disabled || false,
+    selected: radioGroupContext.value === props.value && !mergeDisabled,
+    disabled: mergeDisabled || false,
     labelPositionBelow: labelPosition === 'below',
   };
 

--- a/packages/experimental/RadioGroup/src/Radio/useRadio.ts
+++ b/packages/experimental/RadioGroup/src/Radio/useRadio.ts
@@ -30,7 +30,7 @@ export const useRadio = (props: RadioProps): RadioInfo => {
     ...rest
   } = props;
 
-  const mergeDisabled = radioGroupContext.disabled || disabled;
+  const isDisabled = radioGroupContext.disabled || disabled;
 
   const buttonRef = useViewCommandFocus(componentRef);
 
@@ -46,7 +46,7 @@ export const useRadio = (props: RadioProps): RadioInfo => {
     element in a RadioGroup. Since the componentRef isn't generated until after initial render,
     we must update it once here. */
   React.useEffect(() => {
-    if (value === radioGroupContext.value && !mergeDisabled) {
+    if (value === radioGroupContext.value && !isDisabled) {
       radioGroupContext.updateSelectedButtonRef && componentRef && radioGroupContext.updateSelectedButtonRef(componentRef);
     }
   }, []);
@@ -80,8 +80,8 @@ export const useRadio = (props: RadioProps): RadioInfo => {
 
   const state = {
     ...pressable.state,
-    selected: radioGroupContext.value === props.value && !mergeDisabled,
-    disabled: mergeDisabled || false,
+    selected: radioGroupContext.value === props.value && !isDisabled,
+    disabled: isDisabled || false,
     labelPositionBelow: labelPosition === 'below',
   };
 

--- a/packages/experimental/RadioGroup/src/Radio/useRadio.ts
+++ b/packages/experimental/RadioGroup/src/Radio/useRadio.ts
@@ -37,7 +37,6 @@ export const useRadio = (props: RadioProps): RadioInfo => {
   /* We don't want to call the user's onChange multiple times on the same selection. */
   const changeSelection = React.useCallback(() => {
     if (value !== radioGroupContext.value) {
-      // && !mergeDisabled
       radioGroupContext.onChange && radioGroupContext.onChange(value);
       radioGroupContext.updateSelectedButtonRef && componentRef && radioGroupContext.updateSelectedButtonRef(componentRef);
     }

--- a/packages/experimental/RadioGroup/src/RadioGroup/RadioGroup.types.ts
+++ b/packages/experimental/RadioGroup/src/RadioGroup/RadioGroup.types.ts
@@ -63,7 +63,9 @@ export interface RadioGroupProps extends Pick<FocusZoneProps, 'isCircularNavigat
   label?: string;
 
   /**
-   * The key of the RadioButton that will initially be selected
+   * The key of the RadioButton that will initially be selected.
+   *
+   * This is mutually-exclusive if radiogroup is disabled or radio button is disabled.
    */
   defaultValue?: string;
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Fixed bug related to tabbing over disabled RadioGroup or Radio. The issue was that selection was being set on a disabled Radio so, on tab, focus was trying to set on a disabled Radio which is mutually exclusive. 

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
