### PR TITLE
Allow V2 variants to be used in V1-style Text elements and still respect Dynamic Type

### DIFF
--- a/apps/fluent-tester/ios/Podfile.lock
+++ b/apps/fluent-tester/ios/Podfile.lock
@@ -10,13 +10,13 @@ PODS:
     - React-jsi (= 0.68.5)
     - ReactCommon/turbomodule/core (= 0.68.5)
   - fmt (6.2.1)
-  - FRNAvatar (0.16.24):
+  - FRNAvatar (0.16.25):
     - MicrosoftFluentUI (= 0.8.3)
     - React
   - FRNDatePicker (0.7.3):
     - MicrosoftFluentUI (= 0.8.3)
     - React
-  - FRNFontMetrics (0.2.0):
+  - FRNFontMetrics (0.3.0):
     - React
   - glog (0.3.5)
   - MicrosoftFluentUI (0.8.3):
@@ -453,7 +453,7 @@ PODS:
     - React-jsi (= 0.68.5)
     - React-logger (= 0.68.5)
     - React-perflogger (= 0.68.5)
-  - ReactTestApp-DevSupport (2.0.2):
+  - ReactTestApp-DevSupport (2.1.0):
     - React-Core
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
@@ -600,9 +600,9 @@ SPEC CHECKSUMS:
   FBLazyVector: 2b47ff52037bd9ae07cc9b051c9975797814b736
   FBReactNativeSpec: dd89c4a5591e20015aa55c6efbf9c7740a83efbf
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  FRNAvatar: 3911021ed95a08f19e0ee696712aa48b6dff010a
+  FRNAvatar: 0c18045ffd13fb317f27c4111c5de6f4ad0ab1a8
   FRNDatePicker: 241cd55b8d2b63d4427d782951f31504f09fbe1a
-  FRNFontMetrics: 472e7952e454ece364a91babd8bb2a32219676e7
+  FRNFontMetrics: c756b9bb1627909a7673b68caf7a7b14239c212e
   glog: 476ee3e89abb49e07f822b48323c51c57124b572
   MicrosoftFluentUI: e30487dd18aba04beeed4caf1ce1988073f8b03a
   RCT-Folly: 4d8508a426467c48885f1151029bc15fa5d7b3b8
@@ -632,7 +632,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: 9819a3bf6230e4b2a99877c21268b0b2416157a1
   React-runtimeexecutor: b1f1995089b90696dbc2a7ffe0059a80db5c8eb1
   ReactCommon: 149e2c0acab9bac61378da0db5b2880a1b5ff59b
-  ReactTestApp-DevSupport: 93a3ec4d2affbd491128b89e922d7f1a359f547a
+  ReactTestApp-DevSupport: bc72bbe8928c428f73e23d740fb13161609d9b9d
   ReactTestApp-Resources: ecba662266ac5af3e30e1e3004c0fa8c0298b61a
   RNCPicker: 0bf8ef8f7800524f32d2bb2a8bcadd53eda0ecd1
   RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8

