### PR TITLE
chore: address Android build issues

### DIFF
--- a/apps/fluent-tester/android/build.gradle
+++ b/apps/fluent-tester/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
         if (isNewArchitectureEnabled(project)) {
             classpath("com.facebook.react:react-native-gradle-plugin")
-            classpath("de.undercouch:gradle-download-task:5.1.0")
+            classpath("de.undercouch:gradle-download-task:5.3.0")
         }
     }
 }

--- a/apps/fluent-tester/ios/Podfile
+++ b/apps/fluent-tester/ios/Podfile
@@ -18,6 +18,7 @@ if [ -z "${RCT_NO_LAUNCH_PACKAGER+xxx}" ] ; then
   fi
 fi
 }
+
 use_flipper!(false)
 use_test_app! do |target|
   target.app do

--- a/apps/fluent-tester/ios/Podfile.lock
+++ b/apps/fluent-tester/ios/Podfile.lock
@@ -1,19 +1,19 @@
 PODS:
   - boost (1.76.0)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.68.3)
-  - FBReactNativeSpec (0.68.3):
+  - FBLazyVector (0.68.5)
+  - FBReactNativeSpec (0.68.5):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.3)
-    - RCTTypeSafety (= 0.68.3)
-    - React-Core (= 0.68.3)
-    - React-jsi (= 0.68.3)
-    - ReactCommon/turbomodule/core (= 0.68.3)
+    - RCTRequired (= 0.68.5)
+    - RCTTypeSafety (= 0.68.5)
+    - React-Core (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - ReactCommon/turbomodule/core (= 0.68.5)
   - fmt (6.2.1)
-  - FRNAvatar (0.16.12):
+  - FRNAvatar (0.16.20):
     - MicrosoftFluentUI (= 0.8.3)
     - React
-  - FRNDatePicker (0.7.2):
+  - FRNDatePicker (0.7.3):
     - MicrosoftFluentUI (= 0.8.3)
     - React
   - glog (0.3.5)
@@ -186,276 +186,276 @@ PODS:
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
-  - RCTRequired (0.68.3)
-  - RCTTypeSafety (0.68.3):
-    - FBLazyVector (= 0.68.3)
+  - RCTRequired (0.68.5)
+  - RCTTypeSafety (0.68.5):
+    - FBLazyVector (= 0.68.5)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.3)
-    - React-Core (= 0.68.3)
-  - React (0.68.3):
-    - React-Core (= 0.68.3)
-    - React-Core/DevSupport (= 0.68.3)
-    - React-Core/RCTWebSocket (= 0.68.3)
-    - React-RCTActionSheet (= 0.68.3)
-    - React-RCTAnimation (= 0.68.3)
-    - React-RCTBlob (= 0.68.3)
-    - React-RCTImage (= 0.68.3)
-    - React-RCTLinking (= 0.68.3)
-    - React-RCTNetwork (= 0.68.3)
-    - React-RCTSettings (= 0.68.3)
-    - React-RCTText (= 0.68.3)
-    - React-RCTVibration (= 0.68.3)
-  - React-callinvoker (0.68.3)
-  - React-Codegen (0.68.3):
-    - FBReactNativeSpec (= 0.68.3)
+    - RCTRequired (= 0.68.5)
+    - React-Core (= 0.68.5)
+  - React (0.68.5):
+    - React-Core (= 0.68.5)
+    - React-Core/DevSupport (= 0.68.5)
+    - React-Core/RCTWebSocket (= 0.68.5)
+    - React-RCTActionSheet (= 0.68.5)
+    - React-RCTAnimation (= 0.68.5)
+    - React-RCTBlob (= 0.68.5)
+    - React-RCTImage (= 0.68.5)
+    - React-RCTLinking (= 0.68.5)
+    - React-RCTNetwork (= 0.68.5)
+    - React-RCTSettings (= 0.68.5)
+    - React-RCTText (= 0.68.5)
+    - React-RCTVibration (= 0.68.5)
+  - React-callinvoker (0.68.5)
+  - React-Codegen (0.68.5):
+    - FBReactNativeSpec (= 0.68.5)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.3)
-    - RCTTypeSafety (= 0.68.3)
-    - React-Core (= 0.68.3)
-    - React-jsi (= 0.68.3)
-    - React-jsiexecutor (= 0.68.3)
-    - ReactCommon/turbomodule/core (= 0.68.3)
-  - React-Core (0.68.3):
+    - RCTRequired (= 0.68.5)
+    - RCTTypeSafety (= 0.68.5)
+    - React-Core (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-jsiexecutor (= 0.68.5)
+    - ReactCommon/turbomodule/core (= 0.68.5)
+  - React-Core (0.68.5):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.3)
-    - React-cxxreact (= 0.68.3)
-    - React-jsi (= 0.68.3)
-    - React-jsiexecutor (= 0.68.3)
-    - React-perflogger (= 0.68.3)
+    - React-Core/Default (= 0.68.5)
+    - React-cxxreact (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-jsiexecutor (= 0.68.5)
+    - React-perflogger (= 0.68.5)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.68.3):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default
-    - React-cxxreact (= 0.68.3)
-    - React-jsi (= 0.68.3)
-    - React-jsiexecutor (= 0.68.3)
-    - React-perflogger (= 0.68.3)
-    - Yoga
-  - React-Core/Default (0.68.3):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.68.3)
-    - React-jsi (= 0.68.3)
-    - React-jsiexecutor (= 0.68.3)
-    - React-perflogger (= 0.68.3)
-    - Yoga
-  - React-Core/DevSupport (0.68.3):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.3)
-    - React-Core/RCTWebSocket (= 0.68.3)
-    - React-cxxreact (= 0.68.3)
-    - React-jsi (= 0.68.3)
-    - React-jsiexecutor (= 0.68.3)
-    - React-jsinspector (= 0.68.3)
-    - React-perflogger (= 0.68.3)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.68.3):
+  - React-Core/CoreModulesHeaders (0.68.5):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.3)
-    - React-jsi (= 0.68.3)
-    - React-jsiexecutor (= 0.68.3)
-    - React-perflogger (= 0.68.3)
+    - React-cxxreact (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-jsiexecutor (= 0.68.5)
+    - React-perflogger (= 0.68.5)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.68.3):
+  - React-Core/Default (0.68.5):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-cxxreact (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-jsiexecutor (= 0.68.5)
+    - React-perflogger (= 0.68.5)
+    - Yoga
+  - React-Core/DevSupport (0.68.5):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-Core/Default (= 0.68.5)
+    - React-Core/RCTWebSocket (= 0.68.5)
+    - React-cxxreact (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-jsiexecutor (= 0.68.5)
+    - React-jsinspector (= 0.68.5)
+    - React-perflogger (= 0.68.5)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.68.5):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.3)
-    - React-jsi (= 0.68.3)
-    - React-jsiexecutor (= 0.68.3)
-    - React-perflogger (= 0.68.3)
+    - React-cxxreact (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-jsiexecutor (= 0.68.5)
+    - React-perflogger (= 0.68.5)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.68.3):
+  - React-Core/RCTAnimationHeaders (0.68.5):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.3)
-    - React-jsi (= 0.68.3)
-    - React-jsiexecutor (= 0.68.3)
-    - React-perflogger (= 0.68.3)
+    - React-cxxreact (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-jsiexecutor (= 0.68.5)
+    - React-perflogger (= 0.68.5)
     - Yoga
-  - React-Core/RCTImageHeaders (0.68.3):
+  - React-Core/RCTBlobHeaders (0.68.5):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.3)
-    - React-jsi (= 0.68.3)
-    - React-jsiexecutor (= 0.68.3)
-    - React-perflogger (= 0.68.3)
+    - React-cxxreact (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-jsiexecutor (= 0.68.5)
+    - React-perflogger (= 0.68.5)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.68.3):
+  - React-Core/RCTImageHeaders (0.68.5):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.3)
-    - React-jsi (= 0.68.3)
-    - React-jsiexecutor (= 0.68.3)
-    - React-perflogger (= 0.68.3)
+    - React-cxxreact (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-jsiexecutor (= 0.68.5)
+    - React-perflogger (= 0.68.5)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.68.3):
+  - React-Core/RCTLinkingHeaders (0.68.5):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.3)
-    - React-jsi (= 0.68.3)
-    - React-jsiexecutor (= 0.68.3)
-    - React-perflogger (= 0.68.3)
+    - React-cxxreact (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-jsiexecutor (= 0.68.5)
+    - React-perflogger (= 0.68.5)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.68.3):
+  - React-Core/RCTNetworkHeaders (0.68.5):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.3)
-    - React-jsi (= 0.68.3)
-    - React-jsiexecutor (= 0.68.3)
-    - React-perflogger (= 0.68.3)
+    - React-cxxreact (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-jsiexecutor (= 0.68.5)
+    - React-perflogger (= 0.68.5)
     - Yoga
-  - React-Core/RCTTextHeaders (0.68.3):
+  - React-Core/RCTSettingsHeaders (0.68.5):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.3)
-    - React-jsi (= 0.68.3)
-    - React-jsiexecutor (= 0.68.3)
-    - React-perflogger (= 0.68.3)
+    - React-cxxreact (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-jsiexecutor (= 0.68.5)
+    - React-perflogger (= 0.68.5)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.68.3):
+  - React-Core/RCTTextHeaders (0.68.5):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.3)
-    - React-jsi (= 0.68.3)
-    - React-jsiexecutor (= 0.68.3)
-    - React-perflogger (= 0.68.3)
+    - React-cxxreact (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-jsiexecutor (= 0.68.5)
+    - React-perflogger (= 0.68.5)
     - Yoga
-  - React-Core/RCTWebSocket (0.68.3):
+  - React-Core/RCTVibrationHeaders (0.68.5):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.3)
-    - React-cxxreact (= 0.68.3)
-    - React-jsi (= 0.68.3)
-    - React-jsiexecutor (= 0.68.3)
-    - React-perflogger (= 0.68.3)
+    - React-Core/Default
+    - React-cxxreact (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-jsiexecutor (= 0.68.5)
+    - React-perflogger (= 0.68.5)
     - Yoga
-  - React-CoreModules (0.68.3):
+  - React-Core/RCTWebSocket (0.68.5):
+    - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.3)
-    - React-Codegen (= 0.68.3)
-    - React-Core/CoreModulesHeaders (= 0.68.3)
-    - React-jsi (= 0.68.3)
-    - React-RCTImage (= 0.68.3)
-    - ReactCommon/turbomodule/core (= 0.68.3)
-  - React-cxxreact (0.68.3):
+    - React-Core/Default (= 0.68.5)
+    - React-cxxreact (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-jsiexecutor (= 0.68.5)
+    - React-perflogger (= 0.68.5)
+    - Yoga
+  - React-CoreModules (0.68.5):
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - RCTTypeSafety (= 0.68.5)
+    - React-Codegen (= 0.68.5)
+    - React-Core/CoreModulesHeaders (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-RCTImage (= 0.68.5)
+    - ReactCommon/turbomodule/core (= 0.68.5)
+  - React-cxxreact (0.68.5):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.68.3)
-    - React-jsi (= 0.68.3)
-    - React-jsinspector (= 0.68.3)
-    - React-logger (= 0.68.3)
-    - React-perflogger (= 0.68.3)
-    - React-runtimeexecutor (= 0.68.3)
-  - React-jsi (0.68.3):
+    - React-callinvoker (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-jsinspector (= 0.68.5)
+    - React-logger (= 0.68.5)
+    - React-perflogger (= 0.68.5)
+    - React-runtimeexecutor (= 0.68.5)
+  - React-jsi (0.68.5):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-jsi/Default (= 0.68.3)
-  - React-jsi/Default (0.68.3):
+    - React-jsi/Default (= 0.68.5)
+  - React-jsi/Default (0.68.5):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-  - React-jsiexecutor (0.68.3):
+  - React-jsiexecutor (0.68.5):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.68.3)
-    - React-jsi (= 0.68.3)
-    - React-perflogger (= 0.68.3)
-  - React-jsinspector (0.68.3)
-  - React-logger (0.68.3):
+    - React-cxxreact (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-perflogger (= 0.68.5)
+  - React-jsinspector (0.68.5)
+  - React-logger (0.68.5):
     - glog
   - react-native-menu (0.1.2):
     - React
   - react-native-slider (4.3.2):
     - React-Core
-  - React-perflogger (0.68.3)
-  - React-RCTActionSheet (0.68.3):
-    - React-Core/RCTActionSheetHeaders (= 0.68.3)
-  - React-RCTAnimation (0.68.3):
+  - React-perflogger (0.68.5)
+  - React-RCTActionSheet (0.68.5):
+    - React-Core/RCTActionSheetHeaders (= 0.68.5)
+  - React-RCTAnimation (0.68.5):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.3)
-    - React-Codegen (= 0.68.3)
-    - React-Core/RCTAnimationHeaders (= 0.68.3)
-    - React-jsi (= 0.68.3)
-    - ReactCommon/turbomodule/core (= 0.68.3)
-  - React-RCTBlob (0.68.3):
+    - RCTTypeSafety (= 0.68.5)
+    - React-Codegen (= 0.68.5)
+    - React-Core/RCTAnimationHeaders (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - ReactCommon/turbomodule/core (= 0.68.5)
+  - React-RCTBlob (0.68.5):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Codegen (= 0.68.3)
-    - React-Core/RCTBlobHeaders (= 0.68.3)
-    - React-Core/RCTWebSocket (= 0.68.3)
-    - React-jsi (= 0.68.3)
-    - React-RCTNetwork (= 0.68.3)
-    - ReactCommon/turbomodule/core (= 0.68.3)
-  - React-RCTImage (0.68.3):
+    - React-Codegen (= 0.68.5)
+    - React-Core/RCTBlobHeaders (= 0.68.5)
+    - React-Core/RCTWebSocket (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-RCTNetwork (= 0.68.5)
+    - ReactCommon/turbomodule/core (= 0.68.5)
+  - React-RCTImage (0.68.5):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.3)
-    - React-Codegen (= 0.68.3)
-    - React-Core/RCTImageHeaders (= 0.68.3)
-    - React-jsi (= 0.68.3)
-    - React-RCTNetwork (= 0.68.3)
-    - ReactCommon/turbomodule/core (= 0.68.3)
-  - React-RCTLinking (0.68.3):
-    - React-Codegen (= 0.68.3)
-    - React-Core/RCTLinkingHeaders (= 0.68.3)
-    - React-jsi (= 0.68.3)
-    - ReactCommon/turbomodule/core (= 0.68.3)
-  - React-RCTNetwork (0.68.3):
+    - RCTTypeSafety (= 0.68.5)
+    - React-Codegen (= 0.68.5)
+    - React-Core/RCTImageHeaders (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-RCTNetwork (= 0.68.5)
+    - ReactCommon/turbomodule/core (= 0.68.5)
+  - React-RCTLinking (0.68.5):
+    - React-Codegen (= 0.68.5)
+    - React-Core/RCTLinkingHeaders (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - ReactCommon/turbomodule/core (= 0.68.5)
+  - React-RCTNetwork (0.68.5):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.3)
-    - React-Codegen (= 0.68.3)
-    - React-Core/RCTNetworkHeaders (= 0.68.3)
-    - React-jsi (= 0.68.3)
-    - ReactCommon/turbomodule/core (= 0.68.3)
-  - React-RCTSettings (0.68.3):
+    - RCTTypeSafety (= 0.68.5)
+    - React-Codegen (= 0.68.5)
+    - React-Core/RCTNetworkHeaders (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - ReactCommon/turbomodule/core (= 0.68.5)
+  - React-RCTSettings (0.68.5):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.3)
-    - React-Codegen (= 0.68.3)
-    - React-Core/RCTSettingsHeaders (= 0.68.3)
-    - React-jsi (= 0.68.3)
-    - ReactCommon/turbomodule/core (= 0.68.3)
-  - React-RCTText (0.68.3):
-    - React-Core/RCTTextHeaders (= 0.68.3)
-  - React-RCTVibration (0.68.3):
+    - RCTTypeSafety (= 0.68.5)
+    - React-Codegen (= 0.68.5)
+    - React-Core/RCTSettingsHeaders (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - ReactCommon/turbomodule/core (= 0.68.5)
+  - React-RCTText (0.68.5):
+    - React-Core/RCTTextHeaders (= 0.68.5)
+  - React-RCTVibration (0.68.5):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Codegen (= 0.68.3)
-    - React-Core/RCTVibrationHeaders (= 0.68.3)
-    - React-jsi (= 0.68.3)
-    - ReactCommon/turbomodule/core (= 0.68.3)
-  - React-runtimeexecutor (0.68.3):
-    - React-jsi (= 0.68.3)
-  - ReactCommon/turbomodule/core (0.68.3):
+    - React-Codegen (= 0.68.5)
+    - React-Core/RCTVibrationHeaders (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - ReactCommon/turbomodule/core (= 0.68.5)
+  - React-runtimeexecutor (0.68.5):
+    - React-jsi (= 0.68.5)
+  - ReactCommon/turbomodule/core (0.68.5):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.68.3)
-    - React-Core (= 0.68.3)
-    - React-cxxreact (= 0.68.3)
-    - React-jsi (= 0.68.3)
-    - React-logger (= 0.68.3)
-    - React-perflogger (= 0.68.3)
-  - ReactTestApp-DevSupport (1.6.20):
+    - React-callinvoker (= 0.68.5)
+    - React-Core (= 0.68.5)
+    - React-cxxreact (= 0.68.5)
+    - React-jsi (= 0.68.5)
+    - React-logger (= 0.68.5)
+    - React-perflogger (= 0.68.5)
+  - ReactTestApp-DevSupport (2.0.2):
     - React-Core
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
-  - RNCPicker (2.4.7):
+  - RNCPicker (2.4.8):
     - React-Core
   - RNSVG (12.3.0):
     - React-Core
@@ -592,46 +592,46 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
-  FBLazyVector: 34f7420274737b6fcf2e2d9fd42641e66b4436a3
-  FBReactNativeSpec: 46f650441373ea75c83aec30f23378f6523245f2
+  FBLazyVector: 2b47ff52037bd9ae07cc9b051c9975797814b736
+  FBReactNativeSpec: dd89c4a5591e20015aa55c6efbf9c7740a83efbf
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  FRNAvatar: 0086d80917e8530e8f35147e8a9d06016a95ce30
-  FRNDatePicker: 3681a15ca6fcdc66e6e184fafe963ba48b02a04b
+  FRNAvatar: de1aec8a9011ade478f2148677b4f2c076d77110
+  FRNDatePicker: 241cd55b8d2b63d4427d782951f31504f09fbe1a
   glog: 476ee3e89abb49e07f822b48323c51c57124b572
   MicrosoftFluentUI: e30487dd18aba04beeed4caf1ce1988073f8b03a
   RCT-Folly: 4d8508a426467c48885f1151029bc15fa5d7b3b8
-  RCTRequired: b8caca023d386d43740dfb94c2cf68f695fa5e77
-  RCTTypeSafety: ec44ea1d6ad1e5cd6447b22159ff40c2ebbd23b1
-  React: 9f8c8afb9a9d61b7a1b01a1c6fb7f0d4f902988f
-  React-callinvoker: f813eee352cfd333208e8d67a72f584f5435769d
-  React-Codegen: 771562186fec8c7830897f97ca59de683abd3184
-  React-Core: 74670b4b715083e1c9003462f3f4fe32a70ba5c5
-  React-CoreModules: 34bd5b93e5322e60102a5ad78b992c882e558022
-  React-cxxreact: adc9fc6a9333ae779bd72effaf77173bd9f22bf7
-  React-jsi: ab91137ea7d92a86e48b6f15d3a5580bea471776
-  React-jsiexecutor: a5043e9e1e1bd13b80b58b228c6901b3721a4f54
-  React-jsinspector: 86e89b9f135787a2e8eb74b3fc00ec61e9a80ae1
-  React-logger: f790bd10f86b38012e108fb4b564023602702270
+  RCTRequired: 0f06b6068f530932d10e1a01a5352fad4eaacb74
+  RCTTypeSafety: b0ee81f10ef1b7d977605a2b266823dabd565e65
+  React: 3becd12bd51ea8a43bdde7e09d0f40fba7820e03
+  React-callinvoker: 11abfff50e6bf7a55b3a90b4dc2187f71f224593
+  React-Codegen: f8946ce0768fb8e92e092e30944489c4b2955b2d
+  React-Core: 203cdb6ee2657b198d97d41031c249161060e6ca
+  React-CoreModules: 6eb0c06a4a223fde2cb6a8d0f44f58b67e808942
+  React-cxxreact: afb0c6c07d19adbd850747fedeac20c6832d40b9
+  React-jsi: 14d37a6db2af2c1a49f6f5c2e4ee667c364ae45c
+  React-jsiexecutor: 45c0496ca8cef6b02d9fa0274c25cf458fe91a56
+  React-jsinspector: eb202e43b3879aba9a14f3f65788aec85d4e1ea9
+  React-logger: 98f663b292a60967ebbc6d803ae96c1381183b6d
   react-native-menu: 9fe07f72e075b250295eeae25425490cc9608951
   react-native-slider: e540525ea731783850802b7af457d8551edb0711
-  React-perflogger: fa15d1d29ff7557ee25ea48f7f59e65896fb3215
-  React-RCTActionSheet: e83515333352a3cc19c146e3c7a63a8a9269da8f
-  React-RCTAnimation: 8032daa2846e3db7ac28c4c5a207d0bfb5e1e3ad
-  React-RCTBlob: fe40e206cebcb4f552e0ecdac3ef81b3baf3cb37
-  React-RCTImage: dfc0df14cbfec1ec54fdd4700b8fe3bf8127dde2
-  React-RCTLinking: ac9f65f0c8db738a6156ae7640ba92494b4770a5
-  React-RCTNetwork: cf289a0386a1bd057e5eabb8563dfe5ce0af868c
-  React-RCTSettings: 7889cfcf6c7d5738f3cb8889557a38eeea2f04ff
-  React-RCTText: fd249e1f8406fb6e35cc77a2b9ff66a3477bf41a
-  React-RCTVibration: f41f116aad644973f24653effb3db3de64fa0314
-  React-runtimeexecutor: 8cdd80915ed6dabf2221a689f1f7ddb50ea5e9f3
-  ReactCommon: 5b1b43a7d81a1ac4eec85f7c4db3283a14a3b13d
-  ReactTestApp-DevSupport: f65d9f20da50012c9fa224c9e0431e48f70a32e8
-  ReactTestApp-Resources: 8c0164a3cc5052418c92018e2af0e05d564aa307
-  RNCPicker: 35b5d45693bb46c0e5514116081509e15a64a145
+  React-perflogger: 0458a87ea9a7342079e7a31b0d32b3734fb8415f
+  React-RCTActionSheet: 22538001ea2926dea001111dd2846c13a0730bc9
+  React-RCTAnimation: 732ce66878d4aa151d56a0d142b1105aa12fd313
+  React-RCTBlob: 9cb9e3e9a41d27be34aaf89b0e0f52c7ca415d57
+  React-RCTImage: 6bd16627eb9c4bb79903c4cdec7c551266ee1a5b
+  React-RCTLinking: e9edfc8919c8fa9a3f3c7b34362811f58a2ebba4
+  React-RCTNetwork: 880eccd21bbe2660a0b63da5ccba75c46eceeaa6
+  React-RCTSettings: 8c85d8188c97d6c6bd470af6631a6c4555b79bb3
+  React-RCTText: bbd275ee287730c5acbab1aadc0db39c25c5c64e
+  React-RCTVibration: 9819a3bf6230e4b2a99877c21268b0b2416157a1
+  React-runtimeexecutor: b1f1995089b90696dbc2a7ffe0059a80db5c8eb1
+  ReactCommon: 149e2c0acab9bac61378da0db5b2880a1b5ff59b
+  ReactTestApp-DevSupport: 93a3ec4d2affbd491128b89e922d7f1a359f547a
+  ReactTestApp-Resources: ecba662266ac5af3e30e1e3004c0fa8c0298b61a
+  RNCPicker: 0bf8ef8f7800524f32d2bb2a8bcadd53eda0ecd1
   RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8
-  Yoga: 2f6a78c58dcc2963bd8e34d96a4246d9dff2e3a7
+  Yoga: c4d61225a466f250c35c1ee78d2d0b3d41fe661c
 
-PODFILE CHECKSUM: dfe15f1d6484c77bac1ab1b46c2e44215ca8558b
+PODFILE CHECKSUM: eeba196fb25cf059c631787109cecd08a4ac85a6
 
 COCOAPODS: 1.11.3

--- a/apps/fluent-tester/macos/Podfile
+++ b/apps/fluent-tester/macos/Podfile
@@ -20,6 +20,7 @@ fi
 }
 
 use_flipper!(false)
+
 use_test_app! do |target|
   target.app do
     platform :osx, '10.15'

--- a/apps/fluent-tester/macos/Podfile.lock
+++ b/apps/fluent-tester/macos/Podfile.lock
@@ -1,25 +1,25 @@
 PODS:
   - boost (1.76.0)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.68.54)
-  - FBReactNativeSpec (0.68.54):
+  - FBLazyVector (0.68.57)
+  - FBReactNativeSpec (0.68.57):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.54)
-    - RCTTypeSafety (= 0.68.54)
-    - React-Core (= 0.68.54)
-    - React-jsi (= 0.68.54)
-    - ReactCommon/turbomodule/core (= 0.68.54)
+    - RCTRequired (= 0.68.57)
+    - RCTTypeSafety (= 0.68.57)
+    - React-Core (= 0.68.57)
+    - React-jsi (= 0.68.57)
+    - ReactCommon/turbomodule/core (= 0.68.57)
   - fmt (6.2.1)
-  - FRNAvatar (0.16.12):
+  - FRNAvatar (0.16.20):
     - MicrosoftFluentUI (= 0.8.3)
     - React
-  - FRNCallout (0.21.20):
+  - FRNCallout (0.21.30):
     - React
-  - FRNCheckbox (0.12.25):
+  - FRNCheckbox (0.12.36):
     - React
-  - FRNMenuButton (0.8.41):
+  - FRNMenuButton (0.8.60):
     - React
-  - FRNRadioButton (0.15.22):
+  - FRNRadioButton (0.15.35):
     - React
   - glog (0.3.5)
   - MicrosoftFluentUI (0.8.3):
@@ -101,274 +101,274 @@ PODS:
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
-  - RCTFocusZone (0.10.20):
+  - RCTFocusZone (0.10.33):
     - React
-  - RCTRequired (0.68.54)
-  - RCTTypeSafety (0.68.54):
-    - FBLazyVector (= 0.68.54)
+  - RCTRequired (0.68.57)
+  - RCTTypeSafety (0.68.57):
+    - FBLazyVector (= 0.68.57)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.54)
-    - React-Core (= 0.68.54)
-  - React (0.68.54):
-    - React-Core (= 0.68.54)
-    - React-Core/DevSupport (= 0.68.54)
-    - React-Core/RCTWebSocket (= 0.68.54)
-    - React-RCTActionSheet (= 0.68.54)
-    - React-RCTAnimation (= 0.68.54)
-    - React-RCTBlob (= 0.68.54)
-    - React-RCTImage (= 0.68.54)
-    - React-RCTLinking (= 0.68.54)
-    - React-RCTNetwork (= 0.68.54)
-    - React-RCTSettings (= 0.68.54)
-    - React-RCTText (= 0.68.54)
-    - React-RCTVibration (= 0.68.54)
-  - React-callinvoker (0.68.54)
-  - React-Codegen (0.68.54):
-    - FBReactNativeSpec (= 0.68.54)
+    - RCTRequired (= 0.68.57)
+    - React-Core (= 0.68.57)
+  - React (0.68.57):
+    - React-Core (= 0.68.57)
+    - React-Core/DevSupport (= 0.68.57)
+    - React-Core/RCTWebSocket (= 0.68.57)
+    - React-RCTActionSheet (= 0.68.57)
+    - React-RCTAnimation (= 0.68.57)
+    - React-RCTBlob (= 0.68.57)
+    - React-RCTImage (= 0.68.57)
+    - React-RCTLinking (= 0.68.57)
+    - React-RCTNetwork (= 0.68.57)
+    - React-RCTSettings (= 0.68.57)
+    - React-RCTText (= 0.68.57)
+    - React-RCTVibration (= 0.68.57)
+  - React-callinvoker (0.68.57)
+  - React-Codegen (0.68.57):
+    - FBReactNativeSpec (= 0.68.57)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.54)
-    - RCTTypeSafety (= 0.68.54)
-    - React-Core (= 0.68.54)
-    - React-jsi (= 0.68.54)
-    - React-jsiexecutor (= 0.68.54)
-    - ReactCommon/turbomodule/core (= 0.68.54)
-  - React-Core (0.68.54):
+    - RCTRequired (= 0.68.57)
+    - RCTTypeSafety (= 0.68.57)
+    - React-Core (= 0.68.57)
+    - React-jsi (= 0.68.57)
+    - React-jsiexecutor (= 0.68.57)
+    - ReactCommon/turbomodule/core (= 0.68.57)
+  - React-Core (0.68.57):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.54)
-    - React-cxxreact (= 0.68.54)
-    - React-jsi (= 0.68.54)
-    - React-jsiexecutor (= 0.68.54)
-    - React-perflogger (= 0.68.54)
+    - React-Core/Default (= 0.68.57)
+    - React-cxxreact (= 0.68.57)
+    - React-jsi (= 0.68.57)
+    - React-jsiexecutor (= 0.68.57)
+    - React-perflogger (= 0.68.57)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.68.54):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default
-    - React-cxxreact (= 0.68.54)
-    - React-jsi (= 0.68.54)
-    - React-jsiexecutor (= 0.68.54)
-    - React-perflogger (= 0.68.54)
-    - Yoga
-  - React-Core/Default (0.68.54):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.68.54)
-    - React-jsi (= 0.68.54)
-    - React-jsiexecutor (= 0.68.54)
-    - React-perflogger (= 0.68.54)
-    - Yoga
-  - React-Core/DevSupport (0.68.54):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.54)
-    - React-Core/RCTWebSocket (= 0.68.54)
-    - React-cxxreact (= 0.68.54)
-    - React-jsi (= 0.68.54)
-    - React-jsiexecutor (= 0.68.54)
-    - React-jsinspector (= 0.68.54)
-    - React-perflogger (= 0.68.54)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.68.54):
+  - React-Core/CoreModulesHeaders (0.68.57):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.54)
-    - React-jsi (= 0.68.54)
-    - React-jsiexecutor (= 0.68.54)
-    - React-perflogger (= 0.68.54)
+    - React-cxxreact (= 0.68.57)
+    - React-jsi (= 0.68.57)
+    - React-jsiexecutor (= 0.68.57)
+    - React-perflogger (= 0.68.57)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.68.54):
+  - React-Core/Default (0.68.57):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-cxxreact (= 0.68.57)
+    - React-jsi (= 0.68.57)
+    - React-jsiexecutor (= 0.68.57)
+    - React-perflogger (= 0.68.57)
+    - Yoga
+  - React-Core/DevSupport (0.68.57):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-Core/Default (= 0.68.57)
+    - React-Core/RCTWebSocket (= 0.68.57)
+    - React-cxxreact (= 0.68.57)
+    - React-jsi (= 0.68.57)
+    - React-jsiexecutor (= 0.68.57)
+    - React-jsinspector (= 0.68.57)
+    - React-perflogger (= 0.68.57)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.68.57):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.54)
-    - React-jsi (= 0.68.54)
-    - React-jsiexecutor (= 0.68.54)
-    - React-perflogger (= 0.68.54)
+    - React-cxxreact (= 0.68.57)
+    - React-jsi (= 0.68.57)
+    - React-jsiexecutor (= 0.68.57)
+    - React-perflogger (= 0.68.57)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.68.54):
+  - React-Core/RCTAnimationHeaders (0.68.57):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.54)
-    - React-jsi (= 0.68.54)
-    - React-jsiexecutor (= 0.68.54)
-    - React-perflogger (= 0.68.54)
+    - React-cxxreact (= 0.68.57)
+    - React-jsi (= 0.68.57)
+    - React-jsiexecutor (= 0.68.57)
+    - React-perflogger (= 0.68.57)
     - Yoga
