### PR TITLE
📦 applying package updates ***NO_CI***

### DIFF
--- a/apps/fluent-tester/CHANGELOG.json
+++ b/apps/fluent-tester/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@fluentui-react-native/tester",
   "entries": [
     {
+      "date": "Mon, 05 Dec 2022 22:48:51 GMT",
+      "tag": "@fluentui-react-native/tester_v0.111.2",
+      "version": "0.111.2",
+      "comments": {
+        "patch": [
+          {
+            "author": "sanajmi@microsoft.com",
+            "package": "@fluentui-react-native/tester",
+            "commit": "299ed92c52bf1d2603cd46b7848dcb4935c5954a",
+            "comment": "Fix NPM publish pipeline"
+          },
+          {
+            "author": "beachball",
+            "package": "@fluentui-react-native/tester",
+            "comment": "Bump @fluentui-react-native/avatar to v1.3.6",
+            "commit": "38b6fb126876b0428ca86e742c970e428581a7db"
+          },
+          {
+            "author": "beachball",
+            "package": "@fluentui-react-native/tester",
+            "comment": "Bump @fluentui-react-native/badge to v0.3.2",
+            "commit": "38b6fb126876b0428ca86e742c970e428581a7db"
+          }
+        ]
+      }
+    },
+    {
       "date": "Thu, 01 Dec 2022 03:12:20 GMT",
       "tag": "@fluentui-react-native/tester_v0.111.0",
       "version": "0.111.0",

--- a/apps/fluent-tester/CHANGELOG.md
+++ b/apps/fluent-tester/CHANGELOG.md
@@ -1,8 +1,18 @@
 # Change Log - @fluentui-react-native/tester
 
-This log was last generated on Thu, 01 Dec 2022 03:12:20 GMT and should not be manually modified.
+This log was last generated on Mon, 05 Dec 2022 22:48:51 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 0.111.2
+
+Mon, 05 Dec 2022 22:48:51 GMT
+
+### Patches
+
+- Fix NPM publish pipeline (sanajmi@microsoft.com)
+- Bump @fluentui-react-native/avatar to v1.3.6
+- Bump @fluentui-react-native/badge to v0.3.2
 
 ## 0.111.0
 
@@ -1936,7 +1946,7 @@ Fri, 19 Aug 2022 15:32:12 GMT
 
 ### Patches
 
-- Menu Picker for desktop is now using a FURN text  element (nkhalil942@gmail.com)
+- Menu Picker for desktop is now using a FURN text element (nkhalil942@gmail.com)
 
 ## 0.86.2
 
@@ -5978,7 +5988,7 @@ Fri, 25 Jun 2021 06:21:11 GMT
 
 ### Minor changes
 
-- 📦 applying package updates ***NO_CI*** (tamasane@gmail.com)
+- 📦 applying package updates **_NO_CI_** (tamasane@gmail.com)
 
 ## 0.27.0
 

--- a/apps/fluent-tester/CHANGELOG.md
+++ b/apps/fluent-tester/CHANGELOG.md
@@ -1946,7 +1946,7 @@ Fri, 19 Aug 2022 15:32:12 GMT
 
 ### Patches
 
-- Menu Picker for desktop is now using a FURN text element (nkhalil942@gmail.com)
+- Menu Picker for desktop is now using a FURN text  element (nkhalil942@gmail.com)
 
 ## 0.86.2
 
@@ -5988,7 +5988,7 @@ Fri, 25 Jun 2021 06:21:11 GMT
 
 ### Minor changes
 
-- 📦 applying package updates **_NO_CI_** (tamasane@gmail.com)
+- 📦 applying package updates ***NO_CI*** (tamasane@gmail.com)
 
 ## 0.27.0
 

--- a/apps/fluent-tester/package.json
+++ b/apps/fluent-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/tester",
-  "version": "0.111.1",
+  "version": "0.111.2",
   "description": "A test app to test FluentUI React Native Components during development",
   "license": "MIT",
   "author": "Microsoft <fluentuinativeowners@microsoft.com>",
@@ -39,8 +39,8 @@
   "dependencies": {
     "@fluentui-react-native/android-theme": ">=0.14.5 <1.0.0",
     "@fluentui-react-native/apple-theme": ">=0.16.11 <1.0.0",
-    "@fluentui-react-native/avatar": "^1.3.5",
-    "@fluentui-react-native/badge": ">=0.3.1 <1.0.0",
+    "@fluentui-react-native/avatar": "^1.3.6",
+    "@fluentui-react-native/badge": ">=0.3.2 <1.0.0",
     "@fluentui-react-native/button": ">=0.32.3 <1.0.0",
     "@fluentui-react-native/default-theme": ">=0.16.13 <1.0.0",
     "@fluentui-react-native/dropdown": ">=0.6.0 <1.0.0",

--- a/apps/win32/CHANGELOG.json
+++ b/apps/win32/CHANGELOG.json
@@ -2,6 +2,27 @@
   "name": "@fluentui-react-native/tester-win32",
   "entries": [
     {
+      "date": "Mon, 05 Dec 2022 22:48:51 GMT",
+      "tag": "@fluentui-react-native/tester-win32_v0.29.6",
+      "version": "0.29.6",
+      "comments": {
+        "patch": [
+          {
+            "author": "sanajmi@microsoft.com",
+            "package": "@fluentui-react-native/tester-win32",
+            "commit": "299ed92c52bf1d2603cd46b7848dcb4935c5954a",
+            "comment": "Fix NPM publish pipeline"
+          },
+          {
+            "author": "beachball",
+            "package": "@fluentui-react-native/tester-win32",
+            "comment": "Bump @fluentui-react-native/tester to v0.111.2",
+            "commit": "38b6fb126876b0428ca86e742c970e428581a7db"
+          }
+        ]
+      }
+    },
+    {
       "date": "Thu, 01 Dec 2022 03:12:20 GMT",
       "tag": "@fluentui-react-native/tester-win32_v0.29.4",
       "version": "0.29.4",

--- a/apps/win32/CHANGELOG.md
+++ b/apps/win32/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Change Log - @fluentui-react-native/tester-win32
 
-This log was last generated on Thu, 01 Dec 2022 03:12:20 GMT and should not be manually modified.
+This log was last generated on Mon, 05 Dec 2022 22:48:51 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 0.29.6
+
+Mon, 05 Dec 2022 22:48:51 GMT
+
+### Patches
+
+- Fix NPM publish pipeline (sanajmi@microsoft.com)
+- Bump @fluentui-react-native/tester to v0.111.2
 
 ## 0.29.4
 
@@ -3612,7 +3621,7 @@ Mon, 28 Sep 2020 20:32:21 GMT
 
 ### Minor changes
 
-- 🚚Move files around, rename things.  Makes FluentTester more canonical (aliciakds88@gmail.com)
+- 🚚Move files around, rename things. Makes FluentTester more canonical (aliciakds88@gmail.com)
 
 ## 0.4.0
 

--- a/apps/win32/CHANGELOG.md
+++ b/apps/win32/CHANGELOG.md
@@ -3621,7 +3621,7 @@ Mon, 28 Sep 2020 20:32:21 GMT
 
 ### Minor changes
 
-- 🚚Move files around, rename things. Makes FluentTester more canonical (aliciakds88@gmail.com)
+- 🚚Move files around, rename things.  Makes FluentTester more canonical (aliciakds88@gmail.com)
 
 ## 0.4.0
 

--- a/apps/win32/package.json
+++ b/apps/win32/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/tester-win32",
-  "version": "0.29.5",
+  "version": "0.29.6",
   "main": "src/index.tsx",
   "module": "src/index.tsx",
   "typings": "lib/index.d.ts",
@@ -31,7 +31,7 @@
     "directory": "apps/win32"
   },
   "dependencies": {
-    "@fluentui-react-native/tester": "^0.111.1",
+    "@fluentui-react-native/tester": "^0.111.2",
     "react": "17.0.2",
     "react-native": "^0.68.0",
     "react-native-svg": "12.3.0",

--- a/change/@fluentui-react-native-avatar-32793470-25e3-42ce-a376-b931469f1de7.json
+++ b/change/@fluentui-react-native-avatar-32793470-25e3-42ce-a376-b931469f1de7.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Fix NPM publish pipeline",
-  "packageName": "@fluentui-react-native/avatar",
-  "email": "sanajmi@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-react-native-badge-708da181-97f3-4f39-81ef-0d5475f436e4.json
+++ b/change/@fluentui-react-native-badge-708da181-97f3-4f39-81ef-0d5475f436e4.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Fix NPM publish pipeline",
-  "packageName": "@fluentui-react-native/badge",
-  "email": "sanajmi@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-react-native-badge-db330f59-8935-49d2-ac0e-7fe85ceef403.json
+++ b/change/@fluentui-react-native-badge-db330f59-8935-49d2-ac0e-7fe85ceef403.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Updated danger and success colors",
-  "packageName": "@fluentui-react-native/badge",
-  "email": "vkozlova@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-react-native-dependency-profiles-a77da27b-5049-4724-8e01-a47d729d7fed.json
+++ b/change/@fluentui-react-native-dependency-profiles-a77da27b-5049-4724-8e01-a47d729d7fed.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Fix NPM publish pipeline",
-  "packageName": "@fluentui-react-native/dependency-profiles",
-  "email": "sanajmi@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-react-native-tester-20287d3a-9236-4eaa-95c6-d4cfc2ecf656.json
+++ b/change/@fluentui-react-native-tester-20287d3a-9236-4eaa-95c6-d4cfc2ecf656.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Fix NPM publish pipeline",
-  "packageName": "@fluentui-react-native/tester",
-  "email": "sanajmi@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-react-native-tester-4dccf286-c0ef-4cc6-8c53-e7c15ebfd991.json
+++ b/change/@fluentui-react-native-tester-4dccf286-c0ef-4cc6-8c53-e7c15ebfd991.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Tester changes for FAB iOS",
-  "packageName": "@fluentui-react-native/tester",
-  "email": "ayushsinghs@yahoo.in",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-react-native-tester-win32-cbc1957c-8678-4be7-a497-08571760aa29.json
+++ b/change/@fluentui-react-native-tester-win32-cbc1957c-8678-4be7-a497-08571760aa29.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Fix NPM publish pipeline",
-  "packageName": "@fluentui-react-native/tester-win32",
-  "email": "sanajmi@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/packages/components/Avatar/CHANGELOG.json
+++ b/packages/components/Avatar/CHANGELOG.json
@@ -2,6 +2,27 @@
   "name": "@fluentui-react-native/avatar",
   "entries": [
     {
+      "date": "Mon, 05 Dec 2022 22:48:51 GMT",
+      "tag": "@fluentui-react-native/avatar_v1.3.6",
+      "version": "1.3.6",
+      "comments": {
+        "patch": [
+          {
+            "author": "sanajmi@microsoft.com",
+            "package": "@fluentui-react-native/avatar",
+            "commit": "299ed92c52bf1d2603cd46b7848dcb4935c5954a",
+            "comment": "Fix NPM publish pipeline"
+          },
+          {
+            "author": "beachball",
+            "package": "@fluentui-react-native/avatar",
+            "comment": "Bump @fluentui-react-native/badge to v0.3.2",
+            "commit": "38b6fb126876b0428ca86e742c970e428581a7db"
+          }
+        ]
+      }
+    },
+    {
       "date": "Thu, 01 Dec 2022 03:12:20 GMT",
       "tag": "@fluentui-react-native/avatar_v1.3.4",
       "version": "1.3.4",

--- a/packages/components/Avatar/CHANGELOG.md
+++ b/packages/components/Avatar/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Change Log - @fluentui-react-native/avatar
 
-This log was last generated on Thu, 01 Dec 2022 03:12:20 GMT and should not be manually modified.
+This log was last generated on Mon, 05 Dec 2022 22:48:51 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 1.3.6
+
+Mon, 05 Dec 2022 22:48:51 GMT
+
+### Patches
+
+- Fix NPM publish pipeline (sanajmi@microsoft.com)
+- Bump @fluentui-react-native/badge to v0.3.2
 
 ## 1.3.4
 
@@ -376,7 +385,7 @@ Thu, 08 Sep 2022 15:59:45 GMT
 
 ### Patches
 
-- [Avatar] Fixed bug with  multi-word titles (vkozlova@microsoft.com)
+- [Avatar] Fixed bug with multi-word titles (vkozlova@microsoft.com)
 
 ## 1.2.6
 

--- a/packages/components/Avatar/CHANGELOG.md
+++ b/packages/components/Avatar/CHANGELOG.md
@@ -385,7 +385,7 @@ Thu, 08 Sep 2022 15:59:45 GMT
 
 ### Patches
 
-- [Avatar] Fixed bug with multi-word titles (vkozlova@microsoft.com)
+- [Avatar] Fixed bug with  multi-word titles (vkozlova@microsoft.com)
 
 ## 1.2.6
 

--- a/packages/components/Avatar/package.json
+++ b/packages/components/Avatar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/avatar",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "A cross-platform Avatar component using the Fluent Design System",
   "license": "MIT",
   "author": "Microsoft <fluentuinativeowners@microsoft.com>",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@fluentui-react-native/adapters": "^0.10.0",
-    "@fluentui-react-native/badge": "^0.3.1",
+    "@fluentui-react-native/badge": "^0.3.2",
     "@fluentui-react-native/framework": "0.8.22",
     "@fluentui-react-native/icon": "^0.15.4",
     "@fluentui-react-native/theme-tokens": "^0.21.4",

--- a/packages/components/Badge/CHANGELOG.json
+++ b/packages/components/Badge/CHANGELOG.json
@@ -2,6 +2,27 @@
   "name": "@fluentui-react-native/badge",
   "entries": [
     {
+      "date": "Mon, 05 Dec 2022 22:48:51 GMT",
+      "tag": "@fluentui-react-native/badge_v0.3.2",
+      "version": "0.3.2",
+      "comments": {
+        "patch": [
+          {
+            "author": "sanajmi@microsoft.com",
+            "package": "@fluentui-react-native/badge",
+            "commit": "299ed92c52bf1d2603cd46b7848dcb4935c5954a",
+            "comment": "Fix NPM publish pipeline"
+          },
+          {
+            "author": "vkozlova@microsoft.com",
+            "package": "@fluentui-react-native/badge",
+            "commit": "e8719ef6830f02ac0d8477614c6957629edb9bdb",
+            "comment": "Updated danger and success colors"
+          }
+        ]
+      }
+    },
+    {
       "date": "Thu, 01 Dec 2022 03:12:19 GMT",
       "tag": "@fluentui-react-native/badge_v0.3.0",
       "version": "0.3.0",

--- a/packages/components/Badge/CHANGELOG.md
+++ b/packages/components/Badge/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Change Log - @fluentui-react-native/badge
 
-This log was last generated on Thu, 01 Dec 2022 03:12:19 GMT and should not be manually modified.
+This log was last generated on Mon, 05 Dec 2022 22:48:51 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 0.3.2
+
+Mon, 05 Dec 2022 22:48:51 GMT
+
+### Patches
+
+- Fix NPM publish pipeline (sanajmi@microsoft.com)
+- Updated danger and success colors (vkozlova@microsoft.com)
 
 ## 0.3.0
 

--- a/packages/components/Badge/package.json
+++ b/packages/components/Badge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/badge",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A cross-platform Badge component using the Fluent Design System. A badge is an additional visual descriptor for UI elements.",
   "license": "MIT",
   "author": "Microsoft <fluentuinativeowners@microsoft.com>",

--- a/packages/dependency-profiles/CHANGELOG.json
+++ b/packages/dependency-profiles/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "@fluentui-react-native/dependency-profiles",
   "entries": [
     {
+      "date": "Mon, 05 Dec 2022 22:48:51 GMT",
+      "tag": "@fluentui-react-native/dependency-profiles_v0.1.42",
+      "version": "0.1.42",
+      "comments": {
+        "patch": [
+          {
+            "author": "sanajmi@microsoft.com",
+            "package": "@fluentui-react-native/dependency-profiles",
+            "commit": "299ed92c52bf1d2603cd46b7848dcb4935c5954a",
+            "comment": "Fix NPM publish pipeline"
+          }
+        ]
+      }
+    },
+    {
       "date": "Tue, 25 Oct 2022 15:26:47 GMT",
       "tag": "@fluentui-react-native/dependency-profiles_v0.1.0",
       "version": "0.1.0",

--- a/packages/dependency-profiles/CHANGELOG.md
+++ b/packages/dependency-profiles/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log - @fluentui-react-native/dependency-profiles
 
-This log was last generated on Tue, 25 Oct 2022 15:26:47 GMT and should not be manually modified.
+This log was last generated on Mon, 05 Dec 2022 22:48:51 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 0.1.42
+
+Mon, 05 Dec 2022 22:48:51 GMT
+
+### Patches
+
+- Fix NPM publish pipeline (sanajmi@microsoft.com)
 
 ## 0.1.0
 

--- a/packages/dependency-profiles/package.json
+++ b/packages/dependency-profiles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/dependency-profiles",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "description": "@rnx-kit/align-deps profiles covering packages published from FluentUI-React-Native",
   "license": "MIT",
   "files": [

--- a/packages/dependency-profiles/src/index.js
+++ b/packages/dependency-profiles/src/index.js
@@ -8,19 +8,19 @@ module.exports = {
     },
     "@fluentui-react-native/tester": {
       "name": "@fluentui-react-native/tester",
-      "version": "0.111.0"
+      "version": "0.111.2"
     },
     "@fluentui-react-native/tester-win32": {
       "name": "@fluentui-react-native/tester-win32",
-      "version": "0.29.4"
+      "version": "0.29.6"
     },
     "@fluentui-react-native/avatar": {
       "name": "@fluentui-react-native/avatar",
-      "version": "1.3.4"
+      "version": "1.3.6"
     },
     "@fluentui-react-native/badge": {
       "name": "@fluentui-react-native/badge",
-      "version": "0.3.0"
+      "version": "0.3.2"
     },
     "@fluentui-react-native/button": {
       "name": "@fluentui-react-native/button",


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Looked at the output of this command

> yarn beachball publish --no-publish --bump-deps -m"📦 applying package updates ***NO_CI***"  --verbose -b origin/manual-publish -n *** --access public -y

.. and then undid a bunch of it to manually only bump the packages I wanted bumped (avatar, badge, dependency-profiles. tester, and tester-win32)

### Verification

Went through updated package.json version numbers and compared with NPM

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
