### PR TITLE
 Creating NuGet package for win32 js bundle specs

### DIFF
--- a/.ado/templates/e2e-dependency-nuget-publish.yml
+++ b/.ado/templates/e2e-dependency-nuget-publish.yml
@@ -31,6 +31,14 @@ steps:
       arguments: 'pack Microsoft.FluentUI.WebDriverIO.Appium.Deps.nuspec -OutputDirectory $(Build.ArtifactStagingDirectory) -OutputFileNamesWithoutVersion -Verbosity detailed -Version $(Build.BuildNumber) -properties CommitId=$(Build.SourceVersion)'
       workingFolder: 'tester_deps/nuget'
 
+  # Pack the NuGet package
+  - task: CmdLine@1
+    displayName: 'Create NuGet package for win32 test specs.'
+    inputs:
+      filename: nuget
+      arguments: 'pack Microsoft.FluentUI.Win32.E2E.Testing.Specs.nuspec -OutputDirectory $(Build.ArtifactStagingDirectory) -OutputFileNamesWithoutVersion -Verbosity detailed -Version $(Build.BuildNumber) -properties CommitId=$(Build.SourceVersion)'
+      workingFolder: 'apps/E2E/nuget'
+
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 📒 Generate Manifest Tester Dependencies
     inputs:
@@ -46,8 +54,16 @@ steps:
 
   # Push the NuGet package
   - task: NuGetCommand@2
-    displayName: 'NuGet push'
+    displayName: 'NuGet push WebDriverIO/Appium dependencies'
     inputs:
       command: push
       packagesToPush: '$(Build.ArtifactStagingDirectory)/Microsoft.FluentUI.WebDriverIO.Appium.Deps.nupkg'
+      publishVstsFeed: Office
+
+  # Push the NuGet package
+  - task: NuGetCommand@2
+    displayName: 'NuGet push Win32 test specs'
+    inputs:
+      command: push
+      packagesToPush: '$(Build.ArtifactStagingDirectory)/Microsoft.FluentUI.Win32.E2E.Testing.Specs.Appium.Deps.nupkg'
       publishVstsFeed: Office

--- a/.ado/templates/e2e-dependency-nuget-publish.yml
+++ b/.ado/templates/e2e-dependency-nuget-publish.yml
@@ -65,5 +65,5 @@ steps:
     displayName: 'NuGet push Win32 test specs'
     inputs:
       command: push
-      packagesToPush: '$(Build.ArtifactStagingDirectory)/Microsoft.FluentUI.Win32.E2E.Testing.Specs.Appium.Deps.nupkg'
+      packagesToPush: '$(Build.ArtifactStagingDirectory)/Microsoft.FluentUI.Win32.E2E.Testing.Specs.nupkg'
       publishVstsFeed: Office

--- a/apps/E2E/nuget/Microsoft.FluentUI.WebDriverIO.Appium.Deps.nuspec
+++ b/apps/E2E/nuget/Microsoft.FluentUI.WebDriverIO.Appium.Deps.nuspec
@@ -6,7 +6,7 @@
     <title>FluentUI React Native's E2E Testing Specs for Win32</title>
     <authors>Microsoft Office CXE</authors>
     <projectUrl>https://github.com/microsoft/fluentui-react-native.git</projectUrl>
-    <description>This package contains a bundle of all Win32 E2E testing specs using WebDriverIO and Appium.</description>
+    <description>This package contains a JS bundle of all Win32 E2E testing specs using WebDriverIO and Appium. This exports a JS bundle in a NuGet package because the consuming test infrastructure is setup to pull in NuGet packages, but does not yet support NPM packages.</description>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <repository type="git"
       url="https://github.com/microsoft/fluentui-react-native.git"

--- a/apps/E2E/nuget/Microsoft.FluentUI.WebDriverIO.Appium.Deps.nuspec
+++ b/apps/E2E/nuget/Microsoft.FluentUI.WebDriverIO.Appium.Deps.nuspec
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.FluentUI.Win32.E2E.Testing.Specs</id>
+    <version>1.0.0</version>
+    <title>FluentUI React Native's E2E Testing Specs for Win32</title>
+    <authors>Microsoft Office CXE</authors>
+    <projectUrl>https://github.com/microsoft/fluentui-react-native.git</projectUrl>
+    <description>This package contains a bundle of all Win32 E2E testing specs using WebDriverIO and Appium.</description>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <repository type="git"
+      url="https://github.com/microsoft/fluentui-react-native.git"
+      commit="$CommitId$" />
+  </metadata>
+  <files>
+    <file src="..\dist\**" target="win32\specs" />
+  </files>
+</package>

--- a/change/@fluentui-react-native-e2e-testing-7516b37f-a7c5-4b4d-94a5-b215f4265d6c.json
+++ b/change/@fluentui-react-native-e2e-testing-7516b37f-a7c5-4b4d-94a5-b215f4265d6c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Creating NuGet package for win32 js bundle specs",
+  "packageName": "@fluentui-react-native/e2e-testing",
+  "email": "safreibe@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [X] windows
- [ ] android

### Description of changes

This PR creates a NuGet package that contains a JS bundle containing all Win32 E2E test specs. This makes the bundle easier to consume natively.

This exports a JS bundle in a NuGet package because the consuming test infrastructure is setup to pull in NuGet packages, but does not yet support NPM packages.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
