### PR TITLE
Change jest endpoint to win32 for Callout, Menu, MenuButton, Separator, Tab

### DIFF
--- a/change/@fluentui-react-native-callout-6c795ef2-9651-4d1d-9397-24ebe1de6fda.json
+++ b/change/@fluentui-react-native-callout-6c795ef2-9651-4d1d-9397-24ebe1de6fda.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update config",
+  "packageName": "@fluentui-react-native/callout",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-menu-button-a8f09018-2b1f-4148-8f82-71bb6b925b24.json
+++ b/change/@fluentui-react-native-experimental-menu-button-a8f09018-2b1f-4148-8f82-71bb6b925b24.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update config",
+  "packageName": "@fluentui-react-native/experimental-menu-button",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-tabs-79964f5f-fd12-44a9-8592-b50891bc10d1.json
+++ b/change/@fluentui-react-native-experimental-tabs-79964f5f-fd12-44a9-8592-b50891bc10d1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update config",
+  "packageName": "@fluentui-react-native/experimental-tabs",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-menu-3ed6d9e9-a0de-4558-add5-93c1cea2712b.json
+++ b/change/@fluentui-react-native-menu-3ed6d9e9-a0de-4558-add5-93c1cea2712b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update config",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-menu-button-17e3d670-f2f3-4500-b59f-6b7d6d3fc8c6.json
+++ b/change/@fluentui-react-native-menu-button-17e3d670-f2f3-4500-b59f-6b7d6d3fc8c6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update config",
+  "packageName": "@fluentui-react-native/menu-button",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-separator-bbba6801-60b9-4a5d-ae6d-7c17c8db4bb7.json
+++ b/change/@fluentui-react-native-separator-bbba6801-60b9-4a5d-ae6d-7c17c8db4bb7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update config",
+  "packageName": "@fluentui-react-native/separator",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tabs-f6f0f228-986d-491b-9d30-82e7749f8d1e.json
+++ b/change/@fluentui-react-native-tabs-f6f0f228-986d-491b-9d30-82e7749f8d1e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update config",
+  "packageName": "@fluentui-react-native/tabs",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Callout/jest.config.js
+++ b/packages/components/Callout/jest.config.js
@@ -1,2 +1,2 @@
 const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
-module.exports = configureReactNativeJest('android');
+module.exports = configureReactNativeJest('win32');

--- a/packages/components/Callout/package.json
+++ b/packages/components/Callout/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/scripts": "^0.1.1",
+    "@office-iss/react-native-win32": "^0.68.0",
     "@types/react-native": "^0.68.0",
     "react": "17.0.2",
     "react-native": "^0.68.0"

--- a/packages/components/Menu/jest.config.js
+++ b/packages/components/Menu/jest.config.js
@@ -1,2 +1,2 @@
 const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
-module.exports = configureReactNativeJest('ios');
+module.exports = configureReactNativeJest('win32');

--- a/packages/components/Menu/package.json
+++ b/packages/components/Menu/package.json
@@ -43,6 +43,7 @@
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/scripts": "^0.1.1",
     "@fluentui-react-native/test-tools": ">=0.1.1 <1.0.0",
+    "@office-iss/react-native-win32": "^0.68.0",
     "@types/react-native": "^0.68.0",
     "react": "17.0.2",
     "react-native": "^0.68.0"

--- a/packages/components/Menu/src/__tests__/__snapshots__/Menu.test.tsx.snap
+++ b/packages/components/Menu/src/__tests__/__snapshots__/Menu.test.tsx.snap
@@ -2,7 +2,16 @@
 
 exports[`Menu component tests Menu default 1`] = `
 <View
-  accessibilityActions={Array []}
+  accessibilityActions={
+    Array [
+      Object {
+        "name": "Expand",
+      },
+      Object {
+        "name": "Collapse",
+      },
+    ]
+  }
   accessibilityLabel="Default"
   accessibilityRole="button"
   accessibilityState={
@@ -11,14 +20,27 @@ exports[`Menu component tests Menu default 1`] = `
     }
   }
   accessible={true}
-  collapsable={false}
   enableFocusRing={true}
   focusable={true}
+  keyUpEvents={
+    Array [
+      Object {
+        "key": " ",
+      },
+      Object {
+        "key": "Enter",
+      },
+    ]
+  }
   onAccessibilityAction={[Function]}
   onAccessibilityTap={[Function]}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   onResponderGrant={[Function]}
   onResponderMove={[Function]}
   onResponderRelease={[Function]}
@@ -29,16 +51,17 @@ exports[`Menu component tests Menu default 1`] = `
     Object {
       "alignItems": "center",
       "alignSelf": "flex-start",
-      "backgroundColor": "#0f6cbd",
-      "borderColor": "#0f548c",
+      "backgroundColor": "#ffffff",
+      "borderColor": "#d1d1d1",
       "borderRadius": 4,
       "borderWidth": 1,
       "display": "flex",
       "flexDirection": "row",
       "justifyContent": "center",
-      "minWidth": 96,
-      "padding": 8,
-      "paddingHorizontal": 15,
+      "minHeight": 32,
+      "minWidth": 64,
+      "padding": 3,
+      "paddingHorizontal": 7,
       "width": undefined,
     }
   }
@@ -46,17 +69,18 @@ exports[`Menu component tests Menu default 1`] = `
   <Text
     ellipsizeMode="tail"
     numberOfLines={0}
+    onAccessibilityTap={[Function]}
     style={
       Object {
-        "color": "#ffffff",
-        "fontFamily": "System",
-        "fontSize": 15,
-        "fontWeight": "600",
+        "color": "#242424",
+        "fontFamily": "Segoe UI",
+        "fontSize": 12,
+        "fontWeight": "400",
         "margin": 0,
-        "marginBottom": 0,
-        "marginEnd": 0,
+        "marginBottom": 1,
+        "marginEnd": -2,
         "marginStart": 0,
-        "marginTop": 0,
+        "marginTop": -1,
       }
     }
   >
