### PR TITLE
Update list of exports of main FURN package

### DIFF
--- a/change/@fluentui-react-native-e37c6730-a90a-4266-ad3d-01fd7af2e3f9.json
+++ b/change/@fluentui-react-native-e37c6730-a90a-4266-ad3d-01fd7af2e3f9.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add missing entries to export of library/core",
+  "packageName": "@fluentui/react-native",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/libraries/core/src/index.ts
+++ b/packages/libraries/core/src/index.ts
@@ -8,6 +8,11 @@ export {
   PrimaryButton,
   StealthButton,
   buttonName,
+  compoundButtonName,
+  fabName,
+  toggleButtonName,
+  useButton,
+  useToggleButton,
 } from '@fluentui-react-native/button';
 export type {
   ButtonAppearance,
@@ -20,6 +25,15 @@ export type {
   ButtonInfo,
   ButtonTokens,
   ButtonType,
+  CompoundButtonProps,
+  CompoundButtonSlotProps,
+  CompoundButtonTokens,
+  CompoundButtonType,
+  FABSize,
+  FABSlotProps,
+  FABProps,
+  FABTokens,
+  FABType,
   IButtonInfo,
   IButtonProps,
   IButtonRenderData,
@@ -27,6 +41,11 @@ export type {
   IButtonState,
   IButtonTokens,
   IButtonType,
+  ToggleButtonProps,
+  ToggleButtonSlotProps,
+  ToggleButtonInfo,
+  ToggleButtonTokens,
+  ToggleButtonType,
 } from '@fluentui-react-native/button';
 
 export { Callout, calloutName } from '@fluentui-react-native/callout';
@@ -41,7 +60,7 @@ export type {
   RestoreFocusEvent,
 } from '@fluentui-react-native/callout';
 
-export { Checkbox, checkboxName, CheckboxV1, checkboxNameV1 } from '@fluentui-react-native/checkbox';
+export { Checkbox, checkboxName, CheckboxV1, checkboxNameV1, useCheckbox } from '@fluentui-react-native/checkbox';
 export type {
   CheckboxInfo,
   CheckboxProps,
@@ -183,6 +202,8 @@ export type {
   TextProps,
   TextTokens,
   Caption1,
+  Caption1Strong,
+  Caption2,
   Body1,
   Body1Strong,
   Body2,
@@ -193,6 +214,8 @@ export type {
   Subtitle2Strong,
   Title1,
   Title1Strong,
+  Title2,
+  Title3,
   LargeTitle,
   Display,
   ITextProps,
@@ -200,6 +223,11 @@ export type {
 } from '@fluentui-react-native/text';
 
 export {
+  getAccessibilityState,
+  isAccessibilityActionEvent,
+  isGestureResponderEvent,
+  isKeyPressEvent,
+  isMouseEvent,
   normalizeRect,
   preferKeyDownForKeyEvents,
   useAsPressable,
@@ -225,6 +253,7 @@ export type {
   IFocusState,
   IFocusable,
   IHoverState,
+  InteractionEvent,
   IPressState,
   IPressableHooks,
   IPressableOptions,


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

@fluentui/react-native package is missing a few outputs from its input packages. Updating the index file.
Would be nice to have a linter check for this or something now that we can't export * but not within the scope of this PR.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
