### PR TITLE
chore: use `rnx-start` for dev server

### DIFF
--- a/apps/fluent-tester/package.json
+++ b/apps/fluent-tester/package.json
@@ -31,7 +31,7 @@
     "macos": "react-native run-macos --scheme FluentTester",
     "prettier": "fluentui-scripts prettier",
     "prettier-fix": "fluentui-scripts prettier --fix true",
-    "start": "react-native start",
+    "start": "react-native rnx-start",
     "windows": "react-native run-windows --arch x64 --sln windows/FluentTester.sln"
   },
   "repository": {

--- a/apps/win32/metro.config.js
+++ b/apps/win32/metro.config.js
@@ -5,12 +5,15 @@
  * @format
  */
 
-const { defaultWatchFolders, exclusionList } = require('@rnx-kit/metro-config');
+const { defaultWatchFolders, exclusionList, resolveUniqueModule } = require('@rnx-kit/metro-config');
 const { getDefaultConfig } = require('metro-config');
+
+const [reactIs, reactIsExcludePattern] = resolveUniqueModule('react-is');
 
 const blockList = exclusionList([
   // Exclude build output directory
   /.*\/apps\/win32\/dist\/.*/,
+  reactIsExcludePattern,
 ]);
 
 module.exports = (async () => {
@@ -24,6 +27,9 @@ module.exports = (async () => {
       sourceExts: [...sourceExts, 'svg'],
       blacklistRE: blockList,
       blockList,
+      extraNodeModules: {
+        'react-is': reactIs,
+      },
     },
     // Metro doesn't currently handle assets coming from hoisted packages within a monorepo.  This is the current workaround people use
     // In this case this is to ensure that the image assets that are part of logbox get loaded correctly.

--- a/apps/win32/package.json
+++ b/apps/win32/package.json
@@ -14,7 +14,7 @@
     "clean": "fluentui-scripts clean",
     "depcheck": "fluentui-scripts depcheck",
     "lint": "fluentui-scripts eslint",
-    "start": "react-native start --port 8081",
+    "start": "react-native rnx-start",
     "bundle": "react-native rnx-bundle --dev false",
     "bundle-dev": "react-native rnx-bundle",
     "run-win32": "rex-win32 --bundle index.win32 --component FluentTester --windowTitle \"FluentUI Tester\" --basePath ./dist --pluginProps --debugBundlePath index --jsEngine v8",

--- a/change/@fluentui-react-native-tester-3bd76101-33f5-4918-9f48-584a5c48130b.json
+++ b/change/@fluentui-react-native-tester-3bd76101-33f5-4918-9f48-584a5c48130b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use `rnx-start` for dev server",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-tester-win32-d4ef0a79-a98f-432b-bab9-f22c81ffabb6.json
+++ b/change/@fluentui-react-native-tester-win32-d4ef0a79-a98f-432b-bab9-f22c81ffabb6.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use `rnx-start` for dev server",
+  "packageName": "@fluentui-react-native/tester-win32",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}


### PR DESCRIPTION
### Platforms Impacted

- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Use `rnx-start` for dev server.

### Verification

```
cd apps/fluent-tester
yarn start
```