### PR TITLE
Add shadow crash + assert testing

### DIFF
--- a/apps/fluent-tester/src/E2E/Shadow/pages/ShadowPageObject.ts
+++ b/apps/fluent-tester/src/E2E/Shadow/pages/ShadowPageObject.ts
@@ -1,0 +1,17 @@
+import { SHADOW_TESTPAGE, HOMEPAGE_SHADOW_BUTTON } from '../../../TestComponents/Shadow/consts';
+import { BasePage, By } from '../../common/BasePage';
+
+class ShadowTestPage extends BasePage {
+  /*****************************************/
+  /**************** Getters ****************/
+  /*****************************************/
+  get _testPage() {
+    return By(SHADOW_TESTPAGE);
+  }
+
+  get _pageButton() {
+    return By(HOMEPAGE_SHADOW_BUTTON);
+  }
+}
+
+export default new ShadowTestPage();

--- a/apps/fluent-tester/src/E2E/Shadow/specs/Shadow.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/Shadow/specs/Shadow.spec.ios.ts
@@ -18,6 +18,5 @@ describe('Shadow Testing Initialization', function () {
     await ShadowPageObject.waitForPageDisplayed(PAGE_TIMEOUT);
 
     await expect(await ShadowPageObject.isPageLoaded()).toBeTruthy(ShadowPageObject.ERRORMESSAGE_PAGELOAD);
-    await expect(await ShadowPageObject.didAssertPopup()).toBeFalsy(ShadowPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
   });
 });