-  - React-Core/RCTImageHeaders (0.68.54):
+  - React-Core/RCTBlobHeaders (0.68.57):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.54)
-    - React-jsi (= 0.68.54)
-    - React-jsiexecutor (= 0.68.54)
-    - React-perflogger (= 0.68.54)
+    - React-cxxreact (= 0.68.57)
+    - React-jsi (= 0.68.57)
+    - React-jsiexecutor (= 0.68.57)
+    - React-perflogger (= 0.68.57)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.68.54):
+  - React-Core/RCTImageHeaders (0.68.57):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.54)
-    - React-jsi (= 0.68.54)
-    - React-jsiexecutor (= 0.68.54)
-    - React-perflogger (= 0.68.54)
+    - React-cxxreact (= 0.68.57)
+    - React-jsi (= 0.68.57)
+    - React-jsiexecutor (= 0.68.57)
+    - React-perflogger (= 0.68.57)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.68.54):
+  - React-Core/RCTLinkingHeaders (0.68.57):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.54)
-    - React-jsi (= 0.68.54)
-    - React-jsiexecutor (= 0.68.54)
-    - React-perflogger (= 0.68.54)
+    - React-cxxreact (= 0.68.57)
+    - React-jsi (= 0.68.57)
+    - React-jsiexecutor (= 0.68.57)
+    - React-perflogger (= 0.68.57)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.68.54):
+  - React-Core/RCTNetworkHeaders (0.68.57):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.54)
-    - React-jsi (= 0.68.54)
-    - React-jsiexecutor (= 0.68.54)
-    - React-perflogger (= 0.68.54)
+    - React-cxxreact (= 0.68.57)
+    - React-jsi (= 0.68.57)
+    - React-jsiexecutor (= 0.68.57)
+    - React-perflogger (= 0.68.57)
     - Yoga
