### PR TITLE
[Draft] Fix typescript type of compose()

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Button/ButtonHOCTestSection.tsx
+++ b/apps/fluent-tester/src/TestComponents/Button/ButtonHOCTestSection.tsx
@@ -10,8 +10,6 @@ const CustomText = Text.customize({ fontSize: 'header', color: 'hotpink' });
 const CustomButton = Button.customize({ backgroundColor: 'pink' });
 const CustomIconButton = Button.customize({ iconColor: 'yellow' });
 const ComposedButton = Button.compose({
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore Not all slots have to be overridden for compose to work
   slots: {
     content: CustomText,
   },

--- a/change/@fluentui-react-native-composition-78024f29-f7e4-4745-aeaa-58431169548e.json
+++ b/change/@fluentui-react-native-composition-78024f29-f7e4-4745-aeaa-58431169548e.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "[Draft] Fix typescript type of compose()",
+  "comment": "Fix typescript type of compose()",
   "packageName": "@fluentui-react-native/composition",
   "email": "sanajmi@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-native-composition-78024f29-f7e4-4745-aeaa-58431169548e.json
+++ b/change/@fluentui-react-native-composition-78024f29-f7e4-4745-aeaa-58431169548e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[Draft] Fix typescript type of compose()",
+  "packageName": "@fluentui-react-native/composition",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-a1807e3c-ef12-45ce-a6ee-72a09bc56df8.json
+++ b/change/@fluentui-react-native-tester-a1807e3c-ef12-45ce-a6ee-72a09bc56df8.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "[Draft] Fix typescript type of compose()",
+  "comment": "Fix typescript type of compose()",
   "packageName": "@fluentui-react-native/tester",
   "email": "sanajmi@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-native-tester-a1807e3c-ef12-45ce-a6ee-72a09bc56df8.json
+++ b/change/@fluentui-react-native-tester-a1807e3c-ef12-45ce-a6ee-72a09bc56df8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[Draft] Fix typescript type of compose()",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/framework/composition/src/composeFactory.ts
+++ b/packages/framework/composition/src/composeFactory.ts
@@ -29,11 +29,13 @@ export type ComposeFactoryOptions<TProps, TSlotProps, TTokens, TTheme, TStatics 
     statics?: TStatics;
   };
 
+type TwoLevelPartial<T> = { [K in keyof T]?: Partial<T[K]> };
+
 export type ComposeFactoryComponent<TProps, TSlotProps, TTokens, TTheme, TStatics extends object = object> = ComposableFunction<TProps> & {
   __options: ComposeFactoryOptions<TProps, TSlotProps, TTokens, TTheme, TStatics>;
   customize: (...tokens: TokenSettings<TTokens, TTheme>[]) => ComposeFactoryComponent<TProps, TSlotProps, TTokens, TTheme, TStatics>;
   compose: (
-    options: Partial<ComposeFactoryOptions<TProps, TSlotProps, TTokens, TTheme, TStatics>>,
+    options: TwoLevelPartial<ComposeFactoryOptions<TProps, TSlotProps, TTokens, TTheme, TStatics>>,
   ) => ComposeFactoryComponent<TProps, TSlotProps, TTokens, TTheme, TStatics>;
 } & TStatics;
 
@@ -75,7 +77,7 @@ export function composeFactory<TProps, TSlotProps, TTokens, TTheme, TStatics ext
       themeHelper,
     );
 
-  component.compose = (customOptions: Partial<LocalOptions>) =>
+  component.compose = (customOptions: TwoLevelPartial<LocalOptions>) =>
     composeFactory<TProps, TSlotProps, TTokens, TTheme, TStatics>(
       immutableMergeCore(mergeOptions, options, customOptions) as LocalOptions,
       themeHelper,


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Followup to #2356 , attempt to fix the typescript types so we don't need the `@ts-ignore`. 

Needs additional validation to ensure the fix is correct

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
