### PR TITLE
[Icon] Fixed an error about "esModuleInterop: true"

### DIFF
--- a/change/@fluentui-react-native-experimental-icon-9d1fb407-06f2-4609-86c7-1b11f607c3ab.json
+++ b/change/@fluentui-react-native-experimental-icon-9d1fb407-06f2-4609-86c7-1b11f607c3ab.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed import for the Icon",
+  "packageName": "@fluentui-react-native/experimental-icon",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/ExperimentalIcon/src/FontIcon/FontIcon.tsx
+++ b/packages/experimental/ExperimentalIcon/src/FontIcon/FontIcon.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { mergeProps, stagedComponent } from '@fluentui-react-native/framework';
 import { Text } from 'react-native';
 import { fontIconName, FontIconProps } from './FontIcon.types';

--- a/packages/experimental/ExperimentalIcon/src/Icon.tsx
+++ b/packages/experimental/ExperimentalIcon/src/Icon.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import * as React from 'react';
 import { IconProps } from './Icon.types';
 import { SvgIcon } from './SvgIcon/SvgIcon';
-import FontIcon from './FontIcon/FontIcon';
+import { FontIcon } from './FontIcon/FontIcon';
 export const Icon = (props: IconProps) => {
   return props.svgSource ? <SvgIcon {...props.svgSource} /> : props.fontSource ? <FontIcon {...props.fontSource} /> : null;
 };

--- a/packages/experimental/ExperimentalIcon/src/SvgIcon/SvgIcon.tsx
+++ b/packages/experimental/ExperimentalIcon/src/SvgIcon/SvgIcon.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Platform, View } from 'react-native';
 import { SvgUri } from 'react-native-svg';
 import { mergeProps, stagedComponent } from '@fluentui-react-native/framework';

--- a/packages/experimental/ExperimentalIcon/src/index.ts
+++ b/packages/experimental/ExperimentalIcon/src/index.ts
@@ -1,6 +1,8 @@
-export { FontIcon } from './FontIcon/FontIcon';
-export { FontIconProps } from './FontIcon/FontIcon.types';
-export { SvgIcon } from './SvgIcon/SvgIcon';
-export { SvgIconProps } from './SvgIcon/SvgIcon.types';
+export type { FontIconProps } from './FontIcon/FontIcon.types';
+export type { SvgIconProps } from './SvgIcon/SvgIcon.types';
+export type { IconProps } from './Icon.types';
+export { fontIconName } from './FontIcon/FontIcon.types';
+export { svgIconName } from './SvgIcon/SvgIcon.types';
 export { Icon } from './Icon';
-export { IconProps } from './Icon.types';
+export { FontIcon } from './FontIcon/FontIcon';
+export { SvgIcon } from './SvgIcon/SvgIcon';


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
Fixed bug with importing a new FURN Icon in partner's repo.
There was an error `can only be default-imported using the 'esModuleInterop' flag`
It's fixed by changing `import * as React from 'react'` instead of `import React from 'React'`

### Verification
Checked manually in FURN Tester and partner's repo.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