-  - React-Core/RCTTextHeaders (0.68.54):
+  - React-Core/RCTSettingsHeaders (0.68.57):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.54)
-    - React-jsi (= 0.68.54)
-    - React-jsiexecutor (= 0.68.54)
-    - React-perflogger (= 0.68.54)
+    - React-cxxreact (= 0.68.57)
+    - React-jsi (= 0.68.57)
+    - React-jsiexecutor (= 0.68.57)
+    - React-perflogger (= 0.68.57)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.68.54):
+  - React-Core/RCTTextHeaders (0.68.57):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.54)
-    - React-jsi (= 0.68.54)
-    - React-jsiexecutor (= 0.68.54)
-    - React-perflogger (= 0.68.54)
+    - React-cxxreact (= 0.68.57)
+    - React-jsi (= 0.68.57)
+    - React-jsiexecutor (= 0.68.57)
+    - React-perflogger (= 0.68.57)
     - Yoga
-  - React-Core/RCTWebSocket (0.68.54):
+  - React-Core/RCTVibrationHeaders (0.68.57):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.54)
-    - React-cxxreact (= 0.68.54)
-    - React-jsi (= 0.68.54)
-    - React-jsiexecutor (= 0.68.54)
-    - React-perflogger (= 0.68.54)
+    - React-Core/Default
+    - React-cxxreact (= 0.68.57)
+    - React-jsi (= 0.68.57)
+    - React-jsiexecutor (= 0.68.57)
+    - React-perflogger (= 0.68.57)
     - Yoga
