### PR TITLE
Remove unnecessary waiters during test starts

### DIFF
--- a/apps/E2E/src/Avatar/specs/Avatar.spec.win.ts
+++ b/apps/E2E/src/Avatar/specs/Avatar.spec.win.ts
@@ -32,7 +32,6 @@ describe('Avatar Testing Initialization', function () {
 describe('Avatar Accessibility Testing', () => {
   beforeEach(async () => {
     await AvatarPageObject.scrollToTestElement();
-    await AvatarPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
   });
 
   it('Validate accessibilityLabel', async () => {

--- a/apps/E2E/src/Button/specs/Button.spec.win.ts
+++ b/apps/E2E/src/Button/specs/Button.spec.win.ts
@@ -28,7 +28,6 @@ describe('Button Accessibility Testing', () => {
   /* Scrolls and waits for the Button to be visible on the Test Page */
   beforeEach(async () => {
     await ButtonPageObject.scrollToTestElement();
-    await ButtonPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
   });
 
   it('Button - Validate accessibilityRole is correct', async () => {
@@ -51,7 +50,6 @@ describe('Button Functional Testing', () => {
   /* Scrolls and waits for the Button to be visible on the Test Page */
   beforeEach(async () => {
     await ButtonPageObject.scrollToTestElement();
-    await ButtonPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
   });
 
   it('Validate OnClick() callback was fired -> Click', async () => {

--- a/apps/E2E/src/ButtonExperimental/specs/ButtonExperimental.spec.win.ts
+++ b/apps/E2E/src/ButtonExperimental/specs/ButtonExperimental.spec.win.ts
@@ -24,7 +24,6 @@ describe('Experimental Button Testing Initialization', function () {
 describe('Experimental Button Accessibility Testing', async () => {
   it('Experimental Button - Validate accessibilityRole is correct', async () => {
     await ButtonExperimentalPageObject.scrollToTestElement();
-    await ButtonExperimentalPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
 
     await expect(await ButtonExperimentalPageObject.getAccessibilityRole()).toEqual(BUTTON_A11Y_ROLE);
     await expect(await ButtonExperimentalPageObject.didAssertPopup()).toBeFalsy(ButtonExperimentalPageObject.ERRORMESSAGE_ASSERT);
@@ -32,7 +31,6 @@ describe('Experimental Button Accessibility Testing', async () => {
 
   it('Experimental Button - Set accessibilityLabel', async () => {
     await ButtonExperimentalPageObject.scrollToTestElement();
-    await ButtonExperimentalPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
 
     await expect(await ButtonExperimentalPageObject.getAccessibilityLabel(ComponentSelector.Primary)).toEqual(BUTTON_ACCESSIBILITY_LABEL);
     await expect(await ButtonExperimentalPageObject.didAssertPopup()).toBeFalsy(ButtonExperimentalPageObject.ERRORMESSAGE_ASSERT);
@@ -40,7 +38,6 @@ describe('Experimental Button Accessibility Testing', async () => {
 
   it('Experimental Button - Do not set accessibilityLabel -> Default to Button label', async () => {
     await ButtonExperimentalPageObject.scrollToTestElement();
-    await ButtonExperimentalPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
 
     await expect(await ButtonExperimentalPageObject.getAccessibilityLabel(ComponentSelector.Secondary)).toEqual(
       BUTTON_TEST_COMPONENT_LABEL,
@@ -53,7 +50,6 @@ describe('Experimental Button Functional Testing', async () => {
   /* Scrolls and waits for the Button to be visible on the Test Page */
   beforeEach(async () => {
     await ButtonExperimentalPageObject.scrollToTestElement();
-    await ButtonExperimentalPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
   });
 
   it('Validate OnClick() callback was fired -> Click', async () => {

--- a/apps/E2E/src/Checkbox/specs/Checkbox.spec.win.ts
+++ b/apps/E2E/src/Checkbox/specs/Checkbox.spec.win.ts
@@ -24,7 +24,6 @@ describe('Checkbox Accessibility Testing', () => {
   /* Scrolls and waits for the Checkbox to be visible on the Test Page */
   beforeEach(async () => {
     await CheckboxPageObject.scrollToTestElement();
-    await CheckboxPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
   });
 
   it('Checkbox - Validate accessibilityRole is correct', async () => {
@@ -47,7 +46,6 @@ describe('Checkbox Functional Testing', () => {
   /* Scrolls and waits for the Checkbox to be visible on the Test Page AND un-checks the Checkbox */
   beforeEach(async () => {
     await CheckboxPageObject.scrollToTestElement();
-    await CheckboxPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
 
     await CheckboxPageObject.toggleCheckboxToUnchecked();
   });

--- a/apps/E2E/src/Checkbox/specs/Checkbox.spec.windows.ts
+++ b/apps/E2E/src/Checkbox/specs/Checkbox.spec.windows.ts
@@ -23,7 +23,6 @@ describe('Checkbox Accessibility Testing', () => {
   /* Scrolls and waits for the Checkbox to be visible on the Test Page */
   beforeEach(async () => {
     await CheckboxPageObject.scrollToTestElement();
-    await CheckboxPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
   });
 
   it('Checkbox - Validate accessibilityRole is correct', async () => {
@@ -45,7 +44,6 @@ describe('Checkbox Accessibility Testing', () => {
 //   /* Scrolls and waits for the Checkbox to be visible on the Test Page AND un-checks the Checkbox */
 //   beforeEach(() => {
 //     CheckboxPageObject.scrollToTestElement();
-//     CheckboxPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
 
 //     CheckboxPageObject.toggleCheckboxToUnchecked();
 //   });

--- a/apps/E2E/src/CheckboxExperimental/specs/ExperimentalCheckbox.spec.win.ts
+++ b/apps/E2E/src/CheckboxExperimental/specs/ExperimentalCheckbox.spec.win.ts
@@ -27,12 +27,10 @@ describe('Experimental Checkbox Accessibility Testing', () => {
   /* Scrolls and waits for the Checkbox to be visible on the Test Page */
   beforeEach(async () => {
     await ExperimentalCheckboxPageObject.scrollToTestElement();
-    await ExperimentalCheckboxPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
   });
 
   it('Experimental Checkbox - Validate accessibilityRole is correct', async () => {
     await ExperimentalCheckboxPageObject.scrollToTestElement();
-    await ExperimentalCheckboxPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
 
     await expect(await ExperimentalCheckboxPageObject.getAccessibilityRole()).toEqual(CHECKBOX_A11Y_ROLE);
     await expect(await ExperimentalCheckboxPageObject.didAssertPopup()).toBeFalsy(ExperimentalCheckboxPageObject.ERRORMESSAGE_ASSERT);
@@ -40,7 +38,6 @@ describe('Experimental Checkbox Accessibility Testing', () => {
 
   it('Experimental Checkbox - Set accessibilityLabel', async () => {
     await ExperimentalCheckboxPageObject.scrollToTestElement();
-    await ExperimentalCheckboxPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
 
     await expect(await ExperimentalCheckboxPageObject.getAccessibilityLabel(ComponentSelector.Primary)).toEqual(
       EXPERIMENTAL_CHECKBOX_ACCESSIBILITY_LABEL,
@@ -50,7 +47,6 @@ describe('Experimental Checkbox Accessibility Testing', () => {
 
   it('Experimental Checkbox - Do not set accessibilityLabel -> Default to Checkbox label', async () => {
     await ExperimentalCheckboxPageObject.scrollToTestElement();
-    await ExperimentalCheckboxPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
 
     await expect(await ExperimentalCheckboxPageObject.getAccessibilityLabel(ComponentSelector.Secondary)).toEqual(
       EXPERIMENTAL_CHECKBOX_TEST_COMPONENT_LABEL,
@@ -63,7 +59,6 @@ describe('Checkbox Functional Testing', () => {
   /* Scrolls and waits for the Checkbox to be visible on the Test Page AND un-checks the Checkbox */
   beforeEach(async () => {
     await ExperimentalCheckboxPageObject.scrollToTestElement();
-    await ExperimentalCheckboxPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
 
     await ExperimentalCheckboxPageObject.toggleCheckboxToUnchecked();
   });

--- a/apps/E2E/src/ContextualMenu/specs/ContextualMenu.spec.win.ts
+++ b/apps/E2E/src/ContextualMenu/specs/ContextualMenu.spec.win.ts
@@ -23,7 +23,6 @@ describe('ContextualMenu Functional Tests', async () => {
   /* Scrolls and waits for the ContextualMenu to be visible on the Test Page */
   beforeEach(async () => {
     await ContextualMenuPageObjectObject.scrollToTestElement();
-    await ContextualMenuPageObjectObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
 
     await ContextualMenuPageObjectObject.sendKey(ContextualMenuSelector.ContextualMenu, Keys.ESCAPE); // Reset ContextualMenu state for next test
   });

--- a/apps/E2E/src/FocusTrapZone/pages/FocusTrapZonePageObject.win.ts
+++ b/apps/E2E/src/FocusTrapZone/pages/FocusTrapZonePageObject.win.ts
@@ -6,13 +6,6 @@ import {
 import { BasePage, By } from '../../common/BasePage';
 
 class FocusTrapZonePageObject extends BasePage {
-  // OVERRIDE: We use isExisting() here instead of isDisplayed() because FocusTrapZone does not have any UI to it, it's simply
-  // a wrapper that adds keyboard focus functionality
-  async waitForPrimaryElementDisplayed(timeout?: number): Promise<void> {
-    const errorMsg = 'The FocusTrapZone UI Element did not load correctly. Please see logs.';
-    await this.waitForCondition(async () => await (await this._primaryComponent).isExisting(), errorMsg, timeout);
-  }
-
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/

--- a/apps/E2E/src/FocusZone/pages/FocusZonePageObject.ts
+++ b/apps/E2E/src/FocusZone/pages/FocusZonePageObject.ts
@@ -45,11 +45,6 @@ type BooleanGridFocusZoneOption =
   | GridFocusZoneOption.Disable;
 
 class FocusZonePageObject extends BasePage {
-  async waitForPrimaryElementDisplayed(timeout?: number): Promise<void> {
-    const errorMsg = 'The FocusZone UI Element did not load correctly. Please see logs.';
-    await this.waitForCondition(async () => await (await this._primaryComponent).isDisplayed(), errorMsg, timeout);
-  }
-
   async resetTest() {
     await this.configureGridFocusZone(GridFocusZoneOption.SetDirection, 'bidirectional');
     await this.configureGridFocusZone(GridFocusZoneOption.Set2DNavigation, false);

--- a/apps/E2E/src/FocusZone/specs/FocusZone.spec.win.ts
+++ b/apps/E2E/src/FocusZone/specs/FocusZone.spec.win.ts
@@ -28,7 +28,7 @@ describe('FocusZone Testing Initialization', function () {
 describe('FocusZone Functional Testing', () => {
   beforeEach(async () => {
     await FocusZonePageObject.scrollToTestElement();
-    await FocusZonePageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
+
     await FocusZonePageObject.resetTest();
   });
 

--- a/apps/E2E/src/Link/specs/Link.spec.win.ts
+++ b/apps/E2E/src/Link/specs/Link.spec.win.ts
@@ -24,7 +24,6 @@ describe('Link Testing Initialization', function () {
 describe('Link Accessibility Testing', () => {
   it('Link - Validate accessibilityRole is correct', async () => {
     await LinkPageObject.scrollToTestElement();
-    await LinkPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
 
     await expect(await LinkPageObject.getAccessibilityRole()).toEqual(LINK_A11Y_ROLE);
     await expect(await LinkPageObject.didAssertPopup()).toBeFalsy(LinkPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped u
@@ -32,7 +31,6 @@ describe('Link Accessibility Testing', () => {
 
   it('Link - Set accessibilityLabel', async () => {
     await LinkPageObject.scrollToTestElement();
-    await LinkPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
 
     await expect(await LinkPageObject.getAccessibilityLabel(ComponentSelector.Primary)).toEqual(LINK_ACCESSIBILITY_LABEL);
     await expect(await LinkPageObject.didAssertPopup()).toBeFalsy(LinkPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped u

--- a/apps/E2E/src/LinkExperimental/specs/ExperimentalLink.spec.win.ts
+++ b/apps/E2E/src/LinkExperimental/specs/ExperimentalLink.spec.win.ts
@@ -24,7 +24,6 @@ describe('Link Testing Initialization', function () {
 describe('Link Accessibility Testing', () => {
   it('Link - Validate accessibilityRole is correct', async () => {
     await ExperimentalLinkPageObject.scrollToTestElement();
-    await ExperimentalLinkPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
 
     await expect(await ExperimentalLinkPageObject.getAccessibilityRole()).toEqual(LINK_A11Y_ROLE);
     await expect(await ExperimentalLinkPageObject.didAssertPopup()).toBeFalsy(ExperimentalLinkPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
@@ -32,7 +31,6 @@ describe('Link Accessibility Testing', () => {
 
   it('Link - Set accessibilityLabel', async () => {
     await ExperimentalLinkPageObject.scrollToTestElement();
-    await ExperimentalLinkPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
 
     await expect(await ExperimentalLinkPageObject.getAccessibilityLabel(ComponentSelector.Primary)).toEqual(
       EXPERIMENTAL_LINK_ACCESSIBILITY_LABEL,

--- a/apps/E2E/src/Menu/specs/Menu.spec.win.ts
+++ b/apps/E2E/src/Menu/specs/Menu.spec.win.ts
@@ -23,7 +23,7 @@ describe('Menu Testing Initialization', function () {
 describe('Menu Accessibility Testing', () => {
   beforeEach(async () => {
     await MenuPageObject.scrollToTestElement();
-    await MenuPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
+
     await MenuPageObject.resetTest();
   });
 
@@ -50,7 +50,7 @@ describe('Menu Functional Testing', () => {
   /* Scrolls and waits for the Menu to be visible on the Test Page */
   beforeEach(async () => {
     await MenuPageObject.scrollToTestElement();
-    await MenuPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
+
     await MenuPageObject.resetTest();
   });
 

--- a/apps/E2E/src/MenuButton/specs/MenuButton.spec.win.ts
+++ b/apps/E2E/src/MenuButton/specs/MenuButton.spec.win.ts
@@ -29,7 +29,6 @@ describe('MenuButton Accessibility Testing', () => {
   /* Scrolls and waits for the MenuButton to be visible on the Test Page */
   beforeEach(async () => {
     await MenuButtonPageObject.scrollToTestElement();
-    await MenuButtonPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
   });
 
   it('MenuButton - Validate accessibilityRole is correct', async () => {
@@ -52,7 +51,6 @@ describe('MenuButton Functional Testing', () => {
   /* Scrolls and waits for the MenuButton to be visible on the Test Page */
   beforeEach(async () => {
     await MenuButtonPageObject.scrollToTestElement();
-    await MenuButtonPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
 
     await MenuButtonPageObject.sendKey(MenuButtonSelector.MenuButton, Keys.ESCAPE); // Reset MenuButton state for next test
   });

--- a/apps/E2E/src/MenuButtonExperimental/specs/ExperimentalMenuButton.spec.win.ts
+++ b/apps/E2E/src/MenuButtonExperimental/specs/ExperimentalMenuButton.spec.win.ts
@@ -28,7 +28,6 @@ describe('Experimental MenuButton Testing Initialization', function () {
 describe('Experimental MenuButton Accessibility Testing', () => {
   it('Experimental MenuButton - Validate accessibilityRole is correct', async () => {
     await ExperimentalMenuButtonPageObject.scrollToTestElement();
-    await ExperimentalMenuButtonPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
 
     await expect(await ExperimentalMenuButtonPageObject.getAccessibilityRole()).toEqual(MENUBUTTON_A11Y_ROLE);
     await expect(await ExperimentalMenuButtonPageObject.didAssertPopup()).toBeFalsy(ExperimentalMenuButtonPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
@@ -36,7 +35,6 @@ describe('Experimental MenuButton Accessibility Testing', () => {
 
   it('Experimental MenuButton - Set accessibilityLabel', async () => {
     await ExperimentalMenuButtonPageObject.scrollToTestElement();
-    await ExperimentalMenuButtonPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
 
     await expect(await ExperimentalMenuButtonPageObject.getAccessibilityLabel(ComponentSelector.Primary)).toEqual(
       EXPERIMENTAL_MENU_BUTTON_ACCESSIBILITY_LABEL,
@@ -46,7 +44,6 @@ describe('Experimental MenuButton Accessibility Testing', () => {
 
   it('Do not set accessibilityLabel -> Default to Experimental MenuButton label', async () => {
     await ExperimentalMenuButtonPageObject.scrollToTestElement();
-    await ExperimentalMenuButtonPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
 
     await expect(await ExperimentalMenuButtonPageObject.getAccessibilityLabel(ComponentSelector.Secondary)).toEqual(
       EXPERIMENTAL_MENU_BUTTON_TEST_COMPONENT_LABEL,

--- a/apps/E2E/src/RadioGroup/specs/RadioGroup.spec.win.ts
+++ b/apps/E2E/src/RadioGroup/specs/RadioGroup.spec.win.ts
@@ -30,7 +30,6 @@ describe('RadioGroup/RadioButton Accessibility Testing', () => {
   /* Scrolls and waits for the RadioGroup to be visible on the Test Page */
   beforeEach(async () => {
     await RadioGroupPageObject.scrollToTestElement();
-    await RadioGroupPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
   });
 
   it("Validate RadioGroup's accessibilityRole is correct", async () => {
@@ -70,7 +69,6 @@ describe('RadioGroup Functional Testing', async () => {
   /* This resets the RadioGroup state by clicking/selecting the 1st RadioButton in the RadioGroup */
   beforeEach(async () => {
     await RadioGroupPageObject.scrollToTestElement();
-    await RadioGroupPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
 
     await RadioGroupPageObject.resetRadioGroupSelection();
   });

--- a/apps/E2E/src/RadioGroupExperimental/specs/ExperimentalRadioGroup.spec.win.ts
+++ b/apps/E2E/src/RadioGroupExperimental/specs/ExperimentalRadioGroup.spec.win.ts
@@ -30,7 +30,6 @@ describe('RadioGroup/Radio Accessibility Testing', () => {
   /* Scrolls and waits for the RadioGroup to be visible on the Test Page */
   beforeEach(async () => {
     await RadioGroupExperimentalPageObject.scrollToTestElement();
-    await RadioGroupExperimentalPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
   });
 
   it("Validate RadioGroup's accessibilityRole is correct", async () => {
@@ -74,7 +73,6 @@ describe('RadioGroup Functional Testing', async () => {
   /* This resets the RadioGroup state by clicking/selecting the 1st Radio in the RadioGroup */
   beforeEach(async () => {
     await RadioGroupExperimentalPageObject.scrollToTestElement();
-    await RadioGroupExperimentalPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
 
     await RadioGroupExperimentalPageObject.resetRadioGroupSelection();
   });

--- a/apps/E2E/src/Switch/specs/Switch.spec.win.ts
+++ b/apps/E2E/src/Switch/specs/Switch.spec.win.ts
@@ -26,7 +26,6 @@ describe('Switch Accessibility Testing', () => {
   /* Scrolls and waits for the Switch to be visible on the Test Page */
   beforeEach(async () => {
     await SwitchPageObject.scrollToTestElement();
-    await SwitchPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
   });
 
   it('Switch - Validate accessibilityRole is correct', async () => {
@@ -49,7 +48,6 @@ describe('Switch Functional Testing', () => {
   /* Scrolls and waits for the Switch to be visible on the Test Page */
   beforeEach(async () => {
     await SwitchPageObject.scrollToTestElement();
-    await SwitchPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
   });
 
   it("Click on a Switch -> Validate it toggles correctly AND calls the user's onChange", async () => {

--- a/apps/E2E/src/Tabs/specs/Tabs.spec.win.ts
+++ b/apps/E2E/src/Tabs/specs/Tabs.spec.win.ts
@@ -23,7 +23,6 @@ describe('Tabs Accessibility Testing', () => {
   /* Scrolls and waits for the Tabs to be visible on the Test Page */
   beforeEach(async () => {
     await TabsPageObject.scrollToTestElement();
-    await TabsPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
   });
 
   it("Validate Tab's accessibilityRole is correct", async () => {
@@ -41,7 +40,6 @@ describe('Tabs Functional Tests', () => {
   /* Scrolls and waits for the Tabs to be visible on the Test Page */
   beforeEach(async () => {
     await TabsPageObject.scrollToTestElement();
-    await TabsPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
 
     // Reset the TabGroup by putting focus on First tab item
     await TabsPageObject.clickOnTabItem(TabItemSelector.First);

--- a/apps/E2E/src/Tabs/specs/Tabs.spec.windows.ts
+++ b/apps/E2E/src/Tabs/specs/Tabs.spec.windows.ts
@@ -22,7 +22,6 @@ describe('Tabs Accessibility Testing', () => {
   /* Scrolls and waits for the Tabs to be visible on the Test Page */
   beforeEach(async () => {
     await TabsPageObject.scrollToTestElement();
-    await TabsPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
   });
 
   it("Validate Tab's accessibilityRole is correct", async () => {
@@ -38,7 +37,6 @@ describe('Tabs Functional Tests', () => {
   /* Scrolls and waits for the Tabs to be visible on the Test Page */
   beforeEach(async () => {
     await TabsPageObject.scrollToTestElement();
-    await TabsPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
 
     // Reset the TabGroup by putting focus on First tab item
     await TabsPageObject.clickOnTabItem(TabItemSelector.First);

--- a/apps/E2E/src/TabsExperimental/specs/TabsExperimental.spec.win.ts
+++ b/apps/E2E/src/TabsExperimental/specs/TabsExperimental.spec.win.ts
@@ -22,7 +22,6 @@ describe('Experimental Tabs Testing Initialization', function () {
 describe('Experimental Tabs Accessibility Testing', () => {
   it("Validate Experimental Tab's accessibilityRole is correct", async () => {
     await ExperimentalTabsPageObject.scrollToTestElement();
-    await ExperimentalTabsPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
 
     await expect(await ExperimentalTabsPageObject.getAccessibilityRole()).toEqual(TAB_A11Y_ROLE);
     await expect(await ExperimentalTabsPageObject.didAssertPopup()).toBeFalsy(ExperimentalTabsPageObject.ERRORMESSAGE_ASSERT);
@@ -30,7 +29,6 @@ describe('Experimental Tabs Accessibility Testing', () => {
 
   it("Validate Experimental TabItem's accessibilityRole is correct", async () => {
     await ExperimentalTabsPageObject.scrollToTestElement();
-    await ExperimentalTabsPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
 
     await expect(await ExperimentalTabsPageObject.getTabItemAccesibilityRole()).toEqual(TABITEM_A11Y_ROLE);
     await expect(await ExperimentalTabsPageObject.didAssertPopup()).toBeFalsy(ExperimentalTabsPageObject.ERRORMESSAGE_ASSERT);

--- a/apps/E2E/src/Text/specs/Text.spec.win.ts
+++ b/apps/E2E/src/Text/specs/Text.spec.win.ts
@@ -24,7 +24,6 @@ describe('Text Testing Initialization', function () {
 describe('Text Accessibility Testing', () => {
   beforeEach(async () => {
     await TextPageObject.scrollToTestElement();
-    await TextPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
   });
 
   it('Text - Validate accessibilityRole is correct', async () => {

--- a/apps/E2E/src/TextExperimental/specs/ExperimentalText.spec.win.ts
+++ b/apps/E2E/src/TextExperimental/specs/ExperimentalText.spec.win.ts
@@ -22,7 +22,6 @@ describe('Experimental Text Testing Initialization', function () {
 describe('Experimental Text Accessibility Testing', () => {
   it('Text - Validate accessibilityRole is correct', async () => {
     await ExperimentalTextPageObject.scrollToTestElement();
-    await ExperimentalTextPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
 
     await expect(await ExperimentalTextPageObject.getAccessibilityRole()).toEqual(TEXT_A11Y_ROLE);
     await expect(await ExperimentalTextPageObject.didAssertPopup()).toBeFalsy(ExperimentalTextPageObject.ERRORMESSAGE_ASSERT);

--- a/apps/E2E/src/common/BasePage.ts
+++ b/apps/E2E/src/common/BasePage.ts
@@ -157,6 +157,17 @@ export class BasePage {
     });
   }
 
+  /* @deprecated, only use `scrollToTestElement()` instead */
+  async waitForPrimaryElementDisplayed(timeout?: number): Promise<void> {
+    console.warn('`waitForPrimaryElementDisplayed` is deprecated. Only use `scrollToTestElement` in your spec to improve performance.');
+    await browser.waitUntil(async () => await (await this._primaryComponent).isDisplayed(), {
+      timeout: timeout ?? this.waitForUiEvent,
+      timeoutMsg:
+        'The primary UI element for testing did not display correctly. Please see /errorShots of the first failed test for more information.',
+      interval: 1500,
+    });
+  }
+
   /* Scrolls to the primary UI test element until it is displayed. */
   async scrollToTestElement(component?: WebdriverIO.Element): Promise<void> {
     const ComponentToScrollTo = component ?? (await this._primaryComponent);

--- a/apps/E2E/src/common/BasePage.ts
+++ b/apps/E2E/src/common/BasePage.ts
@@ -157,16 +157,6 @@ export class BasePage {
     });
   }
 
-  /* Waits for the primary UI test element to be displayed. If the element doesn't load before the timeout, it causes the test to fail. */
-  async waitForPrimaryElementDisplayed(timeout?: number): Promise<void> {
-    await browser.waitUntil(async () => await (await this._primaryComponent).isDisplayed(), {
-      timeout: timeout ?? this.waitForUiEvent,
-      timeoutMsg:
-        'The primary UI element for testing did not display correctly. Please see /errorShots of the first failed test for more information.',
-      interval: 1500,
-    });
-  }
-
   /* Scrolls to the primary UI test element until it is displayed. */
   async scrollToTestElement(component?: WebdriverIO.Element): Promise<void> {
     const ComponentToScrollTo = component ?? (await this._primaryComponent);

--- a/change/@fluentui-react-native-e2e-testing-fe95f1a9-696a-45d4-8e57-ce928003e59f.json
+++ b/change/@fluentui-react-native-e2e-testing-fe95f1a9-696a-45d4-8e57-ce928003e59f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove waitForPrimaryElementDisplayed method and test calls",
+  "packageName": "@fluentui-react-native/e2e-testing",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-e2e-testing-fe95f1a9-696a-45d4-8e57-ce928003e59f.json
+++ b/change/@fluentui-react-native-e2e-testing-fe95f1a9-696a-45d4-8e57-ce928003e59f.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
-  "comment": "Remove waitForPrimaryElementDisplayed method and test calls",
+  "type": "minor",
+  "comment": "Remove waitForPrimaryElementDisplayed test calls, deprecated method",
   "packageName": "@fluentui-react-native/e2e-testing",
   "email": "winlarry@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "minor"
 }


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [x] windows
- [ ] android

### Description of changes

Currently in our test specs, we use the following pattern:
```ts
await ButtonPageObject.scrollToTestElement();
await ButtonPageObject.waitForPrimaryElementDisplayed(PAGE_TIMEOUT);
```
The `waitForPrimaryElementDisplayed` method is unnecessary because `scrollToTestElement` already contains a similar waiter. 

By removing `waitForPrimaryElementDisplayed` and calls to it in specs, we reduce our test time and increase test performance across the board. 

### Verification

Local testing passes + CI testing also passes. 

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
