### PR TITLE
Enable Switch test page on all platforms

### DIFF
--- a/apps/fluent-tester/src/testPages.ts
+++ b/apps/fluent-tester/src/testPages.ts
@@ -250,7 +250,7 @@ export const tests: TestDescription[] = [
     name: 'Switch',
     component: SwitchTest,
     testPage: HOMEPAGE_SWITCH_BUTTON,
-    platforms: ['win32', 'android'],
+    platforms: ['android', 'ios', 'macos', 'win32', 'windows'],
   },
   {
     name: 'Tabs Legacy',

--- a/change/@fluentui-react-native-tester-f66f4761-737b-4670-afe6-d958cef88b79.json
+++ b/change/@fluentui-react-native-tester-f66f4761-737b-4670-afe6-d958cef88b79.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Enable Switch test page on all platforms",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

Switch is a pure JS control that (apart from its animation) more or less works on all platforms. We can:

- Enable the test page on all platforms
- Let the test pages' Platform Status tell us which platforms it's available on. 

### Verification

Works on macOS

![image](https://user-images.githubusercontent.com/6722175/206777411-efbfc866-2c4c-44b2-9327-cd46d5996c8a.png)


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
