### PR TITLE
MenuV1 (macOS): Update MenuItem tokens

### DIFF
--- a/change/@fluentui-react-native-menu-c1e95f2b-af68-4f1a-8796-bc1caf8a1651.json
+++ b/change/@fluentui-react-native-menu-c1e95f2b-af68-4f1a-8796-bc1caf8a1651.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "MenuV1 (macOS): Update MenuItem tokens",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/MenuItem/MenuItemTokens.macos.ts
+++ b/packages/components/Menu/src/MenuItem/MenuItemTokens.macos.ts
@@ -1,15 +1,13 @@
 import { FontWeightValue, Theme } from '@fluentui-react-native/framework';
 import { globalTokens } from '@fluentui-react-native/theme-tokens';
 import { TokenSettings } from '@fluentui-react-native/use-styling';
-import { PlatformColor } from 'react-native';
-import { ColorWithSystemEffectMacOS } from 'react-native-macos';
 import { MenuItemTokens } from './MenuItem.types';
 
 export const defaultMenuItemTokens: TokenSettings<MenuItemTokens, Theme> = (t: Theme): MenuItemTokens => ({
   backgroundColor: t.colors.transparentBackground,
   borderRadius: 5, // hardcoded for now to match ContextualMenu
   checkmarkSize: 16,
-  color: PlatformColor('labelColor'),
+  color: t.colors.menuItemText, // matches ContextualMenu
   fontFamily: t.typography.families.primary,
   fontSize: globalTokens.font.size[300],
   fontWeight: globalTokens.font.weight.regular as FontWeightValue,
@@ -19,15 +17,15 @@ export const defaultMenuItemTokens: TokenSettings<MenuItemTokens, Theme> = (t: T
   submenuIndicatorPadding: globalTokens.spacing.none,
   submenuIndicatorSize: 16,
   focused: {
-    backgroundColor: PlatformColor('controlAccentColor'),
-    color: t.colors.neutralForegroundOnBrandHover,
+    backgroundColor: t.colors.menuItemBackgroundHovered,
+    color: t.colors.menuItemTextHovered,
   },
   pressed: {
-    backgroundColor: ColorWithSystemEffectMacOS(PlatformColor('controlAccentColor'), 'pressed'),
-    color: t.colors.neutralForegroundOnBrandPressed,
+    backgroundColor: t.colors.menuItemBackgroundPressed,
+    color: t.colors.menuItemTextHovered,
   },
   disabled: {
-    backgroundColor: t.colors.transparentBackground,
-    color: t.colors.neutralForegroundDisabled,
+    backgroundColor: t.colors.menuBackground,
+    color: t.colors.disabledText,
   },
 });

--- a/packages/components/Menu/src/MenuItem/MenuItemTokens.macos.ts
+++ b/packages/components/Menu/src/MenuItem/MenuItemTokens.macos.ts
@@ -1,28 +1,30 @@
 import { FontWeightValue, Theme } from '@fluentui-react-native/framework';
 import { globalTokens } from '@fluentui-react-native/theme-tokens';
 import { TokenSettings } from '@fluentui-react-native/use-styling';
+import { PlatformColor } from 'react-native';
+import { ColorWithSystemEffectMacOS } from 'react-native-macos';
 import { MenuItemTokens } from './MenuItem.types';
 
 export const defaultMenuItemTokens: TokenSettings<MenuItemTokens, Theme> = (t: Theme): MenuItemTokens => ({
   backgroundColor: t.colors.transparentBackground,
   borderRadius: 5, // hardcoded for now to match ContextualMenu
   checkmarkSize: 16,
-  submenuIndicatorPadding: globalTokens.spacing.none,
-  submenuIndicatorSize: 16,
-  color: t.colors.neutralForeground2,
+  color: PlatformColor('labelColor'),
   fontFamily: t.typography.families.primary,
   fontSize: globalTokens.font.size[300],
   fontWeight: globalTokens.font.weight.regular as FontWeightValue,
   gap: globalTokens.spacing.xs,
   paddingHorizontal: 5, // hardcoded for now to match ContextualMenu
   paddingVertical: 3, // hardcoded for now to match ContextualMenu
+  submenuIndicatorPadding: globalTokens.spacing.none,
+  submenuIndicatorSize: 16,
   focused: {
-    backgroundColor: t.colors.brandBackground,
-    color: t.colors.brandedContent,
+    backgroundColor: PlatformColor('controlAccentColor'),
+    color: t.colors.neutralForegroundOnBrandHover,
   },
   pressed: {
-    backgroundColor: t.colors.brandBackgroundPressed,
-    color: t.colors.brandedPressedContent,
+    backgroundColor: ColorWithSystemEffectMacOS(PlatformColor('controlAccentColor'), 'pressed'),
+    color: t.colors.neutralForegroundOnBrandPressed,
   },
   disabled: {
     backgroundColor: t.colors.transparentBackground,


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This updates the MenuV1 macOS tokens so that MenuV1 respects the users' control accent color (which can either be set by the app, or overridden by the user in System settings.

The macOS tokens in the apple theme still don't have PlatformColor support... so I just manually set some of the tokens myself. 

### Verification

https://user-images.githubusercontent.com/6722175/198743054-40d5626a-8804-4584-b6d4-b284f4a99f91.mov

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
