### PR TITLE
Add Buildci to Win32 NuGet Pipeline

### DIFF
--- a/.ado/templates/win32-nuget-publish.yml
+++ b/.ado/templates/win32-nuget-publish.yml
@@ -11,13 +11,8 @@ steps:
   - template: setup-repo-min-build.yml
 
   - script: |
-      yarn build
+      yarn buildci
     displayName: 'Building the repo'
-
-  - script: |
-      yarn bundle
-    workingDirectory: apps/win32
-    displayName: 'Bundling win32'
 
   # Pack the NuGet package
   - task: CmdLine@1


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [X] windows
- [ ] android

### Description of changes

There are two NuGet packages in this job that export a bundle (Microsoft.FluentUI.FluentTesterWin32 and Microsoft.FluentUI.Win32.E2E.Testing.Specs). Rather than having two separate `yarn bundle` scripts in each directory (apps/win32 and apps/e2e), let's add one `yarn buildci` script that also does extra validation + bundle. Mirroring our NPM pipeline and other Publish Pipelines in MS repos.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
