### PR TITLE
Added E2E tests for FURN Icon

### DIFF
--- a/apps/E2E/src/IconExperimental/pages/IconPageObject.ts
+++ b/apps/E2E/src/IconExperimental/pages/IconPageObject.ts
@@ -1,0 +1,34 @@
+import {
+  ICON_TESTPAGE,
+  ICON_TEST_COMPONENT,
+  HOMEPAGE_ICON_BUTTON,
+  ICON_NO_A11Y_LABEL_COMPONENT,
+} from '../../../../fluent-tester/src/TestComponents/Icon/consts';
+import { BasePage, By } from '../../common/BasePage';
+
+class IconPageObject extends BasePage {
+  /*****************************************/
+  /**************** Getters ****************/
+  /*****************************************/
+  get _testPage() {
+    return By(ICON_TESTPAGE);
+  }
+
+  get _pageName() {
+    return ICON_TESTPAGE;
+  }
+
+  get _primaryComponent() {
+    return By(ICON_TEST_COMPONENT);
+  }
+
+  get _secondaryComponent() {
+    return By(ICON_NO_A11Y_LABEL_COMPONENT);
+  }
+
+  get _pageButton() {
+    return By(HOMEPAGE_ICON_BUTTON);
+  }
+}
+
+export default new IconPageObject();

--- a/apps/E2E/src/IconExperimental/pages/IconPageObject.ts
+++ b/apps/E2E/src/IconExperimental/pages/IconPageObject.ts
@@ -2,7 +2,7 @@ import {
   ICON_TESTPAGE,
   ICON_TEST_COMPONENT,
   HOMEPAGE_ICON_BUTTON,
-  ICON_NO_A11Y_LABEL_COMPONENT,
+  ICON_FONT_TEST_COMPONENT,
 } from '../../../../fluent-tester/src/TestComponents/Icon/consts';
 import { BasePage, By } from '../../common/BasePage';
 