-  - React-CoreModules (0.68.54):
+  - React-Core/RCTWebSocket (0.68.57):
+    - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.54)
-    - React-Codegen (= 0.68.54)
-    - React-Core/CoreModulesHeaders (= 0.68.54)
-    - React-jsi (= 0.68.54)
-    - React-RCTImage (= 0.68.54)
-    - ReactCommon/turbomodule/core (= 0.68.54)
-  - React-cxxreact (0.68.54):
+    - React-Core/Default (= 0.68.57)
+    - React-cxxreact (= 0.68.57)
+    - React-jsi (= 0.68.57)
+    - React-jsiexecutor (= 0.68.57)
+    - React-perflogger (= 0.68.57)
+    - Yoga
+  - React-CoreModules (0.68.57):
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - RCTTypeSafety (= 0.68.57)
+    - React-Codegen (= 0.68.57)
+    - React-Core/CoreModulesHeaders (= 0.68.57)
+    - React-jsi (= 0.68.57)
+    - React-RCTImage (= 0.68.57)
+    - ReactCommon/turbomodule/core (= 0.68.57)
+  - React-cxxreact (0.68.57):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.68.54)
-    - React-jsi (= 0.68.54)
-    - React-jsinspector (= 0.68.54)
-    - React-logger (= 0.68.54)
-    - React-perflogger (= 0.68.54)
-    - React-runtimeexecutor (= 0.68.54)
-  - React-jsi (0.68.54):
+    - React-callinvoker (= 0.68.57)
+    - React-jsi (= 0.68.57)
+    - React-jsinspector (= 0.68.57)
+    - React-logger (= 0.68.57)
+    - React-perflogger (= 0.68.57)
+    - React-runtimeexecutor (= 0.68.57)
+  - React-jsi (0.68.57):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-jsi/Default (= 0.68.54)
-  - React-jsi/Default (0.68.54):
+    - React-jsi/Default (= 0.68.57)
+  - React-jsi/Default (0.68.57):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-  - React-jsiexecutor (0.68.54):
+  - React-jsiexecutor (0.68.57):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.68.54)
-    - React-jsi (= 0.68.54)
-    - React-perflogger (= 0.68.54)
-  - React-jsinspector (0.68.54)
-  - React-logger (0.68.54):
+    - React-cxxreact (= 0.68.57)
+    - React-jsi (= 0.68.57)
+    - React-perflogger (= 0.68.57)
+  - React-jsinspector (0.68.57)
+  - React-logger (0.68.57):
     - glog