--- a/apps/fluent-tester/src/TestComponents/TextExperimental/TextExperimentalTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/TextExperimental/TextExperimentalTest.tsx
@@ -14,7 +14,7 @@ const textSections: TestSection[] = [
     component: StandardUsage,
   },
   {
-    name: 'V2 Usage',
+    name: 'V2/V1 Comparison',
     component: V2Usage,
   },
   {

--- a/apps/fluent-tester/src/TestComponents/TextExperimental/V2Usage.ios.tsx
+++ b/apps/fluent-tester/src/TestComponents/TextExperimental/V2Usage.ios.tsx
@@ -12,6 +12,7 @@ import {
   Caption2,
   Display,
   LargeTitle,
+  TextV1,
   Title1,
   Title2,
   Title3,
@@ -22,17 +23,29 @@ export const V2Usage: React.FunctionComponent = () => {
     <View>
       <Stack style={stackStyle} gap={5}>
         <Caption2>Caption2</Caption2>
+        <TextV1 variant="caption2">Caption2</TextV1>
         <Caption1>Caption1</Caption1>
+        <TextV1 variant="caption1">Caption1</TextV1>
         <Caption1Strong>Caption1Strong</Caption1Strong>
+        <TextV1 variant="caption1Strong">Caption1Strong</TextV1>
         <Body2>Body2</Body2>
+        <TextV1 variant="body2">Body2</TextV1>
         <Body2Strong>Body2Strong</Body2Strong>
+        <TextV1 variant="body2Strong">Body2Strong</TextV1>
         <Body1>Body1</Body1>
+        <TextV1 variant="body1">Body1</TextV1>
         <Body1Strong>Body1Strong</Body1Strong>
+        <TextV1 variant="body1Strong">Body1Strong</TextV1>
         <Title3>Title3</Title3>
+        <TextV1 variant="title3">Title3</TextV1>
         <Title2>Title2</Title2>
+        <TextV1 variant="title2">Title2</TextV1>
         <Title1>Title1</Title1>
+        <TextV1 variant="title1">Title1</TextV1>
         <LargeTitle>LargeTitle</LargeTitle>
+        <TextV1 variant="largeTitle">LargeTitle</TextV1>
         <Display>Display</Display>
+        <TextV1 variant="display">Display</TextV1>
       </Stack>
     </View>
   );

--- a/change/@fluentui-react-native-apple-theme-599c1e44-941a-482f-bb95-eab98029da4f.json
+++ b/change/@fluentui-react-native-apple-theme-599c1e44-941a-482f-bb95-eab98029da4f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Allow V1 usage of V2 text variants",
+  "packageName": "@fluentui-react-native/apple-theme",
+  "email": "adgleitm@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-button-05dd0308-7f7d-44be-bba2-51600029c3b0.json
+++ b/change/@fluentui-react-native-button-05dd0308-7f7d-44be-bba2-51600029c3b0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Allow V1 usage of V2 text variants",
+  "packageName": "@fluentui-react-native/button",
+  "email": "adgleitm@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-b1001bfb-5a61-4a2d-abac-89f2f9cc1726.json
+++ b/change/@fluentui-react-native-tester-b1001bfb-5a61-4a2d-abac-89f2f9cc1726.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Allow V1 usage of V2 variants",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "adgleitm@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-text-8957023d-53bf-4040-81d8-43504a89cb93.json
+++ b/change/@fluentui-react-native-text-8957023d-53bf-4040-81d8-43504a89cb93.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Allow V1 usage of V2 variants",
+  "packageName": "@fluentui-react-native/text",
+  "email": "adgleitm@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-theme-types-5e43c7ac-b600-418f-a1d1-f2cc3bb5cadf.json
+++ b/change/@fluentui-react-native-theme-types-5e43c7ac-b600-418f-a1d1-f2cc3bb5cadf.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Allow V1 usage of V2 text variants",
+  "packageName": "@fluentui-react-native/theme-types",
+  "email": "adgleitm@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tokens-026fa91f-1370-4285-8291-e1879b825048.json
+++ b/change/@fluentui-react-native-tokens-026fa91f-1370-4285-8291-e1879b825048.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Allow V1 usage of V2 text variants",
+  "packageName": "@fluentui-react-native/tokens",
+  "email": "adgleitm@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Button/src/__snapshots__/Button.test.tsx.snap
+++ b/packages/components/Button/src/__snapshots__/Button.test.tsx.snap
@@ -97,6 +97,7 @@ exports[`Button component tests Button composed 1`] = `
     style={
       Object {
         "color": "#ffffff",
+        "dynamicTypeRamp": undefined,
         "fontFamily": "System",
         "fontSize": 15,
         "fontWeight": "600",

--- a/packages/components/text/src/Text.tsx
+++ b/packages/components/text/src/Text.tsx
@@ -83,9 +83,6 @@ export const Text = compressible<TextProps, TextTokens>((props: TextProps, useTo
     [onPress, onAccessibilityTap],
   );
 
-  // TODO(#2268): Remove once RN Core properly supports Dynamic Type scaling
-  const dynamicTypeVariant = Platform.OS === 'ios' ? tokens.dynamicTypeRamp : undefined;
-
   // override tokens from props
   [tokens, cache] = patchTokens(tokens, cache, {
     color,
@@ -113,6 +110,9 @@ export const Text = compressible<TextProps, TextTokens>((props: TextProps, useTo
     ['color', 'fontStyle', 'textAlign', 'textDecorationLine', ...fontStyles.keys],
   );
 
+  // TODO(#2268): Remove once RN Core properly supports Dynamic Type scaling
+  const dynamicTypeVariant = Platform.OS === 'ios' ? tokenStyle.dynamicTypeRamp : undefined;
+
   // [TODO(#2268): Remove once RN Core properly supports Dynamic Type scaling
   let scaleStyleAdjustments: TextTokens = emptyProps;
   // tokenStyle.fontSize and tokenStyle.lineHeight can also be strings (e.g., "14px").
@@ -122,6 +122,7 @@ export const Text = compressible<TextProps, TextTokens>((props: TextProps, useTo
     scaleStyleAdjustments = {
       fontSize: tokenStyle.fontSize * scaleFactor,
       lineHeight: tokenStyle.lineHeight * scaleFactor,
+      dynamicTypeRamp: undefined, // RN Text doesn't recognize dynamicTypeRamp yet, so don't let it leak through or RN will be sad
     };
   }
   // ]TODO(#2268)

--- a/packages/components/text/src/Text.tsx
+++ b/packages/components/text/src/Text.tsx
@@ -149,7 +149,7 @@ export const Text = compressible<TextProps, TextTokens>((props: TextProps, useTo
       numberOfLines: truncate || !wrap ? 1 : 0,
       style: mergeStyles(tokenStyle, props.style, extra?.style, scaleStyleAdjustments),
     };
-    delete mergedProps.style.dynamicTypeRamp; // TODO(#2268): RN Text doesn't recognize dynamicTypeRamp yet, so don't let it leak through or RN will complain about it being an invalid prop
+    delete (mergedProps.style as TextTokens).dynamicTypeRamp; // TODO(#2268): RN Text doesn't recognize dynamicTypeRamp yet, so don't let it leak through or RN will complain about it being an invalid prop
     return (
       <RNText ellipsizeMode={!wrap && !truncate ? 'clip' : 'tail'} {...mergedProps}>
         {children}

--- a/packages/components/text/src/Text.tsx
+++ b/packages/components/text/src/Text.tsx
@@ -149,7 +149,7 @@ export const Text = compressible<TextProps, TextTokens>((props: TextProps, useTo
       numberOfLines: truncate || !wrap ? 1 : 0,
       style: mergeStyles(tokenStyle, props.style, extra?.style, scaleStyleAdjustments),
     };
-    delete mergedProps.style.dynamicTypeRamp; // TODO(#2268): RN Text doesn't recognize dynamicTypeRamp yet, so don't let it leak through or RN will be sad
+    delete mergedProps.style.dynamicTypeRamp; // TODO(#2268): RN Text doesn't recognize dynamicTypeRamp yet, so don't let it leak through or RN will complain about it being an invalid prop
     return (
       <RNText ellipsizeMode={!wrap && !truncate ? 'clip' : 'tail'} {...mergedProps}>
         {children}

--- a/packages/components/text/src/Text.tsx
+++ b/packages/components/text/src/Text.tsx
@@ -122,7 +122,6 @@ export const Text = compressible<TextProps, TextTokens>((props: TextProps, useTo
     scaleStyleAdjustments = {
       fontSize: tokenStyle.fontSize * scaleFactor,
       lineHeight: tokenStyle.lineHeight * scaleFactor,
-      dynamicTypeRamp: undefined, // RN Text doesn't recognize dynamicTypeRamp yet, so don't let it leak through or RN will be sad
     };
   }
   // ]TODO(#2268)
@@ -150,6 +149,7 @@ export const Text = compressible<TextProps, TextTokens>((props: TextProps, useTo
       numberOfLines: truncate || !wrap ? 1 : 0,
       style: mergeStyles(tokenStyle, props.style, extra?.style, scaleStyleAdjustments),
     };
+    delete mergedProps.style.dynamicTypeRamp; // TODO(#2268): RN Text doesn't recognize dynamicTypeRamp yet, so don't let it leak through or RN will be sad
     return (
       <RNText ellipsizeMode={!wrap && !truncate ? 'clip' : 'tail'} {...mergedProps}>
         {children}

--- a/packages/components/text/src/Variants.ios.ts
+++ b/packages/components/text/src/Variants.ios.ts
@@ -4,31 +4,24 @@ import { Text } from './Text';
 
 export const Caption1 = Text.customize({
   variant: 'caption1',
-  dynamicTypeRamp: 'footnote',
 } as any);
 export const Caption1Strong = Text.customize({
   variant: 'caption1Strong',
-  dynamicTypeRamp: 'footnote',
 } as any);
 export const Caption2 = Text.customize({
   variant: 'caption2',
-  dynamicTypeRamp: 'caption1',
 } as any);
 export const Body1 = Text.customize({
   variant: 'body1',
-  dynamicTypeRamp: 'body',
 } as any);
 export const Body1Strong = Text.customize({
   variant: 'body1Strong',
-  dynamicTypeRamp: 'body',
 } as any);
 export const Body2 = Text.customize({
   variant: 'body2',
-  dynamicTypeRamp: 'subheadline',
 } as any);
 export const Body2Strong = Text.customize({
   variant: 'body2Strong',
-  dynamicTypeRamp: 'subheadline',
 } as any);
 export const Subtitle1 = null; // Not supported on iOS
 export const Subtitle1Strong = null; // Not supported on iOS
@@ -36,22 +29,17 @@ export const Subtitle2 = null; // Not supported on iOS
 export const Subtitle2Strong = null; // Not supported on iOS
 export const Title1 = Text.customize({
   variant: 'title1',
-  dynamicTypeRamp: 'title1',
 } as any);
 export const Title1Strong = null; // Not supported on iOS
 export const Title2 = Text.customize({
   variant: 'title2',
-  dynamicTypeRamp: 'title2',
 } as any);
 export const Title3 = Text.customize({
   variant: 'title3',
-  dynamicTypeRamp: 'title3',
 } as any);
 export const LargeTitle = Text.customize({
   variant: 'largeTitle',
-  dynamicTypeRamp: 'largeTitle',
 } as any);
 export const Display = Text.customize({
   variant: 'display',
-  dynamicTypeRamp: 'largeTitle',
 } as any);

--- a/packages/theming/apple-theme/src/__tests__/__snapshots__/apple-theme.test.ts.snap
+++ b/packages/theming/apple-theme/src/__tests__/__snapshots__/apple-theme.test.ts.snap
@@ -495,6 +495,7 @@ Object {
     },
     "variants": Object {
       "body1": Object {
+        "dynamicTypeRamp": "body",
         "face": "System",
         "letterSpacing": -0.43,
         "lineHeight": 22,
@@ -502,6 +503,7 @@ Object {
         "weight": "400",
       },
       "body1Strong": Object {
+        "dynamicTypeRamp": "body",
         "face": "System",
         "letterSpacing": -0.43,
         "lineHeight": 22,
@@ -509,6 +511,7 @@ Object {
         "weight": "600",
       },
       "body2": Object {
+        "dynamicTypeRamp": "subheadline",
         "face": "System",
         "letterSpacing": -0.23,
         "lineHeight": 20,
@@ -516,6 +519,7 @@ Object {
         "weight": "400",
       },
       "body2Strong": Object {
+        "dynamicTypeRamp": "subheadline",
         "face": "System",
         "letterSpacing": -0.23,
         "lineHeight": 20,
@@ -533,6 +537,7 @@ Object {
         "weight": "400",
       },
       "caption1": Object {
+        "dynamicTypeRamp": "footnote",
         "face": "System",
         "letterSpacing": -0.08,
         "lineHeight": 18,
@@ -540,6 +545,7 @@ Object {
         "weight": "400",
       },
       "caption1Strong": Object {
+        "dynamicTypeRamp": "footnote",
         "face": "System",
         "letterSpacing": -0.08,
         "lineHeight": 18,
@@ -547,6 +553,7 @@ Object {
         "weight": "600",
       },
       "caption2": Object {
+        "dynamicTypeRamp": "caption1",
         "face": "System",
         "letterSpacing": 0,
         "lineHeight": 16,
@@ -559,6 +566,7 @@ Object {
         "weight": "400",
       },
       "display": Object {
+        "dynamicTypeRamp": "largeTitle",
         "face": "System",
         "letterSpacing": 0.26,
         "lineHeight": 70,
@@ -596,6 +604,7 @@ Object {
         "weight": "400",
       },
       "largeTitle": Object {
+        "dynamicTypeRamp": "largeTitle",
         "face": "System",
         "letterSpacing": 0.4,
         "lineHeight": 41,
@@ -623,6 +632,7 @@ Object {
         "weight": "400",
       },
       "title1": Object {
+        "dynamicTypeRamp": "title1",
         "face": "System",
         "letterSpacing": 0.38,
         "lineHeight": 34,
@@ -630,6 +640,7 @@ Object {
         "weight": "700",
       },
       "title2": Object {
+        "dynamicTypeRamp": "title2",
         "face": "System",
         "letterSpacing": -0.26,
         "lineHeight": 28,
@@ -637,6 +648,7 @@ Object {
         "weight": "600",
       },
       "title3": Object {
+        "dynamicTypeRamp": "title3",
         "face": "System",
         "letterSpacing": -0.45,
         "lineHeight": 25,

--- a/packages/theming/apple-theme/src/appleTypography.ios.ts
+++ b/packages/theming/apple-theme/src/appleTypography.ios.ts
@@ -56,6 +56,7 @@ export function appleTypography(): Typography {
         weight: fontTokens.weight.regular,
         lineHeight: fontTokens.lineHeight100,
         letterSpacing: 0,
+        dynamicTypeRamp: 'caption1', // Not a typo, this corresponds to UIFontTextStypeCaption1
       },
       caption1: {
         face: fontTokens.family.base,
@@ -63,6 +64,7 @@ export function appleTypography(): Typography {
         weight: fontTokens.weight.regular,
         lineHeight: fontTokens.lineHeight200,
         letterSpacing: -0.08,
+        dynamicTypeRamp: 'footnote',
       },
       caption1Strong: {
         face: fontTokens.family.base,
@@ -70,6 +72,7 @@ export function appleTypography(): Typography {
         weight: fontTokens.weight.semibold,
         lineHeight: fontTokens.lineHeight200,
         letterSpacing: -0.08,
+        dynamicTypeRamp: 'footnote',
       },
       body2: {
         face: fontTokens.family.base,
@@ -77,6 +80,7 @@ export function appleTypography(): Typography {
         weight: fontTokens.weight.regular,
         lineHeight: fontTokens.lineHeight300,
         letterSpacing: -0.23,
+        dynamicTypeRamp: 'subheadline',
       },
       body2Strong: {
         face: fontTokens.family.base,
@@ -84,6 +88,7 @@ export function appleTypography(): Typography {
         weight: fontTokens.weight.semibold,
         lineHeight: fontTokens.lineHeight300,
         letterSpacing: -0.23,
+        dynamicTypeRamp: 'subheadline',
       },
       body1: {
         face: fontTokens.family.base,
@@ -91,6 +96,7 @@ export function appleTypography(): Typography {
         weight: fontTokens.weight.regular,
         lineHeight: fontTokens.lineHeight400,
         letterSpacing: -0.43,
+        dynamicTypeRamp: 'body',
       },
       body1Strong: {
         face: fontTokens.family.base,
@@ -98,6 +104,7 @@ export function appleTypography(): Typography {
         weight: fontTokens.weight.semibold,
         lineHeight: fontTokens.lineHeight400,
         letterSpacing: -0.43,
+        dynamicTypeRamp: 'body',
       },
       title3: {
         face: fontTokens.family.base,
@@ -105,6 +112,7 @@ export function appleTypography(): Typography {
         weight: fontTokens.weight.semibold,
         lineHeight: fontTokens.lineHeight500,
         letterSpacing: -0.45,
+        dynamicTypeRamp: 'title3',
       },
       title2: {
         face: fontTokens.family.base,
@@ -112,6 +120,7 @@ export function appleTypography(): Typography {
         weight: fontTokens.weight.semibold,
         lineHeight: fontTokens.lineHeight600,
         letterSpacing: -0.26,
+        dynamicTypeRamp: 'title2',
       },
       title1: {
         face: fontTokens.family.base,
@@ -119,6 +128,7 @@ export function appleTypography(): Typography {
         weight: fontTokens.weight.bold,
         lineHeight: fontTokens.lineHeight700,
         letterSpacing: 0.38,
+        dynamicTypeRamp: 'title1',
       },
       largeTitle: {
         face: fontTokens.family.base,
@@ -126,6 +136,7 @@ export function appleTypography(): Typography {
         weight: fontTokens.weight.bold,
         lineHeight: fontTokens.lineHeight800,
         letterSpacing: 0.4,
+        dynamicTypeRamp: 'largeTitle',
       },
       display: {
         face: fontTokens.family.base,
@@ -133,6 +144,7 @@ export function appleTypography(): Typography {
         weight: fontTokens.weight.bold,
         lineHeight: fontTokens.lineHeight900,
         letterSpacing: 0.26,
+        dynamicTypeRamp: 'largeTitle',
       },
     } as Variants,
   };

--- a/packages/theming/theme-types/src/Typography.types.ts
+++ b/packages/theming/theme-types/src/Typography.types.ts
@@ -102,6 +102,11 @@ export type FontLineHeight = number;
 export type FontLetterSpacing = number;
 
 /**
+ * On iOS, the Dynamic Type ramp that this variant should conform to.
+ */
+export type FontDynamicTypeRamp = string; // TODO(#2268): Import type from RN directly
+
+/**
  * A font variant value.
  */
 export type VariantValue = {
@@ -110,6 +115,7 @@ export type VariantValue = {
   weight: FontWeight;
   lineHeight?: FontLineHeight;
   letterSpacing?: FontLetterSpacing;
+  dynamicTypeRamp?: FontDynamicTypeRamp;
 };
 
 /**

--- a/packages/utils/tokens/src/text-tokens.ts
+++ b/packages/utils/tokens/src/text-tokens.ts
@@ -14,14 +14,19 @@ export interface FontStyleTokens {
   fontWeight?: keyof Typography['weights'] | TextStyle['fontWeight'];
   fontLineHeight?: TextStyle['lineHeight'];
   fontLetterSpacing?: TextStyle['letterSpacing'];
+  fontDynamicTypeRamp?: string; // TODO(#2268): Import type from RN directly
 }
 
 export type FontTokens = FontStyleTokens & FontVariantTokens;
 
 export const fontStyles: TokenBuilder<FontTokens> = {
-  from: ({ fontFamily, fontLetterSpacing, fontLineHeight, fontSize, fontWeight, variant }: FontTokens, { typography }: Theme) => {
+  from: (
+    { fontDynamicTypeRamp, fontFamily, fontLetterSpacing, fontLineHeight, fontSize, fontWeight, variant }: FontTokens,
+    { typography }: Theme,
+  ) => {
     const { families, sizes, weights, variants } = typography;
     if (
+      fontDynamicTypeRamp !== undefined ||
       fontFamily !== undefined ||
       fontLetterSpacing !== undefined ||
       fontLineHeight !== undefined ||
@@ -35,12 +40,13 @@ export const fontStyles: TokenBuilder<FontTokens> = {
         fontWeight: weights[fontWeight] ?? fontWeight ?? weights[variants[variant]?.weight] ?? variants[variant]?.weight,
         lineHeight: fontLineHeight ?? variants[variant]?.lineHeight,
         letterSpacing: fontLetterSpacing ?? variants[variant]?.letterSpacing,
+        dynamicTypeRamp: fontDynamicTypeRamp ?? variants[variant]?.dynamicTypeRamp,
       };
     }
 
     return {};
   },
-  keys: ['fontFamily', 'fontLineHeight', 'fontLetterSpacing', 'fontSize', 'fontWeight', 'variant'],
+  keys: ['fontDynamicTypeRamp', 'fontFamily', 'fontLineHeight', 'fontLetterSpacing', 'fontSize', 'fontWeight', 'variant'],
 };
 
 function _buildTextStyles(tokens: FontTokens, theme: Theme): ITextProps {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

As we were developing documentation, we found that a V1-style `Text` element with a V2 variant doesn't respect Dynamic Type. This is because we originally specified the Dynamic Type ramp independently of the variant type (see the old version of Variants.ios.ts).

The fix here is to make the relevant Dynamic Type ramp dependent on the variant itself. As a result, these ramps are now specified in appleTypography.ios.ts.

Also, to show off the fact that we can do this, we've modified the V2 usage test component.

### Verification

Here's the new V2 test component at UIContentSizeCategoryExtraExtraExtraLarge. The first line uses the V2 version; the second uses the V1 counterpart. The expected behavior is that they look the same.

As an aside, I'm aware that Caption2 looks larger than Caption1 here, despite the fact that it's the other way around at the default content size category. They actually render at the same font size, but Caption1 looks smaller because it has a letter spacing of -0.08. Regardless, in different content size categories, Caption2 is not guaranteed to be smaller than Caption1 because `UIFontMetrics` resizes text based on the ratio of the distances between adjacent baselines (also known as "leading"), not the sizes themselves. If we don't like this, we can address it separately, but it's out of scope for this PR.

![Simulator Screen Shot - iPad Air (5th generation) - 2022-12-01 at 15 01 21](https://user-images.githubusercontent.com/717674/205178907-9d3ce785-e48d-479a-a948-3de771ab3297.png)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
