### PR TITLE
Android Avatar variations

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Avatar/AvatarTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Avatar/AvatarTest.tsx
@@ -4,6 +4,7 @@ import { Test, TestSection, PlatformStatus } from '../Test';
 import { StandardUsage } from './BasicAvatar';
 import { CustomizeUsage } from './CustomizedAvatar';
 import { E2EAvatarTest } from './E2EAvatarTest';
+import { Platform } from 'react-native';
 
 const avatarSections: TestSection[] = [
   {
@@ -11,15 +12,19 @@ const avatarSections: TestSection[] = [
     testID: AVATAR_TESTPAGE,
     component: StandardUsage,
   },
-  {
-    name: 'Customize Usage',
-    component: CustomizeUsage,
-  },
-  {
-    name: 'Avatar E2E',
-    component: E2EAvatarTest,
-  },
-];
+  ...Platform.select({
+    android: [null],
+    default:
+      [{
+        name: 'Customize Usage',
+        component: CustomizeUsage,
+      },
+      {
+        name: 'Avatar E2E',
+        component: E2EAvatarTest,
+      }],
+  })];
+
 
 export const AvatarTest: React.FunctionComponent = () => {
   const status: PlatformStatus = {
@@ -27,7 +32,7 @@ export const AvatarTest: React.FunctionComponent = () => {
     uwpStatus: 'Backlog',
     iosStatus: 'Beta',
     macosStatus: 'Experimental',
-    androidStatus: 'Backlog',
+    androidStatus: 'Experimental',
   };
 
   const description =

--- a/apps/fluent-tester/src/TestComponents/Avatar/AvatarTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Avatar/AvatarTest.tsx
@@ -14,17 +14,18 @@ const avatarSections: TestSection[] = [
   },
   ...Platform.select({
     android: [null],
-    default:
-      [{
+    default: [
+      {
         name: 'Customize Usage',
         component: CustomizeUsage,
       },
       {
         name: 'Avatar E2E',
         component: E2EAvatarTest,
-      }],
-  })];
-
+      },
+    ],
+  }),
+];
 
 export const AvatarTest: React.FunctionComponent = () => {
   const status: PlatformStatus = {

--- a/apps/fluent-tester/src/TestComponents/Avatar/BasicAvatar.android.tsx
+++ b/apps/fluent-tester/src/TestComponents/Avatar/BasicAvatar.android.tsx
@@ -112,13 +112,13 @@ export const StandardUsage: FunctionComponent = () => {
         flex: 1,
         justifyContent: 'space-evenly',
       }}>
-        {/* Variation - Anonymous ascent.*/}
+        {/* Variation - Anonymous accent.*/}
 
         {/* With badge.*/}
         <Avatar
           size={56}
           badge={{ status: 'available' }}
-          avatarColor={'ascent'}
+          avatarColor={'accent'}
         />
 
         {/* No ring and badge.*/}
@@ -126,7 +126,7 @@ export const StandardUsage: FunctionComponent = () => {
           accessibilityLabel="Fall-back Icon"
           accessibilityHint="A picture representing a user"
           size={56}
-          avatarColor={'ascent'}
+          avatarColor={'accent'}
         />
 
         {/* With ring. */}
@@ -136,7 +136,7 @@ export const StandardUsage: FunctionComponent = () => {
           size={56}
           activeAppearance="ring"
           active="active"
-          avatarColor={'ascent'}
+          avatarColor={'accent'}
         />
       </View>
 

--- a/apps/fluent-tester/src/TestComponents/Avatar/BasicAvatar.android.tsx
+++ b/apps/fluent-tester/src/TestComponents/Avatar/BasicAvatar.android.tsx
@@ -1,0 +1,243 @@
+import React, { FunctionComponent } from 'react';
+import { Avatar } from '@fluentui-react-native/avatar';
+import { View } from 'react-native';
+import { steveBallmerPhotoUrl } from './../PersonaCoin/styles';
+
+export const StandardUsage: FunctionComponent = () => {
+  return (
+    <View style={{ paddingBottom: 40 }} >
+      <View style={{
+        flexDirection: 'row',
+        marginHorizontal: 10,
+        paddingTop: 10,
+        paddingBottom: 5,
+        flex: 1,
+        justifyContent: 'space-evenly',
+      }}>
+
+        {/* Variation - Standard */}
+
+        {/* With badge. */}
+        <Avatar
+          badge={{ status: 'available' }}
+          avatarColor={'brand'}
+          size={40}
+        />
+
+        {/* Variation - No Ring and badge. */}
+        <Avatar
+          size={56}
+          avatarColor={'brand'}
+        />
+
+        {/* Variation - With Ring.*/}
+        <Avatar
+          active="active"
+          activeAppearance="ring"
+          size={56}
+          avatarColor={'brand'}
+        />
+      </View>
+
+      <View style={{
+        flexDirection: 'row',
+        marginHorizontal: 10,
+        paddingTop: 10,
+        paddingBottom: 5,
+        flex: 1,
+        justifyContent: 'space-evenly'
+      }}>
+
+        {/* Variation - Standard Inverted */}
+
+        {/* With badge only.*/}
+        <Avatar
+          size={56}
+          badge={{ status: 'available' }}
+          avatarColor={'brandInverted'}
+        />
+
+        {/* No ring and badge.*/}
+        <Avatar
+          size={56}
+          avatarColor={'brandInverted'}
+        />
+
+        {/* With ring.*/}
+        <Avatar
+          active="active"
+          activeAppearance="ring"
+          size={56}
+          avatarColor={'brandInverted'} />
+      </View>
+
+      <View style={{
+        flexDirection: 'row',
+        marginHorizontal: 10,
+        paddingTop: 10,
+        paddingBottom: 5,
+        flex: 1,
+        justifyContent: 'space-evenly',
+      }}>
+        {/*Variation - Anonymous*/}
+
+        {/* With Badge.*/}
+        <Avatar
+          size={56}
+          badge={{ status: 'available' }}
+        />
+
+        {/* No ring and badge.*/}
+        <Avatar
+          accessibilityLabel="Fall-back Icon"
+          accessibilityHint="A picture representing a user"
+          size={56}
+        />
+
+        {/* With ring. */}
+        <Avatar
+          accessibilityLabel="Fall-back Icon"
+          accessibilityHint="A picture representing a user"
+          size={56}
+          activeAppearance="ring"
+          active="active"
+        />
+      </View>
+
+      <View style={{
+        flexDirection: 'row',
+        marginHorizontal: 10,
+        paddingTop: 10,
+        paddingBottom: 5,
+        flex: 1,
+        justifyContent: 'space-evenly',
+      }}>
+        {/* Variation - Anonymous ascent  .*/}
+
+        {/* With badge.*/}
+        <Avatar
+          size={56}
+          badge={{ status: 'available' }}
+          avatarColor={'ascent'}
+        />
+
+        {/* No ring and badge.*/}
+        <Avatar
+          accessibilityLabel="Fall-back Icon"
+          accessibilityHint="A picture representing a user"
+          size={56}
+          avatarColor={'ascent'}
+        />
+
+        {/* With ring. */}
+        <Avatar
+          accessibilityLabel="Fall-back Icon"
+          accessibilityHint="A picture representing a user"
+          size={56}
+          activeAppearance="ring"
+          active="active"
+          avatarColor={'ascent'}
+        />
+      </View>
+
+      <View style={{
+        flexDirection: 'row',
+        marginHorizontal: 10,
+        paddingTop: 10,
+        paddingBottom: 5,
+        flex: 1,
+        justifyContent: 'space-evenly',
+      }}>
+
+        {/* Variation - Initials.*/}
+
+        {/* With badge.*/}
+        <Avatar
+          size={56}
+          badge={{ status: 'outOfOffice' }}
+          name="* Richard Faynman *"
+        />
+
+        {/* No ring and badge.*/}
+        <Avatar
+          size={56}
+          name="* Annie Markus *"
+          avatarColor={'colorful'}
+        />
+
+        {/* With ring. */}
+        <Avatar
+          active="active"
+          activeAppearance="ring"
+          size={56}
+          name="* Keshav Madhav *"
+          avatarColor={'colorful'}
+        />
+      </View>
+
+      <View style={{
+        flexDirection: 'row',
+        marginHorizontal: 10,
+        paddingTop: 10,
+        paddingBottom: 5,
+        flex: 1,
+        justifyContent: 'space-evenly',
+      }}>
+
+        {/* Variation - Image. */}
+
+        {/* With badge.*/}
+        <Avatar
+          size={56}
+          badge={{ status: 'outOfOffice' }}
+          name="* Richard Faynman *"
+          imageUrl={steveBallmerPhotoUrl}
+        />
+
+        {/* No ring and badge.*/}
+        <Avatar
+          size={56}
+          imageUrl={steveBallmerPhotoUrl}
+          avatarColor={'colorful'}
+        />
+
+        {/* With ring.*/}
+        <Avatar
+          active="active"
+          activeAppearance="ring"
+          size={56}
+          name="* Richard Faynman *"
+          imageUrl={steveBallmerPhotoUrl}
+
+        />
+      </View>
+
+      <View style={{
+        flexDirection: 'row',
+        marginHorizontal: 10,
+        paddingTop: 10,
+        paddingBottom: 5,
+        flex: 1,
+        justifyContent: 'space-evenly',
+      }}>
+
+        {/* Variation - Overflow .*/}
+
+        <Avatar
+          size={56}
+          initials="20"
+          avatarColor={'colorful'}
+        />
+
+        {/* Variation - Group avatar*/}
+
+        <Avatar
+          size={56}
+          shape={'square'}
+          avatarColor={'colorful'}
+          name="*Annie Martha*"
+        />
+      </View>
+    </View >
+  );
+};

--- a/apps/fluent-tester/src/TestComponents/Avatar/BasicAvatar.android.tsx
+++ b/apps/fluent-tester/src/TestComponents/Avatar/BasicAvatar.android.tsx
@@ -112,7 +112,7 @@ export const StandardUsage: FunctionComponent = () => {
         flex: 1,
         justifyContent: 'space-evenly',
       }}>
-        {/* Variation - Anonymous ascent  .*/}
+        {/* Variation - Anonymous ascent.*/}
 
         {/* With badge.*/}
         <Avatar

--- a/apps/fluent-tester/src/TestComponents/Avatar/BasicAvatar.android.tsx
+++ b/apps/fluent-tester/src/TestComponents/Avatar/BasicAvatar.android.tsx
@@ -2,97 +2,45 @@ import React, { FunctionComponent } from 'react';
 import { Avatar } from '@fluentui-react-native/avatar';
 import { View } from 'react-native';
 import { steveBallmerPhotoUrl } from './../PersonaCoin/styles';
+import { mobileStyles } from '../Common/styles';
 
 export const StandardUsage: FunctionComponent = () => {
   return (
-    <View style={{ paddingBottom: 40 }} >
-      <View style={{
-        flexDirection: 'row',
-        marginHorizontal: 10,
-        paddingTop: 10,
-        paddingBottom: 5,
-        flex: 1,
-        justifyContent: 'space-evenly',
-      }}>
-
+    <View style={{ paddingBottom: 40 }}>
+      <View style={mobileStyles.testVariants}>
         {/* Variation - Standard */}
 
         {/* With badge. */}
-        <Avatar
-          badge={{ status: 'available' }}
-          avatarColor={'brand'}
-          size={40}
-        />
+        <Avatar badge={{ status: 'available' }} avatarColor={'brand'} size={40} />
 
         {/* Variation - No Ring and badge. */}
-        <Avatar
-          size={56}
-          avatarColor={'brand'}
-        />
+        <Avatar size={56} avatarColor={'brand'} />
 
         {/* Variation - With Ring.*/}
-        <Avatar
-          active="active"
-          activeAppearance="ring"
-          size={56}
-          avatarColor={'brand'}
-        />
+        <Avatar active="active" activeAppearance="ring" size={56} avatarColor={'brand'} />
       </View>
 
-      <View style={{
-        flexDirection: 'row',
-        marginHorizontal: 10,
-        paddingTop: 10,
-        paddingBottom: 5,
-        flex: 1,
-        justifyContent: 'space-evenly'
-      }}>
-
+      <View style={mobileStyles.testVariants}>
         {/* Variation - Standard Inverted */}
 
         {/* With badge only.*/}
-        <Avatar
-          size={56}
-          badge={{ status: 'available' }}
-          avatarColor={'brandInverted'}
-        />
+        <Avatar size={56} badge={{ status: 'available' }} avatarColor={'brandInverted'} />
 
         {/* No ring and badge.*/}
-        <Avatar
-          size={56}
-          avatarColor={'brandInverted'}
-        />
+        <Avatar size={56} avatarColor={'brandInverted'} />
 
         {/* With ring.*/}
-        <Avatar
-          active="active"
-          activeAppearance="ring"
-          size={56}
-          avatarColor={'brandInverted'} />
+        <Avatar active="active" activeAppearance="ring" size={56} avatarColor={'brandInverted'} />
       </View>
 
-      <View style={{
-        flexDirection: 'row',
-        marginHorizontal: 10,
-        paddingTop: 10,
-        paddingBottom: 5,
-        flex: 1,
-        justifyContent: 'space-evenly',
-      }}>
+      <View style={mobileStyles.testVariants}>
         {/*Variation - Anonymous*/}
 
         {/* With Badge.*/}
-        <Avatar
-          size={56}
-          badge={{ status: 'available' }}
-        />
+        <Avatar size={56} badge={{ status: 'available' }} />
 
         {/* No ring and badge.*/}
-        <Avatar
-          accessibilityLabel="Fall-back Icon"
-          accessibilityHint="A picture representing a user"
-          size={56}
-        />
+        <Avatar accessibilityLabel="Fall-back Icon" accessibilityHint="A picture representing a user" size={56} />
 
         {/* With ring. */}
         <Avatar
@@ -104,30 +52,14 @@ export const StandardUsage: FunctionComponent = () => {
         />
       </View>
 
-      <View style={{
-        flexDirection: 'row',
-        marginHorizontal: 10,
-        paddingTop: 10,
-        paddingBottom: 5,
-        flex: 1,
-        justifyContent: 'space-evenly',
-      }}>
+      <View style={mobileStyles.testVariants}>
         {/* Variation - Anonymous accent.*/}
 
         {/* With badge.*/}
-        <Avatar
-          size={56}
-          badge={{ status: 'available' }}
-          avatarColor={'accent'}
-        />
+        <Avatar size={56} badge={{ status: 'available' }} avatarColor={'accent'} />
 
         {/* No ring and badge.*/}
-        <Avatar
-          accessibilityLabel="Fall-back Icon"
-          accessibilityHint="A picture representing a user"
-          size={56}
-          avatarColor={'accent'}
-        />
+        <Avatar accessibilityLabel="Fall-back Icon" accessibilityHint="A picture representing a user" size={56} avatarColor={'accent'} />
 
         {/* With ring. */}
         <Avatar
@@ -140,104 +72,41 @@ export const StandardUsage: FunctionComponent = () => {
         />
       </View>
 
-      <View style={{
-        flexDirection: 'row',
-        marginHorizontal: 10,
-        paddingTop: 10,
-        paddingBottom: 5,
-        flex: 1,
-        justifyContent: 'space-evenly',
-      }}>
-
+      <View style={mobileStyles.testVariants}>
         {/* Variation - Initials.*/}
 
         {/* With badge.*/}
-        <Avatar
-          size={56}
-          badge={{ status: 'outOfOffice' }}
-          name="* Richard Faynman *"
-        />
+        <Avatar size={56} badge={{ status: 'outOfOffice' }} name="* Richard Faynman *" />
 
         {/* No ring and badge.*/}
-        <Avatar
-          size={56}
-          name="* Annie Markus *"
-          avatarColor={'colorful'}
-        />
+        <Avatar size={56} name="* Annie Markus *" avatarColor={'colorful'} />
 
         {/* With ring. */}
-        <Avatar
-          active="active"
-          activeAppearance="ring"
-          size={56}
-          name="* Keshav Madhav *"
-          avatarColor={'colorful'}
-        />
+        <Avatar active="active" activeAppearance="ring" size={56} name="* Keshav Madhav *" avatarColor={'colorful'} />
       </View>
 
-      <View style={{
-        flexDirection: 'row',
-        marginHorizontal: 10,
-        paddingTop: 10,
-        paddingBottom: 5,
-        flex: 1,
-        justifyContent: 'space-evenly',
-      }}>
-
+      <View style={mobileStyles.testVariants}>
         {/* Variation - Image. */}
 
         {/* With badge.*/}
-        <Avatar
-          size={56}
-          badge={{ status: 'outOfOffice' }}
-          name="* Richard Faynman *"
-          imageUrl={steveBallmerPhotoUrl}
-        />
+        <Avatar size={56} badge={{ status: 'outOfOffice' }} name="* Richard Faynman *" imageUrl={steveBallmerPhotoUrl} />
 
         {/* No ring and badge.*/}
-        <Avatar
-          size={56}
-          imageUrl={steveBallmerPhotoUrl}
-          avatarColor={'colorful'}
-        />
+        <Avatar size={56} imageUrl={steveBallmerPhotoUrl} avatarColor={'colorful'} />
 
         {/* With ring.*/}
-        <Avatar
-          active="active"
-          activeAppearance="ring"
-          size={56}
-          name="* Richard Faynman *"
-          imageUrl={steveBallmerPhotoUrl}
-
-        />
+        <Avatar active="active" activeAppearance="ring" size={56} name="* Richard Faynman *" imageUrl={steveBallmerPhotoUrl} />
       </View>
 
-      <View style={{
-        flexDirection: 'row',
-        marginHorizontal: 10,
-        paddingTop: 10,
-        paddingBottom: 5,
-        flex: 1,
-        justifyContent: 'space-evenly',
-      }}>
-
+      <View style={mobileStyles.testVariants}>
         {/* Variation - Overflow .*/}
 
-        <Avatar
-          size={56}
-          initials="20"
-          avatarColor={'colorful'}
-        />
+        <Avatar size={56} initials="20" avatarColor={'colorful'} />
 
         {/* Variation - Group avatar*/}
 
-        <Avatar
-          size={56}
-          shape={'square'}
-          avatarColor={'colorful'}
-          name="*Annie Martha*"
-        />
+        <Avatar size={56} shape={'square'} avatarColor={'colorful'} name="*Annie Martha*" />
       </View>
-    </View >
+    </View>
   );
 };

--- a/apps/fluent-tester/src/TestComponents/Common/styles.ts
+++ b/apps/fluent-tester/src/TestComponents/Common/styles.ts
@@ -148,7 +148,14 @@ export const mobileStyles = StyleSheet.create({
     flexDirection: 'column',
     justifyContent: 'space-between',
   },
-
+  testVariants: {
+    flexDirection: 'row',
+    marginHorizontal: 10,
+    paddingTop: 10,
+    paddingBottom: 5,
+    flex: 1,
+    justifyContent: 'space-evenly',
+  },
   testList: {
     width: '100%',
   },

--- a/change/@fluentui-react-native-avatar-a56474a4-02dd-488b-a97a-61ace5eebf31.json
+++ b/change/@fluentui-react-native-avatar-a56474a4-02dd-488b-a97a-61ace5eebf31.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Android Avatar variations",
+  "packageName": "@fluentui-react-native/avatar",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-4d1799b8-7b3e-4a1d-82e1-cfd3e3a9cdaa.json
+++ b/change/@fluentui-react-native-tester-4d1799b8-7b3e-4a1d-82e1-cfd3e3a9cdaa.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Updated tester styles",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Avatar/SPEC.md
+++ b/packages/components/Avatar/SPEC.md
@@ -48,6 +48,8 @@ The Avatar supports color variants when displaying initials or an icon:
 
 - Neutral - Gray (default).
 - Brand - Brand colors from the theme
+- Brand Inverted - Inverted brand colors. Only supported for android.
+- Accent - Only supported for android.
 - Colorful - Pick from a list of pre-defined Avatar colors. The color will be assigned based on a hash of the name (to "randomly" assign a person a color). The color name (like darkRed) can also be specified explicitly in case the use case requires a different algorithm to pick the color.
 
 ### Icon

--- a/packages/components/Avatar/src/Avatar.styling.ts
+++ b/packages/components/Avatar/src/Avatar.styling.ts
@@ -20,6 +20,8 @@ export const avatarStates: (keyof AvatarTokens)[] = [
   ...AvatarSizesForTokens,
   'neutral',
   'brand',
+  'brandInverted',
+  'accent',
   'circular',
   'square',
   'inactive',

--- a/packages/components/Avatar/src/Avatar.types.ts
+++ b/packages/components/Avatar/src/Avatar.types.ts
@@ -157,6 +157,7 @@ export interface AvatarProps extends IViewProps, AvatarConfigurableProps {
    * using the `getInitials` function.
    *
    * The initials are displayed when there is no image (including while the image is loading).
+   *
    */
   initials?: string;
 

--- a/packages/components/Avatar/src/Avatar.types.ts
+++ b/packages/components/Avatar/src/Avatar.types.ts
@@ -61,7 +61,8 @@ export const AvatarColors = [
   'hotPink',
   'orchid',
 ] as const;
-export const ColorSchemes = ['neutral', 'brand', 'colorful'] as const;
+
+export const ColorSchemes = ['neutral', 'brand', 'colorful', 'brandInverted', 'accent'] as const;
 export type AvatarSize = typeof AvatarSizes[number];
 export type AvatarNamedColor = typeof AvatarColors[number];
 export type AvatarColorSchemes = typeof ColorSchemes[number];
@@ -69,25 +70,27 @@ export type AvatarColorSchemes = typeof ColorSchemes[number];
 export type AvatarShape = 'circular' | 'square';
 export type AvatarActive = 'active' | 'inactive' | 'unset';
 export type AvatarActiveAppearance = 'ring';
+
 export type AvatarColor = AvatarColorSchemes | AvatarNamedColor | ColorValue;
 
 export interface AvatarConfigurableProps {
   /**
-   * Optional activity indicator
+   *   Optional activity indicator
    * * active: the avatar will be decorated according to activeAppearance
    * * inactive: the avatar will be reduced in size and partially transparent
    * * unset: normal display
-   *
    * @defaultvalue unset
    */
   active?: AvatarActive;
+
   /**
    * The color when displaying either an icon or initials.
    * * neutral (default): gray
    * * brand: color from the brand palette
+   * * brandInverted: Inverted color from the brand palette. @platform android
+   * * accent: // TO-DO. @platform android
    * * colorful: picks a color from a set of pre-defined colors, based on a hash of the name (or idForColor if provided)
    * * [AvatarNamedColor]: a specific color from the theme
-   *
    * @defaultvalue neutral
    */
   avatarColor?: AvatarColor;
@@ -235,6 +238,8 @@ export interface AvatarTokens extends IBackgroundColorTokens, IForegroundColorTo
    */
   neutral?: AvatarTokens;
   brand?: AvatarTokens;
+  brandInverted?: AvatarTokens;
+  accent?:AvatarTokens;
   darkRed?: AvatarTokens;
   cranberry?: AvatarTokens;
   red?: AvatarTokens;

--- a/packages/components/Avatar/src/Avatar.types.ts
+++ b/packages/components/Avatar/src/Avatar.types.ts
@@ -240,7 +240,7 @@ export interface AvatarTokens extends IBackgroundColorTokens, IForegroundColorTo
   neutral?: AvatarTokens;
   brand?: AvatarTokens;
   brandInverted?: AvatarTokens;
-  accent?:AvatarTokens;
+  accent?: AvatarTokens;
   darkRed?: AvatarTokens;
   cranberry?: AvatarTokens;
   red?: AvatarTokens;

--- a/packages/components/Avatar/src/Avatar.types.ts
+++ b/packages/components/Avatar/src/Avatar.types.ts
@@ -88,7 +88,7 @@ export interface AvatarConfigurableProps {
    * * neutral (default): gray
    * * brand: color from the brand palette
    * * brandInverted: Inverted color from the brand palette. @platform android
-   * * accent: // TO-DO. @platform android
+   * * accent @platform android
    * * colorful: picks a color from a set of pre-defined colors, based on a hash of the name (or idForColor if provided)
    * * [AvatarNamedColor]: a specific color from the theme
    * @defaultvalue neutral
@@ -103,6 +103,7 @@ export interface AvatarConfigurableProps {
   initialsColor?: ColorValue;
 
   outOfOffice?: boolean;
+
   /**
    * Ring props
    */
@@ -117,7 +118,6 @@ export interface AvatarConfigurableProps {
    *
    * Size is restricted to a limited set of supported values recommended for most uses (see `AvatarSizeValue`) and
    * based on design guidelines for the Avatar control.
-   *
    * @defaultvalue 24
    */
   size?: AvatarSize;
@@ -139,7 +139,6 @@ export interface AvatarProps extends IViewProps, AvatarConfigurableProps {
 
   /**
    * Icon to be displayed when the avatar doesn't have an image or initials.
-   *
    * @defaultvalue `PersonRegular` (the default icon's size depends on the Avatar's size)
    */
   icon?: IconSourcesType;
@@ -157,7 +156,6 @@ export interface AvatarProps extends IViewProps, AvatarConfigurableProps {
    * using the `getInitials` function.
    *
    * The initials are displayed when there is no image (including while the image is loading).
-   *
    */
   initials?: string;
 

--- a/packages/components/Avatar/src/AvatarTokens.android.ts
+++ b/packages/components/Avatar/src/AvatarTokens.android.ts
@@ -1,0 +1,203 @@
+import { Theme } from '@fluentui-react-native/framework';
+import { TokenSettings } from '@fluentui-react-native/use-styling';
+import { AvatarTokens } from '.';
+import { globalTokens } from '@fluentui-react-native/theme-tokens';
+
+export const defaultAvatarTokens: TokenSettings<AvatarTokens, Theme> = (t: Theme) =>
+  ({
+    color: t.colors.neutralForeground3,
+    backgroundColor: t.colors.neutralBackground5,
+    avatarOpacity: 1,
+    fontFamily: t.typography.families.primary,
+    fontWeight: globalTokens.font.weight.semibold,
+    fontSize: globalTokens.font.size200,
+    size: 24,
+    iconSize: 16,
+    iconColor: t.colors.neutralForeground3,
+    ringColor: t.colors.neutralStroke1,
+    borderColor: t.colors.neutralStroke1,
+    borderWidth: t.host.appearance === 'highContrast' ? 1 : 0,
+    circular: {
+      borderRadius: globalTokens.corner.radiusCircular,
+    },
+    square: {
+      borderRadius: globalTokens.corner.radius40,
+    },
+    inactive: {
+      avatarOpacity: 0.8,
+    },
+    size20: {
+      size: 20,
+      badgeSize: 'tiny',
+      iconSize: 16,
+      fontSize: globalTokens.font.size100,
+      square: {
+        borderRadius: globalTokens.corner.radius20,
+      },
+    },
+    size24: {
+      size: 24,
+      badgeSize: 'tiny',
+      iconSize: 16,
+      fontSize: globalTokens.font.size100,
+      square: {
+        borderRadius: globalTokens.corner.radius20,
+      },
+    },
+    size28: {
+      size: 28,
+      badgeSize: 'extraSmall',
+      iconSize: 20,
+      fontWeight: globalTokens.font.weight.semibold,
+      fontSize: globalTokens.font.size100,
+    },
+    size32: {
+      size: 32,
+      badgeSize: 'extraSmall',
+      iconSize: 20,
+      fontSize: globalTokens.font.size100,
+    },
+    size36: {
+      size: 36,
+      badgeSize: 'extraSmall',
+      iconSize: 20,
+    },
+    size40: {
+      size: 40,
+      badgeSize: 'small',
+      iconSize: 20,
+    },
+    size48: {
+      size: 48,
+      badgeSize: 'small',
+      iconSize: 24,
+    },
+    size56: {
+      size: 56,
+      badgeSize: 'medium',
+      iconSize: 28,
+      fontSize: globalTokens.font.size400,
+      square: {
+        borderRadius: globalTokens.corner.radius60,
+      },
+    },
+    size64: {
+      size: 64,
+      badgeSize: 'large',
+      iconSize: 32,
+      fontSize: globalTokens.font.size500,
+      square: {
+        borderRadius: globalTokens.corner.radius60,
+      },
+    },
+    size72: {
+      size: 72,
+      badgeSize: 'large',
+      iconSize: 32,
+      fontSize: globalTokens.font.size500,
+      square: {
+        borderRadius: globalTokens.corner.radius60,
+      },
+    },
+    size96: {
+      size: 96,
+      badgeSize: 'extraLarge',
+      iconSize: 48,
+      fontWeight: globalTokens.font.weight.regular,
+      fontSize: globalTokens.font.size700,
+      square: {
+        borderRadius: globalTokens.corner.radius80,
+      },
+    },
+    size120: {
+      size: 120,
+      badgeSize: 'extraLarge',
+      iconSize: 48,
+      fontWeight: globalTokens.font.weight.regular,
+      fontSize: globalTokens.font.size900,
+      square: {
+        borderRadius: globalTokens.corner.radius80,
+      },
+    },
+    neutral: {
+      color: t.colors.neutralForeground3,
+      iconColor: t.colors.neutralForeground3,
+      ringColor: t.colors.transparentStroke,
+    },
+    brand: {
+      backgroundColor: t.colors.brandBackground,
+      color: t.colors.neutralForegroundOnColor,
+      iconColor: t.colors.neutralForegroundOnBrand,
+      ringColor: t.colors.brandStroke1,
+    },
+     brandInverted: {
+      backgroundColor: t.colors.neutralBackground1,
+      iconColor: t.colors.brandForeground1,
+      ringColor: t.colors.brandStroke1,
+    },
+    accent: {
+      backgroundColor: t.colors.brandBackgroundTint,
+      iconColor:t.colors.brandForegroundTint,
+      ringColor: t.colors.brandStroke1,
+    },
+    darkRed: getColorProps('darkRed', t),
+    cranberry: getColorProps('cranberry', t),
+    red: getColorProps('red', t),
+    pumpkin: getColorProps('pumpkin', t),
+    peach: getColorProps('peach', t),
+    marigold: getColorProps('marigold', t),
+    gold: getColorProps('gold', t),
+    brass: getColorProps('brass', t),
+    brown: getColorProps('brown', t),
+    forest: getColorProps('forest', t),
+    seafoam: getColorProps('seafoam', t),
+    darkGreen: getColorProps('darkGreen', t),
+    lightTeal: getColorProps('lightTeal', t),
+    teal: getColorProps('teal', t),
+    steel: getColorProps('steel', t),
+    blue: getColorProps('blue', t),
+    royalBlue: getColorProps('royalBlue', t),
+    cornflower: getColorProps('cornflower', t),
+    navy: getColorProps('navy', t),
+    lavender: getColorProps('lavender', t),
+    purple: getColorProps('purple', t),
+    grape: getColorProps('grape', t),
+    lilac: getColorProps('lilac', t),
+    pink: getColorProps('pink', t),
+    magenta: getColorProps('magenta', t),
+    plum: getColorProps('plum', t),
+    beige: getColorProps('beige', t),
+    mink: getColorProps('mink', t),
+    platinum: getColorProps('platinum', t),
+    anchor: getColorProps('anchor', t),
+    burgundy: getColorProps('burgundy', t),
+    hotPink: getColorProps('hotPink', t),
+    orchid: getColorProps('orchid', t),
+  } as AvatarTokens);
+
+/**
+ * A function which returns object of props depending on color and theme.
+ * @param color
+ * @param theme
+ * @returns object of props - backgroundColor, color and ringColor
+ */
+function getColorProps(color: string, theme: Theme) {
+  const themeAppearance = theme.host.appearance;
+  switch (themeAppearance) {
+    case 'light':
+    default:
+      return {
+        backgroundColor: globalTokens.color[color].tint40,
+        color: globalTokens.color[color].shade30,
+        iconColor: globalTokens.color[color].shade30,
+        ringColor: globalTokens.color[color].primary,
+      };
+    case 'dark':
+      return {
+        backgroundColor: globalTokens.color[color].shade30,
+        color: globalTokens.color[color].tint40,
+        iconColor: globalTokens.color[color].tint40,
+        ringColor: globalTokens.color[color].tint30,
+      };
+  }
+}

--- a/packages/components/Avatar/src/AvatarTokens.android.ts
+++ b/packages/components/Avatar/src/AvatarTokens.android.ts
@@ -130,14 +130,14 @@ export const defaultAvatarTokens: TokenSettings<AvatarTokens, Theme> = (t: Theme
       iconColor: t.colors.neutralForegroundOnBrand,
       ringColor: t.colors.brandStroke1,
     },
-     brandInverted: {
+    brandInverted: {
       backgroundColor: t.colors.neutralBackground1,
       iconColor: t.colors.brandForeground1,
       ringColor: t.colors.brandStroke1,
     },
     accent: {
       backgroundColor: t.colors.brandBackgroundTint,
-      iconColor:t.colors.brandForegroundTint,
+      iconColor: t.colors.brandForegroundTint,
       ringColor: t.colors.brandStroke1,
     },
     darkRed: getColorProps('darkRed', t),
@@ -170,9 +170,6 @@ export const defaultAvatarTokens: TokenSettings<AvatarTokens, Theme> = (t: Theme
     mink: getColorProps('mink', t),
     platinum: getColorProps('platinum', t),
     anchor: getColorProps('anchor', t),
-    burgundy: getColorProps('burgundy', t),
-    hotPink: getColorProps('hotPink', t),
-    orchid: getColorProps('orchid', t),
   } as AvatarTokens);
 
 /**


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [x] android

### Description of changes
PR proposes to add support for Avatar component for android.
- Updated tester to demonstrate usage for variations.
- Introduced 2 new tokens to provide support for - ascent and standard inverted variations. All other variations are supported re-using current tokens for supporting common types. The full variations in design guidelines are:

**1. Standard
2. Standard inverted
3. Anonymous
4. Anonymous ascent
5. Initials
6. Image
7. Overflow
8. Group**

The tester file for android demonstrates usage for each of above from consumer point, with variations.

Note that this PR does not aim to add tokens support for size, activity ring and badge. 

### Verification
Manual validation on test app.

![dark1](https://user-images.githubusercontent.com/32593094/205281586-7723e0ac-01c1-4a8d-ba73-ba1f90a7b5fe.png)
![dark2](https://user-images.githubusercontent.com/32593094/205281624-7d38f133-a73c-400a-b0b4-725d705a54d5.png)
![light1](https://user-images.githubusercontent.com/32593094/205281637-81606815-55aa-4fe5-9aad-4f50331a184c.png)
![light2](https://user-images.githubusercontent.com/32593094/205281656-f8c2e2ff-81eb-404e-ad04-0c6a7645788e.png)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
