### PR TITLE
Fix infinite loop in ContextualMenu

### DIFF
--- a/change/@fluentui-react-native-focus-zone-2e5b4851-4168-40f4-a1db-48730ab06dd6.json
+++ b/change/@fluentui-react-native-focus-zone-2e5b4851-4168-40f4-a1db-48730ab06dd6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix infinite loop in ContextualMenu",
+  "packageName": "@fluentui-react-native/focus-zone",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/FocusZone/macos/RCTFocusZone.m
+++ b/packages/components/FocusZone/macos/RCTFocusZone.m
@@ -432,6 +432,12 @@ static RCTFocusZone *GetFocusZoneAncestor(NSView *view)
 		nextViewToFocus = [self previousValidKeyView];
 		while([nextViewToFocus isDescendantOf:focusZoneAncestor])
 		{
+			// there are no views left in the key view loop
+			if ([nextViewToFocus isEqual:focusZoneAncestor])
+			{
+				nextViewToFocus = nil;
+				break;
+			}
 			nextViewToFocus = [nextViewToFocus previousValidKeyView];
 		}
 

--- a/packages/components/FocusZone/macos/RCTFocusZone.m
+++ b/packages/components/FocusZone/macos/RCTFocusZone.m
@@ -492,11 +492,8 @@ static RCTFocusZone *GetFocusZoneAncestor(NSView *view)
 		[[self window] makeFirstResponder:viewToFocus];
 		[viewToFocus scrollRectToVisible:[viewToFocus bounds]];
 	}
-	else if (viewToFocus == nil)
-	{
-		// No view to focus, do nothing
-	}
-	else
+	// Call super only if there are views to focus
+	else if (viewToFocus != nil)
 	{
 		[super keyDown:event];
 	}

--- a/packages/components/FocusZone/macos/RCTFocusZone.m
+++ b/packages/components/FocusZone/macos/RCTFocusZone.m
@@ -418,6 +418,7 @@ static RCTFocusZone *GetFocusZoneAncestor(NSView *view)
 		nextViewToFocus = [self nextValidKeyView];
 		while([nextViewToFocus isDescendantOf:focusZoneAncestor])
 		{
+			// there are no views left in the key view loop
 			if ([nextViewToFocus isEqual:focusZoneAncestor])
 			{
 				nextViewToFocus = nil;
@@ -458,8 +459,7 @@ static RCTFocusZone *GetFocusZoneAncestor(NSView *view)
 
 	BOOL passthrough = NO;
 	NSView *viewToFocus = nil;
-	// A flag for handling no op cases
-	BOOL noOp = NO;
+
 	if ([self disabled] || action == FocusZoneActionNone)
 	{
 		passthrough = YES;
@@ -467,10 +467,6 @@ static RCTFocusZone *GetFocusZoneAncestor(NSView *view)
 	else if (action == FocusZoneActionTab || action == FocusZoneActionShiftTab)
 	{
 		viewToFocus = [self nextViewToFocusOutsideZone:action];
-		if (viewToFocus == nil)
-		{
-			noOp = YES;
-		}
 	}
 	else if ((focusZoneDirection == FocusZoneDirectionVertical
 			&& (action == FocusZoneActionRightArrow || action == FocusZoneActionLeftArrow))
@@ -490,7 +486,7 @@ static RCTFocusZone *GetFocusZoneAncestor(NSView *view)
 		[[self window] makeFirstResponder:viewToFocus];
 		[viewToFocus scrollRectToVisible:[viewToFocus bounds]];
 	}
-	else if (noOp)
+	else if (viewToFocus == nil)
 	{
 		// No view to focus, do nothing
 	}

--- a/packages/components/FocusZone/macos/RCTFocusZone.m
+++ b/packages/components/FocusZone/macos/RCTFocusZone.m
@@ -418,6 +418,11 @@ static RCTFocusZone *GetFocusZoneAncestor(NSView *view)
 		nextViewToFocus = [self nextValidKeyView];
 		while([nextViewToFocus isDescendantOf:focusZoneAncestor])
 		{
+			if ([nextViewToFocus isEqual:focusZoneAncestor])
+			{
+				nextViewToFocus = nil;
+				break;
+			}
 			nextViewToFocus = [nextViewToFocus nextValidKeyView];
 		}
 	}
@@ -453,7 +458,7 @@ static RCTFocusZone *GetFocusZoneAncestor(NSView *view)
 
 	BOOL passthrough = NO;
 	NSView *viewToFocus = nil;
-
+	BOOL noOp = NO;
 	if ([self disabled] || action == FocusZoneActionNone)
 	{
 		passthrough = YES;
@@ -461,6 +466,10 @@ static RCTFocusZone *GetFocusZoneAncestor(NSView *view)
 	else if (action == FocusZoneActionTab || action == FocusZoneActionShiftTab)
 	{
 		viewToFocus = [self nextViewToFocusOutsideZone:action];
+		if (viewToFocus == nil)
+		{
+			noOp = YES;
+		}
 	}
 	else if ((focusZoneDirection == FocusZoneDirectionVertical
 			&& (action == FocusZoneActionRightArrow || action == FocusZoneActionLeftArrow))
@@ -479,6 +488,10 @@ static RCTFocusZone *GetFocusZoneAncestor(NSView *view)
 	{
 		[[self window] makeFirstResponder:viewToFocus];
 		[viewToFocus scrollRectToVisible:[viewToFocus bounds]];
+	}
+	if (noOp == YES)
+	{
+		// No view to focus, do nothing
 	}
 	else
 	{

--- a/packages/components/FocusZone/macos/RCTFocusZone.m
+++ b/packages/components/FocusZone/macos/RCTFocusZone.m
@@ -458,6 +458,7 @@ static RCTFocusZone *GetFocusZoneAncestor(NSView *view)
 
 	BOOL passthrough = NO;
 	NSView *viewToFocus = nil;
+	// A flag for handling no op cases
 	BOOL noOp = NO;
 	if ([self disabled] || action == FocusZoneActionNone)
 	{
@@ -489,7 +490,7 @@ static RCTFocusZone *GetFocusZoneAncestor(NSView *view)
 		[[self window] makeFirstResponder:viewToFocus];
 		[viewToFocus scrollRectToVisible:[viewToFocus bounds]];
 	}
-	if (noOp == YES)
+	else if (noOp)
 	{
 		// No view to focus, do nothing
 	}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This PR fixes a hang on tabbing inside a contextual menu. The hang happens in this while loop: `while([nextViewToFocus isDescendantOf:focusZoneAncestor])` in FocusZone where it tries to get to the next key view that's outside of the current FocusZone view. In the context of ContextualMenu, the while loop tries to search for the next valid key view (outside the menu view) but it becomes infinite due to the fact that `isDescendantOf: self` returns true. The expected outcome for tabbing inside a contextual menu should be no op. Let's catch this edge case for the tab and shift-tab scenarios. 

### Verification

Before:


https://user-images.githubusercontent.com/67026167/200396582-2df8e0e2-85e6-4bb9-b834-062d203078d7.mov

After:

https://user-images.githubusercontent.com/67026167/200396618-94e9e8ab-361a-4a82-acef-7fac7410d363.mov


1. Keyboard navigation works as usual in ContextualMenu
2. Ensured the behavior remains unchanged in the FocusZone test page 

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
