### PR TITLE
Add font and typography documentation

### DIFF
--- a/docs/pages/Theming/Tokens/Basics.md
+++ b/docs/pages/Theming/Tokens/Basics.md
@@ -137,12 +137,12 @@ const strokeSize = {
 
 ### Typography
 
-In FURN, typography alias tokens can be passed into a `Text` element or wrapped using a JSX type. For example:
+In FURN, typography alias tokens can be passed into a `TextV1` element or wrapped using a JSX type. For example:
 
 ```tsx
-import { Body1, Text } from '@fluentui-react-native/text';
+import { Body1, TextV1 } from '@fluentui-react-native/text';
 
-const myText = <Text variant="body1">Here is some body text</Text>;
+const myText = <TextV1 variant="body1">Here is some body text</TextV1>;
 const moreText = <Body1>Here is some more body text</Body1>;
 ```
 

--- a/docs/pages/Theming/Tokens/Basics.md
+++ b/docs/pages/Theming/Tokens/Basics.md
@@ -78,9 +78,11 @@ export const defaultAvatarTokens: TokenSettings<AvatarTokens, Theme> = (t: Theme
     ...
 ```
 
-### Font [in progress]
+### Font
 
-TO DO
+You can find global tokens related to fonts, including font families, sizes, and weights, in the `globalTokens.font` property.
+
+While you _could_ use these tokens directly in `Text` elements, this is not recommended. Instead, we recommend that you use the `variant` prop or the predefined JSX types as described in the [Typography](#typography) section, as these will pull in all the needed tokens automatically.
 
 ### Size
 
@@ -132,3 +134,16 @@ const strokeSize = {
   large: globalTokens.stroke.width40,
 };
 ```
+
+### Typography
+
+In FURN, typography alias tokens can be passed into a `Text` element or wrapped using a JSX type. For example:
+
+```tsx
+import { Body1, Text } from '@fluentui-react-native/text';
+
+const myText = <Text variant="body1">Here is some body text</Text>;
+const moreText = <Body1>Here is some more body text</Body1>;
+```
+
+The different text variants available on each platform can be found in the `Variants.platform.ts` files in `packages/components/text/src`. (Note that not all variants are available on every platform, although most of them are.)

--- a/docs/pages/Theming/Tokens/Basics.md
+++ b/docs/pages/Theming/Tokens/Basics.md
@@ -146,4 +146,4 @@ const myText = <TextV1 variant="body1">Here is some body text</TextV1>;
 const moreText = <Body1>Here is some more body text</Body1>;
 ```
 
-The different text variants available on each platform can be found in the `Variants.platform.ts` files in `packages/components/text/src`. (Note that not all variants are available on every platform, although most of them are.)
+Given a `Theme` object named `theme`, you can get the available variants and their tokens by calling `theme.typography.variants`. The different text variants available on each platform can be found in the `Variants.platform.ts` files in `packages/components/text/src`. Note that not all variants are available on every platform, although most of them are.


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Beforehand, the Font section of our token documentation was empty. This fills it in and expands more on typography stuff.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
