### PR TITLE
Use V2 font tokens for Notification text elements

### DIFF
--- a/change/@fluentui-react-native-notification-1f0f653d-8045-4d61-a7d5-93d3d64bafcc.json
+++ b/change/@fluentui-react-native-notification-1f0f653d-8045-4d61-a7d5-93d3d64bafcc.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Use V2 font tokens for Notification text elements",
+  "packageName": "@fluentui-react-native/notification",
+  "email": "adgleitm@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Notification/src/Notification.styling.ts
+++ b/packages/components/Notification/src/Notification.styling.ts
@@ -58,10 +58,6 @@ export const stylingSettings: UseStylingOptions<NotificationProps, NotificationS
         return {
           style: {
             color: tokens.color,
-            fontSize: 15,
-            fontWeight: '600',
-            letterSpacing: -0.24, // iOS only prop
-            lineHeight: 20,
           },
         };
       },

--- a/packages/components/Notification/src/Notification.tsx
+++ b/packages/components/Notification/src/Notification.tsx
@@ -3,7 +3,7 @@ import { notification, NotificationType, NotificationProps } from './Notificatio
 import { Pressable } from '@fluentui-react-native/pressable';
 import { Platform, PressableProps, useWindowDimensions, View, ViewStyle, ViewProps } from 'react-native';
 import { Icon, createIconProps } from '@fluentui-react-native/icon';
-import { TextV1 as Text } from '@fluentui-react-native/text';
+import { Body2, Body2Strong } from '@fluentui-react-native/text';
 import { stylingSettings } from './Notification.styling';
 import { compose, mergeProps, withSlots, UseSlots, memoize } from '@fluentui-react-native/framework';
 import { InteractionEvent } from '@fluentui-react-native/interactive-hooks';
@@ -53,8 +53,8 @@ export const Notification = compose<NotificationType>({
     root: Pressable,
     icon: Icon,
     contentContainer: View,
-    title: Text,
-    message: Text,
+    title: Body2Strong,
+    message: Body2,
     action: NotificationButton,
     shadow: Shadow,
   },

--- a/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
+++ b/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
@@ -108,6 +108,7 @@ exports[`Notification component tests Notification default 1`] = `
       }
     >
       <Text
+        allowFontScaling={false}
         ellipsizeMode="tail"
         numberOfLines={0}
         style={


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [x] android

### Description of changes

Add some of our new font tokens to Notification so we can see how they're used.

Although not tested on Android, this will almost certainly mess with the appearance of Notification on Android because V2 variants have not been defined yet there. However, we've gotten permission from FURN Android developers to go ahead with  this anyway.

### Verification

The Notification element looks exactly the same on iOS.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
