### PR TITLE
Fixing Avatar E2E Testing Constant

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Avatar/consts.ts
+++ b/apps/fluent-tester/src/TestComponents/Avatar/consts.ts
@@ -1,7 +1,7 @@
 export const HOMEPAGE_AVATAR_BUTTON = 'Homepage_Avatar_Button';
 export const HOMEPAGE_NATIVE_AVATAR_BUTTON = 'Homepage_Native_Avatar_Button';
 export const NATIVE_AVATAR_TESTPAGE = 'NativeAvatar_TestPage';
-export const AVATAR_TESTPAGE = 'Avatar_Win32_TestPage';
+export const AVATAR_TESTPAGE = 'Avatar_TestPage';
 
 export const AVATAR_ACCESSIBILITY_LABEL = 'E2E Avatar Accessibility label';
 export const AVATAR_ACCESSIBILITY_LABEL_BY_NAME = 'Richard, available';

--- a/change/@fluentui-react-native-tester-32d512f7-1b5a-4773-bb94-9821ddfc61f8.json
+++ b/change/@fluentui-react-native-tester-32d512f7-1b5a-4773-bb94-9821ddfc61f8.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Fixing Avatar constant",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [X] macOS
- [X] win32 (Office)
- [X] windows
- [ ] android

### Description of changes

One of the Avatar E2E testing constants was not in the correct structure, causing E2E testing failures on the native side. The structure of these constants is displayed in the E2E ReadMe.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
