### PR TITLE
Ignore xcode.env files in gitignore

### DIFF
--- a/apps/fluent-tester/.gitignore
+++ b/apps/fluent-tester/.gitignore
@@ -8,6 +8,7 @@
 .gradle/
 .idea/
 .vs/
+.xcode.env
 Pods/
 build/
 dist/

--- a/change/@fluentui-react-native-tester-fd7c8ed9-7e5a-4cbc-b948-7da722db4b63.json
+++ b/change/@fluentui-react-native-tester-fd7c8ed9-7e5a-4cbc-b948-7da722db4b63.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Ignore xcode.env files in gitignore",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "none"
+}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

A recent version of React Native added a new `.Xcode.env` file to track where our local node installation is so Xcode can know it. React-native-test-app ignores it in it's default gitignore, so lets' update ours to match

### Verification

My local change of having a .Xcode.env file goes away after I updated the gitignore. 

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