-  - React-perflogger (0.68.54)
-  - React-RCTActionSheet (0.68.54):
-    - React-Core/RCTActionSheetHeaders (= 0.68.54)
-  - React-RCTAnimation (0.68.54):
+  - React-perflogger (0.68.57)
+  - React-RCTActionSheet (0.68.57):
+    - React-Core/RCTActionSheetHeaders (= 0.68.57)
+  - React-RCTAnimation (0.68.57):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.54)
-    - React-Codegen (= 0.68.54)
-    - React-Core/RCTAnimationHeaders (= 0.68.54)
-    - React-jsi (= 0.68.54)
-    - ReactCommon/turbomodule/core (= 0.68.54)
-  - React-RCTBlob (0.68.54):
+    - RCTTypeSafety (= 0.68.57)
+    - React-Codegen (= 0.68.57)
+    - React-Core/RCTAnimationHeaders (= 0.68.57)
+    - React-jsi (= 0.68.57)
+    - ReactCommon/turbomodule/core (= 0.68.57)
+  - React-RCTBlob (0.68.57):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Codegen (= 0.68.54)
-    - React-Core/RCTBlobHeaders (= 0.68.54)
-    - React-Core/RCTWebSocket (= 0.68.54)
-    - React-jsi (= 0.68.54)
-    - React-RCTNetwork (= 0.68.54)
-    - ReactCommon/turbomodule/core (= 0.68.54)
-  - React-RCTImage (0.68.54):
+    - React-Codegen (= 0.68.57)
+    - React-Core/RCTBlobHeaders (= 0.68.57)
+    - React-Core/RCTWebSocket (= 0.68.57)
+    - React-jsi (= 0.68.57)
+    - React-RCTNetwork (= 0.68.57)
+    - ReactCommon/turbomodule/core (= 0.68.57)
+  - React-RCTImage (0.68.57):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.54)
-    - React-Codegen (= 0.68.54)
-    - React-Core/RCTImageHeaders (= 0.68.54)
-    - React-jsi (= 0.68.54)
-    - React-RCTNetwork (= 0.68.54)
-    - ReactCommon/turbomodule/core (= 0.68.54)
-  - React-RCTLinking (0.68.54):
-    - React-Codegen (= 0.68.54)
-    - React-Core/RCTLinkingHeaders (= 0.68.54)
-    - React-jsi (= 0.68.54)
-    - ReactCommon/turbomodule/core (= 0.68.54)
-  - React-RCTNetwork (0.68.54):
+    - RCTTypeSafety (= 0.68.57)
+    - React-Codegen (= 0.68.57)
+    - React-Core/RCTImageHeaders (= 0.68.57)
+    - React-jsi (= 0.68.57)
+    - React-RCTNetwork (= 0.68.57)
+    - ReactCommon/turbomodule/core (= 0.68.57)
+  - React-RCTLinking (0.68.57):
+    - React-Codegen (= 0.68.57)
+    - React-Core/RCTLinkingHeaders (= 0.68.57)
+    - React-jsi (= 0.68.57)
+    - ReactCommon/turbomodule/core (= 0.68.57)
+  - React-RCTNetwork (0.68.57):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.54)
-    - React-Codegen (= 0.68.54)
-    - React-Core/RCTNetworkHeaders (= 0.68.54)
-    - React-jsi (= 0.68.54)
-    - ReactCommon/turbomodule/core (= 0.68.54)
-  - React-RCTSettings (0.68.54):
+    - RCTTypeSafety (= 0.68.57)
+    - React-Codegen (= 0.68.57)
+    - React-Core/RCTNetworkHeaders (= 0.68.57)
+    - React-jsi (= 0.68.57)
+    - ReactCommon/turbomodule/core (= 0.68.57)
+  - React-RCTSettings (0.68.57):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.54)
-    - React-Codegen (= 0.68.54)
-    - React-Core/RCTSettingsHeaders (= 0.68.54)
-    - React-jsi (= 0.68.54)
-    - ReactCommon/turbomodule/core (= 0.68.54)
-  - React-RCTText (0.68.54):
-    - React-Core/RCTTextHeaders (= 0.68.54)
-  - React-RCTVibration (0.68.54):
+    - RCTTypeSafety (= 0.68.57)
+    - React-Codegen (= 0.68.57)
+    - React-Core/RCTSettingsHeaders (= 0.68.57)
+    - React-jsi (= 0.68.57)
+    - ReactCommon/turbomodule/core (= 0.68.57)
+  - React-RCTText (0.68.57):
+    - React-Core/RCTTextHeaders (= 0.68.57)
+  - React-RCTVibration (0.68.57):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Codegen (= 0.68.54)
-    - React-Core/RCTVibrationHeaders (= 0.68.54)
-    - React-jsi (= 0.68.54)
-    - ReactCommon/turbomodule/core (= 0.68.54)
-  - React-runtimeexecutor (0.68.54):
-    - React-jsi (= 0.68.54)
-  - ReactCommon/turbomodule/core (0.68.54):
+    - React-Codegen (= 0.68.57)
+    - React-Core/RCTVibrationHeaders (= 0.68.57)
+    - React-jsi (= 0.68.57)
+    - ReactCommon/turbomodule/core (= 0.68.57)
+  - React-runtimeexecutor (0.68.57):
+    - React-jsi (= 0.68.57)
+  - ReactCommon/turbomodule/core (0.68.57):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.68.54)
-    - React-Core (= 0.68.54)
-    - React-cxxreact (= 0.68.54)
-    - React-jsi (= 0.68.54)
-    - React-logger (= 0.68.54)
-    - React-perflogger (= 0.68.54)
-  - ReactTestApp-DevSupport (1.6.20):
+    - React-callinvoker (= 0.68.57)
+    - React-Core (= 0.68.57)
+    - React-cxxreact (= 0.68.57)
+    - React-jsi (= 0.68.57)
+    - React-logger (= 0.68.57)
+    - React-perflogger (= 0.68.57)
+  - ReactTestApp-DevSupport (2.0.2):
     - React-Core
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
-  - RNCPicker (2.4.7):
+  - RNCPicker (2.4.8):
     - React-Core
   - RNSVG (12.3.0):
     - React-Core
