### PR TITLE
Update jest config platform for Shadow to be IOS

### DIFF
--- a/change/@fluentui-react-native-experimental-shadow-1ccdd0bf-d61d-4dc6-bea6-dc1d1c12a140.json
+++ b/change/@fluentui-react-native-experimental-shadow-1ccdd0bf-d61d-4dc6-bea6-dc1d1c12a140.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update jest config platform to be IOS",
+  "packageName": "@fluentui-react-native/experimental-shadow",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Shadow/jest.config.js
+++ b/packages/experimental/Shadow/jest.config.js
@@ -1,2 +1,2 @@
 const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
-module.exports = configureReactNativeJest('android');
+module.exports = configureReactNativeJest('ios');


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Update the jest config file to run the Shadow jest tests on iOS instead of Android. 

The Shadow component is currently available on iOS/macOS/win32. It does not work at all on Android, we should change the tests to run on a platform that it's available on. 

For this change there were no snapshot updates - I think the differences between iOS/Android for this specific component are at the native layer so the jest tests aren't able to capture the differences between iOS/Android shadow.

### Verification

Ran the tests, made sure they passed. 

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