--- a/apps/fluent-tester/src/E2E/Shadow/specs/Shadow.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/Shadow/specs/Shadow.spec.ios.ts
@@ -10,8 +10,8 @@ describe('Shadow Testing Initialization', function () {
   });
 
   it('Click and navigate to Shadow test page', async () => {
-    await NavigateAppPage.mobileScrollToComponentButton();
-    await NavigateAppPage.waitForButtonDisplayed();
+    await ShadowPageObject.mobileScrollToComponentButton();
+    await ShadowPageObject.waitForButtonDisplayed();
 
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToShadowPage();

--- a/apps/fluent-tester/src/E2E/Shadow/specs/Shadow.spec.ios.ts
+++ b/apps/fluent-tester/src/E2E/Shadow/specs/Shadow.spec.ios.ts
@@ -1,0 +1,23 @@
+import NavigateAppPage from '../../common/NavigateAppPage';
+import ShadowPageObject from '../pages/ShadowPageObject';
+import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
+
+// Before testing begins, allow up to 60 seconds for app to open
+describe('Shadow Testing Initialization', function () {
+  it('Wait for app load', async () => {
+    await NavigateAppPage.waitForPageDisplayed(BOOT_APP_TIMEOUT);
+    await expect(await NavigateAppPage.isPageLoaded()).toBeTruthy(NavigateAppPage.ERRORMESSAGE_APPLOAD);
+  });
+
+  it('Click and navigate to Shadow test page', async () => {
+    await NavigateAppPage.mobileScrollToComponentButton();
+    await NavigateAppPage.waitForButtonDisplayed();
+
+    /* Click on component button to navigate to test page */
+    await NavigateAppPage.clickAndGoToShadowPage();
+    await ShadowPageObject.waitForPageDisplayed(PAGE_TIMEOUT);
+
+    await expect(await ShadowPageObject.isPageLoaded()).toBeTruthy(ShadowPageObject.ERRORMESSAGE_PAGELOAD);
+    await expect(await ShadowPageObject.didAssertPopup()).toBeFalsy(ShadowPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+  });
+});

--- a/apps/fluent-tester/src/E2E/Shadow/specs/Shadow.spec.macos.ts
+++ b/apps/fluent-tester/src/E2E/Shadow/specs/Shadow.spec.macos.ts
@@ -17,6 +17,5 @@ describe('Shadow Testing Initialization', function () {
     await ShadowPageObject.waitForPageDisplayed(PAGE_TIMEOUT);
 
     await expect(await ShadowPageObject.isPageLoaded()).toBeTruthy(ShadowPageObject.ERRORMESSAGE_PAGELOAD);
-    await expect(await ShadowPageObject.didAssertPopup()).toBeFalsy(ShadowPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
   });
 });

--- a/apps/fluent-tester/src/E2E/Shadow/specs/Shadow.spec.macos.ts
+++ b/apps/fluent-tester/src/E2E/Shadow/specs/Shadow.spec.macos.ts
@@ -1,0 +1,22 @@
+import NavigateAppPage from '../../common/NavigateAppPage';
+import ShadowPageObject from '../pages/ShadowPageObject';
+import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
+
+// Before testing begins, allow up to 60 seconds for app to open
+describe('Shadow Testing Initialization', function () {
+  it('Wait for app load', async () => {
+    await NavigateAppPage.waitForPageDisplayed(BOOT_APP_TIMEOUT);
+    await expect(await NavigateAppPage.isPageLoaded()).toBeTruthy(NavigateAppPage.ERRORMESSAGE_APPLOAD);
+  });
+
+  it('Click and navigate to Shadow test page', async () => {
+    await NavigateAppPage.waitForButtonDisplayed();
+
+    /* Click on component button to navigate to test page */
+    await NavigateAppPage.clickAndGoToShadowPage();
+    await ShadowPageObject.waitForPageDisplayed(PAGE_TIMEOUT);
+
+    await expect(await ShadowPageObject.isPageLoaded()).toBeTruthy(ShadowPageObject.ERRORMESSAGE_PAGELOAD);
+    await expect(await ShadowPageObject.didAssertPopup()).toBeFalsy(ShadowPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+  });
+});

--- a/apps/fluent-tester/src/E2E/Shadow/specs/Shadow.spec.macos.ts
+++ b/apps/fluent-tester/src/E2E/Shadow/specs/Shadow.spec.macos.ts
@@ -10,7 +10,7 @@ describe('Shadow Testing Initialization', function () {
   });
 
   it('Click and navigate to Shadow test page', async () => {
-    await NavigateAppPage.waitForButtonDisplayed();
+    await ShadowPageObject.waitForButtonDisplayed();
 
     /* Click on component button to navigate to test page */
     await NavigateAppPage.clickAndGoToShadowPage();

--- a/apps/fluent-tester/src/E2E/Shadow/specs/Shadow.spec.win.ts
+++ b/apps/fluent-tester/src/E2E/Shadow/specs/Shadow.spec.win.ts
@@ -1,0 +1,20 @@
+import NavigateAppPage from '../../common/NavigateAppPage';
+import ShadowPageObject from '../pages/ShadowPageObject';
+import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
+
+// Before testing begins, allow up to 60 seconds for app to open
+describe('Shadow Testing Initialization', function () {
+  it('Wait for app load', async () => {
+    await NavigateAppPage.waitForPageDisplayed(BOOT_APP_TIMEOUT);
+    await expect(await NavigateAppPage.isPageLoaded()).toBeTruthy(NavigateAppPage.ERRORMESSAGE_APPLOAD);
+  });
+
+  it('Click and navigate to Shadow test page', async () => {
+    /* Click on component button to navigate to test page */
+    await NavigateAppPage.clickAndGoToShadowPage();
+    await ShadowPageObject.waitForPageDisplayed(PAGE_TIMEOUT);
+
+    await expect(await ShadowPageObject.isPageLoaded()).toBeTruthy(ShadowPageObject.ERRORMESSAGE_PAGELOAD);
+    await expect(await ShadowPageObject.didAssertPopup()).toBeFalsy(ShadowPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+  });
+});

--- a/apps/fluent-tester/src/E2E/common/NavigateAppPage.ts
+++ b/apps/fluent-tester/src/E2E/common/NavigateAppPage.ts
@@ -20,6 +20,7 @@ import { HOMEPAGE_PERSONACOIN_BUTTON } from '../../TestComponents/PersonaCoin/co
 import { HOMEPAGE_PRESSABLE_BUTTON } from '../../TestComponents/Pressable/consts';
 import { HOMEPAGE_RADIOGROUP_BUTTON } from '../../TestComponents/RadioGroup/consts';
 import { HOMEPAGE_SEPARATOR_BUTTON } from '../../TestComponents/Separator/consts';
+import { HOMEPAGE_SHADOW_BUTTON } from '../../TestComponents/Shadow/consts';
 import { HOMEPAGE_SHIMMER_BUTTON } from '../../TestComponents/Shimmer/consts';
 import { HOMEPAGE_SVG_BUTTON } from '../../TestComponents/Svg/consts';
 import { HOMEPAGE_SWITCH_BUTTON } from '../../TestComponents/Switch/consts';
@@ -114,6 +115,10 @@ class NavigateAppPage extends BasePage {
 
   async clickAndGoToSeparatorPage() {
     await (await this.separatorPage).click();
+  }
+
+  async clickAndGoToShadowPage() {
+    await (await this.shadowPage).click();
   }
 
   async clickAndGoToShimmerPage() {
@@ -242,6 +247,10 @@ class NavigateAppPage extends BasePage {
 
   private get separatorPage() {
     return By(HOMEPAGE_SEPARATOR_BUTTON);
+  }
+
+  private get shadowPage() {
+    return By(HOMEPAGE_SHADOW_BUTTON);
   }
 
   private get shimmerPage() {

--- a/apps/fluent-tester/src/TestComponents/Shadow/ShadowTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Shadow/ShadowTest.tsx
@@ -13,12 +13,10 @@ const shadowSections: TestSection[] = [
   },
   {
     name: 'Shadows on Button Examples',
-    testID: SHADOW_TESTPAGE,
     component: ShadowButtonTestSection,
   },
   {
     name: 'Shadows with Different Props Test',
-    testID: SHADOW_TESTPAGE,
     component: ShadowWithDifferentPropsTestSection,
   },
 ];

--- a/apps/fluent-tester/wdio.conf.windows.js
+++ b/apps/fluent-tester/wdio.conf.windows.js
@@ -16,7 +16,6 @@ exports.config = {
     'src/E2E/PersonaCoin/specs/*.win.ts',
     'src/E2E/Pressable/specs/*.win.ts',
     'src/E2E/Separator/specs/*.win.ts',
-    'src/E2E/Shadow/specs/*.win.ts',
     'src/E2E/Tabs/specs/*.windows.ts', // See spec file for more information
     'src/E2E/Text/specs/*.win.ts',
     'src/E2E/TextExperimental/specs/*.win.ts',

--- a/apps/fluent-tester/wdio.conf.windows.js
+++ b/apps/fluent-tester/wdio.conf.windows.js
@@ -16,6 +16,7 @@ exports.config = {
     'src/E2E/PersonaCoin/specs/*.win.ts',
     'src/E2E/Pressable/specs/*.win.ts',
     'src/E2E/Separator/specs/*.win.ts',
+    'src/E2E/Shadow/specs/*.win.ts',
     'src/E2E/Tabs/specs/*.windows.ts', // See spec file for more information
     'src/E2E/Text/specs/*.win.ts',
     'src/E2E/TextExperimental/specs/*.win.ts',

--- a/change/@fluentui-react-native-tester-bd05cfea-8346-43c8-ac5c-9aaf7e1fc44d.json
+++ b/change/@fluentui-react-native-tester-bd05cfea-8346-43c8-ac5c-9aaf7e1fc44d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add shadow crash + assert testing",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Shadow is one of the developed experimental/v1 components which currently lacks base E2E crash + assert testing on our supported testing platforms.

This PR adds the barebones specs for E2E testing on iOS, macOS, and win32. 

### Verification

Testing via pipeline + local verification. All checks seem to pass for the above platforms. 

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
