### PR TITLE
FocusZone (macOS): Ensure we passthrough unhandled keyboard events

### DIFF
--- a/change/@fluentui-react-native-focus-zone-9ddebfb6-37c4-46fd-9bf2-2174b0f25d98.json
+++ b/change/@fluentui-react-native-focus-zone-9ddebfb6-37c4-46fd-9bf2-2174b0f25d98.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "FocusZone (macOS): Ensure we passthrough unhandled keyboard events",
+  "packageName": "@fluentui-react-native/focus-zone",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/FocusZone/macos/RCTFocusZone.m
+++ b/packages/components/FocusZone/macos/RCTFocusZone.m
@@ -465,13 +465,19 @@ static BOOL ShouldSkipFocusZone(NSView *view)
 		viewToFocus = [self nextViewToFocusWithFallback:action];
 	}
 
-	if (passthrough) {
+	if (passthrough)
+	{
 		[super keyDown:event];
 	}
 	else if (viewToFocus != nil)
 	{
 		[[self window] makeFirstResponder:viewToFocus];
 		[viewToFocus scrollRectToVisible:[viewToFocus bounds]];
+	}
+	else
+	{
+		// There are no views to pass focus to and we don't want to call `[super keyDown:event]`.
+		// Explicitly no-op.
 	}
 }
 

--- a/packages/components/FocusZone/macos/RCTFocusZone.m
+++ b/packages/components/FocusZone/macos/RCTFocusZone.m
@@ -465,19 +465,16 @@ static BOOL ShouldSkipFocusZone(NSView *view)
 		viewToFocus = [self nextViewToFocusWithFallback:action];
 	}
 
-	if (passthrough)
-	{
-		[super keyDown:event];
-	}
-	else if (viewToFocus != nil)
+	if (viewToFocus != nil)
 	{
 		[[self window] makeFirstResponder:viewToFocus];
 		[viewToFocus scrollRectToVisible:[viewToFocus bounds]];
 	}
-	else
+	else if (passthrough)
 	{
-		// There are no views to pass focus to and we don't want to call `[super keyDown:event]`.
-		// Explicitly no-op.
+		// Only call super if we explicitly want to passthrough the event
+		// I.E: FocusZone don't handle this specific key
+		[super keyDown:event];
 	}
 }
 

--- a/packages/components/FocusZone/macos/RCTFocusZone.m
+++ b/packages/components/FocusZone/macos/RCTFocusZone.m
@@ -465,15 +465,13 @@ static BOOL ShouldSkipFocusZone(NSView *view)
 		viewToFocus = [self nextViewToFocusWithFallback:action];
 	}
 
-	if (!passthrough && viewToFocus != nil)
+	if (passthrough) {
+		[super keyDown:event];
+	}
+	else if (viewToFocus != nil)
 	{
 		[[self window] makeFirstResponder:viewToFocus];
 		[viewToFocus scrollRectToVisible:[viewToFocus bounds]];
-	}
-	// Call super only if there are views to focus
-	else if (viewToFocus != nil)
-	{
-		[super keyDown:event];
 	}
 }
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

There was a regression from #2297 , where FocusZone no longer correctly called `[super keyDown:event]` for events it didn't handle. This broke a few cases:

1) Escape to close Callouts / Menus
  - Since FocusZone never called `super` the "escape" key event never made it's way up the responder chain to the CalloutWindow, where it could be handled to close itself
  
2) Nested FocusZone:
  - Although it's officially unsupported, we do have a test case for two horizontal FocusZones nested inside a vertical FocusZone. The inner horizontal FocusZone would not properly pass the "ArrowUp/Down" events to the next responder (its superview: the vertical FocusZone), and thus the test case broke. 
  
  
Followup: Enabling more of the macOS E2E tests would have caught this. So.. we should totally do that. 


### Verification

Tested that "ArrowUp/Down" in a Menu work as expected. Tested that "Escape" still closes a menu, and that "Tab" still no-ops instead of hanging. 

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