@@ -68,7 +92,16 @@ exports[`Menu component tests Menu default 1`] = `
 exports[`Menu component tests Menu defaultOpen 1`] = `
 Array [
   <View
-    accessibilityActions={Array []}
+    accessibilityActions={
+      Array [
+        Object {
+          "name": "Expand",
+        },
+        Object {
+          "name": "Collapse",
+        },
+      ]
+    }
     accessibilityLabel="Open"
     accessibilityRole="button"
     accessibilityState={
@@ -77,14 +110,27 @@ Array [
       }
     }
     accessible={true}
-    collapsable={false}
     enableFocusRing={true}
     focusable={true}
+    keyUpEvents={
+      Array [
+        Object {
+          "key": " ",
+        },
+        Object {
+          "key": "Enter",
+        },
+      ]
+    }
     onAccessibilityAction={[Function]}
     onAccessibilityTap={[Function]}
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
     onResponderGrant={[Function]}
     onResponderMove={[Function]}
     onResponderRelease={[Function]}
@@ -95,16 +141,17 @@ Array [
       Object {
         "alignItems": "center",
         "alignSelf": "flex-start",
-        "backgroundColor": "#0f6cbd",
-        "borderColor": "#0f548c",
+        "backgroundColor": "#ffffff",
+        "borderColor": "#d1d1d1",
         "borderRadius": 4,
         "borderWidth": 1,
         "display": "flex",
         "flexDirection": "row",
         "justifyContent": "center",
-        "minWidth": 96,
-        "padding": 8,
-        "paddingHorizontal": 15,
+        "minHeight": 32,
+        "minWidth": 64,
+        "padding": 3,
+        "paddingHorizontal": 7,
         "width": undefined,
       }
     }
@@ -112,17 +159,18 @@ Array [
     <Text
       ellipsizeMode="tail"
       numberOfLines={0}
+      onAccessibilityTap={[Function]}
       style={
         Object {
-          "color": "#ffffff",
-          "fontFamily": "System",
-          "fontSize": 15,
-          "fontWeight": "600",
+          "color": "#242424",
+          "fontFamily": "Segoe UI",
+          "fontSize": 12,
+          "fontWeight": "400",
           "margin": 0,
-          "marginBottom": 0,
-          "marginEnd": 0,
+          "marginBottom": 1,
+          "marginEnd": -2,
           "marginStart": 0,
-          "marginTop": 0,
+          "marginTop": -1,
         }
       }
     >
@@ -135,7 +183,7 @@ Array [
     borderWidth={1}
     doNotTakePointerCapture={false}
     onDismiss={[Function]}
-    setInitialFocus={false}
+    setInitialFocus={true}
     style={
       Object {
         "backgroundColor": "#faf9f8",
@@ -158,7 +206,7 @@ Array [
             "display": "flex",
             "maxWidth": 300,
             "minWidth": 128,
-            "padding": 8,
+            "paddingVertical": 4,
           }
         }
       >
@@ -171,13 +219,26 @@ Array [
             }
           }
           accessible={true}
-          collapsable={false}
           enableFocusRing={true}
           focusable={true}
+          keyDownEvents={
+            Array [
+              Object {
+                "key": " ",
+              },
+              Object {
+                "key": "Enter",
+              },
+            ]
+          }
           onAccessibilityTap={[Function]}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
           onResponderRelease={[Function]}
@@ -188,24 +249,27 @@ Array [
             Object {
               "alignItems": "center",
               "backgroundColor": "#ffffff",
-              "borderRadius": 4,
+              "borderRadius": 0,
               "display": "flex",
               "flexDirection": "row",
               "maxWidth": 300,
-              "minHeight": 32,
+              "minHeight": 24,
               "minWidth": 160,
+              "padding": 4,
+              "paddingHorizontal": 8,
             }
           }
         >
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
+            onAccessibilityTap={[Function]}
             style={
               Object {
-                "color": "#424242",
+                "color": "#242424",
                 "flexGrow": 1,
-                "fontFamily": "System",
-                "fontSize": 15,
+                "fontFamily": "Segoe UI",
+                "fontSize": 12,
                 "fontWeight": "400",
                 "margin": 0,
               }
@@ -223,13 +287,26 @@ Array [
             }
           }
           accessible={true}
-          collapsable={false}
           enableFocusRing={true}
           focusable={true}
+          keyDownEvents={
+            Array [
+              Object {
+                "key": " ",
+              },
+              Object {
+                "key": "Enter",
+              },
+            ]
+          }
           onAccessibilityTap={[Function]}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
           onResponderRelease={[Function]}
@@ -240,25 +317,27 @@ Array [
             Object {
               "alignItems": "center",
               "backgroundColor": "#ffffff",
-              "borderRadius": 4,
+              "borderRadius": 0,
               "display": "flex",
               "flexDirection": "row",
-              "marginTop": 4,
               "maxWidth": 300,
-              "minHeight": 32,
+              "minHeight": 24,
               "minWidth": 160,
+              "padding": 4,
+              "paddingHorizontal": 8,
             }
           }
         >
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
+            onAccessibilityTap={[Function]}
             style={
               Object {
                 "color": "#bdbdbd",
                 "flexGrow": 1,
-                "fontFamily": "System",
-                "fontSize": 15,
+                "fontFamily": "Segoe UI",
+                "fontSize": 12,
                 "fontWeight": "400",
                 "margin": 0,
               }
@@ -276,7 +355,16 @@ Array [
 exports[`Menu component tests Menu open 1`] = `
 Array [
   <View
-    accessibilityActions={Array []}
+    accessibilityActions={
+      Array [
+        Object {
+          "name": "Expand",
+        },
+        Object {
+          "name": "Collapse",
+        },
+      ]
+    }
     accessibilityLabel="Open"
     accessibilityRole="button"
     accessibilityState={
@@ -285,14 +373,27 @@ Array [
       }
     }
     accessible={true}
-    collapsable={false}
     enableFocusRing={true}
     focusable={true}
+    keyUpEvents={
+      Array [
+        Object {
+          "key": " ",
+        },
+        Object {
+          "key": "Enter",
+        },
+      ]
+    }
     onAccessibilityAction={[Function]}
     onAccessibilityTap={[Function]}
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
     onResponderGrant={[Function]}
     onResponderMove={[Function]}
     onResponderRelease={[Function]}
@@ -303,16 +404,17 @@ Array [
       Object {
         "alignItems": "center",
         "alignSelf": "flex-start",
-        "backgroundColor": "#0f6cbd",
-        "borderColor": "#0f548c",
+        "backgroundColor": "#ffffff",
+        "borderColor": "#d1d1d1",
         "borderRadius": 4,
         "borderWidth": 1,
         "display": "flex",
         "flexDirection": "row",
         "justifyContent": "center",
-        "minWidth": 96,
-        "padding": 8,
-        "paddingHorizontal": 15,
+        "minHeight": 32,
+        "minWidth": 64,
+        "padding": 3,
+        "paddingHorizontal": 7,
         "width": undefined,
       }
     }
@@ -320,17 +422,18 @@ Array [
     <Text
       ellipsizeMode="tail"
       numberOfLines={0}
+      onAccessibilityTap={[Function]}
       style={
         Object {
-          "color": "#ffffff",
-          "fontFamily": "System",
-          "fontSize": 15,
-          "fontWeight": "600",
+          "color": "#242424",
+          "fontFamily": "Segoe UI",
+          "fontSize": 12,
+          "fontWeight": "400",
           "margin": 0,
-          "marginBottom": 0,
-          "marginEnd": 0,
+          "marginBottom": 1,
+          "marginEnd": -2,
           "marginStart": 0,
-          "marginTop": 0,
+          "marginTop": -1,
         }
       }
     >
@@ -349,7 +452,7 @@ Array [
     }
     doNotTakePointerCapture={false}
     onDismiss={[Function]}
-    setInitialFocus={false}
+    setInitialFocus={true}
     style={
       Object {
         "backgroundColor": "#faf9f8",
@@ -372,7 +475,7 @@ Array [
             "display": "flex",
             "maxWidth": 300,
             "minWidth": 128,
-            "padding": 8,
+            "paddingVertical": 4,
           }
         }
       >
@@ -385,13 +488,26 @@ Array [
             }
           }
           accessible={true}
-          collapsable={false}
           enableFocusRing={true}
           focusable={true}
+          keyDownEvents={
+            Array [
+              Object {
+                "key": " ",
+              },
+              Object {
+                "key": "Enter",
+              },
+            ]
+          }
           onAccessibilityTap={[Function]}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
           onResponderRelease={[Function]}
@@ -402,24 +518,27 @@ Array [
             Object {
               "alignItems": "center",
               "backgroundColor": "#ffffff",
-              "borderRadius": 4,
+              "borderRadius": 0,
               "display": "flex",
               "flexDirection": "row",
               "maxWidth": 300,
-              "minHeight": 32,
+              "minHeight": 24,
               "minWidth": 160,
+              "padding": 4,
+              "paddingHorizontal": 8,
             }
           }
         >
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
+            onAccessibilityTap={[Function]}
             style={
               Object {
-                "color": "#424242",
+                "color": "#242424",
                 "flexGrow": 1,
-                "fontFamily": "System",
-                "fontSize": 15,
+                "fontFamily": "Segoe UI",
+                "fontSize": 12,
                 "fontWeight": "400",
                 "margin": 0,
               }
@@ -437,7 +556,16 @@ Array [
 exports[`Menu component tests Menu open checkbox and divider 1`] = `
 Array [
   <View
-    accessibilityActions={Array []}
+    accessibilityActions={
+      Array [
+        Object {
+          "name": "Expand",
+        },
+        Object {
+          "name": "Collapse",
+        },
+      ]
+    }
     accessibilityLabel="Open"
     accessibilityRole="button"
     accessibilityState={
@@ -446,14 +574,27 @@ Array [
       }
     }
     accessible={true}
-    collapsable={false}
     enableFocusRing={true}
     focusable={true}
+    keyUpEvents={
+      Array [
+        Object {
+          "key": " ",
+        },
+        Object {
+          "key": "Enter",
+        },
+      ]
+    }
     onAccessibilityAction={[Function]}
     onAccessibilityTap={[Function]}
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
     onResponderGrant={[Function]}
     onResponderMove={[Function]}
     onResponderRelease={[Function]}
@@ -464,16 +605,17 @@ Array [
       Object {
         "alignItems": "center",
         "alignSelf": "flex-start",
-        "backgroundColor": "#0f6cbd",
-        "borderColor": "#0f548c",
+        "backgroundColor": "#ffffff",
+        "borderColor": "#d1d1d1",
         "borderRadius": 4,
         "borderWidth": 1,
         "display": "flex",
         "flexDirection": "row",
         "justifyContent": "center",
-        "minWidth": 96,
-        "padding": 8,
-        "paddingHorizontal": 15,
+        "minHeight": 32,
+        "minWidth": 64,
+        "padding": 3,
+        "paddingHorizontal": 7,
         "width": undefined,
       }
     }
@@ -481,17 +623,18 @@ Array [
     <Text
       ellipsizeMode="tail"
       numberOfLines={0}
+      onAccessibilityTap={[Function]}
       style={
         Object {
-          "color": "#ffffff",
-          "fontFamily": "System",
-          "fontSize": 15,
-          "fontWeight": "600",
+          "color": "#242424",
+          "fontFamily": "Segoe UI",
+          "fontSize": 12,
+          "fontWeight": "400",
           "margin": 0,
-          "marginBottom": 0,
-          "marginEnd": 0,
+          "marginBottom": 1,
+          "marginEnd": -2,
           "marginStart": 0,
-          "marginTop": 0,
+          "marginTop": -1,
         }
       }
     >
@@ -510,7 +653,7 @@ Array [
     }
     doNotTakePointerCapture={false}
     onDismiss={[Function]}
-    setInitialFocus={false}
+    setInitialFocus={true}
     style={
       Object {
         "backgroundColor": "#faf9f8",
@@ -533,7 +676,7 @@ Array [
             "display": "flex",
             "maxWidth": 300,
             "minWidth": 128,
-            "padding": 8,
+            "paddingVertical": 4,
           }
         }
       >
@@ -554,13 +697,26 @@ Array [
             }
           }
           accessible={true}
-          collapsable={false}
           enableFocusRing={true}
           focusable={true}
+          keyDownEvents={
+            Array [
+              Object {
+                "key": " ",
+              },
+              Object {
+                "key": "Enter",
+              },
+            ]
+          }
           onAccessibilityAction={[Function]}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
           onResponderRelease={[Function]}
@@ -571,12 +727,14 @@ Array [
             Object {
               "alignItems": "center",
               "backgroundColor": "#ffffff",
-              "borderRadius": 4,
+              "borderRadius": 0,
               "display": "flex",
               "flexDirection": "row",
               "maxWidth": 300,
-              "minHeight": 32,
+              "minHeight": 24,
               "minWidth": 160,
+              "padding": 4,
+              "paddingHorizontal": 8,
             }
           }
         >
@@ -584,7 +742,7 @@ Array [
             align="xMidYMid"
             bbHeight={16}
             bbWidth={16}
-            color={4282532418}
+            color={4280558628}
             focusable={false}
             height={16}
             meetOrSlice={0}
@@ -597,7 +755,7 @@ Array [
                   "borderWidth": 0,
                 },
                 Object {
-                  "marginEnd": 8,
+                  "marginEnd": 4,
                 },
                 Object {
                   "flex": 0,
@@ -607,9 +765,9 @@ Array [
                 },
               ]
             }
-            tintColor={4282532418}
-            vbHeight={16}
-            vbWidth={16}
+            tintColor={4280558628}
+            vbHeight={12}
+            vbWidth={12}
             width={16}
             xml="
     <svg>
@@ -635,12 +793,13 @@ Array [
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
+            onAccessibilityTap={[Function]}
             style={
               Object {
-                "color": "#424242",
+                "color": "#242424",
                 "flexGrow": 1,
-                "fontFamily": "System",
-                "fontSize": 15,
+                "fontFamily": "Segoe UI",
+                "fontSize": 12,
                 "fontWeight": "400",
                 "margin": 0,
               }
@@ -655,7 +814,7 @@ Array [
               "backgroundColor": "#d1d1d1",
               "display": "flex",
               "height": 1,
-              "margin": 4,
+              "margin": 2,
               "marginVertical": undefined,
               "width": undefined,
             }
@@ -678,13 +837,26 @@ Array [
             }
           }
           accessible={true}
-          collapsable={false}
           enableFocusRing={true}
           focusable={true}
+          keyDownEvents={
+            Array [
+              Object {
+                "key": " ",
+              },
+              Object {
+                "key": "Enter",
+              },
+            ]
+          }
           onAccessibilityAction={[Function]}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
           onResponderRelease={[Function]}
@@ -695,13 +867,14 @@ Array [
             Object {
               "alignItems": "center",
               "backgroundColor": "#ffffff",
-              "borderRadius": 4,
+              "borderRadius": 0,
               "display": "flex",
               "flexDirection": "row",
-              "marginTop": 4,
               "maxWidth": 300,
-              "minHeight": 32,
+              "minHeight": 24,
               "minWidth": 160,
+              "padding": 4,
+              "paddingHorizontal": 8,
             }
           }
         >
@@ -722,7 +895,7 @@ Array [
                   "borderWidth": 0,
                 },
                 Object {
-                  "marginEnd": 8,
+                  "marginEnd": 4,
                 },
                 Object {
                   "flex": 0,
@@ -733,8 +906,8 @@ Array [
               ]
             }
             tintColor={4290624957}
-            vbHeight={16}
-            vbWidth={16}
+            vbHeight={12}
+            vbWidth={12}
             width={16}
             xml="
     <svg>
@@ -760,12 +933,13 @@ Array [
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
+            onAccessibilityTap={[Function]}
             style={
               Object {
                 "color": "#bdbdbd",
                 "flexGrow": 1,
-                "fontFamily": "System",
-                "fontSize": 15,
+                "fontFamily": "Segoe UI",
+                "fontSize": 12,
                 "fontWeight": "400",
                 "margin": 0,
               }
@@ -783,7 +957,16 @@ Array [
 exports[`Menu component tests Menu open checkbox checked 1`] = `
 Array [
   <View
-    accessibilityActions={Array []}
+    accessibilityActions={
+      Array [
+        Object {
+          "name": "Expand",
+        },
+        Object {
+          "name": "Collapse",
+        },
+      ]
+    }
     accessibilityLabel="Open"
     accessibilityRole="button"
     accessibilityState={
@@ -792,14 +975,27 @@ Array [
       }
     }
     accessible={true}
-    collapsable={false}
     enableFocusRing={true}
     focusable={true}
+    keyUpEvents={
+      Array [
+        Object {
+          "key": " ",
+        },
+        Object {
+          "key": "Enter",
+        },
+      ]
+    }
     onAccessibilityAction={[Function]}
     onAccessibilityTap={[Function]}
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
     onResponderGrant={[Function]}
     onResponderMove={[Function]}
     onResponderRelease={[Function]}
@@ -810,16 +1006,17 @@ Array [
       Object {
         "alignItems": "center",
         "alignSelf": "flex-start",
-        "backgroundColor": "#0f6cbd",
-        "borderColor": "#0f548c",
+        "backgroundColor": "#ffffff",
+        "borderColor": "#d1d1d1",
         "borderRadius": 4,
         "borderWidth": 1,
         "display": "flex",
         "flexDirection": "row",
         "justifyContent": "center",
-        "minWidth": 96,
-        "padding": 8,
-        "paddingHorizontal": 15,
+        "minHeight": 32,
+        "minWidth": 64,
+        "padding": 3,
+        "paddingHorizontal": 7,
         "width": undefined,
       }
     }
@@ -827,17 +1024,18 @@ Array [
     <Text
       ellipsizeMode="tail"
       numberOfLines={0}
+      onAccessibilityTap={[Function]}
       style={
         Object {
-          "color": "#ffffff",
-          "fontFamily": "System",
-          "fontSize": 15,
-          "fontWeight": "600",
+          "color": "#242424",
+          "fontFamily": "Segoe UI",
+          "fontSize": 12,
+          "fontWeight": "400",
           "margin": 0,
-          "marginBottom": 0,
-          "marginEnd": 0,
+          "marginBottom": 1,
+          "marginEnd": -2,
           "marginStart": 0,
-          "marginTop": 0,
+          "marginTop": -1,
         }
       }
     >
@@ -856,7 +1054,7 @@ Array [
     }
     doNotTakePointerCapture={false}
     onDismiss={[Function]}
-    setInitialFocus={false}
+    setInitialFocus={true}
     style={
       Object {
         "backgroundColor": "#faf9f8",
@@ -879,7 +1077,7 @@ Array [
             "display": "flex",
             "maxWidth": 300,
             "minWidth": 128,
-            "padding": 8,
+            "paddingVertical": 4,
           }
         }
       >
@@ -900,13 +1098,26 @@ Array [
             }
           }
           accessible={true}
-          collapsable={false}
           enableFocusRing={true}
           focusable={true}
+          keyDownEvents={
+            Array [
+              Object {
+                "key": " ",
+              },
+              Object {
+                "key": "Enter",
+              },
+            ]
+          }
           onAccessibilityAction={[Function]}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
           onResponderRelease={[Function]}
@@ -917,12 +1128,14 @@ Array [
             Object {
               "alignItems": "center",
               "backgroundColor": "#ffffff",
-              "borderRadius": 4,
+              "borderRadius": 0,
               "display": "flex",
               "flexDirection": "row",
               "maxWidth": 300,
-              "minHeight": 32,
+              "minHeight": 24,
               "minWidth": 160,
+              "padding": 4,
+              "paddingHorizontal": 8,
             }
           }
         >
@@ -930,7 +1143,7 @@ Array [
             align="xMidYMid"
             bbHeight={16}
             bbWidth={16}
-            color={4282532418}
+            color={4280558628}
             focusable={false}
             height={16}
             meetOrSlice={0}
@@ -943,7 +1156,7 @@ Array [
                   "borderWidth": 0,
                 },
                 Object {
-                  "marginEnd": 8,
+                  "marginEnd": 4,
                 },
                 Object {
                   "flex": 0,
@@ -953,9 +1166,9 @@ Array [
                 },
               ]
             }
-            tintColor={4282532418}
-            vbHeight={16}
-            vbWidth={16}
+            tintColor={4280558628}
+            vbHeight={12}
+            vbWidth={12}
             width={16}
             xml="
     <svg>
@@ -981,12 +1194,13 @@ Array [
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
+            onAccessibilityTap={[Function]}
             style={
               Object {
-                "color": "#424242",
+                "color": "#242424",
                 "flexGrow": 1,
-                "fontFamily": "System",
-                "fontSize": 15,
+                "fontFamily": "Segoe UI",
+                "fontSize": 12,
                 "fontWeight": "400",
                 "margin": 0,
               }
@@ -1001,7 +1215,7 @@ Array [
               "backgroundColor": "#d1d1d1",
               "display": "flex",
               "height": 1,
-              "margin": 4,
+              "margin": 2,
               "marginVertical": undefined,
               "width": undefined,
             }
@@ -1024,13 +1238,26 @@ Array [
             }
           }
           accessible={true}
-          collapsable={false}
           enableFocusRing={true}
           focusable={true}
+          keyDownEvents={
+            Array [
+              Object {
+                "key": " ",
+              },
+              Object {
+                "key": "Enter",
+              },
+            ]
+          }
           onAccessibilityAction={[Function]}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
           onResponderRelease={[Function]}
@@ -1041,13 +1268,14 @@ Array [
             Object {
               "alignItems": "center",
               "backgroundColor": "#ffffff",
-              "borderRadius": 4,
+              "borderRadius": 0,
               "display": "flex",
               "flexDirection": "row",
-              "marginTop": 4,
               "maxWidth": 300,
-              "minHeight": 32,
+              "minHeight": 24,
               "minWidth": 160,
+              "padding": 4,
+              "paddingHorizontal": 8,
             }
           }
         >
@@ -1055,7 +1283,7 @@ Array [
             align="xMidYMid"
             bbHeight={16}
             bbWidth={16}
-            color={4282532418}
+            color={4280558628}
             focusable={false}
             height={16}
             meetOrSlice={0}
@@ -1068,7 +1296,7 @@ Array [
                   "borderWidth": 0,
                 },
                 Object {
-                  "marginEnd": 8,
+                  "marginEnd": 4,
                 },
                 Object {
                   "flex": 0,
@@ -1078,9 +1306,9 @@ Array [
                 },
               ]
             }
-            tintColor={4282532418}
-            vbHeight={16}
-            vbWidth={16}
+            tintColor={4280558628}
+            vbHeight={12}
+            vbWidth={12}
             width={16}
             xml="
     <svg>
@@ -1106,12 +1334,13 @@ Array [
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
+            onAccessibilityTap={[Function]}
             style={
               Object {
-                "color": "#424242",
+                "color": "#242424",
                 "flexGrow": 1,
-                "fontFamily": "System",
-                "fontSize": 15,
+                "fontFamily": "Segoe UI",
+                "fontSize": 12,
                 "fontWeight": "400",
                 "margin": 0,
               }
@@ -1129,7 +1358,16 @@ Array [
 exports[`Menu component tests Menu open checkbox defaultChecked 1`] = `
 Array [
   <View
-    accessibilityActions={Array []}
+    accessibilityActions={
+      Array [
+        Object {
+          "name": "Expand",
+        },
+        Object {
+          "name": "Collapse",
+        },
+      ]
+    }
     accessibilityLabel="Open"
     accessibilityRole="button"
     accessibilityState={
@@ -1138,14 +1376,27 @@ Array [
       }
     }
     accessible={true}
-    collapsable={false}
     enableFocusRing={true}
     focusable={true}
+    keyUpEvents={
+      Array [
+        Object {
+          "key": " ",
+        },
+        Object {
+          "key": "Enter",
+        },
+      ]
+    }
     onAccessibilityAction={[Function]}
     onAccessibilityTap={[Function]}
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
     onResponderGrant={[Function]}
     onResponderMove={[Function]}
     onResponderRelease={[Function]}
@@ -1156,16 +1407,17 @@ Array [
       Object {
         "alignItems": "center",
         "alignSelf": "flex-start",
-        "backgroundColor": "#0f6cbd",
-        "borderColor": "#0f548c",
+        "backgroundColor": "#ffffff",
+        "borderColor": "#d1d1d1",
         "borderRadius": 4,
         "borderWidth": 1,
         "display": "flex",
         "flexDirection": "row",
         "justifyContent": "center",
-        "minWidth": 96,
-        "padding": 8,
-        "paddingHorizontal": 15,
+        "minHeight": 32,
+        "minWidth": 64,
+        "padding": 3,
+        "paddingHorizontal": 7,
         "width": undefined,
       }
     }
@@ -1173,17 +1425,18 @@ Array [
     <Text
       ellipsizeMode="tail"
       numberOfLines={0}
+      onAccessibilityTap={[Function]}
       style={
         Object {
-          "color": "#ffffff",
-          "fontFamily": "System",
-          "fontSize": 15,
-          "fontWeight": "600",
+          "color": "#242424",
+          "fontFamily": "Segoe UI",
+          "fontSize": 12,
+          "fontWeight": "400",
           "margin": 0,
-          "marginBottom": 0,
-          "marginEnd": 0,
+          "marginBottom": 1,
+          "marginEnd": -2,
           "marginStart": 0,
-          "marginTop": 0,
+          "marginTop": -1,
         }
       }
     >
@@ -1202,7 +1455,7 @@ Array [
     }
     doNotTakePointerCapture={false}
     onDismiss={[Function]}
-    setInitialFocus={false}
+    setInitialFocus={true}
     style={
       Object {
         "backgroundColor": "#faf9f8",
@@ -1225,7 +1478,7 @@ Array [
             "display": "flex",
             "maxWidth": 300,
             "minWidth": 128,
-            "padding": 8,
+            "paddingVertical": 4,
           }
         }
       >
@@ -1246,13 +1499,26 @@ Array [
             }
           }
           accessible={true}
-          collapsable={false}
           enableFocusRing={true}
           focusable={true}
+          keyDownEvents={
+            Array [
+              Object {
+                "key": " ",
+              },
+              Object {
+                "key": "Enter",
+              },
+            ]
+          }
           onAccessibilityAction={[Function]}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
           onResponderRelease={[Function]}
@@ -1263,12 +1529,14 @@ Array [
             Object {
               "alignItems": "center",
               "backgroundColor": "#ffffff",
-              "borderRadius": 4,
+              "borderRadius": 0,
               "display": "flex",
               "flexDirection": "row",
               "maxWidth": 300,
-              "minHeight": 32,
+              "minHeight": 24,
               "minWidth": 160,
+              "padding": 4,
+              "paddingHorizontal": 8,
             }
           }
         >
@@ -1276,7 +1544,7 @@ Array [
             align="xMidYMid"
             bbHeight={16}
             bbWidth={16}
-            color={4282532418}
+            color={4280558628}
             focusable={false}
             height={16}
             meetOrSlice={0}
@@ -1289,7 +1557,7 @@ Array [
                   "borderWidth": 0,
                 },
                 Object {
-                  "marginEnd": 8,
+                  "marginEnd": 4,
                 },
                 Object {
                   "flex": 0,
@@ -1299,9 +1567,9 @@ Array [
                 },
               ]
             }
-            tintColor={4282532418}
-            vbHeight={16}
-            vbWidth={16}
+            tintColor={4280558628}
+            vbHeight={12}
+            vbWidth={12}
             width={16}
             xml="
     <svg>
@@ -1327,12 +1595,13 @@ Array [
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
+            onAccessibilityTap={[Function]}
             style={
               Object {
-                "color": "#424242",
+                "color": "#242424",
                 "flexGrow": 1,
-                "fontFamily": "System",
-                "fontSize": 15,
+                "fontFamily": "Segoe UI",
+                "fontSize": 12,
                 "fontWeight": "400",
                 "margin": 0,
               }
@@ -1347,7 +1616,7 @@ Array [
               "backgroundColor": "#d1d1d1",
               "display": "flex",
               "height": 1,
-              "margin": 4,
+              "margin": 2,
               "marginVertical": undefined,
               "width": undefined,
             }
@@ -1370,13 +1639,26 @@ Array [
             }
           }
           accessible={true}
-          collapsable={false}
           enableFocusRing={true}
           focusable={true}
+          keyDownEvents={
+            Array [
+              Object {
+                "key": " ",
+              },
+              Object {
+                "key": "Enter",
+              },
+            ]
+          }
           onAccessibilityAction={[Function]}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
           onResponderRelease={[Function]}
@@ -1387,13 +1669,14 @@ Array [
             Object {
               "alignItems": "center",
               "backgroundColor": "#ffffff",
-              "borderRadius": 4,
+              "borderRadius": 0,
               "display": "flex",
               "flexDirection": "row",
-              "marginTop": 4,
               "maxWidth": 300,
-              "minHeight": 32,
+              "minHeight": 24,
               "minWidth": 160,
+              "padding": 4,
+              "paddingHorizontal": 8,
             }
           }
         >
@@ -1401,7 +1684,7 @@ Array [
             align="xMidYMid"
             bbHeight={16}
             bbWidth={16}
-            color={4282532418}
+            color={4280558628}
             focusable={false}
             height={16}
             meetOrSlice={0}
@@ -1414,7 +1697,7 @@ Array [
                   "borderWidth": 0,
                 },
                 Object {
-                  "marginEnd": 8,
+                  "marginEnd": 4,
                 },
                 Object {
                   "flex": 0,
@@ -1424,9 +1707,9 @@ Array [
                 },
               ]
             }
-            tintColor={4282532418}
-            vbHeight={16}
-            vbWidth={16}
+            tintColor={4280558628}
+            vbHeight={12}
+            vbWidth={12}
             width={16}
             xml="
     <svg>
@@ -1452,12 +1735,13 @@ Array [
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
+            onAccessibilityTap={[Function]}
             style={
               Object {
-                "color": "#424242",
+                "color": "#242424",
                 "flexGrow": 1,
-                "fontFamily": "System",
-                "fontSize": 15,
+                "fontFamily": "Segoe UI",
+                "fontSize": 12,
                 "fontWeight": "400",
                 "margin": 0,
               }
@@ -1475,7 +1759,16 @@ Array [
 exports[`Menu component tests Menu open radio 1`] = `
 Array [
   <View
-    accessibilityActions={Array []}
+    accessibilityActions={
+      Array [
+        Object {
+          "name": "Expand",
+        },
+        Object {
+          "name": "Collapse",
+        },
+      ]
+    }
     accessibilityLabel="Open"
     accessibilityRole="button"
     accessibilityState={
@@ -1484,14 +1777,27 @@ Array [
       }
     }
     accessible={true}
-    collapsable={false}
     enableFocusRing={true}
     focusable={true}
+    keyUpEvents={
+      Array [
+        Object {
+          "key": " ",
+        },
+        Object {
+          "key": "Enter",
+        },
+      ]
+    }
     onAccessibilityAction={[Function]}
     onAccessibilityTap={[Function]}
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
     onResponderGrant={[Function]}
     onResponderMove={[Function]}
     onResponderRelease={[Function]}
@@ -1502,16 +1808,17 @@ Array [
       Object {
         "alignItems": "center",
         "alignSelf": "flex-start",
-        "backgroundColor": "#0f6cbd",
-        "borderColor": "#0f548c",
+        "backgroundColor": "#ffffff",
+        "borderColor": "#d1d1d1",
         "borderRadius": 4,
         "borderWidth": 1,
         "display": "flex",
         "flexDirection": "row",
         "justifyContent": "center",
-        "minWidth": 96,
-        "padding": 8,
-        "paddingHorizontal": 15,
+        "minHeight": 32,
+        "minWidth": 64,
+        "padding": 3,
+        "paddingHorizontal": 7,
         "width": undefined,
       }
     }
@@ -1519,17 +1826,18 @@ Array [
     <Text
       ellipsizeMode="tail"
       numberOfLines={0}
+      onAccessibilityTap={[Function]}
       style={
         Object {
-          "color": "#ffffff",
-          "fontFamily": "System",
-          "fontSize": 15,
-          "fontWeight": "600",
+          "color": "#242424",
+          "fontFamily": "Segoe UI",
+          "fontSize": 12,
+          "fontWeight": "400",
           "margin": 0,
-          "marginBottom": 0,
-          "marginEnd": 0,
+          "marginBottom": 1,
+          "marginEnd": -2,
           "marginStart": 0,
-          "marginTop": 0,
+          "marginTop": -1,
         }
       }
     >
@@ -1548,7 +1856,7 @@ Array [
     }
     doNotTakePointerCapture={false}
     onDismiss={[Function]}
-    setInitialFocus={false}
+    setInitialFocus={true}
     style={
       Object {
         "backgroundColor": "#faf9f8",
@@ -1571,7 +1879,7 @@ Array [
             "display": "flex",
             "maxWidth": 300,
             "minWidth": 128,
-            "padding": 8,
+            "paddingVertical": 4,
           }
         }
       >
@@ -1592,13 +1900,26 @@ Array [
             }
           }
           accessible={true}
-          collapsable={false}
           enableFocusRing={true}
           focusable={true}
+          keyDownEvents={
+            Array [
+              Object {
+                "key": " ",
+              },
+              Object {
+                "key": "Enter",
+              },
+            ]
+          }
           onAccessibilityAction={[Function]}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
           onResponderRelease={[Function]}
@@ -1609,12 +1930,14 @@ Array [
             Object {
               "alignItems": "center",
               "backgroundColor": "#ffffff",
-              "borderRadius": 4,
+              "borderRadius": 0,
               "display": "flex",
               "flexDirection": "row",
               "maxWidth": 300,
-              "minHeight": 32,
+              "minHeight": 24,
               "minWidth": 160,
+              "padding": 4,
+              "paddingHorizontal": 8,
             }
           }
         >
@@ -1622,7 +1945,7 @@ Array [
             align="xMidYMid"
             bbHeight={16}
             bbWidth={16}
-            color={4282532418}
+            color={4280558628}
             focusable={false}
             height={16}
             meetOrSlice={0}
@@ -1635,7 +1958,7 @@ Array [
                   "borderWidth": 0,
                 },
                 Object {
-                  "marginEnd": 8,
+                  "marginEnd": 4,
                 },
                 Object {
                   "flex": 0,
@@ -1645,9 +1968,9 @@ Array [
                 },
               ]
             }
-            tintColor={4282532418}
-            vbHeight={16}
-            vbWidth={16}
+            tintColor={4280558628}
+            vbHeight={12}
+            vbWidth={12}
             width={16}
             xml="
     <svg>
@@ -1673,12 +1996,13 @@ Array [
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
+            onAccessibilityTap={[Function]}
             style={
               Object {
-                "color": "#424242",
+                "color": "#242424",
                 "flexGrow": 1,
-                "fontFamily": "System",
-                "fontSize": 15,
+                "fontFamily": "Segoe UI",
+                "fontSize": 12,
                 "fontWeight": "400",
                 "margin": 0,
               }
@@ -1704,13 +2028,26 @@ Array [
             }
           }
           accessible={true}
-          collapsable={false}
           enableFocusRing={true}
           focusable={true}
+          keyDownEvents={
+            Array [
+              Object {
+                "key": " ",
+              },
+              Object {
+                "key": "Enter",
+              },
+            ]
+          }
           onAccessibilityAction={[Function]}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
           onResponderRelease={[Function]}
@@ -1721,13 +2058,14 @@ Array [
             Object {
               "alignItems": "center",
               "backgroundColor": "#ffffff",
-              "borderRadius": 4,
+              "borderRadius": 0,
               "display": "flex",
               "flexDirection": "row",
-              "marginTop": 4,
               "maxWidth": 300,
-              "minHeight": 32,
+              "minHeight": 24,
               "minWidth": 160,
+              "padding": 4,
+              "paddingHorizontal": 8,
             }
           }
         >
@@ -1735,7 +2073,7 @@ Array [
             align="xMidYMid"
             bbHeight={16}
             bbWidth={16}
-            color={4282532418}
+            color={4280558628}
             focusable={false}
             height={16}
             meetOrSlice={0}
@@ -1748,7 +2086,7 @@ Array [
                   "borderWidth": 0,
                 },
                 Object {
-                  "marginEnd": 8,
+                  "marginEnd": 4,
                 },
                 Object {
                   "flex": 0,
@@ -1758,9 +2096,9 @@ Array [
                 },
               ]
             }
-            tintColor={4282532418}
-            vbHeight={16}
-            vbWidth={16}
+            tintColor={4280558628}
+            vbHeight={12}
+            vbWidth={12}
             width={16}
             xml="
     <svg>
@@ -1786,12 +2124,13 @@ Array [
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
+            onAccessibilityTap={[Function]}
             style={
               Object {
-                "color": "#424242",
+                "color": "#242424",
                 "flexGrow": 1,
-                "fontFamily": "System",
-                "fontSize": 15,
+                "fontFamily": "Segoe UI",
+                "fontSize": 12,
                 "fontWeight": "400",
                 "margin": 0,
               }
@@ -1809,7 +2148,16 @@ Array [
 exports[`Menu component tests Menu submenu 1`] = `
 Array [
   <View
-    accessibilityActions={Array []}
+    accessibilityActions={
+      Array [
+        Object {
+          "name": "Expand",
+        },
+        Object {
+          "name": "Collapse",
+        },
+      ]
+    }
     accessibilityLabel="Default"
     accessibilityRole="button"
     accessibilityState={
@@ -1818,14 +2166,27 @@ Array [
       }
     }
     accessible={true}
-    collapsable={false}
     enableFocusRing={true}
     focusable={true}
+    keyUpEvents={
+      Array [
+        Object {
+          "key": " ",
+        },
+        Object {
+          "key": "Enter",
+        },
+      ]
+    }
     onAccessibilityAction={[Function]}
     onAccessibilityTap={[Function]}
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
     onResponderGrant={[Function]}
     onResponderMove={[Function]}
     onResponderRelease={[Function]}
@@ -1836,16 +2197,17 @@ Array [
       Object {
         "alignItems": "center",
         "alignSelf": "flex-start",
-        "backgroundColor": "#0f6cbd",
-        "borderColor": "#0f548c",
+        "backgroundColor": "#ffffff",
+        "borderColor": "#d1d1d1",
         "borderRadius": 4,
         "borderWidth": 1,
         "display": "flex",
         "flexDirection": "row",
         "justifyContent": "center",
-        "minWidth": 96,
-        "padding": 8,
-        "paddingHorizontal": 15,
+        "minHeight": 32,
+        "minWidth": 64,
+        "padding": 3,
+        "paddingHorizontal": 7,
         "width": undefined,
       }
     }
@@ -1853,17 +2215,18 @@ Array [
     <Text
       ellipsizeMode="tail"
       numberOfLines={0}
+      onAccessibilityTap={[Function]}
       style={
         Object {
-          "color": "#ffffff",
-          "fontFamily": "System",
-          "fontSize": 15,
-          "fontWeight": "600",
+          "color": "#242424",
+          "fontFamily": "Segoe UI",
+          "fontSize": 12,
+          "fontWeight": "400",
           "margin": 0,
-          "marginBottom": 0,
-          "marginEnd": 0,
+          "marginBottom": 1,
+          "marginEnd": -2,
           "marginStart": 0,
-          "marginTop": 0,
+          "marginTop": -1,
         }
       }
     >
@@ -1882,7 +2245,7 @@ Array [
     }
     doNotTakePointerCapture={false}
     onDismiss={[Function]}
-    setInitialFocus={false}
+    setInitialFocus={true}
     style={
       Object {
         "backgroundColor": "#faf9f8",
@@ -1905,7 +2268,7 @@ Array [
             "display": "flex",
             "maxWidth": 300,
             "minWidth": 128,
-            "padding": 8,
+            "paddingVertical": 4,
           }
         }
       >
@@ -1918,13 +2281,26 @@ Array [
             }
           }
           accessible={true}
-          collapsable={false}
           enableFocusRing={true}
           focusable={true}
+          keyDownEvents={
+            Array [
+              Object {
+                "key": " ",
+              },
+              Object {
+                "key": "Enter",
+              },
+            ]
+          }
           onAccessibilityTap={[Function]}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
           onResponderRelease={[Function]}
@@ -1935,24 +2311,27 @@ Array [
             Object {
               "alignItems": "center",
               "backgroundColor": "#ffffff",
-              "borderRadius": 4,
+              "borderRadius": 0,
               "display": "flex",
               "flexDirection": "row",
               "maxWidth": 300,
-              "minHeight": 32,
+              "minHeight": 24,
               "minWidth": 160,
+              "padding": 4,
+              "paddingHorizontal": 8,
             }
           }
         >
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
+            onAccessibilityTap={[Function]}
             style={
               Object {
-                "color": "#424242",
+                "color": "#242424",
                 "flexGrow": 1,
-                "fontFamily": "System",
-                "fontSize": 15,
+                "fontFamily": "Segoe UI",
+                "fontSize": 12,
                 "fontWeight": "400",
                 "margin": 0,
               }
@@ -1962,7 +2341,16 @@ Array [
           </Text>
         </View>
         <View
-          accessibilityActions={Array []}
+          accessibilityActions={
+            Array [
+              Object {
+                "name": "Expand",
+              },
+              Object {
+                "name": "Collapse",
+              },
+            ]
+          }
           accessibilityLabel="Option 2"
           accessibilityRole="menuitem"
           accessibilityState={
@@ -1972,14 +2360,33 @@ Array [
             }
           }
           accessible={true}
-          collapsable={false}
           enableFocusRing={true}
           focusable={true}
+          keyDownEvents={
+            Array [
+              Object {
+                "key": " ",
+              },
+              Object {
+                "key": "Enter",
+              },
+              Object {
+                "key": "ArrowLeft",
+              },
+              Object {
+                "key": "ArrowRight",
+              },
+            ]
+          }
           onAccessibilityAction={[Function]}
           onAccessibilityTap={[Function]}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
           onResponderRelease={[Function]}
@@ -1990,24 +2397,27 @@ Array [
             Object {
               "alignItems": "center",
               "backgroundColor": "#ffffff",
-              "borderRadius": 4,
+              "borderRadius": 0,
               "display": "flex",
               "flexDirection": "row",
               "maxWidth": 300,
-              "minHeight": 32,
+              "minHeight": 24,
               "minWidth": 160,
+              "padding": 4,
+              "paddingHorizontal": 8,
             }
           }
         >
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
+            onAccessibilityTap={[Function]}
             style={
               Object {
-                "color": "#424242",
+                "color": "#242424",
                 "flexGrow": 1,
-                "fontFamily": "System",
-                "fontSize": 15,
+                "fontFamily": "Segoe UI",
+                "fontSize": 12,
                 "fontWeight": "400",
                 "margin": 0,
               }
@@ -2019,7 +2429,7 @@ Array [
             align="xMidYMid"
             bbHeight={16}
             bbWidth={16}
-            color={4282532418}
+            color={4280558628}
             focusable={false}
             height={16}
             meetOrSlice={0}
@@ -2038,9 +2448,9 @@ Array [
                 },
               ]
             }
-            tintColor={4282532418}
-            vbHeight={16}
-            vbWidth={16}
+            tintColor={4280558628}
+            vbHeight={12}
+            vbWidth={12}
             width={16}
             xml="
           <svg>

--- a/packages/components/MenuButton/jest.config.js
+++ b/packages/components/MenuButton/jest.config.js
@@ -1,2 +1,2 @@
 const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
-module.exports = configureReactNativeJest('ios');
+module.exports = configureReactNativeJest('win32');

--- a/packages/components/MenuButton/package.json
+++ b/packages/components/MenuButton/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/scripts": "^0.1.1",
+    "@office-iss/react-native-win32": "^0.68.0",
     "@types/react-native": "^0.68.0",
     "react": "17.0.2",
     "react-native": "^0.68.0"

--- a/packages/components/MenuButton/src/__tests__/__snapshots__/MenuButton.test.tsx.snap
+++ b/packages/components/MenuButton/src/__tests__/__snapshots__/MenuButton.test.tsx.snap
@@ -5,13 +5,26 @@ exports[`ContextualMenu default 1`] = `
   accessibilityLabel=""
   accessibilityRole="button"
   accessible={true}
-  collapsable={false}
   enableFocusRing={true}
   focusable={true}
+  keyUpEvents={
+    Array [
+      Object {
+        "key": " ",
+      },
+      Object {
+        "key": "Enter",
+      },
+    ]
+  }
   onAccessibilityTap={[Function]}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   onResponderGrant={[Function]}
   onResponderMove={[Function]}
   onResponderRelease={[Function]}
@@ -22,14 +35,14 @@ exports[`ContextualMenu default 1`] = `
     Object {
       "alignItems": "center",
       "alignSelf": "flex-start",
-      "backgroundColor": "#0f6cbd",
-      "borderColor": "#0f548c",
+      "backgroundColor": "#ffffff",
+      "borderColor": "#d1d1d1",
       "borderRadius": 4,
       "borderWidth": 1,
       "display": "flex",
       "flexDirection": "row",
       "justifyContent": "center",
-      "padding": 8,
+      "padding": 3,
       "width": undefined,
     }
   }

--- a/packages/components/Separator/jest.config.js
+++ b/packages/components/Separator/jest.config.js
@@ -1,2 +1,2 @@
 const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
-module.exports = configureReactNativeJest('android');
+module.exports = configureReactNativeJest('win32');

--- a/packages/components/Tabs/jest.config.js
+++ b/packages/components/Tabs/jest.config.js
@@ -1,2 +1,2 @@
 const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
-module.exports = configureReactNativeJest('android');
+module.exports = configureReactNativeJest('win32');

--- a/packages/components/Tabs/src/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/components/Tabs/src/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -4,11 +4,14 @@ exports[`Tabs FocusZone props 1`] = `
 <View
   accessibilityRole="tablist"
   accessible={true}
-  collapsable={false}
   focusable={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   onResponderGrant={[Function]}
   onResponderMove={[Function]}
   onResponderRelease={[Function]}
@@ -45,12 +48,15 @@ exports[`Tabs FocusZone props 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -116,12 +122,15 @@ exports[`Tabs FocusZone props 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -159,7 +168,7 @@ exports[`Tabs FocusZone props 1`] = `
           style={
             Object {
               "alignSelf": "stretch",
-              "backgroundColor": "#0f6cbd",
+              "backgroundColor": "#0078d4",
               "borderRadius": 2,
               "marginBottom": 2,
               "marginHorizontal": 10,
@@ -187,12 +196,15 @@ exports[`Tabs FocusZone props 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -249,11 +261,14 @@ exports[`Tabs default props 1`] = `
 <View
   accessibilityRole="tablist"
   accessible={true}
-  collapsable={false}
   focusable={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   onResponderGrant={[Function]}
   onResponderMove={[Function]}
   onResponderRelease={[Function]}
@@ -290,12 +305,15 @@ exports[`Tabs default props 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -333,7 +351,7 @@ exports[`Tabs default props 1`] = `
           style={
             Object {
               "alignSelf": "stretch",
-              "backgroundColor": "#0f6cbd",
+              "backgroundColor": "#0078d4",
               "borderRadius": 2,
               "marginBottom": 2,
               "marginHorizontal": 10,
@@ -361,12 +379,15 @@ exports[`Tabs default props 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -432,12 +453,15 @@ exports[`Tabs default props 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -494,11 +518,14 @@ exports[`Tabs disabled 1`] = `
 <View
   accessibilityRole="tablist"
   accessible={true}
-  collapsable={false}
   focusable={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   onResponderGrant={[Function]}
   onResponderMove={[Function]}
   onResponderRelease={[Function]}
@@ -535,12 +562,15 @@ exports[`Tabs disabled 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -606,12 +636,15 @@ exports[`Tabs disabled 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -677,12 +710,15 @@ exports[`Tabs disabled 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -720,7 +756,7 @@ exports[`Tabs disabled 1`] = `
           style={
             Object {
               "alignSelf": "stretch",
-              "backgroundColor": "#0f6cbd",
+              "backgroundColor": "#0078d4",
               "borderRadius": 2,
               "marginBottom": 2,
               "marginHorizontal": 10,
@@ -739,11 +775,14 @@ exports[`Tabs header text and count 1`] = `
 <View
   accessibilityRole="tablist"
   accessible={true}
-  collapsable={false}
   focusable={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   onResponderGrant={[Function]}
   onResponderMove={[Function]}
   onResponderRelease={[Function]}
@@ -781,12 +820,15 @@ exports[`Tabs header text and count 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -838,7 +880,7 @@ exports[`Tabs header text and count 1`] = `
           style={
             Object {
               "alignSelf": "stretch",
-              "backgroundColor": "#0f6cbd",
+              "backgroundColor": "#0078d4",
               "borderRadius": 2,
               "marginBottom": 2,
               "marginHorizontal": 10,
@@ -867,12 +909,15 @@ exports[`Tabs header text and count 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -953,12 +998,15 @@ exports[`Tabs header text and count 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -1029,11 +1077,14 @@ exports[`Tabs headers only 1`] = `
 <View
   accessibilityRole="tablist"
   accessible={true}
-  collapsable={false}
   focusable={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   onResponderGrant={[Function]}
   onResponderMove={[Function]}
   onResponderRelease={[Function]}
@@ -1070,12 +1121,15 @@ exports[`Tabs headers only 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -1113,7 +1167,7 @@ exports[`Tabs headers only 1`] = `
           style={
             Object {
               "alignSelf": "stretch",
-              "backgroundColor": "#0f6cbd",
+              "backgroundColor": "#0078d4",
               "borderRadius": 2,
               "marginBottom": 2,
               "marginHorizontal": 10,
@@ -1141,12 +1195,15 @@ exports[`Tabs headers only 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -1212,12 +1269,15 @@ exports[`Tabs headers only 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -1275,11 +1335,14 @@ exports[`Tabs props 1`] = `
   accessibilityLabel="Tabs"
   accessibilityRole="tablist"
   accessible={true}
-  collapsable={false}
   focusable={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   onResponderGrant={[Function]}
   onResponderMove={[Function]}
   onResponderRelease={[Function]}
@@ -1330,12 +1393,15 @@ exports[`Tabs props 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -1372,7 +1438,7 @@ exports[`Tabs props 1`] = `
           <Text
             style={
               Object {
-                "color": "neutralForegroundDisabled",
+                "color": "#bdbdbd",
                 "fontFamily": "Segoe UI",
                 "fontSize": 14,
                 "fontWeight": "400",
@@ -1416,12 +1482,15 @@ exports[`Tabs props 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -1473,7 +1542,7 @@ exports[`Tabs props 1`] = `
           style={
             Object {
               "alignSelf": "stretch",
-              "backgroundColor": "#0f6cbd",
+              "backgroundColor": "#0078d4",
               "borderRadius": 2,
               "marginBottom": 2,
               "marginHorizontal": 10,
@@ -1502,12 +1571,15 @@ exports[`Tabs props 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={true}
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}

--- a/packages/experimental/MenuButton/jest.config.js
+++ b/packages/experimental/MenuButton/jest.config.js
@@ -1,2 +1,2 @@
 const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
-module.exports = configureReactNativeJest('ios');
+module.exports = configureReactNativeJest('win32');

--- a/packages/experimental/MenuButton/package.json
+++ b/packages/experimental/MenuButton/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/scripts": "^0.1.1",
+    "@office-iss/react-native-win32": "^0.68.0",
     "@types/react-native": "^0.68.0",
     "react": "17.0.2",
     "react-native": "^0.68.0"

--- a/packages/experimental/MenuButton/src/__tests__/__snapshots__/MenuButton.test.tsx.snap
+++ b/packages/experimental/MenuButton/src/__tests__/__snapshots__/MenuButton.test.tsx.snap
@@ -5,13 +5,26 @@ exports[`ContextualMenu default 1`] = `
   accessibilityLabel="Press for Nested MenuButton"
   accessibilityRole="button"
   accessible={true}
-  collapsable={false}
   enableFocusRing={true}
   focusable={true}
+  keyUpEvents={
+    Array [
+      Object {
+        "key": " ",
+      },
+      Object {
+        "key": "Enter",
+      },
+    ]
+  }
   onAccessibilityTap={[Function]}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   onResponderGrant={[Function]}
   onResponderMove={[Function]}
   onResponderRelease={[Function]}
@@ -22,16 +35,17 @@ exports[`ContextualMenu default 1`] = `
     Object {
       "alignItems": "center",
       "alignSelf": "flex-start",
-      "backgroundColor": "#0f6cbd",
-      "borderColor": "#0f548c",
+      "backgroundColor": "#ffffff",
+      "borderColor": "#d1d1d1",
       "borderRadius": 4,
       "borderWidth": 1,
       "display": "flex",
       "flexDirection": "row",
       "justifyContent": "center",
-      "minWidth": 96,
-      "padding": 8,
-      "paddingHorizontal": 15,
+      "minHeight": 32,
+      "minWidth": 64,
+      "padding": 3,
+      "paddingHorizontal": 7,
       "width": undefined,
     }
   }
@@ -39,17 +53,18 @@ exports[`ContextualMenu default 1`] = `
   <Text
     ellipsizeMode="tail"
     numberOfLines={0}
+    onAccessibilityTap={[Function]}
     style={
       Object {
-        "color": "#ffffff",
-        "fontFamily": "System",
-        "fontSize": 15,
-        "fontWeight": "600",
+        "color": "#242424",
+        "fontFamily": "Segoe UI",
+        "fontSize": 12,
+        "fontWeight": "400",
         "margin": 0,
-        "marginBottom": 0,
-        "marginEnd": 0,
+        "marginBottom": 1,
+        "marginEnd": -2,
         "marginStart": 0,
-        "marginTop": 0,
+        "marginTop": -1,
       }
     }
   >

--- a/packages/experimental/Tabs/jest.config.js
+++ b/packages/experimental/Tabs/jest.config.js
@@ -1,2 +1,2 @@
 const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
-module.exports = configureReactNativeJest('android');
+module.exports = configureReactNativeJest('win32');

--- a/packages/experimental/Tabs/src/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/experimental/Tabs/src/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -4,7 +4,6 @@ exports[`Tabs FocusZone props 1`] = `
 <View
   accessibilityRole="tablist"
   accessible={true}
-  collapsable={false}
   componentRef={
     Object {
       "current": null,
@@ -15,6 +14,10 @@ exports[`Tabs FocusZone props 1`] = `
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   onResponderGrant={[Function]}
   onResponderMove={[Function]}
   onResponderRelease={[Function]}
@@ -56,12 +59,25 @@ exports[`Tabs FocusZone props 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={true}
+        keyUpEvents={
+          Array [
+            Object {
+              "key": " ",
+            },
+            Object {
+              "key": "Enter",
+            },
+          ]
+        }
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -125,12 +141,25 @@ exports[`Tabs FocusZone props 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={true}
+        keyUpEvents={
+          Array [
+            Object {
+              "key": " ",
+            },
+            Object {
+              "key": "Enter",
+            },
+          ]
+        }
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -169,7 +198,7 @@ exports[`Tabs FocusZone props 1`] = `
           style={
             Object {
               "alignSelf": "stretch",
-              "backgroundColor": "#0f6cbd",
+              "backgroundColor": "#0078d4",
               "borderRadius": 2,
               "marginBottom": 2,
               "marginHorizontal": 10,
@@ -194,12 +223,25 @@ exports[`Tabs FocusZone props 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={true}
+        keyUpEvents={
+          Array [
+            Object {
+              "key": " ",
+            },
+            Object {
+              "key": "Enter",
+            },
+          ]
+        }
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -259,7 +301,6 @@ exports[`Tabs default props 1`] = `
 <View
   accessibilityRole="tablist"
   accessible={true}
-  collapsable={false}
   componentRef={
     Object {
       "current": null,
@@ -269,6 +310,10 @@ exports[`Tabs default props 1`] = `
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   onResponderGrant={[Function]}
   onResponderMove={[Function]}
   onResponderRelease={[Function]}
@@ -310,12 +355,25 @@ exports[`Tabs default props 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={true}
+        keyUpEvents={
+          Array [
+            Object {
+              "key": " ",
+            },
+            Object {
+              "key": "Enter",
+            },
+          ]
+        }
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -354,7 +412,7 @@ exports[`Tabs default props 1`] = `
           style={
             Object {
               "alignSelf": "stretch",
-              "backgroundColor": "#0f6cbd",
+              "backgroundColor": "#0078d4",
               "borderRadius": 2,
               "marginBottom": 2,
               "marginHorizontal": 10,
@@ -379,12 +437,25 @@ exports[`Tabs default props 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={true}
+        keyUpEvents={
+          Array [
+            Object {
+              "key": " ",
+            },
+            Object {
+              "key": "Enter",
+            },
+          ]
+        }
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -448,12 +519,25 @@ exports[`Tabs default props 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={true}
+        keyUpEvents={
+          Array [
+            Object {
+              "key": " ",
+            },
+            Object {
+              "key": "Enter",
+            },
+          ]
+        }
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -513,7 +597,6 @@ exports[`Tabs disabled 1`] = `
 <View
   accessibilityRole="tablist"
   accessible={true}
-  collapsable={false}
   componentRef={
     Object {
       "current": null,
@@ -523,6 +606,10 @@ exports[`Tabs disabled 1`] = `
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   onResponderGrant={[Function]}
   onResponderMove={[Function]}
   onResponderRelease={[Function]}
@@ -564,12 +651,25 @@ exports[`Tabs disabled 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={false}
+        keyUpEvents={
+          Array [
+            Object {
+              "key": " ",
+            },
+            Object {
+              "key": "Enter",
+            },
+          ]
+        }
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -633,12 +733,25 @@ exports[`Tabs disabled 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={false}
+        keyUpEvents={
+          Array [
+            Object {
+              "key": " ",
+            },
+            Object {
+              "key": "Enter",
+            },
+          ]
+        }
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -702,12 +815,25 @@ exports[`Tabs disabled 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={true}
+        keyUpEvents={
+          Array [
+            Object {
+              "key": " ",
+            },
+            Object {
+              "key": "Enter",
+            },
+          ]
+        }
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -746,7 +872,7 @@ exports[`Tabs disabled 1`] = `
           style={
             Object {
               "alignSelf": "stretch",
-              "backgroundColor": "#0f6cbd",
+              "backgroundColor": "#0078d4",
               "borderRadius": 2,
               "marginBottom": 2,
               "marginHorizontal": 10,
@@ -767,7 +893,6 @@ exports[`Tabs header text and count 1`] = `
 <View
   accessibilityRole="tablist"
   accessible={true}
-  collapsable={false}
   componentRef={
     Object {
       "current": null,
@@ -777,6 +902,10 @@ exports[`Tabs header text and count 1`] = `
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   onResponderGrant={[Function]}
   onResponderMove={[Function]}
   onResponderRelease={[Function]}
@@ -819,12 +948,25 @@ exports[`Tabs header text and count 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={true}
+        keyUpEvents={
+          Array [
+            Object {
+              "key": " ",
+            },
+            Object {
+              "key": "Enter",
+            },
+          ]
+        }
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -862,6 +1004,7 @@ exports[`Tabs header text and count 1`] = `
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
+            onAccessibilityTap={[Function]}
             style={
               Object {
                 "color": "#242424",
@@ -879,7 +1022,7 @@ exports[`Tabs header text and count 1`] = `
           style={
             Object {
               "alignSelf": "stretch",
-              "backgroundColor": "#0f6cbd",
+              "backgroundColor": "#0078d4",
               "borderRadius": 2,
               "marginBottom": 2,
               "marginHorizontal": 10,
@@ -905,12 +1048,25 @@ exports[`Tabs header text and count 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={true}
+        keyUpEvents={
+          Array [
+            Object {
+              "key": " ",
+            },
+            Object {
+              "key": "Enter",
+            },
+          ]
+        }
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -948,6 +1104,7 @@ exports[`Tabs header text and count 1`] = `
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
+            onAccessibilityTap={[Function]}
             style={
               Object {
                 "color": "#616161",
@@ -991,12 +1148,25 @@ exports[`Tabs header text and count 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={true}
+        keyUpEvents={
+          Array [
+            Object {
+              "key": " ",
+            },
+            Object {
+              "key": "Enter",
+            },
+          ]
+        }
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -1034,6 +1204,7 @@ exports[`Tabs header text and count 1`] = `
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
+            onAccessibilityTap={[Function]}
             style={
               Object {
                 "color": "#616161",
@@ -1072,7 +1243,6 @@ exports[`Tabs headers only 1`] = `
 <View
   accessibilityRole="tablist"
   accessible={true}
-  collapsable={false}
   componentRef={
     Object {
       "current": null,
@@ -1083,6 +1253,10 @@ exports[`Tabs headers only 1`] = `
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   onResponderGrant={[Function]}
   onResponderMove={[Function]}
   onResponderRelease={[Function]}
@@ -1124,12 +1298,25 @@ exports[`Tabs headers only 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={true}
+        keyUpEvents={
+          Array [
+            Object {
+              "key": " ",
+            },
+            Object {
+              "key": "Enter",
+            },
+          ]
+        }
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -1168,7 +1355,7 @@ exports[`Tabs headers only 1`] = `
           style={
             Object {
               "alignSelf": "stretch",
-              "backgroundColor": "#0f6cbd",
+              "backgroundColor": "#0078d4",
               "borderRadius": 2,
               "marginBottom": 2,
               "marginHorizontal": 10,
@@ -1193,12 +1380,25 @@ exports[`Tabs headers only 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={true}
+        keyUpEvents={
+          Array [
+            Object {
+              "key": " ",
+            },
+            Object {
+              "key": "Enter",
+            },
+          ]
+        }
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -1262,12 +1462,25 @@ exports[`Tabs headers only 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={true}
+        keyUpEvents={
+          Array [
+            Object {
+              "key": " ",
+            },
+            Object {
+              "key": "Enter",
+            },
+          ]
+        }
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -1325,7 +1538,6 @@ exports[`Tabs props 1`] = `
 <View
   accessibilityRole="tablist"
   accessible={true}
-  collapsable={false}
   componentRef={
     Object {
       "current": null,
@@ -1337,6 +1549,10 @@ exports[`Tabs props 1`] = `
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   onResponderGrant={[Function]}
   onResponderMove={[Function]}
   onResponderRelease={[Function]}
@@ -1354,6 +1570,7 @@ exports[`Tabs props 1`] = `
   <Text
     ellipsizeMode="tail"
     numberOfLines={0}
+    onAccessibilityTap={[Function]}
     style={
       Object {
         "color": "#323130",
@@ -1394,12 +1611,25 @@ exports[`Tabs props 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={false}
+        keyUpEvents={
+          Array [
+            Object {
+              "key": " ",
+            },
+            Object {
+              "key": "Enter",
+            },
+          ]
+        }
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -1437,8 +1667,10 @@ exports[`Tabs props 1`] = `
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
+            onAccessibilityTap={[Function]}
             style={
               Object {
+                "color": "#bdbdbd",
                 "fontFamily": "Segoe UI",
                 "fontSize": 14,
                 "fontWeight": "400",
@@ -1479,12 +1711,25 @@ exports[`Tabs props 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={true}
+        keyUpEvents={
+          Array [
+            Object {
+              "key": " ",
+            },
+            Object {
+              "key": "Enter",
+            },
+          ]
+        }
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -1522,6 +1767,7 @@ exports[`Tabs props 1`] = `
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
+            onAccessibilityTap={[Function]}
             style={
               Object {
                 "color": "#242424",
@@ -1539,7 +1785,7 @@ exports[`Tabs props 1`] = `
           style={
             Object {
               "alignSelf": "stretch",
-              "backgroundColor": "#0f6cbd",
+              "backgroundColor": "#0078d4",
               "borderRadius": 2,
               "marginBottom": 2,
               "marginHorizontal": 10,
@@ -1565,12 +1811,25 @@ exports[`Tabs props 1`] = `
           }
         }
         accessible={true}
-        collapsable={false}
         focusable={true}
+        keyUpEvents={
+          Array [
+            Object {
+              "key": " ",
+            },
+            Object {
+              "key": "Enter",
+            },
+          ]
+        }
         onAccessibilityAction={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -1608,6 +1867,7 @@ exports[`Tabs props 1`] = `
           <Text
             ellipsizeMode="tail"
             numberOfLines={0}
+            onAccessibilityTap={[Function]}
             style={
               Object {
                 "color": "#616161",


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Changing the jest endpoint to win32 for the aforementioned components, as they are mainly used in win32.
This consists of changing the config file to win32 and adding RN Win32 as a dev dependency to these packages.

### Verification

yarn test passes locally

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