@@ -511,48 +511,48 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: 613e39eac4239cc72b15421247b5ab05361266a2
   DoubleConversion: ed15e075aa758ac0e4c1f8b830bd4e4d40d669e8
-  FBLazyVector: 5c754a98b1788717d3bd1340606e5385287a319e
-  FBReactNativeSpec: f23024b7ef1f39034b468351719ca265eac0c34a
+  FBLazyVector: 66d7f725f8bfaaf3d3e90ff3ed9f199b8521c557
+  FBReactNativeSpec: 98f957625639d48df1f48693d86c6f325bad8bde
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  FRNAvatar: 0086d80917e8530e8f35147e8a9d06016a95ce30
-  FRNCallout: 317f592b07693b73aa26fb9d681aaf22a189102e
-  FRNCheckbox: 18e91128db9ed4ae11d76341cae1e67776e5ee00
-  FRNMenuButton: 319065f512f101091e14b9d2597c9d0173ad0f10
-  FRNRadioButton: 01390ce04cef211c4c01fa0769f85137978248cd
+  FRNAvatar: de1aec8a9011ade478f2148677b4f2c076d77110
+  FRNCallout: fe863c0d5f14511a24d889628ad2b2bcd3e3ce56
+  FRNCheckbox: 9bae3ed660e1b0639b1de5b6f6785765fd3eeb5f
+  FRNMenuButton: 395471d65633fe00ff669049e73e6c8a849cf7db
+  FRNRadioButton: 64f8fc4867573d96ff1ffca7ba333b8df08b7e1a
   glog: 20113a0d46931b6f096cf8302c68691d75a456ff
   MicrosoftFluentUI: e30487dd18aba04beeed4caf1ce1988073f8b03a
   RCT-Folly: 5544a3ff21f4406e70e92a8711598e97fc81517c
