### PR TITLE
Add E2E Win32 Spec Bundle to NPM Package

### DIFF
--- a/.ado/azure-pipelines.publish.yml
+++ b/.ado/azure-pipelines.publish.yml
@@ -50,6 +50,11 @@ jobs:
         displayName: 'yarn test [test]'
 
       - script: |
+          yarn bundle
+        workingDirectory: apps/E2E
+        displayName: 'bundle e2e spec files'
+
+      - script: |
           echo ##vso[task.setvariable variable=SkipNpmPublishArgs]--no-publish
         displayName: Enable No-Publish (npm)
         condition: ${{ parameters.skipNpmPublish }}

--- a/.ado/azure-pipelines.publish.yml
+++ b/.ado/azure-pipelines.publish.yml
@@ -46,13 +46,8 @@ jobs:
       - template: templates/yarn-install.yml
 
       - script: |
-          yarn test
-        displayName: 'yarn test [test]'
-
-      - script: |
-          yarn bundle
-        workingDirectory: apps/E2E
-        displayName: 'bundle e2e spec files'
+          yarn buildci
+        displayName: 'yarn buildci'
 
       - script: |
           echo ##vso[task.setvariable variable=SkipNpmPublishArgs]--no-publish

--- a/apps/E2E/package.json
+++ b/apps/E2E/package.json
@@ -15,6 +15,10 @@
     "url": "https://github.com/microsoft/fluentui-react-native.git",
     "directory": "apps/E2E"
   },
+  "files": [
+    "src/*",
+    "dist/*"
+  ],
   "devDependencies": {
     "@rnx-kit/cli": "^0.14.8",
     "@rnx-kit/metro-config": "^1.3.1",

--- a/apps/E2E/package.json
+++ b/apps/E2E/package.json
@@ -16,7 +16,7 @@
     "directory": "apps/E2E"
   },
   "files": [
-    "src/*",
+    "src/**/*",
     "dist/*"
   ],
   "devDependencies": {

--- a/change/@fluentui-react-native-e2e-testing-259cd841-5e79-42c5-8cf0-c226c928702c.json
+++ b/change/@fluentui-react-native-e2e-testing-259cd841-5e79-42c5-8cf0-c226c928702c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Adding bundle to NPM package:",
+  "packageName": "@fluentui-react-native/e2e-testing",
+  "email": "safreibe@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [X] windows
- [ ] android

### Description of changes

In order to include the JS Bundle in the NPM package, we need to modify the `files` parameter in the package.json.

Additionally, in the Publish pipeline, we need to bundle the E2E folder to create the bundle.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
