### PR TITLE
Revert usePressableState for SubmenuItem

### DIFF
--- a/change/@fluentui-react-native-contextual-menu-7ad53e28-3c4b-4edf-9836-6995c503e10b.json
+++ b/change/@fluentui-react-native-contextual-menu-7ad53e28-3c4b-4edf-9836-6995c503e10b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Revert usePressableState for SubmenuItem",
+  "packageName": "@fluentui-react-native/contextual-menu",
+  "email": "amchiu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/ContextualMenu/src/SubmenuItem.tsx
+++ b/packages/components/ContextualMenu/src/SubmenuItem.tsx
@@ -15,7 +15,7 @@ import { Text } from '@fluentui-react-native/text';
 import { settings } from './SubmenuItem.settings';
 import { backgroundColorTokens, borderTokens, textTokens, foregroundColorTokens, getPaletteFromTheme } from '@fluentui-react-native/tokens';
 import { mergeSettings } from '@uifabricshared/foundation-settings';
-import { usePressableState, useKeyDownProps, useViewCommandFocus } from '@fluentui-react-native/interactive-hooks';
+import { usePressableState, useKeyDownProps, useViewCommandFocus, useAsPressable } from '@fluentui-react-native/interactive-hooks';
 import { CMContext } from './ContextualMenu';
 import { Icon, SvgIconProps, createIconProps } from '@fluentui-react-native/icon';
 import { Svg, G, Path, SvgProps } from 'react-native-svg';
@@ -63,7 +63,7 @@ export const SubmenuItem = compose<SubmenuItemType>({
       }
     }, [context, disabled, itemKey, onClick]);
 
-    const pressable = usePressableState({
+    const pressable = useAsPressable({
       ...rest,
       onPress: onItemPress,
       onHoverIn: onItemHoverIn,
@@ -188,7 +188,7 @@ export const SubmenuItem = compose<SubmenuItemType>({
     );
   },
   slots: {
-    root: Pressable,
+    root: View,
     startstack: View,
     icon: Icon as React.ComponentType,
     content: Text,

--- a/packages/components/ContextualMenu/src/SubmenuItem.tsx
+++ b/packages/components/ContextualMenu/src/SubmenuItem.tsx
@@ -1,6 +1,6 @@
 /** @jsx withSlots */
 import * as React from 'react';
-import { I18nManager, Platform, Pressable, View } from 'react-native';
+import { I18nManager, Platform, View } from 'react-native';
 import {
   SubmenuItemSlotProps,
   SubmenuItemState,
@@ -15,7 +15,7 @@ import { Text } from '@fluentui-react-native/text';
 import { settings } from './SubmenuItem.settings';
 import { backgroundColorTokens, borderTokens, textTokens, foregroundColorTokens, getPaletteFromTheme } from '@fluentui-react-native/tokens';
 import { mergeSettings } from '@uifabricshared/foundation-settings';
-import { usePressableState, useKeyDownProps, useViewCommandFocus, useAsPressable } from '@fluentui-react-native/interactive-hooks';
+import { useKeyDownProps, useViewCommandFocus, useAsPressable } from '@fluentui-react-native/interactive-hooks';
 import { CMContext } from './ContextualMenu';
 import { Icon, SvgIconProps, createIconProps } from '@fluentui-react-native/icon';
 import { Svg, G, Path, SvgProps } from 'react-native-svg';

--- a/packages/components/ContextualMenu/src/SubmenuItem.types.ts
+++ b/packages/components/ContextualMenu/src/SubmenuItem.types.ts
@@ -4,7 +4,6 @@ import { IRenderData } from '@uifabricshared/foundation-composable';
 import { ITextProps } from '@fluentui-react-native/text';
 import { ContextualMenuItemProps, ContextualMenuItemTokens, ContextualMenuItemState } from './ContextualMenuItem.types';
 import { IconProps } from '@fluentui-react-native/icon';
-import { PressablePropsExtended } from '@fluentui-react-native/interactive-hooks';
 
 export const submenuItemName = 'SubmenuItem';
 export interface SubmenuItemTokens extends ContextualMenuItemTokens {
@@ -15,7 +14,7 @@ export type SubmenuItemProps = ContextualMenuItemProps;
 export type SubmenuItemState = ContextualMenuItemState;
 
 export interface SubmenuItemSlotProps {
-  root: React.PropsWithRef<PressablePropsExtended>;
+  root: React.PropsWithRef<IViewProps>;
   startstack: IViewProps;
   icon: IconProps;
   content: ITextProps;


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS
- [X] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

The usage of usePressableState in SubmenuItem causes a bug on macOS where SubmenuItem doesn't get keyboard focus on mouse hover. I couldn't figure out why onHoverIn gets overridden/not getting called in SubmenuItem, but we can live with this for now until MenuV1 transition is ready.

### Verification

Submenu item works as expected on macOS and win32

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
