### PR TITLE
Use global spacing tokens instead of those from `Theme`

### DIFF
--- a/change/@fluentui-react-native-notification-4e2bf526-3c88-4619-a8a9-3cf10764f7f4.json
+++ b/change/@fluentui-react-native-notification-4e2bf526-3c88-4619-a8a9-3cf10764f7f4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Use global spacing tokens instead of those from `Theme`",
+  "packageName": "@fluentui-react-native/notification",
+  "email": "adgleitm@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Notification/package.json
+++ b/packages/components/Notification/package.json
@@ -34,6 +34,7 @@
     "@fluentui-react-native/interactive-hooks": ">=0.19.4 <1.0.0",
     "@fluentui-react-native/pressable": ">=0.9.26 <1.0.0",
     "@fluentui-react-native/text": ">=0.15.11 <1.0.0",
+    "@fluentui-react-native/theme-tokens": "0.21.0",
     "@fluentui-react-native/theme-types": ">=0.23.0 <1.0.0",
     "@fluentui-react-native/tokens": ">=0.17.6 <1.0.0",
     "@fluentui-react-native/use-styling": ">=0.9.1 <1.0.0",

--- a/packages/components/Notification/src/NotificationTokens.ios.ts
+++ b/packages/components/Notification/src/NotificationTokens.ios.ts
@@ -1,4 +1,5 @@
 import { Theme } from '@fluentui-react-native/framework';
+import { globalTokens } from '@fluentui-react-native/theme-tokens';
 import { TokenSettings } from '@fluentui-react-native/use-styling';
 import { NotificationTokens } from './Notification.types';
 import { DynamicColorIOS } from 'react-native';
@@ -104,8 +105,8 @@ export const defaultNotificationTokens: TokenSettings<NotificationTokens, Theme>
     fontSize: 15,
     fontWeight: '400',
     minHeight: 52,
-    padding: t.spacing.m,
-    paddingVertical: t.spacing.s,
+    padding: globalTokens.spacing.m,
+    paddingVertical: globalTokens.spacing.s,
     shadowToken: notificationShadowStyle,
     isBar: {
       borderRadius: 0,

--- a/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
+++ b/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`Notification component tests Notification default 1`] = `
         "flexWrap": undefined,
         "justifyContent": "space-between",
         "minHeight": 52,
-        "padding": "16px",
+        "padding": 16,
         "paddingBottom": undefined,
         "paddingEnd": undefined,
         "paddingHorizontal": undefined,
@@ -86,7 +86,7 @@ exports[`Notification component tests Notification default 1`] = `
         "paddingRight": undefined,
         "paddingStart": undefined,
         "paddingTop": undefined,
-        "paddingVertical": undefined,
+        "paddingVertical": 12,
         "shadowColor": "#000000",
         "shadowOffset": Object {
           "height": 0,


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

We now use global tokens to get iOS-specific spacing parameters for Notification as an improvement to #2251. As a nice side effect, this undoes the changes previously made to Notification.test.tsx.snap to gives us more accurate values that we would see in the wild, so yay!

### Verification

Things look the same. Not really much to write home about.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Screen Shot 2022-10-31 at 4 35 19 PM](https://user-images.githubusercontent.com/717674/199129400-d8c18318-84e4-4962-b4a0-7db8e0476925.png) | ![Screen Shot 2022-10-31 at 4 34 55 PM](https://user-images.githubusercontent.com/717674/199129410-ff8614ad-832c-41ef-be5e-79b384780499.png) |
