### PR TITLE
[E2E tests] Update comment to explain why iOS FluentTester root view cannot have accessible prop set to true

### DIFF
--- a/apps/fluent-tester/src/FluentTester.tsx
+++ b/apps/fluent-tester/src/FluentTester.tsx
@@ -205,7 +205,7 @@ export const FluentTester: React.FunctionComponent<FluentTesterProps> = (props: 
     // TODO: Setting the testID should disable React Native's layout-only view removal optimization.
     // However, for win32, the view removal still happens even though the testID is being set on this view.
     // As a temporary patch, set the view to be accessible on win32 to ensure that the view is not removed.
-    <RootView style={themedStyles.root} accessible={Platform.OS === 'macos'} testID={ROOT_VIEW}>
+    <RootView style={themedStyles.root} collapsable={false} testID={ROOT_VIEW}>
       <Header enableSinglePaneView={enableSinglePaneView} enableBackButtonIOS={!onTestListView} onBackButtonPressedIOS={onBackPress} />
       <HeaderSeparator />
       <View style={fluentTesterStyles.testRoot}>

--- a/apps/fluent-tester/src/FluentTester.tsx
+++ b/apps/fluent-tester/src/FluentTester.tsx
@@ -205,7 +205,7 @@ export const FluentTester: React.FunctionComponent<FluentTesterProps> = (props: 
     // TODO: Setting the testID should disable React Native's layout-only view removal optimization.
     // However, for win32, the view removal still happens even though the testID is being set on this view.
     // As a temporary patch, set the view to be accessible on win32 to ensure that the view is not removed.
-    <RootView style={themedStyles.root} accessible={Platform.OS === ('win32' as any)} testID={ROOT_VIEW}>
+    <RootView style={themedStyles.root} accessible={Platform.OS === 'macos'} testID={ROOT_VIEW}>
       <Header enableSinglePaneView={enableSinglePaneView} enableBackButtonIOS={!onTestListView} onBackButtonPressedIOS={onBackPress} />
       <HeaderSeparator />
       <View style={fluentTesterStyles.testRoot}>

--- a/apps/fluent-tester/src/FluentTester.tsx
+++ b/apps/fluent-tester/src/FluentTester.tsx
@@ -202,8 +202,10 @@ export const FluentTester: React.FunctionComponent<FluentTesterProps> = (props: 
   };
 
   return (
-    // TODO: Figure out why making this view accessible breaks element querying on iOS.
-    <RootView style={themedStyles.root} accessible={Platform.OS !== 'ios'} testID={ROOT_VIEW}>
+    // TODO: Setting the testID should disable React Native's layout-only view removal optimization.
+    // However, for win32, the view removal still happens even though the testID is being set on this view.
+    // As a temporary patch, set the view to be accessible on win32 to ensure that the view is not removed.
+    <RootView style={themedStyles.root} accessible={Platform.OS === ('win32' as any)} testID={ROOT_VIEW}>
       <Header enableSinglePaneView={enableSinglePaneView} enableBackButtonIOS={!onTestListView} onBackButtonPressedIOS={onBackPress} />
       <HeaderSeparator />
       <View style={fluentTesterStyles.testRoot}>

--- a/apps/fluent-tester/src/FluentTester.tsx
+++ b/apps/fluent-tester/src/FluentTester.tsx
@@ -202,11 +202,8 @@ export const FluentTester: React.FunctionComponent<FluentTesterProps> = (props: 
   };
 
   return (
-    // Setting the testID should disable React Native's layout-only view removal optimization, and keep the view in the native hierarchy.
-    // However, for win32 and macOS, the view removal still seems to happen even though the testID is being set on this view.
-    // As a temporary patch, set the view to be accessible on win32 and macOS to ensure that the view is not removed.
-    // TODO: remove the need for this temporary patch
-    <RootView style={themedStyles.root} accessible={Platform.OS === ('win32' as any) || Platform.OS === 'macos'} testID={ROOT_VIEW}>
+    // On iOS, the accessible prop must be set to false because iOS does not support nested accessibility elements
+    <RootView style={themedStyles.root} accessible={Platform.OS !== 'ios'} testID={ROOT_VIEW}>
       <Header enableSinglePaneView={enableSinglePaneView} enableBackButtonIOS={!onTestListView} onBackButtonPressedIOS={onBackPress} />
       <HeaderSeparator />
       <View style={fluentTesterStyles.testRoot}>

--- a/apps/fluent-tester/src/FluentTester.tsx
+++ b/apps/fluent-tester/src/FluentTester.tsx
@@ -202,10 +202,11 @@ export const FluentTester: React.FunctionComponent<FluentTesterProps> = (props: 
   };
 
   return (
-    // TODO: Setting the testID should disable React Native's layout-only view removal optimization.
-    // However, for win32, the view removal still happens even though the testID is being set on this view.
-    // As a temporary patch, set the view to be accessible on win32 to ensure that the view is not removed.
-    <RootView style={themedStyles.root} collapsable={false} testID={ROOT_VIEW}>
+    // Setting the testID should disable React Native's layout-only view removal optimization, and keep the view in the native hierarchy.
+    // However, for win32 and macOS, the view removal still seems to happen even though the testID is being set on this view.
+    // As a temporary patch, set the view to be accessible on win32 and macOS to ensure that the view is not removed.
+    // TODO: remove the need for this temporary patch
+    <RootView style={themedStyles.root} accessible={Platform.OS === ('win32' as any) || Platform.OS === 'macos'} testID={ROOT_VIEW}>
       <Header enableSinglePaneView={enableSinglePaneView} enableBackButtonIOS={!onTestListView} onBackButtonPressedIOS={onBackPress} />
       <HeaderSeparator />
       <View style={fluentTesterStyles.testRoot}>

--- a/change/@fluentui-react-native-tester-4843057b-102e-4bfe-93ad-d6c049ef1974.json
+++ b/change/@fluentui-react-native-tester-4843057b-102e-4bfe-93ad-d6c049ef1974.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Make accessible prop true for win32 only, update comment",
-  "packageName": "@fluentui-react-native/tester",
-  "email": "78454019+lyzhan7@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-react-native-tester-4843057b-102e-4bfe-93ad-d6c049ef1974.json
+++ b/change/@fluentui-react-native-tester-4843057b-102e-4bfe-93ad-d6c049ef1974.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Make accessible prop true for win32 only, update comment",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-88a83e85-0988-485c-a527-2515aac4fb52.json
+++ b/change/@fluentui-react-native-tester-88a83e85-0988-485c-a527-2515aac4fb52.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update comment on why accessible can't be set to true on iOS",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [ ] android

### Description of changes

Issue https://github.com/microsoft/fluentui-react-native/issues/2264 was opened because setting the accessible prop to true on Fluent Tester root view broke element querying on iOS E2E tests.

After some [investigation](https://github.com/microsoft/fluentui-react-native/issues/2264#issuecomment-1343723430), it seems like the accessible prop on the root view should actually be set to false since iOS accessibility works differently from other platforms - there are no nested accessibility elements on iOS, if a parent view is an accessibility element than its child views cannot be accessibility elements. If the root view is an accessibility element, the whole screen is treated as a single accessibility element

### Verification

The CI will pass if all the e2e tests pass.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
