### PR TITLE
Rename test pages

### DIFF
--- a/apps/fluent-tester/src/testPages.ts
+++ b/apps/fluent-tester/src/testPages.ts
@@ -78,7 +78,7 @@ export const tests: TestDescription[] = [
     platforms: ['android', 'macos', 'win32'],
   },
   {
-    name: 'Checkbox Pre-V1',
+    name: 'Checkbox Legacy',
     component: CheckboxTest,
     testPage: HOMEPAGE_CHECKBOX_BUTTON,
     platforms: ['android', 'ios', 'macos', 'win32', 'windows'],
@@ -145,7 +145,7 @@ export const tests: TestDescription[] = [
     platforms: ['android', 'ios', 'macos', 'win32'],
   },
   {
-    name: 'Link Pre-V1',
+    name: 'Link Legacy',
     component: LinkTest,
     testPage: HOMEPAGE_LINK_BUTTON,
     platforms: ['android', 'ios', 'macos', 'win32', 'windows'],
@@ -163,7 +163,7 @@ export const tests: TestDescription[] = [
     platforms: ['macos', 'win32'],
   },
   {
-    name: 'MenuButton Pre-V1',
+    name: 'MenuButton Legacy',
     component: MenuButtonTest,
     testPage: HOMEPAGE_MENUBUTTON_BUTTON,
     platforms: ['macos', 'win32'],
@@ -199,7 +199,7 @@ export const tests: TestDescription[] = [
     platforms: ['android', 'ios', 'macos', 'win32', 'windows'],
   },
   {
-    name: 'RadioGroup Pre-V1',
+    name: 'RadioGroup Legacy',
     component: RadioGroupTest,
     testPage: HOMEPAGE_RADIOGROUP_BUTTON,
     platforms: ['macos', 'win32'],
@@ -253,7 +253,7 @@ export const tests: TestDescription[] = [
     platforms: ['win32'],
   },
   {
-    name: 'Tabs Pre-V1',
+    name: 'Tabs Legacy',
     component: TabsTest,
     testPage: HOMEPAGE_TABS_BUTTON,
     platforms: ['macos', 'win32', 'windows'],
@@ -265,7 +265,7 @@ export const tests: TestDescription[] = [
     platforms: ['macos', 'win32', 'windows'],
   },
   {
-    name: 'Text Pre-V1',
+    name: 'Text Legacy',
     component: TextTest,
     testPage: HOMEPAGE_TEXT_BUTTON,
     platforms: ['android', 'ios', 'macos', 'win32', 'windows'],

--- a/apps/fluent-tester/src/testPages.ts
+++ b/apps/fluent-tester/src/testPages.ts
@@ -78,13 +78,13 @@ export const tests: TestDescription[] = [
     platforms: ['android', 'macos', 'win32'],
   },
   {
-    name: 'Checkbox',
+    name: 'Checkbox Pre-V1',
     component: CheckboxTest,
     testPage: HOMEPAGE_CHECKBOX_BUTTON,
     platforms: ['android', 'ios', 'macos', 'win32', 'windows'],
   },
   {
-    name: 'Checkbox (Experimental)',
+    name: 'Checkbox V1',
     component: ExperimentalCheckboxTest,
     testPage: HOMEPAGE_CHECKBOX_EXPERIMENTAL_BUTTON,
     platforms: ['android', 'ios', 'macos', 'win32'], // 'windows': GH#935: Temporarily disabling while SVGs don't work in windows
@@ -145,13 +145,13 @@ export const tests: TestDescription[] = [
     platforms: ['android', 'ios', 'macos', 'win32'],
   },
   {
-    name: 'Link',
+    name: 'Link Pre-V1',
     component: LinkTest,
     testPage: HOMEPAGE_LINK_BUTTON,
     platforms: ['android', 'ios', 'macos', 'win32', 'windows'],
   },
   {
-    name: 'Link (Experimental)',
+    name: 'Link V1',
     component: ExperimentalLinkTest,
     testPage: HOMEPAGE_EXPERIMENTAL_LINK_BUTTON,
     platforms: ['win32'],
@@ -163,13 +163,13 @@ export const tests: TestDescription[] = [
     platforms: ['macos', 'win32'],
   },
   {
-    name: 'MenuButton',
+    name: 'MenuButton Pre-V1',
     component: MenuButtonTest,
     testPage: HOMEPAGE_MENUBUTTON_BUTTON,
     platforms: ['macos', 'win32'],
   },
   {
-    name: 'MenuButton (Experimental)',
+    name: 'MenuButton V1',
     component: ExperimentalMenuButtonTest,
     testPage: HOMEPAGE_EXPERIMENTAL_MENU_BUTTON,
     platforms: ['macos', 'win32'],
@@ -199,13 +199,13 @@ export const tests: TestDescription[] = [
     platforms: ['android', 'ios', 'macos', 'win32', 'windows'],
   },
   {
-    name: 'RadioGroup',
+    name: 'RadioGroup Pre-V1',
     component: RadioGroupTest,
     testPage: HOMEPAGE_RADIOGROUP_BUTTON,
     platforms: ['macos', 'win32'],
   },
   {
-    name: 'RadioGroup (Experimental)',
+    name: 'RadioGroup V1',
     component: RadioGroupExperimentalTest,
     testPage: HOMEPAGE_RADIO_GROUP_EXPERIMENTAL_BUTTON,
     platforms: ['macos', 'win32'],
@@ -253,25 +253,25 @@ export const tests: TestDescription[] = [
     platforms: ['win32'],
   },
   {
-    name: 'Tabs',
+    name: 'Tabs Pre-V1',
     component: TabsTest,
     testPage: HOMEPAGE_TABS_BUTTON,
     platforms: ['macos', 'win32', 'windows'],
   },
   {
-    name: 'Tabs (Experimental)',
+    name: 'Tabs V1',
     component: ExperimentalTabsTest,
     testPage: HOMEPAGE_EXPERIMENTAL_TABS_BUTTON,
     platforms: ['macos', 'win32', 'windows'],
   },
   {
-    name: 'Text',
+    name: 'Text Pre-V1',
     component: TextTest,
     testPage: HOMEPAGE_TEXT_BUTTON,
     platforms: ['android', 'ios', 'macos', 'win32', 'windows'],
   },
   {
-    name: 'Text (Experimental)',
+    name: 'Text V1',
     component: TextExperimentalTest,
     testPage: HOMEPAGE_EXPERIMENTAL_TEXT_BUTTON,
     platforms: ['android', 'ios', 'macos', 'win32', 'windows'],

--- a/change/@fluentui-react-native-tester-7e4ea00e-698f-4a49-a188-ddfc5f3d3124.json
+++ b/change/@fluentui-react-native-tester-7e4ea00e-698f-4a49-a188-ddfc5f3d3124.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update test page names",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Renaming test pages that are for two versions of the same component from plain vs. experimental to pre-v1 vs. v1. Hopefully this clears up some confusion around "why is it named experimental when the code isn't in experimental?" This also helps with components that are in different stages on different platforms since pre-v1 doesn't necessarily equate to deprecated for all platforms even if a v1 component exists.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/4602628/206557793-a228fde8-c50e-4ac9-b0a8-4d8f1150848c.png) | ![image](https://user-images.githubusercontent.com/4602628/206557296-f7d39763-eebb-455b-a889-40b1435553fa.png) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