-  RCTFocusZone: d9ec505e8adbf11ab602fc81ff436ac528a1534a
-  RCTRequired: 9ef053e811019c7d9172fc3eee3e9c3d566e243d
-  RCTTypeSafety: 65f4404615ab773359e5af4bbaa6b63fed04b159
-  React: da180e18b635c8a44a590bbf8c2d9c4d05f226c1
-  React-callinvoker: 8ead5679d27f2b8557db234551c24083b1a2415c
-  React-Codegen: aa2e16d5675c898b716e50378bed7ffc212f56b6
-  React-Core: 175c4ed0e41d8fc530c58808ef1b18a442639d6c
-  React-CoreModules: 2957db751a7c6897b69e46728cbaf4abe438e9e9
-  React-cxxreact: e0e8829ab3d541054f9431917db9bf6181afef96
-  React-jsi: 410ac3c9c521be1fc54cb872bd1793c94063c958
-  React-jsiexecutor: fdf66e32a914ce02d2ec11f30a96bc6944b7935a
-  React-jsinspector: b1c95038a95dc2d18ce7630f2b7d91482b5db01f
-  React-logger: bd030448eaab9dae0f2c9c18be898bd084c2dff8
-  React-perflogger: 908a69cb0e1821038cab5e0c329dabfe7d8d51d6
-  React-RCTActionSheet: d225bc08efab3a117e15f6e8388bc6b22beaec55
-  React-RCTAnimation: 41f0b50f450a5e18382a90ea973c45bfc9e28abd
-  React-RCTBlob: 8185fcae21bcbdc1013e0020cf8de1937b054efc
-  React-RCTImage: 8434d821f2dbdc07b6cb084683dbb764dd5db69c
-  React-RCTLinking: 42211b0c17ac83e3c255167eec40c15de2d2777b
-  React-RCTNetwork: 973c0c2f1238a12c565b933e183f4177590f9916
-  React-RCTSettings: 5f35e86c208f4eabe806c88d9ff14ed8432a2f2a
-  React-RCTText: 9e2a36fc367f44734cc181939bcd25cd2d9f8d84
-  React-RCTVibration: 862be0a30585ffd070af406d9eda56ed9303fc2a
-  React-runtimeexecutor: b81ac6dea2f26edd110ea2a264801b34d66f94c6
-  ReactCommon: 4c4a76325ae0319c2d9b337c48d53f9b3f741a7c
-  ReactTestApp-DevSupport: f65d9f20da50012c9fa224c9e0431e48f70a32e8
+  RCTFocusZone: 491313549930fc2dd3fe6e55c0beaa51edaffd38
+  RCTRequired: c00dbb53b206432963611afa9ad5a78b34a62e42
+  RCTTypeSafety: 8b3920a2dc1221379c0f0769040fe756ab4c1196
+  React: 47d8c8932313d61adc547809a008158b8dab892b
+  React-callinvoker: 90a7448649028bcaf7730797dcecf1607be1e45e
+  React-Codegen: b0f2d43424f2bcf5074e76784fcf859c5119d388
+  React-Core: 8d5a722ba46ee6dabd487631db1d2fcc70599f6d
+  React-CoreModules: f7aada0c15ccfa294b051f191d2c0a2af18aef37
+  React-cxxreact: 5d0ba87f2e6c755c09849ff6dcf1a003e06a65d5
+  React-jsi: e5a1be58f939846c0f28c5d9d7c5c0279f1009d9
+  React-jsiexecutor: a1b67ebba3a4e04e06e3e10255d439dfc2a5d344
+  React-jsinspector: c31e945484cef01d10ee1f675a28bfcfe93e868c
+  React-logger: 78070628d4d202051e3474cd3b5c8a55165f65ef
+  React-perflogger: 44a0304e946f93c3451ca0608c99f24f31e50a14
+  React-RCTActionSheet: e1b9dd10434146cad3906a91c4cbb5b5f328d94e
+  React-RCTAnimation: e4df7dd3ca8837d843cfe523525ffd5f9ee8ddec
+  React-RCTBlob: 05d223e33f3dcbcaa802726d8a49347c5bf3f029
+  React-RCTImage: 76a3508460f1b7233bab3df23d6b42a259c49d08
+  React-RCTLinking: f0da27c4c46bb41529f773d6d7daa04d8c46cfc9
+  React-RCTNetwork: 89905f952ac850454e1fb2ed73d803159fd0aab8
+  React-RCTSettings: 8ac89ad7973bf95769998e992382031bb9a97558
+  React-RCTText: e9f886916b784fa7d0a1e56835f8c00fec2b082f
+  React-RCTVibration: 17066859eed43e7785cebe26e9baf6ca9c41cd52
+  React-runtimeexecutor: e3748a580147ae0420f137db733c999d69dfe70b
+  ReactCommon: ddaf7c25e808abec914d313f7b4ec094e6486a38
+  ReactTestApp-DevSupport: 93a3ec4d2affbd491128b89e922d7f1a359f547a
   ReactTestApp-Resources: 8c0164a3cc5052418c92018e2af0e05d564aa307
