### PR TITLE
Clarify V2Usage on iOS

### DIFF
--- a/apps/fluent-tester/ios/Podfile.lock
+++ b/apps/fluent-tester/ios/Podfile.lock
@@ -10,7 +10,7 @@ PODS:
     - React-jsi (= 0.68.5)
     - ReactCommon/turbomodule/core (= 0.68.5)
   - fmt (6.2.1)
-  - FRNAvatar (0.16.26):
+  - FRNAvatar (0.16.30):
     - MicrosoftFluentUI (= 0.8.3)
     - React
   - FRNDatePicker (0.7.3):
@@ -459,7 +459,7 @@ PODS:
   - ReactTestApp-Resources (1.0.0-dev)
   - RNCPicker (2.4.8):
     - React-Core
-  - RNSVG (12.3.0):
+  - RNSVG (12.5.0):
     - React-Core
   - Yoga (1.14.0)
 
@@ -600,7 +600,7 @@ SPEC CHECKSUMS:
   FBLazyVector: 2b47ff52037bd9ae07cc9b051c9975797814b736
   FBReactNativeSpec: dd89c4a5591e20015aa55c6efbf9c7740a83efbf
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  FRNAvatar: b34747d6662c3c556970518a0f3d886eca2205b8
+  FRNAvatar: 8cad4f88070df56347a0e41dd812b2a7c1b6eb06
   FRNDatePicker: 241cd55b8d2b63d4427d782951f31504f09fbe1a
   FRNFontMetrics: c756b9bb1627909a7673b68caf7a7b14239c212e
   glog: 476ee3e89abb49e07f822b48323c51c57124b572
@@ -635,7 +635,7 @@ SPEC CHECKSUMS:
   ReactTestApp-DevSupport: 7ca8e4d798fce59f47adedd8f05a94d41d312921
   ReactTestApp-Resources: ecba662266ac5af3e30e1e3004c0fa8c0298b61a
   RNCPicker: 0bf8ef8f7800524f32d2bb2a8bcadd53eda0ecd1
-  RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8
+  RNSVG: 6adc5c52d2488a476248413064b7f2832e639057
   Yoga: c4d61225a466f250c35c1ee78d2d0b3d41fe661c
 
 PODFILE CHECKSUM: 819f14a4e3e6e335a0b1993fe37edad50db02d86

--- a/apps/fluent-tester/src/TestComponents/TextExperimental/TextExperimentalTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/TextExperimental/TextExperimentalTest.tsx
@@ -15,7 +15,7 @@ const textSections: TestSection[] = [
     component: StandardUsage,
   },
   {
-    name: 'V2/V1 Comparison',
+    name: 'V1/V2 Comparison',
     component: V2Usage,
   },
   {

--- a/apps/fluent-tester/src/TestComponents/TextExperimental/V2Usage.ios.tsx
+++ b/apps/fluent-tester/src/TestComponents/TextExperimental/V2Usage.ios.tsx
@@ -22,30 +22,30 @@ export const V2Usage: React.FunctionComponent = () => {
   return (
     <View>
       <Stack style={stackStyle} gap={5}>
-        <Caption2>Caption2</Caption2>
-        <TextV1 variant="caption2">Caption2</TextV1>
-        <Caption1>Caption1</Caption1>
-        <TextV1 variant="caption1">Caption1</TextV1>
-        <Caption1Strong>Caption1Strong</Caption1Strong>
-        <TextV1 variant="caption1Strong">Caption1Strong</TextV1>
-        <Body2>Body2</Body2>
-        <TextV1 variant="body2">Body2</TextV1>
-        <Body2Strong>Body2Strong</Body2Strong>
-        <TextV1 variant="body2Strong">Body2Strong</TextV1>
-        <Body1>Body1</Body1>
-        <TextV1 variant="body1">Body1</TextV1>
-        <Body1Strong>Body1Strong</Body1Strong>
-        <TextV1 variant="body1Strong">Body1Strong</TextV1>
-        <Title3>Title3</Title3>
-        <TextV1 variant="title3">Title3</TextV1>
-        <Title2>Title2</Title2>
-        <TextV1 variant="title2">Title2</TextV1>
-        <Title1>Title1</Title1>
-        <TextV1 variant="title1">Title1</TextV1>
-        <LargeTitle>LargeTitle</LargeTitle>
-        <TextV1 variant="largeTitle">LargeTitle</TextV1>
-        <Display>Display</Display>
-        <TextV1 variant="display">Display</TextV1>
+        <TextV1 variant="caption2">Caption2 v1</TextV1>
+        <Caption2>Caption2 v2</Caption2>
+        <TextV1 variant="caption1">Caption1 v1</TextV1>
+        <Caption1>Caption1 v2</Caption1>
+        <TextV1 variant="caption1Strong">Caption1Strong v1</TextV1>
+        <Caption1Strong>Caption1Strong v2</Caption1Strong>
+        <TextV1 variant="body2">Body2 v1</TextV1>
+        <Body2>Body2 v2</Body2>
+        <TextV1 variant="body2Strong">Body2Strong v1</TextV1>
+        <Body2Strong>Body2Strongv2 </Body2Strong>
+        <TextV1 variant="body1">Body1 v1</TextV1>
+        <Body1>Body1 v2</Body1>
+        <TextV1 variant="body1Strong">Body1Strong v1</TextV1>
+        <Body1Strong>Body1Strong v2</Body1Strong>
+        <TextV1 variant="title3">Title3 v1</TextV1>
+        <Title3>Title3 v2</Title3>
+        <TextV1 variant="title2">Title2 v1</TextV1>
+        <Title2>Title2 v2</Title2>
+        <TextV1 variant="title1">Title1 v1</TextV1>
+        <Title1>Title1 v2</Title1>
+        <TextV1 variant="largeTitle">LargeTitle v1</TextV1>
+        <LargeTitle>LargeTitle v2</LargeTitle>
+        <TextV1 variant="display">Display v1</TextV1>
+        <Display>Display v2</Display>
       </Stack>
     </View>
   );

--- a/change/@fluentui-react-native-tester-367fb49f-c6a6-4c16-a3c1-6f917965f8ec.json
+++ b/change/@fluentui-react-native-tester-367fb49f-c6a6-4c16-a3c1-6f917965f8ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Clarify V2Usage on iOS",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "adgleitm@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

A couple of slight improvements to the Text test page:
* Put V1 styles before V2 styles.
* List styles next to each V1/V2 comparison text element.

### Verification

![Simulator Screen Shot - iPhone 14 Pro - 2022-12-16 at 17 46 03](https://user-images.githubusercontent.com/717674/208217529-baab243b-a696-49db-bd5a-d595a5a74567.png)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
