### PR TITLE
Add steps for running iOS e2e tests

### DIFF
--- a/apps/E2E/README.md
+++ b/apps/E2E/README.md
@@ -71,7 +71,7 @@ _Note: It could take up to a minute to load the test app with WebDriverIO, don't
 
 ## iOS Steps
 
-First check that iOS configs in wdio.conf.ios.js are updated to match your dev environment.
+First check that iOS configs in wdio.conf.ios.js are updated to match your dev environment. If the config doesn't match you may get an error message "App with bundle identifier 'com.microsoft.ReactTestApp' unknown"
 
 - 'appium:deviceName' should be updated to a simulator that you have. You can check the ones you have by going to the 'Devices and Simulators' window in Xcode.
 - 'appium:platformVersion' should be updated to match the iOS version of the simulator you're using. You can check what version this should be in the same 'Devices and Simulators' window.

--- a/apps/E2E/README.md
+++ b/apps/E2E/README.md
@@ -69,6 +69,25 @@ _Note: It could take up to a minute to load the test app with WebDriverIO, don't
 
 _Note: It could take up to a minute to load the test app with WebDriverIO, don't panic, the tests will run :)_
 
+## iOS Steps
+
+First check that iOS configs in wdio.conf.ios.js are updated to match your dev environment.
+
+- 'appium:deviceName' should be updated to a simulator that you have. You can check the ones you have by going to the 'Devices and Simulators' window in Xcode.
+- 'appium:platformVersion' should be updated to match the iOS version of the simulator you're using. You can check what version this should be in the same 'Devices and Simulators' window.
+
+1. Follow step #1 from "Win32 Steps" section above.
+2. POD Install
+   - C:\repo\fluentui-react-native> `cd apps\fluent-tester\ios`
+   - C:\repo\fluentui-react-native\apps\fluent-tester\macos> `pod install`
+3. Start the server
+   - C:\repo\fluentui-react-native> `cd apps\fluent-tester`
+   - C:\repo\fluentui-react-native\apps\fluent-tester> `yarn start`
+4. Open a new command prompt and run the E2E tests
+   - C:\repo\fluentui-react-native\apps\E2E> `yarn e2etest:ios`
+
+_Note: It could take up to a minute to load the test app with WebDriverIO, don't panic, the tests will run :)_
+
 # Authoring E2E Test
 
 You just added a new component to FURN... Awesome! Now we need to make sure we have proper regression testing to make sure we put the safest product out there (don't worry, it's not as hard as it sounds). Here's what we have to do:

--- a/apps/E2E/README.md
+++ b/apps/E2E/README.md
@@ -59,13 +59,13 @@ _Note: It could take up to a minute to load the test app with WebDriverIO, don't
 
 1. Follow step #1 from "Win32 Steps" section above.
 2. POD Install
-   - C:\repo\fluentui-react-native> `cd apps\fluent-tester\macos`
-   - C:\repo\fluentui-react-native\apps\fluent-tester\macos> `pod install`
+   - (from fluentui-react-native) `cd apps/fluent-tester/macos`
+   - (from fluentui-react-native/apps/fluent-tester/macos) `pod install`
 3. Start the server
-   - C:\repo\fluentui-react-native> `cd apps\fluent-tester`
-   - C:\repo\fluentui-react-native\apps\fluent-tester> `yarn start`
+   - (from fluentui-react-native) `cd apps/fluent-tester`
+   - (from fluentui-react-native/apps/fluent-tester) `yarn start`
 4. Open a new command prompt and run the E2E tests
-   - C:\repo\fluentui-react-native\apps\E2E> `yarn e2etest:macos`
+   - (from fluentui-react-native/apps/E2E) `yarn e2etest:macos`
 
 _Note: It could take up to a minute to load the test app with WebDriverIO, don't panic, the tests will run :)_
 
@@ -78,13 +78,13 @@ First check that iOS configs in wdio.conf.ios.js are updated to match your dev e
 
 1. Follow step #1 from "Win32 Steps" section above.
 2. POD Install
-   - C:\repo\fluentui-react-native> `cd apps\fluent-tester\ios`
-   - C:\repo\fluentui-react-native\apps\fluent-tester\macos> `pod install`
+   - (from fluentui-react-native) `cd apps/fluent-tester/ios`
+   - (from fluentui-react-native/apps/fluent-tester/ios) `pod install`
 3. Start the server
-   - C:\repo\fluentui-react-native> `cd apps\fluent-tester`
-   - C:\repo\fluentui-react-native\apps\fluent-tester> `yarn start`
+   - (from fluentui-react-native) `cd apps/fluent-tester`
+   - (from fluentui-react-native/apps/fluent-tester) `yarn start`
 4. Open a new command prompt and run the E2E tests
-   - C:\repo\fluentui-react-native\apps\E2E> `yarn e2etest:ios`
+   - (from fluentui-react-native/apps/E2E) `yarn e2etest:ios`
 
 _Note: It could take up to a minute to load the test app with WebDriverIO, don't panic, the tests will run :)_
 

--- a/apps/E2E/README.md
+++ b/apps/E2E/README.md
@@ -14,9 +14,9 @@
 
 - [UWP Prerequisites](../fluent-tester/docs/windows.md)
 
-## MacOS Prerequisites
+## macOS Prerequisites
 
-- MacOS 10.15 or later
+- macOS 10.15 or later
 - XCode 12 or later should be installed
 - XCode Helper app should be enabled for Accessibility access. The app itself is usually found at: _/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Xcode/Agents/Xcode Helper.app_.
 
@@ -55,7 +55,7 @@ and drag & drop the **XCode Helper** app to **Security & Privacy -> Privacy -> A
 
 _Note: It could take up to a minute to load the test app with WebDriverIO, don't panic, the tests will run :)_
 
-## MacOS Steps
+## macOS Steps
 
 1. Follow step #1 from "Win32 Steps" section above.
 2. POD Install

--- a/change/@fluentui-react-native-e2e-testing-61cef6e0-7edb-4536-b837-53f3e9b20303.json
+++ b/change/@fluentui-react-native-e2e-testing-61cef6e0-7edb-4536-b837-53f3e9b20303.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add iOS e2e testing steps",
+  "packageName": "@fluentui-react-native/e2e-testing",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

The E2E testing documentation provided steps for running E2E tests on win32, UWP, and macOS, but not iOS.
- Adding steps for iOS documentation - mostly just copied steps from the other platforms, added a note to double check the iOS configs.
- Updated steps for macOS documentation, there were some references to windows-specific things.

### Verification

N/A

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
