### PR TITLE
Text: Render V2Usage on macOS

### DIFF
--- a/apps/fluent-tester/src/TestComponents/TextExperimental/V2Usage.macos.tsx
+++ b/apps/fluent-tester/src/TestComponents/TextExperimental/V2Usage.macos.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { View } from 'react-native';
+import { Stack } from '@fluentui-react-native/stack';
+import { stackStyle } from '../Common/styles';
+import {
+  Body1,
+  Body1Strong,
+  Body2,
+  Body2Strong,
+  Caption1,
+  Caption1Strong,
+  Caption2,
+  Display,
+  LargeTitle,
+  Title1,
+  Title2,
+  Title3,
+} from '@fluentui-react-native/text';
+
+export const V2Usage: React.FunctionComponent = () => {
+  return (
+    <View>
+      <Stack style={stackStyle} gap={5}>
+        <Caption2>Caption2</Caption2>
+        <Caption1>Caption1</Caption1>
+        <Caption1Strong>Caption1Strong</Caption1Strong>
+        <Body2>Body2</Body2>
+        <Body2Strong>Body2Strong</Body2Strong>
+        <Body1>Body1</Body1>
+        <Body1Strong>Body1Strong</Body1Strong>
+        <Title3>Title3</Title3>
+        <Title2>Title2</Title2>
+        <Title1>Title1</Title1>
+        <LargeTitle>LargeTitle</LargeTitle>
+        <Display>Display</Display>
+      </Stack>
+    </View>
+  );
+};

--- a/change/@fluentui-react-native-tester-7bfdb801-0b95-4637-90ac-4eb4eee4db0a.json
+++ b/change/@fluentui-react-native-tester-7bfdb801-0b95-4637-90ac-4eb4eee4db0a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Text: Render V2Usage on macOS",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

"V2Usage" was stubbed out for platforms other than iOS and win32.  I don't see a reason to stub this out on macOS, even if it's not ready yet. It'll also help iOS devs test that their Text changes on iOS don't affect other platforms (since macOS is the next easiest platform to test on a Macbook).

### Verification

V2Usage renders on macOS.. though as we can see, it doesn't work. That in itself is data to me that I'm happy the test app provided. 

![image](https://user-images.githubusercontent.com/6722175/203149188-57ed8d46-eeec-4db5-af2c-6db0e6e017a6.png)


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
