### PR TITLE
[Switch] Documentation and tester update for switch on Android

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Switch/SwitchTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Switch/SwitchTest.tsx
@@ -125,10 +125,13 @@ const toggleSections: TestSection[] = [
       component: () => <OnOffText />,
     },
   }),
-  {
-    name: 'Customized Tokens',
-    component: () => <CustomizedSwitch />,
-  },
+  Platform.select({
+    android: null,
+    default: {
+      name: 'Customized Tokens',
+      component: () => <CustomizedSwitch />,
+    },
+  }),
   {
     name: 'Switch E2E Testing',
     component: () => <E2ESwitchTest />,

--- a/apps/fluent-tester/src/TestComponents/Switch/index.ts
+++ b/apps/fluent-tester/src/TestComponents/Switch/index.ts
@@ -1,2 +1,2 @@
-export * from './Switch';
+export * from './SwitchTest';
 export * from './consts';

--- a/change/@fluentui-react-native-switch-012238f0-f27c-4ecd-9cc2-afc6deaeb91d.json
+++ b/change/@fluentui-react-native-switch-012238f0-f27c-4ecd-9cc2-afc6deaeb91d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "doc update for switch - android",
+  "packageName": "@fluentui-react-native/switch",
+  "email": "rohanpd.work@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-213d33a0-c09b-4761-b66e-f65a9aba9bc6.json
+++ b/change/@fluentui-react-native-tester-213d33a0-c09b-4761-b66e-f65a9aba9bc6.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "doc update for switch - android",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "rohanpd.work@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Switch/SPEC.md
+++ b/packages/experimental/Switch/SPEC.md
@@ -79,11 +79,13 @@ export interface SwitchProps extends Omit<PressablePropsExtended 'onPress'> {
 
   /**
    * The Switch's text that shows when it is in a false state
+   * Note: Not supported for Android
    */
   offText?: string;
 
   /**
    * The Switch's text that shows when it is in a true state
+   * Note: Not supported for Android
    */
   onText?: string;
 
@@ -91,7 +93,7 @@ export interface SwitchProps extends Omit<PressablePropsExtended 'onPress'> {
    * Sets the position of the Switch's label. The position value 'after' is mutually
    * exclusive with the onText and offText props. This is due to variable width
    * of the text props causing the Switch's position to change when it shouldn't.
-   * For Android : 'above' is not supported
+   * Note : 'before' , 'above' are not supported on Android
    */
   labelPosition?: 'before' | 'above' | 'after';
 }
@@ -205,6 +207,7 @@ export interface SwitchTokens extends LayoutTokens, FontTokens, IBorderTokens, I
 
   /**
    * States that can be applied to a switch
+   * Note: 'hovered','focused','before','beforeContent','above' are not supported for Android
    */
   hovered?: SwitchTokens;
   focused?: SwitchTokens;

--- a/packages/experimental/Switch/src/Switch.types.ts
+++ b/packages/experimental/Switch/src/Switch.types.ts
@@ -170,7 +170,7 @@ export interface SwitchProps extends Omit<PressablePropsExtended, 'onPress'> {
    * The position of the label relative to the Switch. The position value 'after' is mutually
    * exclusive with the onText and offText props. This is due to variable width
    * of the text props causing the Switch's position to change when it shouldn't.
-   * Note : 'before' , 'above' are not supported on Android
+   * Note :'before', 'above' are not supported on Android
    */
   labelPosition?: 'before' | 'above' | 'after';
 }

--- a/packages/experimental/Switch/src/Switch.types.ts
+++ b/packages/experimental/Switch/src/Switch.types.ts
@@ -110,6 +110,7 @@ export interface SwitchTokens extends LayoutTokens, FontTokens, IBorderTokens, I
 
   /**
    * States that can be applied to a switch
+   * Note: 'hovered','focused','before','beforeContent','above' are not supported for Android
    */
   hovered?: SwitchTokens;
   focused?: SwitchTokens;
@@ -155,11 +156,13 @@ export interface SwitchProps extends Omit<PressablePropsExtended, 'onPress'> {
 
   /**
    * The Switch's text that shows when it is in a false state
+   * Note: Not supported for Android
    */
   offText?: string;
 
   /**
    * The Switch's text that shows when it is in a true state
+   * Note: Not supported for Android
    */
   onText?: string;
 
@@ -167,6 +170,7 @@ export interface SwitchProps extends Omit<PressablePropsExtended, 'onPress'> {
    * The position of the label relative to the Switch. The position value 'after' is mutually
    * exclusive with the onText and offText props. This is due to variable width
    * of the text props causing the Switch's position to change when it shouldn't.
+   * Note : 'before' , 'above' are not supported on Android
    */
   labelPosition?: 'before' | 'above' | 'after';
 }


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [x] android

### Description of changes

Updates the documentation and tester app for Link for android.



### Verification

Visual Verification on Android



### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
