### PR TITLE
MenuV1: Update types to PressablePropsExtended

### DIFF
--- a/change/@fluentui-react-native-dropdown-88067f75-18e7-4ccf-af3a-10c69aeddd62.json
+++ b/change/@fluentui-react-native-dropdown-88067f75-18e7-4ccf-af3a-10c69aeddd62.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "MenuV1: Update types to PressablePropsExtended",
+  "packageName": "@fluentui-react-native/dropdown",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-menu-8acb28de-ffc3-4ba2-b8f7-066ec449461f.json
+++ b/change/@fluentui-react-native-menu-8acb28de-ffc3-4ba2-b8f7-066ec449461f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "MenuV1: Update types to PressablePropsExtended",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-switch-5f239592-19ad-47ab-aaad-3c028be798f4.json
+++ b/change/@fluentui-react-native-switch-5f239592-19ad-47ab-aaad-3c028be798f4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "MenuV1: Update types to PressablePropsExtended",
+  "packageName": "@fluentui-react-native/switch",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/SPEC.md
+++ b/packages/components/Menu/SPEC.md
@@ -224,7 +224,7 @@ Creates a divider element in the `MenuList`. This divider is purely visual and d
 #### MenuItem Props
 
 ```ts
-export interface MenuItemProps extends Omit<IWithPressableOptions<ViewProps>, 'onPress'> {
+export interface MenuItemProps extends Omit<PressablePropsExtended, 'onPress'> {
   /**
    * A RefObject to access the IButton interface. Use this to access the public methods and properties of the component.
    */

--- a/packages/components/Menu/src/MenuTrigger/MenuTrigger.types.ts
+++ b/packages/components/Menu/src/MenuTrigger/MenuTrigger.types.ts
@@ -1,9 +1,8 @@
-import { IViewProps } from '@fluentui-react-native/adapters';
-import { InteractionEvent, IWithPressableOptions } from '@fluentui-react-native/interactive-hooks';
+import { InteractionEvent, PressablePropsExtended } from '@fluentui-react-native/interactive-hooks';
 
 export const menuTriggerName = 'MenuTrigger';
 
-export interface MenuTriggerChildProps extends Omit<IWithPressableOptions<IViewProps>, 'onPress'> {
+export interface MenuTriggerChildProps extends Omit<PressablePropsExtended, 'onPress'> {
   /**
    * A RefObject to refer to the trigger component.
    */

--- a/packages/components/Menu/src/MenuTrigger/getRevisedProps.ts
+++ b/packages/components/Menu/src/MenuTrigger/getRevisedProps.ts
@@ -34,21 +34,19 @@ function getRevisedPropsWorker(state: MenuTriggerState, props: any): MenuTrigger
     };
   }
 
-  let onHoverIn = undefined;
   if (props.onHoverIn) {
-    onHoverIn = (e: InteractionEvent) => {
+    revisedProps.onHoverIn = (e: InteractionEvent) => {
       state.props.onHoverIn(isMouseEvent(e) && e);
       props.onHoverIn(e);
     };
   }
 
-  let onHoverOut = undefined;
   if (props.onHoverOut) {
-    onHoverOut = (e: InteractionEvent) => {
+    revisedProps.onHoverOut = (e: InteractionEvent) => {
       state.props.onHoverOut(isMouseEvent(e) && e);
       props.onHoverOut(e);
     };
   }
 
-  return { ...revisedProps, onHoverIn, onHoverOut };
+  return { ...revisedProps };
 }

--- a/packages/experimental/Dropdown/src/Dropdown/Dropdown.tsx
+++ b/packages/experimental/Dropdown/src/Dropdown/Dropdown.tsx
@@ -1,5 +1,4 @@
 /** @jsx withSlots */
-import { IViewProps } from '@fluentui-react-native/adapters';
 import { ButtonV1 as Button, ButtonProps } from '@fluentui-react-native/button';
 import { buildUseTokens, compressible, useSlot, UseTokens, withSlots } from '@fluentui-react-native/framework';
 import React from 'react';
@@ -7,6 +6,7 @@ import { View } from 'react-native';
 import { Path, Svg, SvgProps } from 'react-native-svg';
 import { dropdownName, DropdownProps, DropdownTokens } from './Dropdown.types';
 import { Listbox, ListboxProps } from '../Listbox';
+import { PressablePropsExtended } from '@fluentui-react-native/interactive-hooks';
 
 const Dropdown = compressible<DropdownProps, DropdownTokens>((props: DropdownProps, _useTokens: UseTokens<DropdownTokens>) => {
   const [isOpen, setOpen] = React.useState(false);
@@ -43,7 +43,7 @@ const Dropdown = compressible<DropdownProps, DropdownTokens>((props: DropdownPro
     [defaultRef],
   );
 
-  const RootSlot = useSlot<IViewProps>(View, props);
+  const RootSlot = useSlot<PressablePropsExtended>(View, props);
   const ButtonSlot = useSlot<ButtonProps>(Button, buttonProps);
   const ExpandIconSlot = useSlot<SvgProps>(Svg, expandIconProps);
   const ListboxSlot = useSlot<ListboxProps>(Listbox, listboxProps);

--- a/packages/experimental/Dropdown/src/Dropdown/Dropdown.types.ts
+++ b/packages/experimental/Dropdown/src/Dropdown/Dropdown.types.ts
@@ -1,10 +1,14 @@
-import type { IViewProps } from '@fluentui-react-native/adapters';
-import { IPressableHooks, IWithPressableOptions } from '@fluentui-react-native/interactive-hooks';
+import { PressablePropsExtended, PressableState } from '@fluentui-react-native/interactive-hooks';
 
 export const dropdownName = 'Dropdown';
 
 export interface DropdownTokens {}
 
-export interface DropdownProps extends IWithPressableOptions<IViewProps> {}
+export interface DropdownProps extends PressablePropsExtended {}
 
-export interface DropdownState extends IPressableHooks<DropdownProps & React.ComponentPropsWithRef<any>> {}
+export type DropdownState = PressableState;
+
+export interface DropdownInfo {
+  props: DropdownProps & React.ComponentPropsWithRef<any>;
+  state: DropdownProps;
+}

--- a/packages/experimental/Dropdown/src/Dropdown/useDropdown.ts
+++ b/packages/experimental/Dropdown/src/Dropdown/useDropdown.ts
@@ -1,6 +1,6 @@
-import { DropdownProps, DropdownState } from './Dropdown.types';
+import { DropdownInfo, DropdownProps } from './Dropdown.types';
 
-export const useDropdown = (_props: DropdownProps): DropdownState => {
+export const useDropdown = (_props: DropdownProps): DropdownInfo => {
   return {
     props: {},
     state: {},

--- a/packages/experimental/Dropdown/src/Option/Option.types.ts
+++ b/packages/experimental/Dropdown/src/Option/Option.types.ts
@@ -1,6 +1,6 @@
 import type { IViewProps } from '@fluentui-react-native/adapters';
 import { FontTokens, IBorderTokens, IColorTokens, LayoutTokens } from '@fluentui-react-native/framework';
-import { IFocusable, IPressableHooks, IWithPressableOptions } from '@fluentui-react-native/interactive-hooks';
+import { IFocusable, IPressableHooks, PressablePropsExtended } from '@fluentui-react-native/interactive-hooks';
 import { TextProps } from '@fluentui-react-native/text';
 import { ColorValue } from 'react-native';
 import { SvgProps } from 'react-native-svg';
@@ -32,7 +32,7 @@ export interface OptionTokens extends FontTokens, IBorderTokens, IColorTokens, L
   pressed?: OptionTokens;
 }
 
-export interface OptionProps extends IWithPressableOptions<IViewProps> {
+export interface OptionProps extends PressablePropsExtended {
   /**
    * A RefObject to access the IButton interface. Use this to access the public methods and properties of the component.
    */

--- a/packages/experimental/Switch/SPEC.md
+++ b/packages/experimental/Switch/SPEC.md
@@ -51,7 +51,7 @@ The slots can be modified using the `compose` function on the `Switch`. For more
 Below is the set of props the Switch supports:
 
 ```ts
-export interface SwitchProps extends Omit<IWithPressableOptions<ViewProps>, 'onPress'> {
+export interface SwitchProps extends Omit<PressablePropsExtended 'onPress'> {
   /**
    * Reference to the Switch
    */


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

See https://github.com/microsoft/fluentui-react-native/pull/2254#discussion_r1001055479

Some of the types in our components were not using the new `PressablePropsExtended` type, which led to issues like `onHover(In|Out)` getting defined as readonly. Let's update the type everywhere, then simplify the logic in MenuV1 now that `onHover(In|Out)` isn't readonly.

### Verification

I tested that hover effects still work in the test app. The "MenuTrigger hover override" still turns the chevron blue on hover.

https://user-images.githubusercontent.com/6722175/198748399-c4297417-36de-41f9-b535-489c3add9232.mov


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
