### PR TITLE
[Link - Android ] Initial Tokenization 

### DIFF
--- a/apps/fluent-tester/src/TestComponents/LinkExperimental/LinkTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/LinkExperimental/LinkTest.tsx
@@ -6,6 +6,7 @@ import { stackStyle, commonTestStyles as commonStyles } from '../Common/styles';
 import { EXPERIMENTAL_LINK_TESTPAGE } from './consts';
 import { Test, TestSection, PlatformStatus } from '../Test';
 import { LinkE2ETest } from './E2ELinkTest';
+import { Platform } from 'react-native';
 
 const DefaultLinks: React.FunctionComponent = () => {
   const doPress = React.useCallback(() => Alert.alert('Alert.', 'You have been alerted.'), []);
@@ -180,10 +181,16 @@ const linkSections: TestSection[] = [
     name: 'Inline Links',
     component: InlineLinks,
   },
-  {
-    name: 'Subtle Links',
-    component: SubtleLinks,
-  },
+  ...Platform.select({
+    // As per design discussion , There is no use case for subtle link on Android , No tokens available for same.
+    android: [null],
+    default: [
+      {
+        name: 'Subtle Links',
+        component: SubtleLinks,
+      },
+    ],
+  }),
   {
     name: 'Custom Link',
     component: CustomLinks,

--- a/apps/fluent-tester/src/TestComponents/LinkExperimental/LinkTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/LinkExperimental/LinkTest.tsx
@@ -200,7 +200,7 @@ export const ExperimentalLinkTest: React.FunctionComponent = () => {
     uwpStatus: 'Experimental',
     iosStatus: 'Experimental',
     macosStatus: 'Beta',
-    androidStatus: 'Backlog',
+    androidStatus: 'Experimental',
   };
 
   const description =

--- a/apps/fluent-tester/src/testPages.ts
+++ b/apps/fluent-tester/src/testPages.ts
@@ -154,7 +154,7 @@ export const tests: TestDescription[] = [
     name: 'Link (Experimental)',
     component: ExperimentalLinkTest,
     testPage: HOMEPAGE_EXPERIMENTAL_LINK_BUTTON,
-    platforms: ['win32'],
+    platforms: ['win32', 'android'],
   },
   {
     name: 'Menu',

--- a/change/@fluentui-react-native-experimental-link-a5c7648c-18a3-4ac8-8d64-064af9c39c05.json
+++ b/change/@fluentui-react-native-experimental-link-a5c7648c-18a3-4ac8-8d64-064af9c39c05.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "initial tokens for link android",
+  "packageName": "@fluentui-react-native/experimental-link",
+  "email": "rohanpd.work@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-b1083f91-8d54-43ac-8238-579e3c2faecc.json
+++ b/change/@fluentui-react-native-tester-b1083f91-8d54-43ac-8238-579e3c2faecc.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "initial tokens for link android",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "rohanpd.work@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Link/src/LinkTokens.android.ts
+++ b/packages/experimental/Link/src/LinkTokens.android.ts
@@ -1,0 +1,26 @@
+import { Theme } from '@fluentui-react-native/framework';
+import { TokenSettings } from '@fluentui-react-native/use-styling';
+import { LinkTokens } from './Link.types';
+
+export const defaultLinkTokens: TokenSettings<LinkTokens, Theme> = (t: Theme) =>
+  ({
+    color: t.colors.brandForeground1,
+    alignSelf: 'flex-start',
+    variant: 'body1',
+    inline: {
+      textDecorationLine: 'underline',
+    },
+    disabled: {
+      color: t.colors.brandForeground1Disabled,
+      textDecorationLine: 'none',
+    },
+    pressed: {
+      color: t.colors.brandForeground1Pressed,
+    },
+    subtle: {
+      color: t.colors.neutralForeground2,
+      pressed: {
+        color: t.colors.neutralBackground2Pressed,
+      },
+    },
+  } as LinkTokens);

--- a/packages/experimental/Link/src/LinkTokens.android.ts
+++ b/packages/experimental/Link/src/LinkTokens.android.ts
@@ -17,10 +17,4 @@ export const defaultLinkTokens: TokenSettings<LinkTokens, Theme> = (t: Theme) =>
     pressed: {
       color: t.colors.brandForeground1Pressed,
     },
-    subtle: {
-      color: t.colors.neutralForeground2,
-      pressed: {
-        color: t.colors.neutralBackground2Pressed,
-      },
-    },
   } as LinkTokens);

--- a/packages/experimental/Link/src/__tests__/__snapshots__/Link.test.tsx.snap
+++ b/packages/experimental/Link/src/__tests__/__snapshots__/Link.test.tsx.snap
@@ -37,6 +37,7 @@ exports[`Link component tests Default Link 1`] = `
     style={
       Object {
         "alignSelf": "flex-start",
+        "color": "#0f6cbd",
         "fontFamily": "Segoe UI",
         "fontSize": 13,
         "fontWeight": "400",
@@ -86,6 +87,7 @@ exports[`Link component tests Default Link as a pressable 1`] = `
     style={
       Object {
         "alignSelf": "flex-start",
+        "color": "#0f6cbd",
         "fontFamily": "Segoe UI",
         "fontSize": 13,
         "fontWeight": "400",
@@ -126,6 +128,7 @@ exports[`Link component tests Inline Link 1`] = `
   style={
     Object {
       "alignSelf": "flex-start",
+      "color": "#0f6cbd",
       "fontFamily": "Segoe UI",
       "fontSize": 13,
       "fontWeight": "400",
@@ -178,7 +181,7 @@ exports[`Link component tests Subtle Link 1`] = `
     style={
       Object {
         "alignSelf": "flex-start",
-        "color": "#616161",
+        "color": "#0f6cbd",
         "fontFamily": "Segoe UI",
         "fontSize": 13,
         "fontWeight": "400",


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [x] android

### Description of changes
This PR targets to tokenize the Link component for Android. 
packages/experimental/Link/src/LinkTokens.android.ts - Tokens for Android 
apps/fluent-tester/* - tester app changes.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|![Link Before ](https://user-images.githubusercontent.com/30728574/206196845-0e6e48e7-6ac0-4db5-bb22-e156ab9dbe36.png) |   ![Link After](https://user-images.githubusercontent.com/30728574/206196803-fd32a43b-83b7-4d1b-b983-02ed94093a6f.png) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
