### PR TITLE
Changing the destination folder of Nuget package content

### DIFF
--- a/tester_deps/nuget/Microsoft.FluentUI.WebDriverIO.Appium.Deps.nuspec
+++ b/tester_deps/nuget/Microsoft.FluentUI.WebDriverIO.Appium.Deps.nuspec
@@ -13,6 +13,6 @@
       commit="$CommitId$" />
   </metadata>
   <files>
-    <file src="..\node_modules\**" target="win32" />
+    <file src="..\node_modules\**" target="node_modules" />
   </files>
 </package>


### PR DESCRIPTION
…earch patterns when using .require() that depend on node_modules. It should have been from the start, I'm fixing it now

### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [X] windows
- [ ] android

### Description of changes

This change simply modifies the destination folder within the NuGet package. It should've been node_modules from the start. Renaming it caused issues related to Node not finding the correct path of certain modules within the folder.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
