### PR TITLE
Add E2E Tests for Experimental Link

### DIFF
--- a/apps/fluent-tester/src/E2E/LinkExperimental/pages/LinkPageObject.ts
+++ b/apps/fluent-tester/src/E2E/LinkExperimental/pages/LinkPageObject.ts
@@ -1,30 +1,65 @@
 import {
+  EXPERIMENTAL_LINK_CALLBACK_TEXT,
+  EXPERIMENTAL_LINK_CALLBACK_VALUE,
+  EXPERIMENTAL_LINK_DISABLED_COMPONENT,
+  EXPERIMENTAL_LINK_NO_A11Y_LABEL_COMPONENT,
+  EXPERIMENTAL_LINK_RESET_BUTTON,
   EXPERIMENTAL_LINK_TESTPAGE,
   EXPERIMENTAL_LINK_TEST_COMPONENT,
   HOMEPAGE_EXPERIMENTAL_LINK_BUTTON,
-  EXPERIMENTAL_LINK_NO_A11Y_LABEL_COMPONENT,
 } from '../../../TestComponents/LinkExperimental/consts';
-import { BasePage, By, ComponentSelector } from '../../common/BasePage';
-import { Attribute, Keys } from '../../common/consts';
+import { BasePage, By } from '../../common/BasePage';
+import { Keys } from '../../common/consts';
 
