### PR TITLE
Fix notification button padding

### DIFF
--- a/change/@fluentui-react-native-notification-0ed79820-8573-4b3b-b879-2c8af643aa1c.json
+++ b/change/@fluentui-react-native-notification-0ed79820-8573-4b3b-b879-2c8af643aa1c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix notification button padding",
+  "packageName": "@fluentui-react-native/notification",
+  "email": "adgleitm@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Notification/src/Notification.helper.tsx
+++ b/packages/components/Notification/src/Notification.helper.tsx
@@ -3,6 +3,7 @@ import Svg, { G, Path, SvgProps } from 'react-native-svg';
 import { ButtonProps, ButtonTokens, ButtonV1 as Button } from '@fluentui-react-native/button';
 import { mergeProps, stagedComponent } from '@fluentui-react-native/framework';
 import { SvgIconProps, createIconProps } from '@fluentui-react-native/icon';
+import { globalTokens } from '@fluentui-react-native/theme-tokens';
 import { NotificationProps } from './Notification.types';
 
 export type NotificationButtonColorStates = { disabledColor; pressedColor };
@@ -73,8 +74,8 @@ export const NotificationButton = stagedComponent((props: NotificationButtonProp
     medium: {
       hasContent: {
         minWidth: 0,
-        padding: 0,
-        paddingHorizontal: 0,
+        padding: globalTokens.sizeNone,
+        paddingHorizontal: globalTokens.sizeNone,
       },
     },
   });

--- a/packages/components/Notification/src/Notification.helper.tsx
+++ b/packages/components/Notification/src/Notification.helper.tsx
@@ -70,6 +70,13 @@ export const NotificationButton = stagedComponent((props: NotificationButtonProp
         color: props.pressedColor,
       },
     },
+    medium: {
+      hasContent: {
+        minWidth: 0,
+        padding: 0,
+        paddingHorizontal: 0,
+      },
+    },
   });
 
   return (final: NotificationButtonProps, children: React.ReactNode) => {

--- a/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
+++ b/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
@@ -196,9 +196,9 @@ exports[`Notification component tests Notification default 1`] = `
           "flexDirection": "row",
           "justifyContent": "center",
           "marginStart": 16,
-          "minWidth": 96,
-          "padding": 8,
-          "paddingHorizontal": 15,
+          "minWidth": 0,
+          "padding": 0,
+          "paddingHorizontal": 0,
         }
       }
     >


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

0fc0e5ba35779665a6289e58cc364bb5607b61d9 introduced a bug in Notification where the padding on the leading and trailing sides do not appear equal. The ultimate cause of this is that the action button (which is on the trailing side) is being rendered with a minimum width that still comes from [a state-specific style as specified in ButtonTokens.ts](https://github.com/microsoft/fluentui-react-native/blob/5ff648ec406eb97866c0b29c35dcc67cd7f19375/packages/components/Button/src/ButtonTokens.ts#L20).

In order to properly override this as before, we have to specify the relevant overrides in that same state.

### Verification

The relevant areas of the buttons (which have been modified to have a `backgroundColor` of `'pink'`) are shown below, and they've been confirmed to be the same as in 526f2ed74a3c60406265f40e40e9b93e4e9cbfe6, the commit immediately before the one that introduced the bug.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 14 Pro - 2022-12-21 at 16 24 00](https://user-images.githubusercontent.com/717674/209030780-1fbecbba-0860-48c5-9356-4c235602064a.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-12-21 at 16 23 35](https://user-images.githubusercontent.com/717674/209030703-6b426d6e-3f2c-4f5c-b625-f4acf15dac2f.png) |
| ![Simulator Screen Shot - iPhone 14 Pro - 2022-12-21 at 16 23 57](https://user-images.githubusercontent.com/717674/209030726-48303afe-1467-4c98-809a-73a4bd4dcb50.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-12-21 at 16 23 42](https://user-images.githubusercontent.com/717674/209030846-18a3e268-ee52-4219-8ce3-39b398a27ebb.png) |
