### PR TITLE
Fork SubmenuItem pressable

### DIFF
--- a/change/@fluentui-react-native-contextual-menu-59d1d1ea-40db-437d-80ab-b615797ee124.json
+++ b/change/@fluentui-react-native-contextual-menu-59d1d1ea-40db-437d-80ab-b615797ee124.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fork SubmenuItem pressable",
+  "packageName": "@fluentui-react-native/contextual-menu",
+  "email": "amchiu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/ContextualMenu/src/SubmenuItem.tsx
+++ b/packages/components/ContextualMenu/src/SubmenuItem.tsx
@@ -1,6 +1,6 @@
 /** @jsx withSlots */
 import * as React from 'react';
-import { I18nManager, Platform, View } from 'react-native';
+import { I18nManager, Platform, Pressable, View } from 'react-native';
 import {
   SubmenuItemSlotProps,
   SubmenuItemState,
@@ -15,7 +15,7 @@ import { Text } from '@fluentui-react-native/text';
 import { settings } from './SubmenuItem.settings';
 import { backgroundColorTokens, borderTokens, textTokens, foregroundColorTokens, getPaletteFromTheme } from '@fluentui-react-native/tokens';
 import { mergeSettings } from '@uifabricshared/foundation-settings';
-import { useKeyDownProps, useViewCommandFocus, useAsPressable } from '@fluentui-react-native/interactive-hooks';
+import { useKeyDownProps, useViewCommandFocus, useAsPressable, usePressableState } from '@fluentui-react-native/interactive-hooks';
 import { CMContext } from './ContextualMenu';
 import { Icon, SvgIconProps, createIconProps } from '@fluentui-react-native/icon';
 import { Svg, G, Path, SvgProps } from 'react-native-svg';
@@ -63,13 +63,23 @@ export const SubmenuItem = compose<SubmenuItemType>({
       }
     }, [context, disabled, itemKey, onClick]);
 
-    const pressable = useAsPressable({
+    const pressableWin32 = usePressableState({
       ...rest,
       onPress: onItemPress,
       onHoverIn: onItemHoverIn,
       delayHoverIn: onHoverInDelay,
       onHoverOut: onItemHoverOut,
     });
+
+    const pressableMacOS = useAsPressable({
+      ...rest,
+      onPress: onItemPress,
+      onHoverIn: onItemHoverIn,
+      delayHoverIn: onHoverInDelay,
+      onHoverOut: onItemHoverOut,
+    });
+
+    const pressable = Platform.OS === 'macos' ? pressableMacOS : pressableWin32;
 
     /**
      * GH #1267
@@ -188,7 +198,7 @@ export const SubmenuItem = compose<SubmenuItemType>({
     );
   },
   slots: {
-    root: View,
+    root: Platform.OS === 'macos' ? View : Pressable,
     startstack: View,
     icon: Icon as React.ComponentType,
     content: Text,

--- a/packages/components/ContextualMenu/src/SubmenuItem.types.macos.ts
+++ b/packages/components/ContextualMenu/src/SubmenuItem.types.macos.ts
@@ -4,7 +4,6 @@ import { IRenderData } from '@uifabricshared/foundation-composable';
 import { ITextProps } from '@fluentui-react-native/text';
 import { ContextualMenuItemProps, ContextualMenuItemTokens, ContextualMenuItemState } from './ContextualMenuItem.types';
 import { IconProps } from '@fluentui-react-native/icon';
-import { PressablePropsExtended } from '@fluentui-react-native/interactive-hooks';
 
 export const submenuItemName = 'SubmenuItem';
 export interface SubmenuItemTokens extends ContextualMenuItemTokens {
@@ -15,7 +14,7 @@ export type SubmenuItemProps = ContextualMenuItemProps;
 export type SubmenuItemState = ContextualMenuItemState;
 
 export interface SubmenuItemSlotProps {
-  root: React.PropsWithRef<PressablePropsExtended>;
+  root: React.PropsWithRef<IViewProps>;
   startstack: IViewProps;
   icon: IconProps;
   content: ITextProps;


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS
- [X] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

PR #2403 reverted SubmenuItem pressable to useAsPressable, which caused a regression on Win32 where submenu doesn't open on mouse click. Note that this regression does not repro in FluentTester but only in our client app. Since the intent of the initial fix was to address a bug on macOS, let's fork the SubmenuItem pressable code to mitigate the regression.
### Verification

No behavioral changes on CM.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
