### PR TITLE
Link fix keyboarding

### DIFF
--- a/change/@fluentui-react-native-experimental-link-4e33e7a3-e419-4956-978f-aabd5f07da03.json
+++ b/change/@fluentui-react-native-experimental-link-4e33e7a3-e419-4956-978f-aabd5f07da03.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix Link space/enter keyboarding",
+  "packageName": "@fluentui-react-native/experimental-link",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Link/src/useLink.ts
+++ b/packages/experimental/Link/src/useLink.ts
@@ -9,6 +9,22 @@ import {
 import { LinkProps, LinkInfo } from './Link.types';
 import { Linking, Platform } from 'react-native';
 
+/*These callbacks are not implemented on iOS/macOS, and cause Redboxes if passed in. Limit to only windows/win32 for now*/
+const isWinPlatform = Platform.OS === (('win32' as any) || 'windows');
+const filteredProps = isWinPlatform
+  ? {}
+  : {
+      onKeyUp: undefined,
+      keyUpEvents: undefined,
+      validKeysUp: undefined,
+      onKeyDown: undefined,
+      keyDownEvents: undefined,
+      validKeysDown: undefined,
+      onMouseEnter: undefined,
+      onMouseLeave: undefined,
+      onAccessibilityTap: undefined,
+    };
+
 export const useLink = (props: LinkProps): LinkInfo => {
   const defaultComponentRef = React.useRef(null);
   const {
@@ -64,20 +80,6 @@ export const useLink = (props: LinkProps): LinkInfo => {
 
   const linkTooltip = tooltip ?? url ?? undefined;
 
-  /*These callbacks are not implemented on iOS/macOS, and cause Redboxes if passed in. Limit to only windows/win32 for now*/
-  const isWinPlatform = Platform.OS === (('win32' as any) || 'windows');
-  const filteredProps = {
-    onKeyUp: isWinPlatform ? onKeyUp : undefined,
-    keyUpEvents: isWinPlatform ? keyUpEvents : undefined,
-    validKeysUp: undefined,
-    onKeyDown: isWinPlatform ? onKeyDown : undefined,
-    keyDownEvents: isWinPlatform ? keyDownEvents : undefined,
-    validKeysDown: undefined,
-    onMouseEnter: isWinPlatform ? pressable.props.onMouseEnter : undefined,
-    onMouseLeave: isWinPlatform ? pressable.props.onMouseLeave : undefined,
-    onAccessibilityTap: isWinPlatform ? onAccTap : undefined,
-  };
-
   let inline = props.inline;
   const supportsInlineLinks = Platform.OS !== ('win32' as any);
   if (inline && !supportsInlineLinks) {
@@ -96,6 +98,7 @@ export const useLink = (props: LinkProps): LinkInfo => {
       ...rest,
       ...onKeyUpProps,
       ...pressable.props, // allow user key events to override those set by us
+      onAccessibilityTap: onAccTap, // Place here so it can be overridden by filteredProps if needed
       ...filteredProps,
       accessible: accessible,
       accessibilityRole: 'link',


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Link Keyboarding (invoking Link via space/keyboard) was broken, fixing by simplifying and moving filter.

### Verification

Using Tester to test out keyboarding.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
