### PR TITLE
FURN Tester: Fix FocusTrapZone test component not trapping focus

### DIFF
--- a/apps/fluent-tester/src/FluentTester.tsx
+++ b/apps/fluent-tester/src/FluentTester.tsx
@@ -1,5 +1,5 @@
 import { Theme } from '@fluentui-react-native/framework';
-import { FocusTrapZone, Separator, Text } from '@fluentui/react-native';
+import { Separator, Text } from '@fluentui/react-native';
 import { ButtonV1 as Button } from '@fluentui-react-native/button';
 import { themedStyleSheet } from '@fluentui-react-native/themed-stylesheet';
 import * as React from 'react';
@@ -135,6 +135,14 @@ export const FluentTester: React.FunctionComponent<FluentTesterProps> = (props: 
   const isTestSectionVisible = !enableSinglePaneView || (enableSinglePaneView && !onTestListView);
 
   const TestList: React.FunctionComponent = () => {
+    const ref = React.useRef<View>();
+
+    React.useEffect(() => {
+      if (Platform.OS === ('win32' as any)) {
+        ref.current.focus();
+      }
+    }, []);
+
     return (
       <View style={fluentTesterStyles.testList}>
         <ScrollView contentContainerStyle={fluentTesterStyles.testListContainerStyle} testID={TESTPAGE_BUTTONS_SCROLLVIEWER}>
@@ -147,6 +155,7 @@ export const FluentTester: React.FunctionComponent<FluentTesterProps> = (props: 
                 onClick={() => setSelectedTestIndex(index)}
                 style={fluentTesterStyles.testListItem}
                 testID={description.testPage}
+                componentRef={index === 0 ? ref : undefined}
               >
                 {description.name}
               </Button>
@@ -227,15 +236,9 @@ export const FluentTester: React.FunctionComponent<FluentTesterProps> = (props: 
   return (
     // TODO: Figure out why making this view accessible breaks element querying on iOS.
     <View accessible={Platform.OS !== 'ios'} testID={ROOT_VIEW} style={commonTestStyles.flex}>
-      {Platform.OS === ('win32' as any) ? (
-        <FocusTrapZone style={themedStyles.root}>
-          <TesterContent />
-        </FocusTrapZone>
-      ) : (
-        <RootView style={themedStyles.root}>
-          <TesterContent />
-        </RootView>
-      )}
+      <RootView style={themedStyles.root}>
+        <TesterContent />
+      </RootView>
     </View>
   );
 };


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Currently, the FocusTrapZone page in the win32 FURN Tester app is not working correctly as the test component fails to trap focus going forward (#2324). This bug is caused by nested FocusTrapZone behavior: functionality for children trapzones in some cases does not take precedence over the parent. The immediate question this brings is why there is a nested FocusTrapZone in the win32 app is because of issue #674 (focus not initially setting in the win32 app) and its fix #722 (adds a FocusTrapZone to the root of the win32 app). 

This commit removes the FocusTrapZone at the root of the win32 app, fixing the behavior of the FocusTrapZone page. To set focus on the app on render, I use a React ref and call `.focus()` on the first button of the TestPage list in a `useEffect` hook. 

### Verification

Manual testing was done to see if:
1. The FocusTrapZone test component traps focus correctly.
2. The win32 app initially sets focus on something.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| [Video of FocusTrapZone not doing its job](https://user-images.githubusercontent.com/15683103/200965200-5674c2c7-0f32-4981-8784-c1659027bfb3.mp4) | [Video of FocusTrapZone doing its job 👍](https://user-images.githubusercontent.com/15683103/203435376-9af86e7a-dc42-4073-b99e-5fa4deb90cd8.mp4) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