@@ -23,7 +23,7 @@ class IconPageObject extends BasePage {
   }
 
   get _secondaryComponent() {
-    return By(ICON_NO_A11Y_LABEL_COMPONENT);
+    return By(ICON_FONT_TEST_COMPONENT);
   }
 
   get _pageButton() {

--- a/apps/E2E/src/IconExperimental/specs/Icon.spec.ios.ts
+++ b/apps/E2E/src/IconExperimental/specs/Icon.spec.ios.ts
@@ -1,0 +1,22 @@
+import NavigateAppPage from '../../common/NavigateAppPage';
+import IconPageObject from '../pages/IconPageObject';
+import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
+
+// Before testing begins, allow up to 60 seconds for app to open
+describe('Icon Testing Initialization', function () {
+  it('Wait for app load', async () => {
+    await NavigateAppPage.waitForPageDisplayed(BOOT_APP_TIMEOUT);
+    await expect(await NavigateAppPage.isPageLoaded()).toBeTruthy();
+  });
+
+  it('Click and navigate to Icon test page', async () => {
+    await IconPageObject.mobileScrollToComponentButton();
+    await IconPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
+
+    /* Click on component button to navigate to test page */
+    await NavigateAppPage.clickAndGoToIconPage();
+    await IconPageObject.waitForPageDisplayed(PAGE_TIMEOUT);
+
+    await expect(await IconPageObject.isPageLoaded()).toBeTruthy();
+  });
+});

--- a/apps/E2E/src/IconExperimental/specs/Icon.spec.macos.ts
+++ b/apps/E2E/src/IconExperimental/specs/Icon.spec.macos.ts
@@ -1,0 +1,21 @@
+import NavigateAppPage from '../../common/NavigateAppPage';
+import IconPageObject from '../pages/IconPageObject';
+import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
+
+// Before testing begins, allow up to 60 seconds for app to open
+describe('Icon Testing Initialization', function () {
+  it('Wait for app load', async () => {
+    await NavigateAppPage.waitForPageDisplayed(BOOT_APP_TIMEOUT);
+    await expect(await NavigateAppPage.isPageLoaded()).toBeTruthy();
+  });
+
+  it('Click and navigate to Icon test page', async () => {
+    await IconPageObject.waitForButtonDisplayed(PAGE_TIMEOUT);
+
+    /* Click on component button to navigate to test page */
+    await NavigateAppPage.clickAndGoToIconPage();
+    await IconPageObject.waitForPageDisplayed(PAGE_TIMEOUT);
+
+    await expect(await IconPageObject.isPageLoaded()).toBeTruthy();
+  });
+});

--- a/apps/E2E/src/IconExperimental/specs/Icon.spec.win.ts
+++ b/apps/E2E/src/IconExperimental/specs/Icon.spec.win.ts
@@ -1,6 +1,8 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import IconPageObject from '../pages/IconPageObject';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
+import { ComponentSelector } from '../../common/BasePage';
+import { ICON_ACCESSIBILITY_LABEL } from '../../../../fluent-tester/src/TestComponents/Icon/consts';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Icon Testing Initialization', function () {
@@ -16,5 +18,26 @@ describe('Icon Testing Initialization', function () {
 
     await expect(await IconPageObject.isPageLoaded()).toBeTruthy(IconPageObject.ERRORMESSAGE_PAGELOAD);
     await expect(await IconPageObject.didAssertPopup()).toBeFalsy(IconPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+  });
+});
+
+describe('Icon Accessibility Testing', () => {
+  beforeEach(async () => {
+    await IconPageObject.scrollToTestElement();
+  });
+
+  it('Validate accessibilityLabel for SVG Icon', async () => {
+    await expect(await IconPageObject.getAccessibilityLabel(ComponentSelector.Primary)).toEqual(ICON_ACCESSIBILITY_LABEL);
+    await expect(await IconPageObject.didAssertPopup()).toBeFalsy(IconPageObject.ERRORMESSAGE_ASSERT);
+  });
+
+  it('Validate accessibilityLabel for Font Icon', async () => {
+    await expect(await IconPageObject.getAccessibilityLabel(ComponentSelector.Secondary)).toEqual(ICON_ACCESSIBILITY_LABEL);
+    await expect(await IconPageObject.didAssertPopup()).toBeFalsy(IconPageObject.ERRORMESSAGE_ASSERT);
+  });
+
+  it('Validate accessibilityRole for SVG Icon', async () => {
+    await expect(await IconPageObject.getAccessibilityRole()).toEqual('ControlType.Image');
+    await expect(await IconPageObject.didAssertPopup()).toBeFalsy(IconPageObject.ERRORMESSAGE_ASSERT);
   });
 });