-  RNCPicker: 35b5d45693bb46c0e5514116081509e15a64a145
+  RNCPicker: 0bf8ef8f7800524f32d2bb2a8bcadd53eda0ecd1
   RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8
-  Yoga: dcf9e7eac68fb6d648381baad9b13300582e9821
+  Yoga: 2ff4dcde4d6e0896a0b325e3a52173e1cea342da
 
-PODFILE CHECKSUM: 553ec4eec9578ceafbc92e27e0789d7ddcd88c74
+PODFILE CHECKSUM: d3fe834dea1e24594a8ba545f70b5250bbc25c91
 
 COCOAPODS: 1.11.3

--- a/apps/fluent-tester/package.json
+++ b/apps/fluent-tester/package.json
@@ -109,7 +109,7 @@
     "metro-config": "^0.67.0",
     "metro-react-native-babel-preset": "^0.67.0",
     "react-native-svg-transformer": "^1.0.0",
-    "react-native-test-app": "^1.6.2",
+    "react-native-test-app": "^2.0.2",
     "react-test-renderer": "17.0.2",
     "ts-node": "^8.10.1",
     "tsconfig-paths": "^3.9.0",
@@ -169,12 +169,11 @@
       "core-ios",
       "core-macos",
       "core-windows",
-      "react",
-      "svg",
-      "metro-config",
       "babel-preset-react-native",
-      "test-app",
-      "react-dom"
+      "metro-config",
+      "react",
+      "react-dom",
+      "svg"
     ]
   },
   "depcheck": {

--- a/change/@fluentui-react-native-tester-a780436b-9e67-43c4-adab-4189579f9370.json
+++ b/change/@fluentui-react-native-tester-a780436b-9e67-43c4-adab-4189579f9370.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: address Android build issues",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12155,9 +12155,9 @@ react-native-windows@^0.68.0:
     ws "^6.1.4"
 
 react-native@^0.68.0:
-  version "0.68.4"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.68.4.tgz#c52c590f93e9d115010e458650957824c0b1406e"
-  integrity sha512-Hp5qwztQ1XNnV43QTz1kUx33iZHmJqbbe7L19V9psaWtX/h9j6SEtZ3UHBrigIPlppkIP1E5x3CDr9FdD4d6CA==
+  version "0.68.5"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.68.5.tgz#8ba7389e00b757c59b6ea23bf38303d52367d155"
+  integrity sha512-t3kiQ/gumFV+0r/NRSIGtYxanjY4da0utFqHgkMcRPJVwXFWC0Fr8YiOeRGYO1dp8EfrSsOjtfWic/inqVYlbQ==
   dependencies:
     "@jest/create-cache-key-function" "^27.0.1"
     "@react-native-community/cli" "^7.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12099,15 +12099,14 @@ react-native-svg@12.3.0:
     css-select "^4.2.1"
     css-tree "^1.0.0-alpha.39"
 
-react-native-test-app@^1.6.2:
-  version "1.6.20"
-  resolved "https://registry.yarnpkg.com/react-native-test-app/-/react-native-test-app-1.6.20.tgz#ab9a6315c81fb080d7b14e0c5f8ab6983bb95d90"
-  integrity sha512-uAiiARR61kPf2JUUSVHPXOgM7D0WTS/zRXEGSj09vpzf1KxLZdcBdFLy7IkqvsKo6tXlBTyPKwdLWORXVHfEPw==
+react-native-test-app@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/react-native-test-app/-/react-native-test-app-2.0.2.tgz#132b601199f4cddadd24c26237dfeda5b918b0e2"
+  integrity sha512-OZeVBwTjndLCyh7/L8TYTcbSdE2oV+mPoY0AD4awTKLMaLFycfT0cSEWlfSdj8Va2KPj+AmXwfQIoI9l6/w7/Q==
   dependencies:
     ajv "^8.0.0"
     chalk "^4.1.0"
     prompts "^2.4.0"
-    rimraf "^3.0.0"
     semver "^7.3.5"
     uuid "^8.3.2"
     yargs "^16.0.0"


### PR DESCRIPTION
A recent publishing mistake is breaking all Android build regardless of React Native version. This patch release works around the issue.

For more details, see https://github.com/facebook/react-native/issues/35210.