### PR TITLE
Have CG ignore react-native's template files

### DIFF
--- a/.ado/azure-pipelines.publish.yml
+++ b/.ado/azure-pipelines.publish.yml
@@ -75,6 +75,8 @@ jobs:
           targetPath: $(System.DefaultWorkingDirectory)/_manifest
 
       - task: ComponentGovernanceComponentDetection@0
+        inputs:
+          ignoreDirectories: 'node_modules/react-native/template'
 
   - job: NuGetPublish
     displayName: NuGet Publish


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

RN's template files shouldn't be used in our repo, so we can safely ignore them in CG.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
