### PR TITLE
Undo workaround needed for old haul polyfill

### DIFF
--- a/change/@fluentui-react-native-button-6399fee5-cc70-4032-9e1f-c1a2aad9cc6e.json
+++ b/change/@fluentui-react-native-button-6399fee5-cc70-4032-9e1f-c1a2aad9cc6e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Undo workaround needed for old haul polyfill",
+  "packageName": "@fluentui-react-native/button",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-focus-zone-8a6e8646-593a-4ded-82b2-4c81fdcb4709.json
+++ b/change/@fluentui-react-native-focus-zone-8a6e8646-593a-4ded-82b2-4c81fdcb4709.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Undo workaround needed for old haul polyfill",
+  "packageName": "@fluentui-react-native/focus-zone",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-menu-d09117d0-32a3-4ebc-928f-7b81a4840e6a.json
+++ b/change/@fluentui-react-native-menu-d09117d0-32a3-4ebc-928f-7b81a4840e6a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Undo workaround needed for old haul polyfill",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Button/src/useButton.ts
+++ b/packages/components/Button/src/useButton.ts
@@ -22,7 +22,7 @@ export const useButton = (props: ButtonProps): ButtonInfo => {
        * Due to a bug in React Native, unconditionally passing this may cause unnecessary re-renders.
        * Therefore, let's only pass it in if it's defined to limit this issue.
        */
-      ...(isDisabled ? { disabled: isDisabled } : null),
+      ...(isDisabled && { disabled: isDisabled }),
       accessible: true,
       accessibilityRole: 'button',
       onAccessibilityTap: props.onAccessibilityTap || (!hasTogglePattern ? props.onClick : undefined),

--- a/packages/components/FocusZone/src/FocusZone.ts
+++ b/packages/components/FocusZone/src/FocusZone.ts
@@ -29,7 +29,7 @@ export const FocusZone = composable<FocusZoneType>({
       slotProps: mergeSettings<FocusZoneSlotProps>(useStyling(userProps), {
         root: {
           ...rest,
-          ...(Platform.OS === 'macos' ? { forceFocus: forceFocusMacOS } : null),
+          ...(Platform.OS === 'macos' && { forceFocus: forceFocusMacOS }),
           defaultTabbableElement: targetNativeTag,
           ref: ftzRef,
           navigateAtEnd: isCircularNavigation ? 'NavigateWrap' : 'NavigateStopAtEnds',

--- a/packages/components/Menu/src/MenuList/MenuList.tsx
+++ b/packages/components/Menu/src/MenuList/MenuList.tsx
@@ -34,7 +34,7 @@ export const MenuList = compose<MenuListType>({
   ...stylingSettings,
   slots: {
     root: MenuStack,
-    ...(Platform.OS === 'macos' ? { focusZone: FocusZone } : null),
+    ...(Platform.OS === 'macos' && { focusZone: FocusZone }),
   },
   useRender: (userProps: MenuListProps, useSlots: UseSlots<MenuListType>) => {
     const menuList = useMenuList(userProps);


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

With #2274 we needed to workaround a JS feature not available in older haul polyfills. We no longer use that haul polypill downstream, so I can bring them back. 

### Verification

CI should be enough

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