+export const enum ExperimentalLinkSelector {
+  First = 0,
+  Second,
+  Third,
+}
 class ExperimentalLinkPageObject extends BasePage {
-  async click(selector: ComponentSelector) {
+  async click(selector: ExperimentalLinkSelector) {
     await (await this.getComponent(selector)).click();
   }
 
-  async sendKeys(selector: ComponentSelector, keys: Keys[]) {
+  async sendKeys(selector: ExperimentalLinkSelector, keys: Keys[]) {
     await (await this.getComponent(selector)).addValue(keys);
   }
 
-  async getHelpText(selector: ComponentSelector) {
-    return await this.getElementAttribute(await this.getComponent(selector), Attribute.HelpText);
+  async getComponent(selector: ExperimentalLinkSelector) {
+    switch (selector) {
+      case ExperimentalLinkSelector.First:
+        return await this._primaryComponent;
+      case ExperimentalLinkSelector.Second:
+        return await this._secondaryComponent;
+      case ExperimentalLinkSelector.Third:
+        return await this._tertiaryComponent;
+    }
   }
 
-  private async getComponent(selector: ComponentSelector) {
-    if (selector === ComponentSelector.Primary) {
-      return await this._primaryComponent;
-    }
-    return await this._secondaryComponent;
+  async callbackDidFire() {
+    await browser.waitUntil(
+      async () => {
+        return (await (await this._callbackText).getText()) === EXPERIMENTAL_LINK_CALLBACK_VALUE;
+      },
+      {
+        timeout: this.waitForUiEvent,
+        timeoutMsg: 'Experimental link callback did not fire.',
+      },
+    );
+    return (await (await this._callbackText).getText()) === EXPERIMENTAL_LINK_CALLBACK_VALUE;
+  }
+
+  async resetCallback() {
+    await (await this._resetButton).click();
+    await browser.waitUntil(
+      async () => {
+        return (await (await this._callbackText).getText()) === '';
+      },
+      {
+        timeout: this.waitForUiEvent,
+        timeoutMsg: 'Experimental link callback did not reset.',
+      },
+    );
   }
 
   /*****************************************/
@@ -44,6 +79,18 @@ class ExperimentalLinkPageObject extends BasePage {
 
   get _secondaryComponent() {
     return By(EXPERIMENTAL_LINK_NO_A11Y_LABEL_COMPONENT);
+  }
+
+  get _tertiaryComponent() {
+    return By(EXPERIMENTAL_LINK_DISABLED_COMPONENT);
+  }
+
+  get _resetButton() {
+    return By(EXPERIMENTAL_LINK_RESET_BUTTON);
+  }
+
+  get _callbackText() {
+    return By(EXPERIMENTAL_LINK_CALLBACK_TEXT);
   }
 
   get _pageButton() {

--- a/apps/fluent-tester/src/E2E/LinkExperimental/pages/LinkPageObject.ts
+++ b/apps/fluent-tester/src/E2E/LinkExperimental/pages/LinkPageObject.ts
@@ -4,9 +4,29 @@ import {
   HOMEPAGE_EXPERIMENTAL_LINK_BUTTON,
   EXPERIMENTAL_LINK_NO_A11Y_LABEL_COMPONENT,
 } from '../../../TestComponents/LinkExperimental/consts';
-import { BasePage, By } from '../../common/BasePage';
+import { BasePage, By, ComponentSelector } from '../../common/BasePage';
+import { Attribute, Keys } from '../../common/consts';
 
 class ExperimentalLinkPageObject extends BasePage {
+  async click(selector: ComponentSelector) {
+    await (await this.getComponent(selector)).click();
+  }
+
+  async sendKeys(selector: ComponentSelector, keys: Keys[]) {
+    await (await this.getComponent(selector)).addValue(keys);
+  }
+
+  async getHelpText(selector: ComponentSelector) {
+    return await this.getElementAttribute(await this.getComponent(selector), Attribute.HelpText);
+  }
+
+  private async getComponent(selector: ComponentSelector) {
+    if (selector === ComponentSelector.Primary) {
+      return await this._primaryComponent;
+    }
+    return await this._secondaryComponent;
+  }
+
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/

--- a/apps/fluent-tester/src/E2E/LinkExperimental/specs/Link.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/LinkExperimental/specs/Link.spec.win.ts
@@ -1,8 +1,7 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
-import ExperimentalLinkPageObject from '../pages/LinkPageObject';
-import { ComponentSelector } from '../../common/BasePage';
+import ExperimentalLinkPageObject, { ExperimentalLinkSelector } from '../pages/LinkPageObject';
 import { EXPERIMENTAL_LINK_ACCESSIBILITY_LABEL, EXPERIMENTAL_LINK_URL } from '../../../TestComponents/LinkExperimental/consts';
-import { LINK_A11Y_ROLE, PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
+import { LINK_A11Y_ROLE, PAGE_TIMEOUT, BOOT_APP_TIMEOUT, Attribute, Keys, AttributeValue } from '../../common/consts';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Link Testing Initialization', function () {
@@ -33,17 +32,47 @@ describe('Link Accessibility Testing', () => {
   });
 
   it('Link - Set accessibilityLabel', async () => {
-    await expect(await ExperimentalLinkPageObject.getAccessibilityLabel(ComponentSelector.Primary)).toEqual(
-      EXPERIMENTAL_LINK_ACCESSIBILITY_LABEL,
-    );
+    await expect(
+      await ExperimentalLinkPageObject.getElementAttribute(
+        await ExperimentalLinkPageObject.getComponent(ExperimentalLinkSelector.First),
+        Attribute.AccessibilityLabel,
+      ),
+    ).toEqual(EXPERIMENTAL_LINK_ACCESSIBILITY_LABEL);
     await expect(await ExperimentalLinkPageObject.didAssertPopup()).toBeFalsy(ExperimentalLinkPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
   });
 
   it('Link - Set help text', async () => {
     // This help text gets used in the hyperlink popup when hovered
-    await expect(await ExperimentalLinkPageObject.getHelpText(ComponentSelector.Primary)).toEqual(EXPERIMENTAL_LINK_URL);
+    await expect(
+      await ExperimentalLinkPageObject.getElementAttribute(
+        await ExperimentalLinkPageObject.getComponent(ExperimentalLinkSelector.First),
+        Attribute.HelpText,
+      ),
+    ).toEqual(EXPERIMENTAL_LINK_URL);
     // Links that don't go anywhere shouldn't have an alert
-    await expect(await ExperimentalLinkPageObject.getHelpText(ComponentSelector.Secondary)).toBeFalsy();
+    await expect(
+      await ExperimentalLinkPageObject.getElementAttribute(
+        await ExperimentalLinkPageObject.getComponent(ExperimentalLinkSelector.Second),
+        Attribute.HelpText,
+      ),
+    ).toBeFalsy();
+
+    await expect(await ExperimentalLinkPageObject.didAssertPopup()).toBeFalsy(ExperimentalLinkPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+  });
+
+  it('Link - Disabled link sets isEnabled and isFocusable as false', async () => {
+    await expect(
+      await ExperimentalLinkPageObject.getElementAttribute(
+        await ExperimentalLinkPageObject.getComponent(ExperimentalLinkSelector.Third),
+        Attribute.IsEnabled,
+      ),
+    ).toEqual(AttributeValue.false);
+    await expect(
+      await ExperimentalLinkPageObject.getElementAttribute(
+        await ExperimentalLinkPageObject.getComponent(ExperimentalLinkSelector.Third),
+        Attribute.IsKeyboardFocusable,
+      ),
+    ).toEqual(AttributeValue.false);
 
     await expect(await ExperimentalLinkPageObject.didAssertPopup()).toBeFalsy(ExperimentalLinkPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
   });
@@ -52,26 +81,32 @@ describe('Link Accessibility Testing', () => {
   // on a Text component which we have testing for in our Text component spec
 });
 
-// describe('Link Functionality Testing', () => {
-//   beforeEach(async () => {
-//     await ExperimentalLinkPageObject.scrollToTestElement();
-//     await ExperimentalLinkPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
-//   });
+describe('Link Functionality Testing', () => {
+  beforeEach(async () => {
+    await ExperimentalLinkPageObject.scrollToTestElement();
+    await ExperimentalLinkPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
+    await ExperimentalLinkPageObject.resetCallback();
+  });
 
-//   // Question: How can we test whether a browser opens up
-//   it('Link - Clicking pops alert', async () => {
-//     await ExperimentalLinkPageObject.saveTesterWindowHandle();
-//     await ExperimentalLinkPageObject.click(ComponentSelector.Secondary);
-//     await expect(await ExperimentalLinkPageObject.verifyAndCloseLinkAlert()).toBeTruthy();
+  // Question: How can we test whether a browser opens up
+  it('Link - Click; onPress callback fires.', async () => {
+    await ExperimentalLinkPageObject.click(ExperimentalLinkSelector.Second);
+    await expect(await ExperimentalLinkPageObject.callbackDidFire()).toBeTruthy();
 
-//     // await expect(await ExperimentalLinkPageObject.didAssertPopup()).toBeFalsy(ExperimentalLinkPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
-//   });
+    await expect(await ExperimentalLinkPageObject.didAssertPopup()).toBeFalsy(ExperimentalLinkPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+  });
 
-//   it('Link - Keyboard pops alert', async () => {
-//     await ExperimentalLinkPageObject.saveTesterWindowHandle();
-//     await ExperimentalLinkPageObject.sendKeys(ComponentSelector.Secondary, [Keys.ENTER]);
-//     await expect(await ExperimentalLinkPageObject.verifyAndCloseLinkAlert()).toBeTruthy();
+  it('Link - Press enter; onPress callback fires.', async () => {
+    await ExperimentalLinkPageObject.sendKeys(ExperimentalLinkSelector.Second, [Keys.ENTER]);
+    await expect(await ExperimentalLinkPageObject.callbackDidFire()).toBeTruthy();
 
-//     // await expect(await ExperimentalLinkPageObject.didAssertPopup()).toBeFalsy(ExperimentalLinkPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
-//   });
-// });
+    await expect(await ExperimentalLinkPageObject.didAssertPopup()).toBeFalsy(ExperimentalLinkPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+  });
+
+  it('Link - Press space; onPress callback fires.', async () => {
+    await ExperimentalLinkPageObject.sendKeys(ExperimentalLinkSelector.Second, [Keys.SPACE]);
+    await expect(await ExperimentalLinkPageObject.callbackDidFire()).toBeTruthy();
+
+    await expect(await ExperimentalLinkPageObject.didAssertPopup()).toBeFalsy(ExperimentalLinkPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+  });
+});

--- a/apps/fluent-tester/src/E2E/LinkExperimental/specs/Link.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/LinkExperimental/specs/Link.spec.win.ts
@@ -1,7 +1,7 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import ExperimentalLinkPageObject, { ExperimentalLinkSelector } from '../pages/LinkPageObject';
-import { EXPERIMENTAL_LINK_ACCESSIBILITY_LABEL, EXPERIMENTAL_LINK_URL } from '../../../TestComponents/LinkExperimental/consts';
-import { LINK_A11Y_ROLE, PAGE_TIMEOUT, BOOT_APP_TIMEOUT, Attribute, Keys, AttributeValue } from '../../common/consts';
+import { EXPERIMENTAL_LINK_ACCESSIBILITY_LABEL } from '../../../TestComponents/LinkExperimental/consts';
+import { LINK_A11Y_ROLE, PAGE_TIMEOUT, BOOT_APP_TIMEOUT, Attribute, Keys } from '../../common/consts';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Link Testing Initialization', function () {
@@ -38,42 +38,6 @@ describe('Link Accessibility Testing', () => {
         Attribute.AccessibilityLabel,
       ),
     ).toEqual(EXPERIMENTAL_LINK_ACCESSIBILITY_LABEL);
-    await expect(await ExperimentalLinkPageObject.didAssertPopup()).toBeFalsy(ExperimentalLinkPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
-  });
-
-  it('Link - Set help text', async () => {
-    // This help text gets used in the hyperlink popup when hovered
-    await expect(
-      await ExperimentalLinkPageObject.getElementAttribute(
-        await ExperimentalLinkPageObject.getComponent(ExperimentalLinkSelector.First),
-        Attribute.HelpText,
-      ),
-    ).toEqual(EXPERIMENTAL_LINK_URL);
-    // Links that don't go anywhere shouldn't have an alert
-    await expect(
-      await ExperimentalLinkPageObject.getElementAttribute(
-        await ExperimentalLinkPageObject.getComponent(ExperimentalLinkSelector.Second),
-        Attribute.HelpText,
-      ),
-    ).toBeFalsy();
-
-    await expect(await ExperimentalLinkPageObject.didAssertPopup()).toBeFalsy(ExperimentalLinkPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
-  });
-
-  it('Link - Disabled link sets isEnabled and isFocusable as false', async () => {
-    await expect(
-      await ExperimentalLinkPageObject.getElementAttribute(
-        await ExperimentalLinkPageObject.getComponent(ExperimentalLinkSelector.Third),
-        Attribute.IsEnabled,
-      ),
-    ).toEqual(AttributeValue.false);
-    await expect(
-      await ExperimentalLinkPageObject.getElementAttribute(
-        await ExperimentalLinkPageObject.getComponent(ExperimentalLinkSelector.Third),
-        Attribute.IsKeyboardFocusable,
-      ),
-    ).toEqual(AttributeValue.false);
-
     await expect(await ExperimentalLinkPageObject.didAssertPopup()).toBeFalsy(ExperimentalLinkPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
   });
 

--- a/apps/fluent-tester/src/E2E/LinkExperimental/specs/Link.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/LinkExperimental/specs/Link.spec.win.ts
@@ -1,7 +1,7 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import ExperimentalLinkPageObject from '../pages/LinkPageObject';
 import { ComponentSelector } from '../../common/BasePage';
-import { EXPERIMENTAL_LINK_ACCESSIBILITY_LABEL } from '../../../TestComponents/LinkExperimental/consts';
+import { EXPERIMENTAL_LINK_ACCESSIBILITY_LABEL, EXPERIMENTAL_LINK_URL } from '../../../TestComponents/LinkExperimental/consts';
 import { LINK_A11Y_ROLE, PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
 
 // Before testing begins, allow up to 60 seconds for app to open
@@ -22,24 +22,56 @@ describe('Link Testing Initialization', function () {
 });
 
 describe('Link Accessibility Testing', () => {
-  it('Link - Validate accessibilityRole is correct', async () => {
+  beforeEach(async () => {
     await ExperimentalLinkPageObject.scrollToTestElement();
     await ExperimentalLinkPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
+  });
 
+  it('Link - Validate accessibilityRole is correct', async () => {
     await expect(await ExperimentalLinkPageObject.getAccessibilityRole()).toEqual(LINK_A11Y_ROLE);
     await expect(await ExperimentalLinkPageObject.didAssertPopup()).toBeFalsy(ExperimentalLinkPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
   });
 
   it('Link - Set accessibilityLabel', async () => {
-    await ExperimentalLinkPageObject.scrollToTestElement();
-    await ExperimentalLinkPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
-
     await expect(await ExperimentalLinkPageObject.getAccessibilityLabel(ComponentSelector.Primary)).toEqual(
       EXPERIMENTAL_LINK_ACCESSIBILITY_LABEL,
     );
     await expect(await ExperimentalLinkPageObject.didAssertPopup()).toBeFalsy(ExperimentalLinkPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
   });
 
+  it('Link - Set help text', async () => {
+    // This help text gets used in the hyperlink popup when hovered
+    await expect(await ExperimentalLinkPageObject.getHelpText(ComponentSelector.Primary)).toEqual(EXPERIMENTAL_LINK_URL);
+    // Links that don't go anywhere shouldn't have an alert
+    await expect(await ExperimentalLinkPageObject.getHelpText(ComponentSelector.Secondary)).toBeFalsy();
+
+    await expect(await ExperimentalLinkPageObject.didAssertPopup()).toBeFalsy(ExperimentalLinkPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+  });
+
   // No need to test not setting a11y label. The content prop gets passed down to the child Text component. This equates to not setting the a11y label
   // on a Text component which we have testing for in our Text component spec
 });
+
+// describe('Link Functionality Testing', () => {
+//   beforeEach(async () => {
+//     await ExperimentalLinkPageObject.scrollToTestElement();
+//     await ExperimentalLinkPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
+//   });
+
+//   // Question: How can we test whether a browser opens up
+//   it('Link - Clicking pops alert', async () => {
+//     await ExperimentalLinkPageObject.saveTesterWindowHandle();
+//     await ExperimentalLinkPageObject.click(ComponentSelector.Secondary);
+//     await expect(await ExperimentalLinkPageObject.verifyAndCloseLinkAlert()).toBeTruthy();
+
+//     // await expect(await ExperimentalLinkPageObject.didAssertPopup()).toBeFalsy(ExperimentalLinkPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+//   });
+
+//   it('Link - Keyboard pops alert', async () => {
+//     await ExperimentalLinkPageObject.saveTesterWindowHandle();
+//     await ExperimentalLinkPageObject.sendKeys(ComponentSelector.Secondary, [Keys.ENTER]);
+//     await expect(await ExperimentalLinkPageObject.verifyAndCloseLinkAlert()).toBeTruthy();
+
+//     // await expect(await ExperimentalLinkPageObject.didAssertPopup()).toBeFalsy(ExperimentalLinkPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+//   });
+// });

--- a/apps/fluent-tester/src/E2E/common/consts.ts
+++ b/apps/fluent-tester/src/E2E/common/consts.ts
@@ -22,6 +22,7 @@ export const enum Attribute {
   AccessibilityLabel = 'Name',
   AccessibilityRole = 'ControlType',
   ExpandCollapseState = 'ExpandCollapse.ExpandCollapseState',
+  HelpText = 'HelpText',
   IsEnabled = 'IsEnabled',
   IsFocused = 'HasKeyboardFocus',
   IsRequiredForForm = 'IsRequiredForForm',

--- a/apps/fluent-tester/src/E2E/common/consts.ts
+++ b/apps/fluent-tester/src/E2E/common/consts.ts
@@ -25,6 +25,7 @@ export const enum Attribute {
   HelpText = 'HelpText',
   IsEnabled = 'IsEnabled',
   IsFocused = 'HasKeyboardFocus',
+  IsKeyboardFocusable = 'IsKeyboardFocusable',
   IsRequiredForForm = 'IsRequiredForForm',
   IsTogglePatternAvailable = 'IsTogglePatternAvailable',
   ToggleState = 'Toggle.ToggleState',

--- a/apps/fluent-tester/src/TestComponents/LinkExperimental/E2ELinkTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/LinkExperimental/E2ELinkTest.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { Alert } from 'react-native';
 import { Link } from '@fluentui-react-native/experimental-link';
 import { Stack } from '@fluentui-react-native/stack';
+import { Text } from '@fluentui-react-native/text';
+import { Button } from '@fluentui-react-native/experimental-button';
 import { stackStyle } from '../Common/styles';
 import {
   EXPERIMENTAL_LINK_TEST_COMPONENT,
@@ -9,12 +10,14 @@ import {
   EXPERIMENTAL_LINK_NO_A11Y_LABEL_COMPONENT,
   EXPERIMENTAL_LINK_TEST_COMPONENT_LABEL,
   EXPERIMENTAL_LINK_URL,
+  EXPERIMENTAL_LINK_RESET_BUTTON,
+  EXPERIMENTAL_LINK_CALLBACK_TEXT,
+  EXPERIMENTAL_LINK_CALLBACK_VALUE,
+  EXPERIMENTAL_LINK_DISABLED_COMPONENT,
 } from './consts';
 
 export const LinkE2ETest: React.FunctionComponent = () => {
-  const doPress = (): void => {
-    Alert.alert('Alert.', 'You have been alerted.');
-  };
+  const [text, setText] = React.useState('');
 
   return (
     <Stack style={stackStyle}>
@@ -25,8 +28,15 @@ export const LinkE2ETest: React.FunctionComponent = () => {
       >
         Link with Accessibility Label
       </Link>
-      <Link onPress={doPress} testID={EXPERIMENTAL_LINK_NO_A11Y_LABEL_COMPONENT}>
+      <Link onPress={() => setText(EXPERIMENTAL_LINK_CALLBACK_VALUE)} testID={EXPERIMENTAL_LINK_NO_A11Y_LABEL_COMPONENT}>
         {EXPERIMENTAL_LINK_TEST_COMPONENT_LABEL}
+      </Link>
+      <Text testID={EXPERIMENTAL_LINK_CALLBACK_TEXT}>{text}</Text>
+      <Button testID={EXPERIMENTAL_LINK_RESET_BUTTON} onClick={() => setText('')}>
+        Reset Callback
+      </Button>
+      <Link testID={EXPERIMENTAL_LINK_DISABLED_COMPONENT} disabled>
+        Disabled link
       </Link>
     </Stack>
   );

--- a/apps/fluent-tester/src/TestComponents/LinkExperimental/E2ELinkTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/LinkExperimental/E2ELinkTest.tsx
@@ -8,6 +8,7 @@ import {
   EXPERIMENTAL_LINK_ACCESSIBILITY_LABEL,
   EXPERIMENTAL_LINK_NO_A11Y_LABEL_COMPONENT,
   EXPERIMENTAL_LINK_TEST_COMPONENT_LABEL,
+  EXPERIMENTAL_LINK_URL,
 } from './consts';
 
 export const LinkE2ETest: React.FunctionComponent = () => {
@@ -18,7 +19,7 @@ export const LinkE2ETest: React.FunctionComponent = () => {
   return (
     <Stack style={stackStyle}>
       <Link
-        url="https://www.bing.com/"
+        url={EXPERIMENTAL_LINK_URL}
         testID={EXPERIMENTAL_LINK_TEST_COMPONENT}
         accessibilityLabel={EXPERIMENTAL_LINK_ACCESSIBILITY_LABEL}
       >

--- a/apps/fluent-tester/src/TestComponents/LinkExperimental/consts.ts
+++ b/apps/fluent-tester/src/TestComponents/LinkExperimental/consts.ts
@@ -4,6 +4,7 @@ export const EXPERIMENTAL_LINK_TESTPAGE = 'LinkExperimental_TestPage';
 /* E2E Testing Link 1 */
 export const EXPERIMENTAL_LINK_TEST_COMPONENT = 'Experimental_Link_Test_Component'; // A component on each specific test page
 export const EXPERIMENTAL_LINK_ACCESSIBILITY_LABEL = 'E2E testing Experimental Link accessibility label';
+export const EXPERIMENTAL_LINK_URL = 'https://www.bing.com/';
 
 /* E2E Testing Link 2 */
 export const EXPERIMENTAL_LINK_NO_A11Y_LABEL_COMPONENT = 'Experimental Link_No_A11y_label_Component';

--- a/apps/fluent-tester/src/TestComponents/LinkExperimental/consts.ts
+++ b/apps/fluent-tester/src/TestComponents/LinkExperimental/consts.ts
@@ -7,5 +7,13 @@ export const EXPERIMENTAL_LINK_ACCESSIBILITY_LABEL = 'E2E testing Experimental L
 export const EXPERIMENTAL_LINK_URL = 'https://www.bing.com/';
 
 /* E2E Testing Link 2 */
-export const EXPERIMENTAL_LINK_NO_A11Y_LABEL_COMPONENT = 'Experimental Link_No_A11y_label_Component';
+export const EXPERIMENTAL_LINK_NO_A11Y_LABEL_COMPONENT = 'Experimental_Link_No_A11y_label_Component';
 export const EXPERIMENTAL_LINK_TEST_COMPONENT_LABEL = 'Test Experimental Link2 - No Accessibility Label'; // A component on each specific test page
+
+/* E2E Testing Link 3 */
+export const EXPERIMENTAL_LINK_DISABLED_COMPONENT = 'Experimental_Link_Disabled_Component';
+
+/* E2E Testing Reset Button */
+export const EXPERIMENTAL_LINK_RESET_BUTTON = 'Experimental_Link_Reset_Button';
+export const EXPERIMENTAL_LINK_CALLBACK_TEXT = 'Experimental_Link_Callback_Text';
+export const EXPERIMENTAL_LINK_CALLBACK_VALUE = 'Callback fired.';

--- a/change/@fluentui-react-native-tester-a4ef6d93-181e-4372-9924-6a1875fcaa88.json
+++ b/change/@fluentui-react-native-tester-a4ef6d93-181e-4372-9924-6a1875fcaa88.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add more ExperimentalLink E2E tests",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

The LinkV1 component has some holes within E2E testing. Right now, there is basic A11y testing for accessibilityRole + accessibilityLabel as well as baseline crash/assert testing.

This PR adds basic functional testing:
- Tests onClick callback firing with a mouse click.
- Tests onClick callback firing with focus + enter.
- Tests onClick callback firing with focus + space.

The PR also changes the E2E test component in the tester app to remove the use of asserts within the LinkV1 onClick callback. 

### Verification

This commit passes tests both locally and within the CI.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
