### PR TITLE
Update token documentation: shadow, corner radius, stroke width, size

### DIFF
--- a/.ado/markdown-link-check-config.json
+++ b/.ado/markdown-link-check-config.json
@@ -5,6 +5,9 @@
     },
     {
       "pattern": "https://cla.opensource.microsoft.com"
+    },
+    {
+      "pattern": "https://github.com/microsoft/fluentui-design-tokens"
     }
   ],
   "timeout": "5s",

--- a/docs/pages/Theming/Tokens/Basics.md
+++ b/docs/pages/Theming/Tokens/Basics.md
@@ -37,27 +37,7 @@ const colorTableFluent: { [P in PersonaCoinFluentColor]: string } = {
 
 ### Font
 
-You can find tokens related to fonts such as weight and size in the `globalTokens.font` property.
-
-An example of usage is in our Badge component, where we specify different font sizes for different Badge sizes.
-
-```ts
-import { globalTokens } from '@fluentui-react-native/theme-tokens';
-
-export const badgeFontTokens: TokenSettings<BadgeTokens, Theme> = (t: Theme) =>
-  ({
-    ...
-    fontSize: globalTokens.font.size100,
-    fontWeight: globalTokens.font.weight.regular,
-    large: {
-      fontSize: globalTokens.font.size200,
-    },
-    extraLarge: {
-      fontSize: globalTokens.font.size200,
-    },
-  } as BadgeTokens);
-
-```
+TO DO
 
 ### Stroke
 

--- a/docs/pages/Theming/Tokens/Basics.md
+++ b/docs/pages/Theming/Tokens/Basics.md
@@ -16,7 +16,22 @@ Global tokens can be imported directly:
 
 The full set of global tokens is here: [android](https://github.com/microsoft/fluentui-design-tokens/blob/main/src/global.android.json) / [ios](https://github.com/microsoft/fluentui-design-tokens/blob/main/src/global.ios.json) / [macOS](https://github.com/microsoft/fluentui-design-tokens/blob/main/src/global.macos.json) / [win32](https://github.com/microsoft/fluentui-design-tokens/blob/main/src/global.win32.json) / [windows](https://github.com/microsoft/fluentui-design-tokens/blob/main/src/global.windows.json)
 
-### Color
+## Alias
+
+Alias tokens are used to refer to the global tokens that are appropriate based on the current platform or theme. For example for `neutralForeground1`, in a light mode it points to a global token whose value is a light grey, but in a dark mode will change to point to a global token whose value is a dark grey. This allows component builders to point to the same color name and have it change to the correct value without having to know about the underlying theme.
+
+Alias tokens can be accessed from the `Theme` object. So if you have a `Theme` object and want to access the `neutralForeground1` alias token:
+
+```ts
+import { useFluentTheme } from '@fluentui-react-native/framework';
+
+const theme = useFluentTheme();
+const foreground = theme.colors.neutralForeground1;
+```
+
+## Types of tokens
+
+### Color [in progress]
 
 If accessing a specific color, you can find it in the `globalTokens.color` property.
 
@@ -32,26 +47,6 @@ const colorTableFluent: { [P in PersonaCoinFluentColor]: string } = {
   teal: globalTokens.color.teal.primary,
   forest: globalTokens.color.forest.primary,
   ...
-};
-```
-
-### Font
-
-TO DO
-
-### Stroke
-
-You can find tokens related to stroke in the `globalTokens.stroke` property. Currently the only type of token related to stroke is stroke width.
-
-An example of usage is in our Avatar component, where we specify different ring thicknesses for different avatar sizes.
-
-```ts
-import { globalTokens } from '@fluentui-react-native/theme-tokens';
-
-const strokeSize = {
-  small: globalTokens.stroke.width20,
-  medium: globalTokens.stroke.width30,
-  large: globalTokens.stroke.width40,
 };
 ```
 
@@ -81,6 +76,10 @@ export const defaultAvatarTokens: TokenSettings<AvatarTokens, Theme> = (t: Theme
     ...
 ```
 
+### Font
+
+TO DO
+
 ### Size
 
 You can find tokens related to size in the `globalTokens.size property`.
@@ -100,15 +99,18 @@ export const defaultMenuItemTokens: TokenSettings<MenuItemTokens, Theme> = (t: T
 })
 ```
 
-## Alias
+### Stroke
 
-Alias tokens are used to refer to the global tokens that are appropriate based on the current platform or theme. For example for `neutralForeground1`, in a light mode it points to a global token whose value is a light grey, but in a dark mode will change to point to a global token whose value is a dark grey. This allows component builders to point to the same color name and have it change to the correct value without having to know about the underlying theme.
+You can find tokens related to stroke in the `globalTokens.stroke` property. Currently the only type of token related to stroke is stroke width.
 
-Alias tokens can be accessed from the `Theme` object. So if you have a `Theme` object and want to access the `neutralForeground1` alias token:
+An example of usage is in our Avatar component, where we specify different ring thicknesses for different avatar sizes.
 
 ```ts
-import { useFluentTheme } from '@fluentui-react-native/framework';
+import { globalTokens } from '@fluentui-react-native/theme-tokens';
 
-const theme = useFluentTheme();
-const foreground = theme.colors.neutralForeground1;
+const strokeSize = {
+  small: globalTokens.stroke.width20,
+  medium: globalTokens.stroke.width30,
+  large: globalTokens.stroke.width40,
+};
 ```

--- a/docs/pages/Theming/Tokens/Basics.md
+++ b/docs/pages/Theming/Tokens/Basics.md
@@ -6,7 +6,7 @@ With the Fluent Design System, we have a set of named design values, that we hav
 
 Our set of global tokens is the complete set of the design values that we agree to use for our UI. Each token has a specific name that is assigned to a certain value. For example, `grey74` is `#bdbdbd`.
 
-These names and values do not change no matter the platform or theme; however, there are some exceptions. The only current exception is that brand color definitions change depending on platform.
+These names and values do not change no matter the platform or theme; however, there is an exception: currently brand color definitions differ depending on platform.
 
 In most cases you will not be referring to global tokens directly. The case where you may be referring to global tokens is when you're defining your own alias token, or need to access brand colors.
 
@@ -33,7 +33,9 @@ const foreground = theme.colors.neutralForeground1;
 
 ### Color [in progress]
 
-If accessing a specific color, you can find it in the `globalTokens.color` property.
+TO DO - recommended usage is through alias tokens rather than global
+
+Special case: if accessing a specific color, you can find it in the `globalTokens.color` property.
 
 An example of usage is in our PersonaCoin, where we use colors for the coin background if an image is not used.
 
@@ -82,7 +84,7 @@ TO DO
 
 ### Size
 
-You can find tokens related to size in the `globalTokens.size` property.
+You can find tokens related to size and spacing in the `globalTokens.size` property.
 
 Example usage: in our Menu Item component, we use global size tokens to specific values for padding.
 

--- a/docs/pages/Theming/Tokens/Basics.md
+++ b/docs/pages/Theming/Tokens/Basics.md
@@ -52,9 +52,9 @@ const colorTableFluent: { [P in PersonaCoinFluentColor]: string } = {
 
 ### Corner Radius
 
-You can find tokens related to corner radius in the `globalTokens.corner` property. Currently the only type of token related to corner is corner radius.
+You can find tokens related to corner radius in the `globalTokens.corner` property. Currently the only type of token related to corners is corner radius.
 
-An example of usage is in our Avatar component, where we have the option of both circular and square avatars.
+An example of usage is in our Avatar component, where we have the option of both circular and square avatars that use different corner radii.
 
 ```ts
 import { globalTokens } from '@fluentui-react-native/theme-tokens';
@@ -76,13 +76,13 @@ export const defaultAvatarTokens: TokenSettings<AvatarTokens, Theme> = (t: Theme
     ...
 ```
 
-### Font
+### Font [in progress]
 
 TO DO
 
 ### Size
 
-You can find tokens related to size in the `globalTokens.size property`.
+You can find tokens related to size in the `globalTokens.size` property.
 
 Example usage: in our Menu Item component, we use global size tokens to specific values for padding.
 
@@ -97,6 +97,22 @@ export const defaultMenuItemTokens: TokenSettings<MenuItemTokens, Theme> = (t: T
   submenuIndicatorPadding: globalTokens.size20,
   ...
 })
+```
+
+### Shadow
+
+Shadow tokens are a type of alias token and can be accessed through the theme.
+
+The shadow token is an object describing the two shadows that comprise a single Fluent shadow. In FURN, The recommended usage of the shadow token is with the custom Shadow component - more documentation can be found [here](https://github.com/microsoft/fluentui-react-native/blob/main/packages/experimental/Shadow/SPEC.md)
+
+```ts
+import { useFluentTheme } from '@fluentui-react-native/framework';
+
+const theme = useFluentTheme();
+
+<Shadow shadowToken={theme.shadows.shadow8}>
+  <Button>Text box with shadow8</Button>
+</Shadow>;
 ```
 
 ### Stroke

--- a/docs/pages/Theming/Tokens/Basics.md
+++ b/docs/pages/Theming/Tokens/Basics.md
@@ -1,18 +1,22 @@
 # Using Tokens
 
-With the Fluent Design System, we have a set of colors that we have agreed to use for our UI.
-This page describes how to access these colors.
+With the Fluent Design System, we have a set of named design values, that we have agreed to use for our UI. These values include colors, shadows, sizing, typography, stroke width, corner radius, etc. The [fluentui-design-tokens](https://github.com/microsoft/fluentui-design-tokens) repo contains all the token definitions. This page describes how to access these values in the fluentui-react-native repo.
 
 ## Global
 
-Our set of global tokens is the complete set of the colors that we agree to use for our UI. Each color has a specific name that is assigned to a hex value. For example, `grey74` is `#bdbdbd`.
-These names and values do not change no matter the platform or theme.\*
+Our set of global tokens is the complete set of the design values that we agree to use for our UI. Each token has a specific name that is assigned to a certain value. For example, `grey74` is `#bdbdbd`.
+
+These names and values do not change no matter the platform or theme; however, there are some exceptions. The only current exception is that brand color definitions change depending on platform.
 
 In most cases you will not be referring to global tokens directly. The case where you may be referring to global tokens is when you're defining your own alias token, or need to access brand colors.
 
 Global tokens can be imported directly:
 
 `import { globalTokens } from '@fluentui-react-native\theme-tokens'`
+
+The full set of global tokens is here: [android](https://github.com/microsoft/fluentui-design-tokens/blob/main/src/global.android.json) / [ios](https://github.com/microsoft/fluentui-design-tokens/blob/main/src/global.ios.json) / [macOS](https://github.com/microsoft/fluentui-design-tokens/blob/main/src/global.macos.json) / [win32](https://github.com/microsoft/fluentui-design-tokens/blob/main/src/global.win32.json) / [windows](https://github.com/microsoft/fluentui-design-tokens/blob/main/src/global.windows.json)
+
+### Color
 
 If accessing a specific color, you can find it in the `globalTokens.color` property.
 
@@ -31,13 +35,96 @@ const colorTableFluent: { [P in PersonaCoinFluentColor]: string } = {
 };
 ```
 
-\* An exception is that brand color definitions change depending on platform.
+### Font
+
+You can find tokens related to fonts such as weight and size in the `globalTokens.font` property.
+
+An example of usage is in our Badge component, where we specify different font sizes for different Badge sizes.
+
+```ts
+import { globalTokens } from '@fluentui-react-native/theme-tokens';
+
+export const badgeFontTokens: TokenSettings<BadgeTokens, Theme> = (t: Theme) =>
+  ({
+    ...
+    fontSize: globalTokens.font.size100,
+    fontWeight: globalTokens.font.weight.regular,
+    large: {
+      fontSize: globalTokens.font.size200,
+    },
+    extraLarge: {
+      fontSize: globalTokens.font.size200,
+    },
+  } as BadgeTokens);
+
+```
+
+### Stroke
+
+You can find tokens related to stroke in the `globalTokens.stroke` property. Currently the only type of token related to stroke is stroke width.
+
+An example of usage is in our Avatar component, where we specify different ring thicknesses for different avatar sizes.
+
+```ts
+import { globalTokens } from '@fluentui-react-native/theme-tokens';
+
+const strokeSize = {
+  small: globalTokens.stroke.width20,
+  medium: globalTokens.stroke.width30,
+  large: globalTokens.stroke.width40,
+};
+```
+
+### Corner Radius
+
+You can find tokens related to corner radius in the `globalTokens.corner` property. Currently the only type of token related to corner is corner radius.
+
+An example of usage is in our Avatar component, where we have the option of both circular and square avatars.
+
+```ts
+import { globalTokens } from '@fluentui-react-native/theme-tokens';
+
+export const defaultAvatarTokens: TokenSettings<AvatarTokens, Theme> = (t: Theme) =>
+  ({
+    ...
+    circular: {
+      borderRadius: globalTokens.corner.radiusCircular,
+    },
+    square: {
+      borderRadius: globalTokens.corner.radius40,
+    },
+    size20: {
+      square: {
+        borderRadius: globalTokens.corner.radius20,
+      },
+    },
+    ...
+```
+
+### Size
+
+You can find tokens related to size in the `globalTokens.size property`.
+
+Example usage: in our Menu Item component, we use global size tokens to specific values for padding.
+
+```ts
+import { globalTokens } from '@fluentui-react-native/theme-tokens';
+
+export const defaultMenuItemTokens: TokenSettings<MenuItemTokens, Theme> = (t: Theme): MenuItemTokens => ({
+  ...
+  gap: globalTokens.size40,
+  padding: globalTokens.size40,
+  paddingHorizontal: globalTokens.size80,
+  submenuIndicatorPadding: globalTokens.size20,
+  ...
+})
+```
 
 ## Alias
 
 Alias tokens are used to refer to the global tokens that are appropriate based on the current platform or theme. For example for `neutralForeground1`, in a light mode it points to a global token whose value is a light grey, but in a dark mode will change to point to a global token whose value is a dark grey. This allows component builders to point to the same color name and have it change to the correct value without having to know about the underlying theme.
 
-Alias tokens can be accessed from the `Theme` object. Alias tokens are defined under the `colors` property on a theme. So if you have a `Theme` object and want to access the `neutralForeground1` alias token:
+Alias tokens can be accessed from the `Theme` object. So if you have a `Theme` object and want to access the `neutralForeground1` alias token:
 
 ```ts
 import { useFluentTheme } from '@fluentui-react-native/framework';


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

The previous documentation seemed to be written when the only tokens available were color tokens, updated the documentation to be more general. Added links to where the tokens are defined, also added examples of using all the different types of global tokens.

Note: the documentation about "size" is currently not relevant since as of publishing this PR FURN is still using the old spacing ramp. After the new size ramp is added to FURN the documentation should match.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
