### PR TITLE
Fix broken Button HOC test section

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Button/ButtonHOCTestSection.tsx
+++ b/apps/fluent-tester/src/TestComponents/Button/ButtonHOCTestSection.tsx
@@ -1,8 +1,7 @@
 import { ButtonV1 as Button } from '@fluentui/react-native';
 import { TextV1 as Text } from '@fluentui-react-native/text';
-import { Icon } from '@fluentui-react-native/icon';
 import * as React from 'react';
-import { Platform, Pressable, View } from 'react-native';
+import { Platform, View } from 'react-native';
 import { commonTestStyles, stackStyle } from '../Common/styles';
 import { InteractionEvent, isGestureResponderEvent } from '@fluentui-react-native/interactive-hooks';
 import { svgProps } from '../Common/iconExamples';
@@ -10,9 +9,9 @@ import { svgProps } from '../Common/iconExamples';
 const CustomText = Text.customize({ fontSize: 'header', color: 'hotpink' });
 const CustomButton = Button.customize({ backgroundColor: 'pink' });
 const CustomIconButton = Button.customize({ iconColor: 'yellow' });
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore Not all slots have to be overridden for compose to work
 const ComposedButton = Button.compose({
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore Not all slots have to be overridden for compose to work
   slots: {
     content: CustomText,
   },

--- a/apps/fluent-tester/src/TestComponents/Button/ButtonHOCTestSection.tsx
+++ b/apps/fluent-tester/src/TestComponents/Button/ButtonHOCTestSection.tsx
@@ -10,10 +10,10 @@ import { svgProps } from '../Common/iconExamples';
 const CustomText = Text.customize({ fontSize: 'header', color: 'hotpink' });
 const CustomButton = Button.customize({ backgroundColor: 'pink' });
 const CustomIconButton = Button.customize({ iconColor: 'yellow' });
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore Not all slots have to be overridden for compose to work
 const ComposedButton = Button.compose({
   slots: {
-    root: Pressable,
-    icon: Icon,
     content: CustomText,
   },
   slotProps: {

--- a/change/@fluentui-react-native-tester-f99c1cb2-ea24-4588-bcef-bdb079d01887.json
+++ b/change/@fluentui-react-native-tester-f99c1cb2-ea24-4588-bcef-bdb079d01887.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix ButtonHOCTestSection",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

The "Button HOC" test section in Fluent tester would error on any interaction. This seems be because you can't use `.compose()` to swap out a Pressable slot. After some investigation, the fixes will be as follows:


1) Remove the offending lines in our example, supressing typescript errors as needed.
2) Fix the Typescript types for `composeFactory` so we don't need the supression
3) Investigate / fix upstream whatever is making Pressable (or other React.memo'ed components) not work with our compose function.

### Verification

Uploading... video of Button HOC test section working with interaction as well. 

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
