### PR TITLE
Update useViewCommandFocus

### DIFF
--- a/change/@fluentui-react-native-interactive-hooks-3e4c94c4-418f-487a-9669-47e9a4b76d95.json
+++ b/change/@fluentui-react-native-interactive-hooks-3e4c94c4-418f-487a-9669-47e9a4b76d95.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update useViewCommandFocus",
+  "packageName": "@fluentui-react-native/interactive-hooks",
+  "email": "amchiu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/utils/interactive-hooks/src/useViewCommandFocus.ts
+++ b/packages/utils/interactive-hooks/src/useViewCommandFocus.ts
@@ -30,14 +30,14 @@ export function useViewCommandFocus(
        */
       if (localRef) {
         localRef.focus = () => {
-          const commands = UIManager.getViewManagerConfig('RCTView').Commands;
-          if ('focus' in commands) {
+          const commands = UIManager.getViewManagerConfig('RCTView')?.Commands;
+          if (commands != null && 'focus' in commands) {
             UIManager.dispatchViewManagerCommand(findNodeHandle(localRef), commands.focus, null);
           }
         };
         localRef.blur = () => {
-          const commands = UIManager.getViewManagerConfig('RCTView').Commands;
-          if ('blur' in commands) {
+          const commands = UIManager.getViewManagerConfig('RCTView')?.Commands;
+          if (commands != null && 'blur' in commands) {
             UIManager.dispatchViewManagerCommand(findNodeHandle(localRef), commands.blur, null);
           }
         };

--- a/packages/utils/interactive-hooks/src/useViewCommandFocus.ts
+++ b/packages/utils/interactive-hooks/src/useViewCommandFocus.ts
@@ -26,13 +26,19 @@ export function useViewCommandFocus(
       focusRef.current = localRef;
 
       /**
-       * Add focus() as a callable function to the forwarded reference.
+       * Add focus() and blur() as callable functions to the forwarded reference.
        */
       if (localRef) {
         localRef.focus = () => {
           const commands = UIManager.getViewManagerConfig('RCTView').Commands;
           if ('focus' in commands) {
             UIManager.dispatchViewManagerCommand(findNodeHandle(localRef), commands.focus, null);
+          }
+        };
+        localRef.blur = () => {
+          const commands = UIManager.getViewManagerConfig('RCTView').Commands;
+          if ('blur' in commands) {
+            UIManager.dispatchViewManagerCommand(findNodeHandle(localRef), commands.blur, null);
           }
         };
       }


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This PR maps the JavaScript ref.blur to the native ref, which enables the blurring effect to work properly on macOS.

### Verification

Tested hover states on Menu, menu item loses focus on mouse leave.

Before:

https://user-images.githubusercontent.com/67026167/200672625-f4643c84-583d-4f22-be3a-ed8f9629eea4.mov

After:


https://user-images.githubusercontent.com/67026167/200672818-c8e38392-d30f-45cc-bcde-d912a4cdfe7e.mov




### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
