### PR TITLE
[Link] Disabled links should not be focusable

### DIFF
--- a/apps/fluent-tester/src/TestComponents/LinkExperimental/LinkTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/LinkExperimental/LinkTest.tsx
@@ -21,7 +21,7 @@ const DefaultLinks: React.FunctionComponent = () => {
         Click to alert.
       </Link>
       <Link disabled focusable>
-        Disabled focusable Link
+        Disabled Link not focusable
       </Link>
     </Stack>
   );

--- a/apps/fluent-tester/src/TestComponents/LinkExperimental/LinkTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/LinkExperimental/LinkTest.tsx
@@ -20,9 +20,7 @@ const DefaultLinks: React.FunctionComponent = () => {
       <Link onPress={doPress} onAccessibilityTap={doAllyTap}>
         Click to alert.
       </Link>
-      <Link disabled focusable>
-        Disabled Link not focusable
-      </Link>
+      <Link disabled>Disabled Link</Link>
     </Stack>
   );
 };

--- a/change/@fluentui-react-native-experimental-link-2f0a1b29-9098-4ca0-bd88-3455dc63481c.json
+++ b/change/@fluentui-react-native-experimental-link-2f0a1b29-9098-4ca0-bd88-3455dc63481c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Change disabled link to not be focusable",
+  "packageName": "@fluentui-react-native/experimental-link",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-37d13a6a-b65e-4468-8bb9-44ffcdda29f1.json
+++ b/change/@fluentui-react-native-tester-37d13a6a-b65e-4468-8bb9-44ffcdda29f1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Edit text",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Link/src/useLink.ts
+++ b/packages/experimental/Link/src/useLink.ts
@@ -26,7 +26,7 @@ export const useLink = (props: LinkProps): LinkInfo => {
     componentRef = defaultComponentRef,
     disabled,
     enableFocusRing,
-    focusable,
+    focusable = true,
     ...rest
   } = props;
   const isDisabled = !!disabled;
@@ -46,7 +46,7 @@ export const useLink = (props: LinkProps): LinkInfo => {
   );
 
   // GH #1336: Set focusRef to null if link is disabled to prevent getting keyboard focus.
-  const focusRef = isDisabled && !focusable ? null : componentRef;
+  const focusRef = isDisabled || !focusable ? null : componentRef;
   const onPressWithFocus = useOnPressWithFocus(focusRef, linkOnPress);
   const pressable = useAsPressable({ ...rest, disabled: isDisabled, onPress: onPressWithFocus });
   const onKeyUpProps = useKeyProps(linkOnPress, ' ', 'Enter');
@@ -88,7 +88,7 @@ export const useLink = (props: LinkProps): LinkInfo => {
       accessibilityRole: 'link',
       accessibilityState: getAccessibilityState(isDisabled, accessibilityState),
       enableFocusRing: enableFocusRing ?? true,
-      focusable: focusable ?? !isDisabled,
+      focusable: focusable && !isDisabled,
       cursor: isDisabled ? 'not-allowed' : 'pointer',
       ref: useViewCommandFocus(componentRef),
       tooltip: linkTooltip,


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

In win32, disabled Links are not meant to be focusable, this is a common pattern on win32. Changing the block link to be not focusable when disabled.

This is a deviation from web behavior which allows for disabledFocusable

### Verification

Tested scenario via tester.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