--- a/apps/E2E/src/IconExperimental/specs/Icon.spec.win.ts
+++ b/apps/E2E/src/IconExperimental/specs/Icon.spec.win.ts
@@ -1,0 +1,20 @@
+import NavigateAppPage from '../../common/NavigateAppPage';
+import IconPageObject from '../pages/IconPageObject';
+import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
+
+// Before testing begins, allow up to 60 seconds for app to open
+describe('Icon Testing Initialization', function () {
+  it('Wait for app load', async () => {
+    await NavigateAppPage.waitForPageDisplayed(BOOT_APP_TIMEOUT);
+    await expect(await NavigateAppPage.isPageLoaded()).toBeTruthy(NavigateAppPage.ERRORMESSAGE_APPLOAD);
+  });
+
+  it('Click and navigate to Icon test page', async () => {
+    /* Click on component button to navigate to test page */
+    await NavigateAppPage.clickAndGoToIconPage();
+    await IconPageObject.waitForPageDisplayed(PAGE_TIMEOUT);
+
+    await expect(await IconPageObject.isPageLoaded()).toBeTruthy(IconPageObject.ERRORMESSAGE_PAGELOAD);
+    await expect(await IconPageObject.didAssertPopup()).toBeFalsy(IconPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+  });
+});

--- a/apps/fluent-tester/src/TestComponents/Icon/IconExperimentalE2ETest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Icon/IconExperimentalE2ETest.tsx
@@ -1,0 +1,47 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+import * as React from 'react';
+import { View } from 'react-native';
+import { Text } from '@fluentui/react-native';
+import { FontIcon, SvgIcon, Icon, FontIconProps, SvgIconProps } from '@fluentui-react-native/experimental-icon';
+import { ICON_ACCESSIBILITY_LABEL, ICON_TEST_COMPONENT, ICON_NO_A11Y_LABEL_COMPONENT } from './consts';
+import TestSvg from '../../../assets/test.svg';
+
+const fontBuiltInProps: FontIconProps = {
+  fontFamily: 'Arial',
+  codepoint: 0x2663,
+  fontSize: 100,
+  color: '#f09',
+  accessibilityLabel: ICON_ACCESSIBILITY_LABEL,
+};
+
+const svgUriProps: SvgIconProps = {
+  uri: 'https://upload.wikimedia.org/wikipedia/commons/8/84/Example.svg',
+  viewBox: '0 0 1000 1000',
+  width: 100,
+  height: 100,
+  accessibilityLabel: ICON_ACCESSIBILITY_LABEL,
+  testID: ICON_TEST_COMPONENT,
+};
+
+const svgSrcProps: SvgIconProps = {
+  viewBox: '0 0 500 500',
+  src: TestSvg,
+  width: 72,
+  height: 72,
+  testID: ICON_NO_A11Y_LABEL_COMPONENT,
+};
+
+export const E2ETestingIcon: React.FunctionComponent = () => {
+  return (
+    <View>
+      <Text>Icon component</Text>
+      <Icon svgSource={svgUriProps} />
+
+      <Text>SVG</Text>
+      <SvgIcon {...svgSrcProps} />
+
+      <Text>FontIcon</Text>
+      <FontIcon {...fontBuiltInProps} />
+    </View>
+  );
+};

--- a/apps/fluent-tester/src/TestComponents/Icon/IconExperimentalE2ETest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Icon/IconExperimentalE2ETest.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { View } from 'react-native';
 import { Text } from '@fluentui/react-native';
 import { FontIcon, SvgIcon, Icon, FontIconProps, SvgIconProps } from '@fluentui-react-native/experimental-icon';
-import { ICON_ACCESSIBILITY_LABEL, ICON_TEST_COMPONENT, ICON_NO_A11Y_LABEL_COMPONENT } from './consts';
+import { ICON_ACCESSIBILITY_LABEL, ICON_TEST_COMPONENT, ICON_FONT_TEST_COMPONENT, ICON_SVG_TEST_COMPONENT } from './consts';
 import TestSvg from '../../../assets/test.svg';
 
 const fontBuiltInProps: FontIconProps = {
@@ -11,6 +11,7 @@ const fontBuiltInProps: FontIconProps = {
   codepoint: 0x2663,
   fontSize: 100,
   color: '#f09',
+  testID: ICON_FONT_TEST_COMPONENT,
   accessibilityLabel: ICON_ACCESSIBILITY_LABEL,
 };
 
@@ -28,10 +29,11 @@ const svgSrcProps: SvgIconProps = {
   src: TestSvg,
   width: 72,
   height: 72,
-  testID: ICON_NO_A11Y_LABEL_COMPONENT,
+  testID: ICON_SVG_TEST_COMPONENT,
+  accessibilityLabel: ICON_ACCESSIBILITY_LABEL,
 };
 
-export const E2ETestingIcon: React.FunctionComponent = () => {
+export const E2ETestingExperimentalIcon: React.FunctionComponent = () => {
   return (
     <View>
       <Text>Icon component</Text>

--- a/apps/fluent-tester/src/TestComponents/Icon/IconTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Icon/IconTest.tsx
@@ -6,6 +6,7 @@ import { Icon, RasterImageIconProps, SvgIconProps, FontIconProps } from '@fluent
 import { Test, TestSection, PlatformStatus } from '../Test';
 import { ICON_TESTPAGE } from './consts';
 import { E2ETestingIcon } from './IconE2ETest';
+import { E2ETestingExperimentalIcon } from './IconExperimentalE2ETest';
 import { IconExperimental } from './IconExperimental';
 import { testImage, testTtf, svgProps } from '../Common/iconExamples';
 
@@ -100,6 +101,10 @@ const iconSections: TestSection[] = [
   {
     name: 'Default Icon',
     component: IconExperimental,
+  },
+  {
+    name: 'Icon Experimental for E2E Testing',
+    component: E2ETestingExperimentalIcon,
   },
 ];
 

--- a/apps/fluent-tester/src/TestComponents/Icon/consts.ts
+++ b/apps/fluent-tester/src/TestComponents/Icon/consts.ts
@@ -7,3 +7,9 @@ export const ICON_ACCESSIBILITY_LABEL = 'E2E testing Icon accessibility label';
 
 /* E2E Testing Icon 2 */
 export const ICON_NO_A11Y_LABEL_COMPONENT = 'Icon_No_A11y_label_Component';
+
+/* E2E Testing SVG Icon */
+export const ICON_SVG_TEST_COMPONENT = 'Icon_Svg_Test_Component';
+
+/* E2E Testing Font Icon */
+export const ICON_FONT_TEST_COMPONENT = 'Icon_Font_Test_Component';

--- a/change/@fluentui-react-native-e2e-testing-cf0df221-edc4-4600-b35d-5eba041a7e24.json
+++ b/change/@fluentui-react-native-e2e-testing-cf0df221-edc4-4600-b35d-5eba041a7e24.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added E2E tests for FURN Icon. This is code of existing Icon tests. Changes will be done in separate commits",
+  "packageName": "@fluentui-react-native/e2e-testing",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-icon-9acf4eaf-f386-428a-9d5c-f4cfa5ab3432.json
+++ b/change/@fluentui-react-native-experimental-icon-9acf4eaf-f386-428a-9d5c-f4cfa5ab3432.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added accessibility tests",
+  "packageName": "@fluentui-react-native/experimental-icon",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-740b5921-cecd-47b9-be7f-cdb88718934d.json
+++ b/change/@fluentui-react-native-tester-740b5921-cecd-47b9-be7f-cdb88718934d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added E2E tests for FURN Icon. This is code of existing Icon tests. Changes will be done in separate commits",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/ExperimentalIcon/SPEC.md
+++ b/packages/experimental/ExperimentalIcon/SPEC.md
@@ -172,5 +172,9 @@ export interface FontIconProps extends AccessibilityProps {
    * Style object which contains TextStyle props.
    */
   style?: StyleProp<TextStyle>;
+  /**
+   * Used to locate this view in end-to-end tests.
+   */
+  testID?: string | undefined;
 }
 ```

--- a/packages/experimental/ExperimentalIcon/src/FontIcon/FontIcon.types.ts
+++ b/packages/experimental/ExperimentalIcon/src/FontIcon/FontIcon.types.ts
@@ -27,4 +27,8 @@ export interface FontIconProps extends AccessibilityProps {
    * Style object which contains TextStyle props.
    */
   style?: StyleProp<TextStyle>;
+  /**
+   * Used to locate this view in end-to-end tests.
+   */
+  testID?: string | undefined;
 }


### PR DESCRIPTION
Added E2E tests for FURN Icon

### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
E2E tests for FURN Icon.
1st commit is a copy of existing Icon tests.
The following ones contain changes for better code readability

### Verification

### Pull request checklist

This PR has considered (when applicable):
- [X] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
