### PR TITLE
Update Fluent UI Apple to version 0.10.0

### DIFF
--- a/apps/fluent-tester/ios/Podfile.lock
+++ b/apps/fluent-tester/ios/Podfile.lock
@@ -10,86 +10,87 @@ PODS:
     - React-jsi (= 0.68.5)
     - ReactCommon/turbomodule/core (= 0.68.5)
   - fmt (6.2.1)
-  - FRNAvatar (0.16.26):
-    - MicrosoftFluentUI (= 0.8.3)
+  - FRNAvatar (0.16.30):
+    - MicrosoftFluentUI (= 0.10.0)
     - React
   - FRNDatePicker (0.7.3):
-    - MicrosoftFluentUI (= 0.8.3)
+    - MicrosoftFluentUI (= 0.10.0)
     - React
   - FRNFontMetrics (0.3.0):
     - React
   - glog (0.3.5)
-  - MicrosoftFluentUI (0.8.3):
-    - MicrosoftFluentUI/ActivityIndicator_ios (= 0.8.3)
-    - MicrosoftFluentUI/Appearance_mac (= 0.8.3)
-    - MicrosoftFluentUI/Avatar_ios (= 0.8.3)
-    - MicrosoftFluentUI/AvatarGroup_ios (= 0.8.3)
-    - MicrosoftFluentUI/AvatarView_mac (= 0.8.3)
-    - MicrosoftFluentUI/BadgeField_ios (= 0.8.3)
-    - MicrosoftFluentUI/BadgeView_mac (= 0.8.3)
-    - MicrosoftFluentUI/BarButtonItems_ios (= 0.8.3)
-    - MicrosoftFluentUI/BottomCommanding_ios (= 0.8.3)
-    - MicrosoftFluentUI/BottomSheet_ios (= 0.8.3)
-    - MicrosoftFluentUI/Button_ios (= 0.8.3)
-    - MicrosoftFluentUI/Button_mac (= 0.8.3)
-    - MicrosoftFluentUI/Calendar_ios (= 0.8.3)
-    - MicrosoftFluentUI/Card_ios (= 0.8.3)
-    - MicrosoftFluentUI/CardNudge_ios (= 0.8.3)
-    - MicrosoftFluentUI/CommandBar_ios (= 0.8.3)
-    - MicrosoftFluentUI/Core_ios (= 0.8.3)
-    - MicrosoftFluentUI/Core_mac (= 0.8.3)
-    - MicrosoftFluentUI/DatePicker_mac (= 0.8.3)
-    - MicrosoftFluentUI/DotView_ios (= 0.8.3)
-    - MicrosoftFluentUI/Drawer_ios (= 0.8.3)
-    - MicrosoftFluentUI/DynamicColor_mac (= 0.8.3)
-    - MicrosoftFluentUI/EasyTapButton_ios (= 0.8.3)
-    - MicrosoftFluentUI/HUD_ios (= 0.8.3)
-    - MicrosoftFluentUI/IndeterminateProgressBar_ios (= 0.8.3)
-    - MicrosoftFluentUI/Label_ios (= 0.8.3)
-    - MicrosoftFluentUI/Link_mac (= 0.8.3)
-    - MicrosoftFluentUI/Navigation_ios (= 0.8.3)
-    - MicrosoftFluentUI/Notification_ios (= 0.8.3)
-    - MicrosoftFluentUI/Obscurable_ios (= 0.8.3)
-    - MicrosoftFluentUI/OtherCells_ios (= 0.8.3)
-    - MicrosoftFluentUI/PeoplePicker_ios (= 0.8.3)
-    - MicrosoftFluentUI/PersonaButton_ios (= 0.8.3)
-    - MicrosoftFluentUI/PersonaButtonCarousel_ios (= 0.8.3)
-    - MicrosoftFluentUI/PillButtonBar_ios (= 0.8.3)
-    - MicrosoftFluentUI/PopupMenu_ios (= 0.8.3)
-    - MicrosoftFluentUI/Presenters_ios (= 0.8.3)
-    - MicrosoftFluentUI/ResizingHandleView_ios (= 0.8.3)
-    - MicrosoftFluentUI/SegmentedControl_ios (= 0.8.3)
-    - MicrosoftFluentUI/Separator_ios (= 0.8.3)
-    - MicrosoftFluentUI/Separator_mac (= 0.8.3)
-    - MicrosoftFluentUI/Shimmer_ios (= 0.8.3)
-    - MicrosoftFluentUI/TabBar_ios (= 0.8.3)
-    - MicrosoftFluentUI/TableView_ios (= 0.8.3)
-    - MicrosoftFluentUI/Tooltip_ios (= 0.8.3)
-    - MicrosoftFluentUI/TouchForwardingView_ios (= 0.8.3)
-    - MicrosoftFluentUI/TwoLineTitleView_ios (= 0.8.3)
-    - MicrosoftFluentUI/Utilities_ios (= 0.8.3)
-  - MicrosoftFluentUI/ActivityIndicator_ios (0.8.3):
+  - MicrosoftFluentUI (0.10.0):
+    - MicrosoftFluentUI/ActivityIndicator_ios (= 0.10.0)
+    - MicrosoftFluentUI/Appearance_mac (= 0.10.0)
+    - MicrosoftFluentUI/Avatar_ios (= 0.10.0)
+    - MicrosoftFluentUI/AvatarGroup_ios (= 0.10.0)
+    - MicrosoftFluentUI/AvatarView_mac (= 0.10.0)
+    - MicrosoftFluentUI/BadgeField_ios (= 0.10.0)
+    - MicrosoftFluentUI/BadgeView_mac (= 0.10.0)
+    - MicrosoftFluentUI/BarButtonItems_ios (= 0.10.0)
+    - MicrosoftFluentUI/BottomCommanding_ios (= 0.10.0)
+    - MicrosoftFluentUI/BottomSheet_ios (= 0.10.0)
+    - MicrosoftFluentUI/Button_ios (= 0.10.0)
+    - MicrosoftFluentUI/Button_mac (= 0.10.0)
+    - MicrosoftFluentUI/Calendar_ios (= 0.10.0)
+    - MicrosoftFluentUI/Card_ios (= 0.10.0)
+    - MicrosoftFluentUI/CardNudge_ios (= 0.10.0)
+    - MicrosoftFluentUI/CommandBar_ios (= 0.10.0)
+    - MicrosoftFluentUI/Core_ios (= 0.10.0)
+    - MicrosoftFluentUI/Core_mac (= 0.10.0)
+    - MicrosoftFluentUI/DatePicker_mac (= 0.10.0)
+    - MicrosoftFluentUI/Divider_ios (= 0.10.0)
+    - MicrosoftFluentUI/DotView_ios (= 0.10.0)
+    - MicrosoftFluentUI/Drawer_ios (= 0.10.0)
+    - MicrosoftFluentUI/DynamicColor_mac (= 0.10.0)
+    - MicrosoftFluentUI/EasyTapButton_ios (= 0.10.0)
+    - MicrosoftFluentUI/HUD_ios (= 0.10.0)
+    - MicrosoftFluentUI/IndeterminateProgressBar_ios (= 0.10.0)
+    - MicrosoftFluentUI/Label_ios (= 0.10.0)
+    - MicrosoftFluentUI/Link_mac (= 0.10.0)
+    - MicrosoftFluentUI/Navigation_ios (= 0.10.0)
+    - MicrosoftFluentUI/Notification_ios (= 0.10.0)
+    - MicrosoftFluentUI/Obscurable_ios (= 0.10.0)
+    - MicrosoftFluentUI/OtherCells_ios (= 0.10.0)
+    - MicrosoftFluentUI/PeoplePicker_ios (= 0.10.0)
+    - MicrosoftFluentUI/PersonaButton_ios (= 0.10.0)
+    - MicrosoftFluentUI/PersonaButtonCarousel_ios (= 0.10.0)
+    - MicrosoftFluentUI/PillButtonBar_ios (= 0.10.0)
+    - MicrosoftFluentUI/PopupMenu_ios (= 0.10.0)
+    - MicrosoftFluentUI/Presenters_ios (= 0.10.0)
+    - MicrosoftFluentUI/ResizingHandleView_ios (= 0.10.0)
+    - MicrosoftFluentUI/SegmentedControl_ios (= 0.10.0)
+    - MicrosoftFluentUI/Separator_ios (= 0.10.0)
+    - MicrosoftFluentUI/Separator_mac (= 0.10.0)
+    - MicrosoftFluentUI/Shimmer_ios (= 0.10.0)
+    - MicrosoftFluentUI/TabBar_ios (= 0.10.0)
+    - MicrosoftFluentUI/TableView_ios (= 0.10.0)
+    - MicrosoftFluentUI/Tooltip_ios (= 0.10.0)
+    - MicrosoftFluentUI/TouchForwardingView_ios (= 0.10.0)
+    - MicrosoftFluentUI/TwoLineTitleView_ios (= 0.10.0)
+    - MicrosoftFluentUI/Utilities_ios (= 0.10.0)
+  - MicrosoftFluentUI/ActivityIndicator_ios (0.10.0):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/Avatar_ios (0.8.3):
+  - MicrosoftFluentUI/Avatar_ios (0.10.0):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/AvatarGroup_ios (0.8.3):
+  - MicrosoftFluentUI/AvatarGroup_ios (0.10.0):
     - MicrosoftFluentUI/Avatar_ios
-  - MicrosoftFluentUI/BadgeField_ios (0.8.3):
+  - MicrosoftFluentUI/BadgeField_ios (0.10.0):
     - MicrosoftFluentUI/Label_ios
-  - MicrosoftFluentUI/BarButtonItems_ios (0.8.3):
+  - MicrosoftFluentUI/BarButtonItems_ios (0.10.0):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/BottomCommanding_ios (0.8.3):
+  - MicrosoftFluentUI/BottomCommanding_ios (0.10.0):
     - MicrosoftFluentUI/BottomSheet_ios
     - MicrosoftFluentUI/OtherCells_ios
     - MicrosoftFluentUI/Separator_ios
     - MicrosoftFluentUI/TabBar_ios
     - MicrosoftFluentUI/TableView_ios
-  - MicrosoftFluentUI/BottomSheet_ios (0.8.3):
+  - MicrosoftFluentUI/BottomSheet_ios (0.10.0):
     - MicrosoftFluentUI/Obscurable_ios
     - MicrosoftFluentUI/ResizingHandleView_ios
-  - MicrosoftFluentUI/Button_ios (0.8.3):
+  - MicrosoftFluentUI/Button_ios (0.10.0):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/Calendar_ios (0.8.3):
+  - MicrosoftFluentUI/Calendar_ios (0.10.0):
     - MicrosoftFluentUI/BarButtonItems_ios
     - MicrosoftFluentUI/DotView_ios
     - MicrosoftFluentUI/Label_ios
@@ -97,86 +98,88 @@ PODS:
     - MicrosoftFluentUI/SegmentedControl_ios
     - MicrosoftFluentUI/Separator_ios
     - MicrosoftFluentUI/TwoLineTitleView_ios
-  - MicrosoftFluentUI/Card_ios (0.8.3):
+  - MicrosoftFluentUI/Card_ios (0.10.0):
     - MicrosoftFluentUI/Label_ios
-  - MicrosoftFluentUI/CardNudge_ios (0.8.3):
+  - MicrosoftFluentUI/CardNudge_ios (0.10.0):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/CommandBar_ios (0.8.3):
+  - MicrosoftFluentUI/CommandBar_ios (0.10.0):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/Core_ios (0.8.3)
-  - MicrosoftFluentUI/DotView_ios (0.8.3):
+  - MicrosoftFluentUI/Core_ios (0.10.0)
+  - MicrosoftFluentUI/Divider_ios (0.10.0):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/Drawer_ios (0.8.3):
+  - MicrosoftFluentUI/DotView_ios (0.10.0):
+    - MicrosoftFluentUI/Core_ios
+  - MicrosoftFluentUI/Drawer_ios (0.10.0):
     - MicrosoftFluentUI/Obscurable_ios
     - MicrosoftFluentUI/ResizingHandleView_ios
     - MicrosoftFluentUI/Separator_ios
     - MicrosoftFluentUI/TouchForwardingView_ios
-  - MicrosoftFluentUI/EasyTapButton_ios (0.8.3):
+  - MicrosoftFluentUI/EasyTapButton_ios (0.10.0):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/HUD_ios (0.8.3):
+  - MicrosoftFluentUI/HUD_ios (0.10.0):
     - MicrosoftFluentUI/ActivityIndicator_ios
     - MicrosoftFluentUI/Label_ios
     - MicrosoftFluentUI/TouchForwardingView_ios
-  - MicrosoftFluentUI/IndeterminateProgressBar_ios (0.8.3):
+  - MicrosoftFluentUI/IndeterminateProgressBar_ios (0.10.0):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/Label_ios (0.8.3):
+  - MicrosoftFluentUI/Label_ios (0.10.0):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/Navigation_ios (0.8.3):
+  - MicrosoftFluentUI/Navigation_ios (0.10.0):
     - MicrosoftFluentUI/ActivityIndicator_ios
     - MicrosoftFluentUI/Avatar_ios
     - MicrosoftFluentUI/Separator_ios
     - MicrosoftFluentUI/TwoLineTitleView_ios
-  - MicrosoftFluentUI/Notification_ios (0.8.3):
+  - MicrosoftFluentUI/Notification_ios (0.10.0):
     - MicrosoftFluentUI/Label_ios
     - MicrosoftFluentUI/Obscurable_ios
-  - MicrosoftFluentUI/Obscurable_ios (0.8.3):
+  - MicrosoftFluentUI/Obscurable_ios (0.10.0):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/OtherCells_ios (0.8.3):
+  - MicrosoftFluentUI/OtherCells_ios (0.10.0):
     - MicrosoftFluentUI/ActivityIndicator_ios
     - MicrosoftFluentUI/TableView_ios
-  - MicrosoftFluentUI/PeoplePicker_ios (0.8.3):
+  - MicrosoftFluentUI/PeoplePicker_ios (0.10.0):
     - MicrosoftFluentUI/Avatar_ios
     - MicrosoftFluentUI/BadgeField_ios
     - MicrosoftFluentUI/OtherCells_ios
     - MicrosoftFluentUI/Separator_ios
-  - MicrosoftFluentUI/PersonaButton_ios (0.8.3):
+  - MicrosoftFluentUI/PersonaButton_ios (0.10.0):
     - MicrosoftFluentUI/Avatar_ios
-  - MicrosoftFluentUI/PersonaButtonCarousel_ios (0.8.3):
+  - MicrosoftFluentUI/PersonaButtonCarousel_ios (0.10.0):
     - MicrosoftFluentUI/PersonaButton_ios
-  - MicrosoftFluentUI/PillButtonBar_ios (0.8.3):
+  - MicrosoftFluentUI/PillButtonBar_ios (0.10.0):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/PopupMenu_ios (0.8.3):
+  - MicrosoftFluentUI/PopupMenu_ios (0.10.0):
     - MicrosoftFluentUI/Drawer_ios
     - MicrosoftFluentUI/Label_ios
     - MicrosoftFluentUI/Separator_ios
     - MicrosoftFluentUI/TableView_ios
-  - MicrosoftFluentUI/Presenters_ios (0.8.3):
+  - MicrosoftFluentUI/Presenters_ios (0.10.0):
     - MicrosoftFluentUI/Obscurable_ios
-  - MicrosoftFluentUI/ResizingHandleView_ios (0.8.3):
+  - MicrosoftFluentUI/ResizingHandleView_ios (0.10.0):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/SegmentedControl_ios (0.8.3):
+  - MicrosoftFluentUI/SegmentedControl_ios (0.10.0):
     - MicrosoftFluentUI/Separator_ios
-  - MicrosoftFluentUI/Separator_ios (0.8.3):
+  - MicrosoftFluentUI/Separator_ios (0.10.0):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/Shimmer_ios (0.8.3):
+  - MicrosoftFluentUI/Shimmer_ios (0.10.0):
     - MicrosoftFluentUI/Core_ios
     - MicrosoftFluentUI/Utilities_ios
-  - MicrosoftFluentUI/TabBar_ios (0.8.3):
+  - MicrosoftFluentUI/TabBar_ios (0.10.0):
     - MicrosoftFluentUI/Avatar_ios
     - MicrosoftFluentUI/Label_ios
     - MicrosoftFluentUI/Separator_ios
-  - MicrosoftFluentUI/TableView_ios (0.8.3):
+  - MicrosoftFluentUI/TableView_ios (0.10.0):
     - MicrosoftFluentUI/Label_ios
     - MicrosoftFluentUI/Separator_ios
-  - MicrosoftFluentUI/Tooltip_ios (0.8.3):
+  - MicrosoftFluentUI/Tooltip_ios (0.10.0):
     - MicrosoftFluentUI/Label_ios
     - MicrosoftFluentUI/TouchForwardingView_ios
-  - MicrosoftFluentUI/TouchForwardingView_ios (0.8.3):
+  - MicrosoftFluentUI/TouchForwardingView_ios (0.10.0):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/TwoLineTitleView_ios (0.8.3):
+  - MicrosoftFluentUI/TwoLineTitleView_ios (0.10.0):
     - MicrosoftFluentUI/EasyTapButton_ios
     - MicrosoftFluentUI/Label_ios
-  - MicrosoftFluentUI/Utilities_ios (0.8.3)
+  - MicrosoftFluentUI/Utilities_ios (0.10.0)
   - RCT-Folly (2021.06.28.00-v2):
     - boost
     - DoubleConversion
@@ -386,7 +389,7 @@ PODS:
     - glog
   - react-native-menu (0.1.2):
     - React
-  - react-native-slider (4.3.3):
+  - react-native-slider (4.4.0):
     - React-Core
   - React-perflogger (0.68.5)
   - React-RCTActionSheet (0.68.5):
@@ -459,7 +462,7 @@ PODS:
   - ReactTestApp-Resources (1.0.0-dev)
   - RNCPicker (2.4.8):
     - React-Core
-  - RNSVG (12.3.0):
+  - RNSVG (12.5.0):
     - React-Core
   - Yoga (1.14.0)
 
@@ -600,11 +603,11 @@ SPEC CHECKSUMS:
   FBLazyVector: 2b47ff52037bd9ae07cc9b051c9975797814b736
   FBReactNativeSpec: dd89c4a5591e20015aa55c6efbf9c7740a83efbf
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  FRNAvatar: b34747d6662c3c556970518a0f3d886eca2205b8
-  FRNDatePicker: 241cd55b8d2b63d4427d782951f31504f09fbe1a
+  FRNAvatar: b57500ffd4955a077c6318e7485de44f4a663042
+  FRNDatePicker: 898a7629602571ab16ba018407397608874bca2e
   FRNFontMetrics: c756b9bb1627909a7673b68caf7a7b14239c212e
   glog: 476ee3e89abb49e07f822b48323c51c57124b572
-  MicrosoftFluentUI: e30487dd18aba04beeed4caf1ce1988073f8b03a
+  MicrosoftFluentUI: f6db695718efb93f4ca9bdc366c00b80a1f91dba
   RCT-Folly: 4d8508a426467c48885f1151029bc15fa5d7b3b8
   RCTRequired: 0f06b6068f530932d10e1a01a5352fad4eaacb74
   RCTTypeSafety: b0ee81f10ef1b7d977605a2b266823dabd565e65
@@ -619,7 +622,7 @@ SPEC CHECKSUMS:
   React-jsinspector: eb202e43b3879aba9a14f3f65788aec85d4e1ea9
   React-logger: 98f663b292a60967ebbc6d803ae96c1381183b6d
   react-native-menu: 9fe07f72e075b250295eeae25425490cc9608951
-  react-native-slider: 7d19220da2f2ae7cbb9aa80127cb73c597fa221f
+  react-native-slider: d2938a12c4e439a227c70eec65d119136eb4aeb5
   React-perflogger: 0458a87ea9a7342079e7a31b0d32b3734fb8415f
   React-RCTActionSheet: 22538001ea2926dea001111dd2846c13a0730bc9
   React-RCTAnimation: 732ce66878d4aa151d56a0d142b1105aa12fd313
@@ -635,7 +638,7 @@ SPEC CHECKSUMS:
   ReactTestApp-DevSupport: 7ca8e4d798fce59f47adedd8f05a94d41d312921
   ReactTestApp-Resources: ecba662266ac5af3e30e1e3004c0fa8c0298b61a
   RNCPicker: 0bf8ef8f7800524f32d2bb2a8bcadd53eda0ecd1
-  RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8
+  RNSVG: 6adc5c52d2488a476248413064b7f2832e639057
   Yoga: c4d61225a466f250c35c1ee78d2d0b3d41fe661c
 
 PODFILE CHECKSUM: 819f14a4e3e6e335a0b1993fe37edad50db02d86

--- a/apps/fluent-tester/macos/Podfile.lock
+++ b/apps/fluent-tester/macos/Podfile.lock
@@ -1,94 +1,95 @@
 PODS:
   - boost (1.76.0)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.68.58)
-  - FBReactNativeSpec (0.68.58):
+  - FBLazyVector (0.68.59)
+  - FBReactNativeSpec (0.68.59):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.58)
-    - RCTTypeSafety (= 0.68.58)
-    - React-Core (= 0.68.58)
-    - React-jsi (= 0.68.58)
-    - ReactCommon/turbomodule/core (= 0.68.58)
+    - RCTRequired (= 0.68.59)
+    - RCTTypeSafety (= 0.68.59)
+    - React-Core (= 0.68.59)
+    - React-jsi (= 0.68.59)
+    - ReactCommon/turbomodule/core (= 0.68.59)
   - fmt (6.2.1)
-  - FRNAvatar (0.16.23):
-    - MicrosoftFluentUI (= 0.8.3)
+  - FRNAvatar (0.16.30):
+    - MicrosoftFluentUI (= 0.10.0)
     - React
-  - FRNCallout (0.21.34):
+  - FRNCallout (0.21.43):
     - React
-  - FRNCheckbox (0.13.2):
+  - FRNCheckbox (0.13.14):
     - React
-  - FRNMenuButton (0.8.67):
+  - FRNMenuButton (0.10.4):
     - React
-  - FRNRadioButton (0.16.4):
+  - FRNRadioButton (0.16.14):
     - React
   - glog (0.3.5)
-  - MicrosoftFluentUI (0.8.3):
-    - MicrosoftFluentUI/ActivityIndicator_ios (= 0.8.3)
-    - MicrosoftFluentUI/Appearance_mac (= 0.8.3)
-    - MicrosoftFluentUI/Avatar_ios (= 0.8.3)
-    - MicrosoftFluentUI/AvatarGroup_ios (= 0.8.3)
-    - MicrosoftFluentUI/AvatarView_mac (= 0.8.3)
-    - MicrosoftFluentUI/BadgeField_ios (= 0.8.3)
-    - MicrosoftFluentUI/BadgeView_mac (= 0.8.3)
-    - MicrosoftFluentUI/BarButtonItems_ios (= 0.8.3)
-    - MicrosoftFluentUI/BottomCommanding_ios (= 0.8.3)
-    - MicrosoftFluentUI/BottomSheet_ios (= 0.8.3)
-    - MicrosoftFluentUI/Button_ios (= 0.8.3)
-    - MicrosoftFluentUI/Button_mac (= 0.8.3)
-    - MicrosoftFluentUI/Calendar_ios (= 0.8.3)
-    - MicrosoftFluentUI/Card_ios (= 0.8.3)
-    - MicrosoftFluentUI/CardNudge_ios (= 0.8.3)
-    - MicrosoftFluentUI/CommandBar_ios (= 0.8.3)
-    - MicrosoftFluentUI/Core_ios (= 0.8.3)
-    - MicrosoftFluentUI/Core_mac (= 0.8.3)
-    - MicrosoftFluentUI/DatePicker_mac (= 0.8.3)
-    - MicrosoftFluentUI/DotView_ios (= 0.8.3)
-    - MicrosoftFluentUI/Drawer_ios (= 0.8.3)
-    - MicrosoftFluentUI/DynamicColor_mac (= 0.8.3)
-    - MicrosoftFluentUI/EasyTapButton_ios (= 0.8.3)
-    - MicrosoftFluentUI/HUD_ios (= 0.8.3)
-    - MicrosoftFluentUI/IndeterminateProgressBar_ios (= 0.8.3)
-    - MicrosoftFluentUI/Label_ios (= 0.8.3)
-    - MicrosoftFluentUI/Link_mac (= 0.8.3)
-    - MicrosoftFluentUI/Navigation_ios (= 0.8.3)
-    - MicrosoftFluentUI/Notification_ios (= 0.8.3)
-    - MicrosoftFluentUI/Obscurable_ios (= 0.8.3)
-    - MicrosoftFluentUI/OtherCells_ios (= 0.8.3)
-    - MicrosoftFluentUI/PeoplePicker_ios (= 0.8.3)
-    - MicrosoftFluentUI/PersonaButton_ios (= 0.8.3)
-    - MicrosoftFluentUI/PersonaButtonCarousel_ios (= 0.8.3)
-    - MicrosoftFluentUI/PillButtonBar_ios (= 0.8.3)
-    - MicrosoftFluentUI/PopupMenu_ios (= 0.8.3)
-    - MicrosoftFluentUI/Presenters_ios (= 0.8.3)
-    - MicrosoftFluentUI/ResizingHandleView_ios (= 0.8.3)
-    - MicrosoftFluentUI/SegmentedControl_ios (= 0.8.3)
-    - MicrosoftFluentUI/Separator_ios (= 0.8.3)
-    - MicrosoftFluentUI/Separator_mac (= 0.8.3)
-    - MicrosoftFluentUI/Shimmer_ios (= 0.8.3)
-    - MicrosoftFluentUI/TabBar_ios (= 0.8.3)
-    - MicrosoftFluentUI/TableView_ios (= 0.8.3)
-    - MicrosoftFluentUI/Tooltip_ios (= 0.8.3)
-    - MicrosoftFluentUI/TouchForwardingView_ios (= 0.8.3)
-    - MicrosoftFluentUI/TwoLineTitleView_ios (= 0.8.3)
-    - MicrosoftFluentUI/Utilities_ios (= 0.8.3)
-  - MicrosoftFluentUI/Appearance_mac (0.8.3)
-  - MicrosoftFluentUI/AvatarView_mac (0.8.3):
+  - MicrosoftFluentUI (0.10.0):
+    - MicrosoftFluentUI/ActivityIndicator_ios (= 0.10.0)
+    - MicrosoftFluentUI/Appearance_mac (= 0.10.0)
+    - MicrosoftFluentUI/Avatar_ios (= 0.10.0)
+    - MicrosoftFluentUI/AvatarGroup_ios (= 0.10.0)
+    - MicrosoftFluentUI/AvatarView_mac (= 0.10.0)
+    - MicrosoftFluentUI/BadgeField_ios (= 0.10.0)
+    - MicrosoftFluentUI/BadgeView_mac (= 0.10.0)
+    - MicrosoftFluentUI/BarButtonItems_ios (= 0.10.0)
+    - MicrosoftFluentUI/BottomCommanding_ios (= 0.10.0)
+    - MicrosoftFluentUI/BottomSheet_ios (= 0.10.0)
+    - MicrosoftFluentUI/Button_ios (= 0.10.0)
+    - MicrosoftFluentUI/Button_mac (= 0.10.0)
+    - MicrosoftFluentUI/Calendar_ios (= 0.10.0)
+    - MicrosoftFluentUI/Card_ios (= 0.10.0)
+    - MicrosoftFluentUI/CardNudge_ios (= 0.10.0)
+    - MicrosoftFluentUI/CommandBar_ios (= 0.10.0)
+    - MicrosoftFluentUI/Core_ios (= 0.10.0)
+    - MicrosoftFluentUI/Core_mac (= 0.10.0)
+    - MicrosoftFluentUI/DatePicker_mac (= 0.10.0)
+    - MicrosoftFluentUI/Divider_ios (= 0.10.0)
+    - MicrosoftFluentUI/DotView_ios (= 0.10.0)
+    - MicrosoftFluentUI/Drawer_ios (= 0.10.0)
+    - MicrosoftFluentUI/DynamicColor_mac (= 0.10.0)
+    - MicrosoftFluentUI/EasyTapButton_ios (= 0.10.0)
+    - MicrosoftFluentUI/HUD_ios (= 0.10.0)
+    - MicrosoftFluentUI/IndeterminateProgressBar_ios (= 0.10.0)
+    - MicrosoftFluentUI/Label_ios (= 0.10.0)
+    - MicrosoftFluentUI/Link_mac (= 0.10.0)
+    - MicrosoftFluentUI/Navigation_ios (= 0.10.0)
+    - MicrosoftFluentUI/Notification_ios (= 0.10.0)
+    - MicrosoftFluentUI/Obscurable_ios (= 0.10.0)
+    - MicrosoftFluentUI/OtherCells_ios (= 0.10.0)
+    - MicrosoftFluentUI/PeoplePicker_ios (= 0.10.0)
+    - MicrosoftFluentUI/PersonaButton_ios (= 0.10.0)
+    - MicrosoftFluentUI/PersonaButtonCarousel_ios (= 0.10.0)
+    - MicrosoftFluentUI/PillButtonBar_ios (= 0.10.0)
+    - MicrosoftFluentUI/PopupMenu_ios (= 0.10.0)
+    - MicrosoftFluentUI/Presenters_ios (= 0.10.0)
+    - MicrosoftFluentUI/ResizingHandleView_ios (= 0.10.0)
+    - MicrosoftFluentUI/SegmentedControl_ios (= 0.10.0)
+    - MicrosoftFluentUI/Separator_ios (= 0.10.0)
+    - MicrosoftFluentUI/Separator_mac (= 0.10.0)
+    - MicrosoftFluentUI/Shimmer_ios (= 0.10.0)
+    - MicrosoftFluentUI/TabBar_ios (= 0.10.0)
+    - MicrosoftFluentUI/TableView_ios (= 0.10.0)
+    - MicrosoftFluentUI/Tooltip_ios (= 0.10.0)
+    - MicrosoftFluentUI/TouchForwardingView_ios (= 0.10.0)
+    - MicrosoftFluentUI/TwoLineTitleView_ios (= 0.10.0)
+    - MicrosoftFluentUI/Utilities_ios (= 0.10.0)
+  - MicrosoftFluentUI/Appearance_mac (0.10.0)
+  - MicrosoftFluentUI/AvatarView_mac (0.10.0):
     - MicrosoftFluentUI/Core_mac
     - MicrosoftFluentUI/DynamicColor_mac
-  - MicrosoftFluentUI/BadgeView_mac (0.8.3):
+  - MicrosoftFluentUI/BadgeView_mac (0.10.0):
     - MicrosoftFluentUI/Core_mac
     - MicrosoftFluentUI/DynamicColor_mac
-  - MicrosoftFluentUI/Button_mac (0.8.3):
+  - MicrosoftFluentUI/Button_mac (0.10.0):
     - MicrosoftFluentUI/Core_mac
-  - MicrosoftFluentUI/Core_mac (0.8.3)
-  - MicrosoftFluentUI/DatePicker_mac (0.8.3):
+  - MicrosoftFluentUI/Core_mac (0.10.0)
+  - MicrosoftFluentUI/DatePicker_mac (0.10.0):
     - MicrosoftFluentUI/Appearance_mac
     - MicrosoftFluentUI/Core_mac
-  - MicrosoftFluentUI/DynamicColor_mac (0.8.3):
+  - MicrosoftFluentUI/DynamicColor_mac (0.10.0):
     - MicrosoftFluentUI/Appearance_mac
-  - MicrosoftFluentUI/Link_mac (0.8.3):
+  - MicrosoftFluentUI/Link_mac (0.10.0):
     - MicrosoftFluentUI/Core_mac
-  - MicrosoftFluentUI/Separator_mac (0.8.3):
+  - MicrosoftFluentUI/Separator_mac (0.10.0):
     - MicrosoftFluentUI/Core_mac
   - RCT-Folly (2021.06.28.00-v2):
     - boost
@@ -101,276 +102,276 @@ PODS:
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
-  - RCTFocusZone (0.11.4):
+  - RCTFocusZone (0.11.13):
     - React
-  - RCTRequired (0.68.58)
-  - RCTTypeSafety (0.68.58):
-    - FBLazyVector (= 0.68.58)
+  - RCTRequired (0.68.59)
+  - RCTTypeSafety (0.68.59):
+    - FBLazyVector (= 0.68.59)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.58)
-    - React-Core (= 0.68.58)
-  - React (0.68.58):
-    - React-Core (= 0.68.58)
-    - React-Core/DevSupport (= 0.68.58)
-    - React-Core/RCTWebSocket (= 0.68.58)
-    - React-RCTActionSheet (= 0.68.58)
-    - React-RCTAnimation (= 0.68.58)
-    - React-RCTBlob (= 0.68.58)
-    - React-RCTImage (= 0.68.58)
-    - React-RCTLinking (= 0.68.58)
-    - React-RCTNetwork (= 0.68.58)
-    - React-RCTSettings (= 0.68.58)
-    - React-RCTText (= 0.68.58)
-    - React-RCTVibration (= 0.68.58)
-  - React-callinvoker (0.68.58)
-  - React-Codegen (0.68.58):
-    - FBReactNativeSpec (= 0.68.58)
+    - RCTRequired (= 0.68.59)
+    - React-Core (= 0.68.59)
+  - React (0.68.59):
+    - React-Core (= 0.68.59)
+    - React-Core/DevSupport (= 0.68.59)
+    - React-Core/RCTWebSocket (= 0.68.59)
+    - React-RCTActionSheet (= 0.68.59)
+    - React-RCTAnimation (= 0.68.59)
+    - React-RCTBlob (= 0.68.59)
+    - React-RCTImage (= 0.68.59)
+    - React-RCTLinking (= 0.68.59)
+    - React-RCTNetwork (= 0.68.59)
+    - React-RCTSettings (= 0.68.59)
+    - React-RCTText (= 0.68.59)
+    - React-RCTVibration (= 0.68.59)
+  - React-callinvoker (0.68.59)
+  - React-Codegen (0.68.59):
+    - FBReactNativeSpec (= 0.68.59)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.58)
-    - RCTTypeSafety (= 0.68.58)
-    - React-Core (= 0.68.58)
-    - React-jsi (= 0.68.58)
-    - React-jsiexecutor (= 0.68.58)
-    - ReactCommon/turbomodule/core (= 0.68.58)
-  - React-Core (0.68.58):
+    - RCTRequired (= 0.68.59)
+    - RCTTypeSafety (= 0.68.59)
+    - React-Core (= 0.68.59)
+    - React-jsi (= 0.68.59)
+    - React-jsiexecutor (= 0.68.59)
+    - ReactCommon/turbomodule/core (= 0.68.59)
+  - React-Core (0.68.59):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.58)
-    - React-cxxreact (= 0.68.58)
-    - React-jsi (= 0.68.58)
-    - React-jsiexecutor (= 0.68.58)
-    - React-perflogger (= 0.68.58)
+    - React-Core/Default (= 0.68.59)
+    - React-cxxreact (= 0.68.59)
+    - React-jsi (= 0.68.59)
+    - React-jsiexecutor (= 0.68.59)
+    - React-perflogger (= 0.68.59)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.68.58):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default
-    - React-cxxreact (= 0.68.58)
-    - React-jsi (= 0.68.58)
-    - React-jsiexecutor (= 0.68.58)
-    - React-perflogger (= 0.68.58)
-    - Yoga
-  - React-Core/Default (0.68.58):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.68.58)
-    - React-jsi (= 0.68.58)
-    - React-jsiexecutor (= 0.68.58)
-    - React-perflogger (= 0.68.58)
-    - Yoga
-  - React-Core/DevSupport (0.68.58):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.58)
-    - React-Core/RCTWebSocket (= 0.68.58)
-    - React-cxxreact (= 0.68.58)
-    - React-jsi (= 0.68.58)
-    - React-jsiexecutor (= 0.68.58)
-    - React-jsinspector (= 0.68.58)
-    - React-perflogger (= 0.68.58)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.68.58):
+  - React-Core/CoreModulesHeaders (0.68.59):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.58)
-    - React-jsi (= 0.68.58)
-    - React-jsiexecutor (= 0.68.58)
-    - React-perflogger (= 0.68.58)
+    - React-cxxreact (= 0.68.59)
+    - React-jsi (= 0.68.59)
+    - React-jsiexecutor (= 0.68.59)
+    - React-perflogger (= 0.68.59)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.68.58):
+  - React-Core/Default (0.68.59):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-cxxreact (= 0.68.59)
+    - React-jsi (= 0.68.59)
+    - React-jsiexecutor (= 0.68.59)
+    - React-perflogger (= 0.68.59)
+    - Yoga
+  - React-Core/DevSupport (0.68.59):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-Core/Default (= 0.68.59)
+    - React-Core/RCTWebSocket (= 0.68.59)
+    - React-cxxreact (= 0.68.59)
+    - React-jsi (= 0.68.59)
+    - React-jsiexecutor (= 0.68.59)
+    - React-jsinspector (= 0.68.59)
+    - React-perflogger (= 0.68.59)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.68.59):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.58)
-    - React-jsi (= 0.68.58)
-    - React-jsiexecutor (= 0.68.58)
-    - React-perflogger (= 0.68.58)
+    - React-cxxreact (= 0.68.59)
+    - React-jsi (= 0.68.59)
+    - React-jsiexecutor (= 0.68.59)
+    - React-perflogger (= 0.68.59)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.68.58):
+  - React-Core/RCTAnimationHeaders (0.68.59):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.58)
-    - React-jsi (= 0.68.58)
-    - React-jsiexecutor (= 0.68.58)
-    - React-perflogger (= 0.68.58)
+    - React-cxxreact (= 0.68.59)
+    - React-jsi (= 0.68.59)
+    - React-jsiexecutor (= 0.68.59)
+    - React-perflogger (= 0.68.59)
     - Yoga
-  - React-Core/RCTImageHeaders (0.68.58):
+  - React-Core/RCTBlobHeaders (0.68.59):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.58)
-    - React-jsi (= 0.68.58)
-    - React-jsiexecutor (= 0.68.58)
-    - React-perflogger (= 0.68.58)
+    - React-cxxreact (= 0.68.59)
+    - React-jsi (= 0.68.59)
+    - React-jsiexecutor (= 0.68.59)
+    - React-perflogger (= 0.68.59)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.68.58):
+  - React-Core/RCTImageHeaders (0.68.59):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.58)
-    - React-jsi (= 0.68.58)
-    - React-jsiexecutor (= 0.68.58)
-    - React-perflogger (= 0.68.58)
+    - React-cxxreact (= 0.68.59)
+    - React-jsi (= 0.68.59)
+    - React-jsiexecutor (= 0.68.59)
+    - React-perflogger (= 0.68.59)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.68.58):
+  - React-Core/RCTLinkingHeaders (0.68.59):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.58)
-    - React-jsi (= 0.68.58)
-    - React-jsiexecutor (= 0.68.58)
-    - React-perflogger (= 0.68.58)
+    - React-cxxreact (= 0.68.59)
+    - React-jsi (= 0.68.59)
+    - React-jsiexecutor (= 0.68.59)
+    - React-perflogger (= 0.68.59)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.68.58):
+  - React-Core/RCTNetworkHeaders (0.68.59):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.58)
-    - React-jsi (= 0.68.58)
-    - React-jsiexecutor (= 0.68.58)
-    - React-perflogger (= 0.68.58)
+    - React-cxxreact (= 0.68.59)
+    - React-jsi (= 0.68.59)
+    - React-jsiexecutor (= 0.68.59)
+    - React-perflogger (= 0.68.59)
     - Yoga
-  - React-Core/RCTTextHeaders (0.68.58):
+  - React-Core/RCTSettingsHeaders (0.68.59):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.58)
-    - React-jsi (= 0.68.58)
-    - React-jsiexecutor (= 0.68.58)
-    - React-perflogger (= 0.68.58)
+    - React-cxxreact (= 0.68.59)
+    - React-jsi (= 0.68.59)
+    - React-jsiexecutor (= 0.68.59)
+    - React-perflogger (= 0.68.59)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.68.58):
+  - React-Core/RCTTextHeaders (0.68.59):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.58)
-    - React-jsi (= 0.68.58)
-    - React-jsiexecutor (= 0.68.58)
-    - React-perflogger (= 0.68.58)
+    - React-cxxreact (= 0.68.59)
+    - React-jsi (= 0.68.59)
+    - React-jsiexecutor (= 0.68.59)
+    - React-perflogger (= 0.68.59)
     - Yoga
-  - React-Core/RCTWebSocket (0.68.58):
+  - React-Core/RCTVibrationHeaders (0.68.59):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.58)
-    - React-cxxreact (= 0.68.58)
-    - React-jsi (= 0.68.58)
-    - React-jsiexecutor (= 0.68.58)
-    - React-perflogger (= 0.68.58)
+    - React-Core/Default
+    - React-cxxreact (= 0.68.59)
+    - React-jsi (= 0.68.59)
+    - React-jsiexecutor (= 0.68.59)
+    - React-perflogger (= 0.68.59)
     - Yoga
-  - React-CoreModules (0.68.58):
+  - React-Core/RCTWebSocket (0.68.59):
+    - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.58)
-    - React-Codegen (= 0.68.58)
-    - React-Core/CoreModulesHeaders (= 0.68.58)
-    - React-jsi (= 0.68.58)
-    - React-RCTImage (= 0.68.58)
-    - ReactCommon/turbomodule/core (= 0.68.58)
-  - React-cxxreact (0.68.58):
+    - React-Core/Default (= 0.68.59)
+    - React-cxxreact (= 0.68.59)
+    - React-jsi (= 0.68.59)
+    - React-jsiexecutor (= 0.68.59)
+    - React-perflogger (= 0.68.59)
+    - Yoga
+  - React-CoreModules (0.68.59):
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - RCTTypeSafety (= 0.68.59)
+    - React-Codegen (= 0.68.59)
+    - React-Core/CoreModulesHeaders (= 0.68.59)
+    - React-jsi (= 0.68.59)
+    - React-RCTImage (= 0.68.59)
+    - ReactCommon/turbomodule/core (= 0.68.59)
+  - React-cxxreact (0.68.59):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.68.58)
-    - React-jsi (= 0.68.58)
-    - React-jsinspector (= 0.68.58)
-    - React-logger (= 0.68.58)
-    - React-perflogger (= 0.68.58)
-    - React-runtimeexecutor (= 0.68.58)
-  - React-jsi (0.68.58):
+    - React-callinvoker (= 0.68.59)
+    - React-jsi (= 0.68.59)
+    - React-jsinspector (= 0.68.59)
+    - React-logger (= 0.68.59)
+    - React-perflogger (= 0.68.59)
+    - React-runtimeexecutor (= 0.68.59)
+  - React-jsi (0.68.59):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-jsi/Default (= 0.68.58)
-  - React-jsi/Default (0.68.58):
+    - React-jsi/Default (= 0.68.59)
+  - React-jsi/Default (0.68.59):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-  - React-jsiexecutor (0.68.58):
+  - React-jsiexecutor (0.68.59):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.68.58)
-    - React-jsi (= 0.68.58)
-    - React-perflogger (= 0.68.58)
-  - React-jsinspector (0.68.58)
-  - React-logger (0.68.58):
+    - React-cxxreact (= 0.68.59)
+    - React-jsi (= 0.68.59)
+    - React-perflogger (= 0.68.59)
+  - React-jsinspector (0.68.59)
+  - React-logger (0.68.59):
     - glog
-  - React-perflogger (0.68.58)
-  - React-RCTActionSheet (0.68.58):
-    - React-Core/RCTActionSheetHeaders (= 0.68.58)
-  - React-RCTAnimation (0.68.58):
+  - React-perflogger (0.68.59)
+  - React-RCTActionSheet (0.68.59):
+    - React-Core/RCTActionSheetHeaders (= 0.68.59)
+  - React-RCTAnimation (0.68.59):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.58)
-    - React-Codegen (= 0.68.58)
-    - React-Core/RCTAnimationHeaders (= 0.68.58)
-    - React-jsi (= 0.68.58)
-    - ReactCommon/turbomodule/core (= 0.68.58)
-  - React-RCTBlob (0.68.58):
+    - RCTTypeSafety (= 0.68.59)
+    - React-Codegen (= 0.68.59)
+    - React-Core/RCTAnimationHeaders (= 0.68.59)
+    - React-jsi (= 0.68.59)
+    - ReactCommon/turbomodule/core (= 0.68.59)
+  - React-RCTBlob (0.68.59):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Codegen (= 0.68.58)
-    - React-Core/RCTBlobHeaders (= 0.68.58)
-    - React-Core/RCTWebSocket (= 0.68.58)
-    - React-jsi (= 0.68.58)
-    - React-RCTNetwork (= 0.68.58)
-    - ReactCommon/turbomodule/core (= 0.68.58)
-  - React-RCTImage (0.68.58):
+    - React-Codegen (= 0.68.59)
+    - React-Core/RCTBlobHeaders (= 0.68.59)
+    - React-Core/RCTWebSocket (= 0.68.59)
+    - React-jsi (= 0.68.59)
+    - React-RCTNetwork (= 0.68.59)
+    - ReactCommon/turbomodule/core (= 0.68.59)
+  - React-RCTImage (0.68.59):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.58)
-    - React-Codegen (= 0.68.58)
-    - React-Core/RCTImageHeaders (= 0.68.58)
-    - React-jsi (= 0.68.58)
-    - React-RCTNetwork (= 0.68.58)
-    - ReactCommon/turbomodule/core (= 0.68.58)
-  - React-RCTLinking (0.68.58):
-    - React-Codegen (= 0.68.58)
-    - React-Core/RCTLinkingHeaders (= 0.68.58)
-    - React-jsi (= 0.68.58)
-    - ReactCommon/turbomodule/core (= 0.68.58)
-  - React-RCTNetwork (0.68.58):
+    - RCTTypeSafety (= 0.68.59)
+    - React-Codegen (= 0.68.59)
+    - React-Core/RCTImageHeaders (= 0.68.59)
+    - React-jsi (= 0.68.59)
+    - React-RCTNetwork (= 0.68.59)
+    - ReactCommon/turbomodule/core (= 0.68.59)
+  - React-RCTLinking (0.68.59):
+    - React-Codegen (= 0.68.59)
+    - React-Core/RCTLinkingHeaders (= 0.68.59)
+    - React-jsi (= 0.68.59)
+    - ReactCommon/turbomodule/core (= 0.68.59)
+  - React-RCTNetwork (0.68.59):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.58)
-    - React-Codegen (= 0.68.58)
-    - React-Core/RCTNetworkHeaders (= 0.68.58)
-    - React-jsi (= 0.68.58)
-    - ReactCommon/turbomodule/core (= 0.68.58)
-  - React-RCTSettings (0.68.58):
+    - RCTTypeSafety (= 0.68.59)
+    - React-Codegen (= 0.68.59)
+    - React-Core/RCTNetworkHeaders (= 0.68.59)
+    - React-jsi (= 0.68.59)
+    - ReactCommon/turbomodule/core (= 0.68.59)
+  - React-RCTSettings (0.68.59):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.58)
-    - React-Codegen (= 0.68.58)
-    - React-Core/RCTSettingsHeaders (= 0.68.58)
-    - React-jsi (= 0.68.58)
-    - ReactCommon/turbomodule/core (= 0.68.58)
-  - React-RCTText (0.68.58):
-    - React-Core/RCTTextHeaders (= 0.68.58)
-  - React-RCTVibration (0.68.58):
+    - RCTTypeSafety (= 0.68.59)
+    - React-Codegen (= 0.68.59)
+    - React-Core/RCTSettingsHeaders (= 0.68.59)
+    - React-jsi (= 0.68.59)
+    - ReactCommon/turbomodule/core (= 0.68.59)
+  - React-RCTText (0.68.59):
+    - React-Core/RCTTextHeaders (= 0.68.59)
+  - React-RCTVibration (0.68.59):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Codegen (= 0.68.58)
-    - React-Core/RCTVibrationHeaders (= 0.68.58)
-    - React-jsi (= 0.68.58)
-    - ReactCommon/turbomodule/core (= 0.68.58)
-  - React-runtimeexecutor (0.68.58):
-    - React-jsi (= 0.68.58)
-  - ReactCommon/turbomodule/core (0.68.58):
+    - React-Codegen (= 0.68.59)
+    - React-Core/RCTVibrationHeaders (= 0.68.59)
+    - React-jsi (= 0.68.59)
+    - ReactCommon/turbomodule/core (= 0.68.59)
+  - React-runtimeexecutor (0.68.59):
+    - React-jsi (= 0.68.59)
+  - ReactCommon/turbomodule/core (0.68.59):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.68.58)
-    - React-Core (= 0.68.58)
-    - React-cxxreact (= 0.68.58)
-    - React-jsi (= 0.68.58)
-    - React-logger (= 0.68.58)
-    - React-perflogger (= 0.68.58)
-  - ReactTestApp-DevSupport (2.0.2):
+    - React-callinvoker (= 0.68.59)
+    - React-Core (= 0.68.59)
+    - React-cxxreact (= 0.68.59)
+    - React-jsi (= 0.68.59)
+    - React-logger (= 0.68.59)
+    - React-perflogger (= 0.68.59)
+  - ReactTestApp-DevSupport (2.1.1):
     - React-Core
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
   - RNCPicker (2.4.8):
     - React-Core
-  - RNSVG (12.3.0):
+  - RNSVG (12.5.0):
     - React-Core
   - Yoga (1.14.0)
 
@@ -511,47 +512,47 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: 613e39eac4239cc72b15421247b5ab05361266a2
   DoubleConversion: ed15e075aa758ac0e4c1f8b830bd4e4d40d669e8
-  FBLazyVector: b1b36b1d24d838d9f677ce83d5c6e9cb14622c87
-  FBReactNativeSpec: 49883a49fea9ea7955793addaea36ef386df15da
+  FBLazyVector: 6cffa71e5650b5cb43db82d8f0ba09faba2880ca
+  FBReactNativeSpec: f81567c045ac83ecbe6f21eb778a759986274955
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  FRNAvatar: 8d2cee7b5a7dd3b5ef6b264ae72c4824c2596ed0
-  FRNCallout: 753af19ce28c8265b4227c31e60ab2162e976507
-  FRNCheckbox: 8a657228e721705addd9b07c9c6fd861f7073246
-  FRNMenuButton: 678b0b139119df0382420007f01c22b47e6c3f1a
-  FRNRadioButton: 816c1c0ac02527a902070e75a3264e8a072ef0e0
+  FRNAvatar: b57500ffd4955a077c6318e7485de44f4a663042
+  FRNCallout: fb2db03b402f59b4b8bbf8738a8ec17bd25db2da
+  FRNCheckbox: 2fc8c5cd67f8ef2b82dae2eef14bb0e42ffa64fe
+  FRNMenuButton: 86cc9e8f25b2593478de59c81bdc67b70881c893
+  FRNRadioButton: 51e6d490bdcc60ab4e0310d545cec8f9bdf81b01
   glog: 20113a0d46931b6f096cf8302c68691d75a456ff
-  MicrosoftFluentUI: e30487dd18aba04beeed4caf1ce1988073f8b03a
+  MicrosoftFluentUI: f6db695718efb93f4ca9bdc366c00b80a1f91dba
   RCT-Folly: 5544a3ff21f4406e70e92a8711598e97fc81517c
-  RCTFocusZone: bd075c77477fb10c5cd3243c50817384cfb25def
-  RCTRequired: e0cecae54330f4835a499aae69b7d54fad0b05ec
-  RCTTypeSafety: f6d1b7b5ecc7c990ae17c7435128811c24437967
-  React: cf3c008bc9481232848114ec3010d2a3118e78db
-  React-callinvoker: 26c72eb69620e70a0222d5b774b6d6202fd23ed7
-  React-Codegen: 15c64a09646e94de22b799f05824b2052a0c4b0f
-  React-Core: bc49d8fec97a40be7b4c315d2d178818a5092872
-  React-CoreModules: 1df5d97fe324e7a0430623039613e87495d6fcec
-  React-cxxreact: e64c91a294dc3d8b95a06afb3b4e644bbdbc37de
-  React-jsi: d6bc95e32da837892f04d1709df4a14b84b73ed6
-  React-jsiexecutor: 563ed16aaf96d7706a68b90e64dba36e8b28913f
-  React-jsinspector: 2168cee27e2792dab747a8068567e65e63152f31
-  React-logger: b9289dd410326ac046cc7bfabb3797fe0e8d9b6e
-  React-perflogger: 55b00aa01445f2bc974719a027d5a53bae129da6
-  React-RCTActionSheet: 44da45a6f559b8b2a3603974af39cf1a5082dcfa
-  React-RCTAnimation: d2e800cc875587a1a364a7b4dff08b220289f9b5
-  React-RCTBlob: 6da817cea1717f95d2af28b6ed8173777a879840
-  React-RCTImage: d9b69e0446a96d690f7a4396e7f4b65fca706979
-  React-RCTLinking: a8fe11195352b5f233e07fa857c87833e550259b
-  React-RCTNetwork: 5470f2e0b414c05932f0e6c7e2b91cdfd7b227dd
-  React-RCTSettings: 6bb71bcdeb788c3cfc18cb953a989879d3fbd157
-  React-RCTText: 83ff5bde4f9a2538e452ee5c388151e4f20c40db
-  React-RCTVibration: 1e5353b37f3626d600a04588fa6b6a0a4770bcc1
-  React-runtimeexecutor: e2fec149115069d18be80653411b50aac2c57b2c
-  ReactCommon: fa9dd5c8fbb2fb41d23b035af3785966714fee42
-  ReactTestApp-DevSupport: 93a3ec4d2affbd491128b89e922d7f1a359f547a
+  RCTFocusZone: 44f158f3332829d5c2895e1bf2dc29ce03a9aa53
+  RCTRequired: b95cf30b8216e43c6c409af3bf8cb1662f611553
+  RCTTypeSafety: 59e5eb122ec87d02fabf90aa1ce5ba3294e782e3
+  React: 7a33419f3df43edc47a72557921d714469a843e0
+  React-callinvoker: ca9726c44669c0f4839cd7ee24b13ee4a0d9b4f5
+  React-Codegen: 21f1da14c226e09685069972527b1043bdd0a4d5
+  React-Core: 9117908c9e819d11501d993596915be616e7e198
+  React-CoreModules: 50a564ffba9ed156ca43107bb6f3be6038250fcc
+  React-cxxreact: 503fc094a735da2e41cf53b2cbc36d1ee41545c8
+  React-jsi: e2c06ced7ad1f6a0bbb97aa82012f531fb08e6bd
+  React-jsiexecutor: c4d4de8fc5562df2e1bb0b49ca5152d72ba5ae44
+  React-jsinspector: d0913ee975ac48f0a6f025adf18763857993bb8d
+  React-logger: d511b77d33a96bf771d558fdf7d32db7939890ba
+  React-perflogger: a70044daee607dae27c5e3c829a9b85fcc46f816
+  React-RCTActionSheet: 4dfc5c1880dfac4348dd6dfaf08e2fc282f18040
+  React-RCTAnimation: cc4351fe1ae4f45c273b7cf01013a24458b9a3cf
+  React-RCTBlob: 3005fd95a831b30847403537d41d561a4ccc624c
+  React-RCTImage: f57cb0a88b74baf5ede093e8bb5a1118dfbe75a0
+  React-RCTLinking: b4831cc5c57dc3f9c731580dbf94b063548af72a
+  React-RCTNetwork: b8781bdfcbf0adaac7eee89eb69ef4d6d8445afa
+  React-RCTSettings: c50254e6db9800d64bea38808cc50b5921b4b453
+  React-RCTText: e1234cd32a880eb29aaf44f3bf7f59d1066b0767
+  React-RCTVibration: 7d6ce1162b543b837347b8e1989ac4f44b4a7427
+  React-runtimeexecutor: 6c80fffe5267158c59786907e93079ac6e2ade46
+  ReactCommon: 83ac4fac05c1604a59b8f404a233908f3bc09a57
+  ReactTestApp-DevSupport: 7ca8e4d798fce59f47adedd8f05a94d41d312921
   ReactTestApp-Resources: 8c0164a3cc5052418c92018e2af0e05d564aa307
   RNCPicker: 0bf8ef8f7800524f32d2bb2a8bcadd53eda0ecd1
-  RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8
-  Yoga: 565e2adf6e8d84ccd8a197117e40ae1f55e62d19
+  RNSVG: 6adc5c52d2488a476248413064b7f2832e639057
+  Yoga: 89eab6ce9fcb1fb5d498ac606c4315a3d6290297
 
 PODFILE CHECKSUM: d3fe834dea1e24594a8ba545f70b5250bbc25c91
 

--- a/apps/fluent-tester/src/TestComponents/Avatar/NativeAvatarTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Avatar/NativeAvatarTest.tsx
@@ -37,7 +37,7 @@ export const BasicAvatar: React.FunctionComponent = () => {
         imageSource={showImage ? testImageSource : undefined}
         presence={showPresence ? 'available' : null}
         isRingVisible={showRing}
-        size={'xxLarge'}
+        size={'size72'}
       />
     </View>
   );
@@ -85,14 +85,14 @@ export const CustomizeColors: React.FunctionComponent = () => {
         customBorderImageSource={showCustomBorderImage ? rainbowGradientSource : null}
         isRingVisible={true}
         hasRingInnerGap={showRingGap}
-        size={'xxLarge'}
+        size={'size72'}
       />
     </View>
   );
 };
 
 const AvatarSizeRamp: React.FunctionComponent = () => {
-  const allSizes: Size[] = ['xSmall', 'small', 'medium', 'large', 'xLarge', 'xxLarge'];
+  const allSizes: Size[] = ['size16', 'size20', 'size24', 'size32', 'size40', 'size56', 'size72'];
 
   return (
     <Stack style={{ flexDirection: 'row' }}>

--- a/change/@fluentui-react-native-experimental-avatar-9d393dad-ed74-402d-8400-8b5f7099bb3b.json
+++ b/change/@fluentui-react-native-experimental-avatar-9d393dad-ed74-402d-8400-8b5f7099bb3b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Update Mac",
+  "packageName": "@fluentui-react-native/experimental-avatar",
+  "email": "67026548+huwilkes@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-native-date-picker-32a9d33b-ea75-4958-881f-40ac61a847e4.json
+++ b/change/@fluentui-react-native-experimental-native-date-picker-32a9d33b-ea75-4958-881f-40ac61a847e4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update iOS",
+  "packageName": "@fluentui-react-native/experimental-native-date-picker",
+  "email": "67026548+huwilkes@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-90bc1c79-f7e3-4951-b329-b24510a535e4.json
+++ b/change/@fluentui-react-native-tester-90bc1c79-f7e3-4951-b329-b24510a535e4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update tester",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "67026548+huwilkes@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Avatar/FRNAvatar.podspec
+++ b/packages/experimental/Avatar/FRNAvatar.podspec
@@ -16,11 +16,11 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = "14.0"
   s.ios.source_files      = "ios/*.{swift,h,m}"
-  s.ios.dependency 'MicrosoftFluentUI', '0.8.3'
+  s.ios.dependency 'MicrosoftFluentUI', '0.10.0'
 
   s.osx.deployment_target = "10.15"
   s.osx.source_files      = "macos/*.{swift,h,m}"
-  s.osx.dependency 'MicrosoftFluentUI', '0.8.3'
+  s.osx.dependency 'MicrosoftFluentUI', '0.10.0'
 
   s.dependency 'React'
 end

--- a/packages/experimental/Avatar/ios/AvatarViewManager.swift
+++ b/packages/experimental/Avatar/ios/AvatarViewManager.swift
@@ -17,12 +17,13 @@ class AvatarViewManager: RCTViewManager {
 	override func constantsToExport() -> [AnyHashable : Any]! {
 		return [
 			"sizes" : [
-				"xSmall" : 16,
-				"small" : 24,
-				"medium" : 32,
-				"large" : 42,
-				"xLarge" : 52,
-				"xxLarge" : 72,
+				"size16" : 16,
+				"size20" : 20,
+				"size24" : 24,
+				"size32" : 32,
+				"size40" : 40,
+				"size56" : 56,
+				"size72" : 72,
 			]
 		]
 	}

--- a/packages/experimental/Avatar/ios/FRNAvatarViewManager.m
+++ b/packages/experimental/Avatar/ios/FRNAvatarViewManager.m
@@ -7,13 +7,14 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation RCTConvert (FRNAvatarAdditions)
 
 RCT_ENUM_CONVERTER(MSFAvatarSize, (@{
-    @"xSmall": @(MSFAvatarSizeXsmall),
-    @"small": @(MSFAvatarSizeSmall),
-    @"medium": @(MSFAvatarSizeMedium),
-    @"large": @(MSFAvatarSizeLarge),
-    @"xLarge": @(MSFAvatarSizeXlarge),
-    @"xxLarge": @(MSFAvatarSizeXxlarge),
-}), MSFAvatarSizeSmall, integerValue);
+    @"size16": @(MSFAvatarSizeSize16),
+    @"size20": @(MSFAvatarSizeSize20),
+    @"size24": @(MSFAvatarSizeSize24),
+    @"size32": @(MSFAvatarSizeSize32),
+    @"size40": @(MSFAvatarSizeSize40),
+    @"size56": @(MSFAvatarSizeSize56),
+    @"size72": @(MSFAvatarSizeSize72),
+}), MSFAvatarSizeSize24, integerValue);
 
 RCT_ENUM_CONVERTER(MSFAvatarPresence, (@{
     @"none": @(MSFAvatarPresenceNone),

--- a/packages/experimental/Avatar/macos/AvatarViewManager.swift
+++ b/packages/experimental/Avatar/macos/AvatarViewManager.swift
@@ -17,12 +17,13 @@ class AvatarViewManager: RCTViewManager {
 	override func constantsToExport() -> [AnyHashable : Any]! {
 		return [
 			"sizes" : [
-				"xSmall" : 16,
-				"small" : 24,
-				"medium" : 32,
-				"large" : 40,
-				"xLarge" : 52,
-				"xxLarge" : 72
+				"size16" : 16,
+				"size20" : 20,
+				"size24" : 24,
+				"size32" : 32,
+				"size40" : 40,
+				"size56" : 56,
+				"size72" : 72,
 			]
 		]
 	}

--- a/packages/experimental/Avatar/macos/FRNAvatarViewManager.m
+++ b/packages/experimental/Avatar/macos/FRNAvatarViewManager.m
@@ -16,17 +16,19 @@ RCT_REMAP_VIEW_PROPERTY(backgroundColor, avatarBackgroundColor, UIColor)
 RCT_CUSTOM_VIEW_PROPERTY(size, NSString, MSFAvatarView)
 {
 	NSString *avatarSizeString = [RCTConvert NSString:json];
-	if ([avatarSizeString isEqualToString:@"xSmall"]) {
+	if ([avatarSizeString isEqualToString:@"size16"]) {
 		[view setAvatarSize:16];
-	} else if ([avatarSizeString isEqualToString:@"small"]) {
+	} else if ([avatarSizeString isEqualToString:@"size20"]) {
+		[view setAvatarSize:20];
+	} else if ([avatarSizeString isEqualToString:@"size24"]) {
 		[view setAvatarSize:24];
-	} else if ([avatarSizeString isEqualToString:@"medium"]) {
+	} else if ([avatarSizeString isEqualToString:@"size32"]) {
 		[view setAvatarSize:32];
-	} else if ([avatarSizeString isEqualToString:@"large"]) {
+	} else if ([avatarSizeString isEqualToString:@"size40"]) {
 		[view setAvatarSize:40];
-	} else if ([avatarSizeString isEqualToString:@"xLarge"]) {
-		[view setAvatarSize:52];
-	} else if ([avatarSizeString isEqualToString:@"xxLarge"]) {
+	} else if ([avatarSizeString isEqualToString:@"size56"]) {
+		[view setAvatarSize:56];
+	} else if ([avatarSizeString isEqualToString:@"size72"]) {
 		[view setAvatarSize:72];
 	}
 }

--- a/packages/experimental/Avatar/src/NativeAvatar.tsx
+++ b/packages/experimental/Avatar/src/NativeAvatar.tsx
@@ -7,7 +7,7 @@ const avatarName = 'NativeAvatar';
 
 const NativeAvatarView = ensureNativeComponent('FRNAvatarView');
 
-export type Size = 'xSmall' | 'small' | 'medium' | 'large' | 'xLarge' | 'xxLarge';
+export type Size = 'size16' | 'size20' | 'size24' | 'size32' | 'size40' | 'size56' | 'size72' as const;
 
 export type AvatarStyle = 'default' | 'accent' | 'group' | 'outlined' | 'outlinedPrimary' | 'overflow';
 

--- a/packages/experimental/Avatar/src/NativeAvatar.tsx
+++ b/packages/experimental/Avatar/src/NativeAvatar.tsx
@@ -7,7 +7,8 @@ const avatarName = 'NativeAvatar';
 
 const NativeAvatarView = ensureNativeComponent('FRNAvatarView');
 
-export const Size = ['size16', 'size20', 'size24', 'size32', 'size40', 'size56', 'size72'] as const;
+export const Sizes = ['size16', 'size20', 'size24', 'size32', 'size40', 'size56', 'size72'] as const;
+export type Size = typeof Sizes[number];
 
 export type AvatarStyle = 'default' | 'accent' | 'group' | 'outlined' | 'outlinedPrimary' | 'overflow';
 
@@ -107,7 +108,7 @@ export const NativeAvatar = compose<AvatarType>({
   displayName: avatarName,
   tokens: [
     {
-      size: 'small',
+      size: 'size24',
       avatarStyle: 'default',
     },
     avatarName,

--- a/packages/experimental/Avatar/src/NativeAvatar.tsx
+++ b/packages/experimental/Avatar/src/NativeAvatar.tsx
@@ -7,7 +7,7 @@ const avatarName = 'NativeAvatar';
 
 const NativeAvatarView = ensureNativeComponent('FRNAvatarView');
 
-export type Size = ['size16', 'size20', 'size24', 'size32', 'size40', 'size56', 'size72'] as const;
+export const Size = ['size16', 'size20', 'size24', 'size32', 'size40', 'size56', 'size72'] as const;
 
 export type AvatarStyle = 'default' | 'accent' | 'group' | 'outlined' | 'outlinedPrimary' | 'overflow';
 

--- a/packages/experimental/Avatar/src/NativeAvatar.tsx
+++ b/packages/experimental/Avatar/src/NativeAvatar.tsx
@@ -7,7 +7,7 @@ const avatarName = 'NativeAvatar';
 
 const NativeAvatarView = ensureNativeComponent('FRNAvatarView');
 
-export type Size = 'size16' | 'size20' | 'size24' | 'size32' | 'size40' | 'size56' | 'size72' as const;
+export type Size = ['size16', 'size20', 'size24', 'size32', 'size40', 'size56', 'size72'] as const;
 
 export type AvatarStyle = 'default' | 'accent' | 'group' | 'outlined' | 'outlinedPrimary' | 'overflow';
 

--- a/packages/experimental/NativeDatePicker/FRNDatePicker.podspec
+++ b/packages/experimental/NativeDatePicker/FRNDatePicker.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = "14.0"
   s.ios.source_files      = "ios/*.{swift,h,m}"
-  s.ios.dependency 'MicrosoftFluentUI', '0.8.3'
+  s.ios.dependency 'MicrosoftFluentUI', '0.10.0'
 
 end


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Updated Fluent UI Apple to 0.10.0. Going from 0.9 to 0.10 didn't really have any impact, but we seem to have missed the bump to 0.9, which had some changes to the Avatar.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![FURN_Avatar_Mac_Before](https://user-images.githubusercontent.com/67026548/209225085-fdfd3f3e-077d-45b2-adb7-f9d4ab4258cb.png) | ![FURN_Avatar_Mac_After](https://user-images.githubusercontent.com/67026548/209224857-25bc970d-d241-4519-b45e-6b75ed2a7ced.png) |
| ![FURN_Avatar_iOS_Before](https://user-images.githubusercontent.com/67026548/209224875-b1520df6-90fc-42a2-8fc0-c9b55cd0eeab.png) | ![FURN_Avatar_iOS_After](https://user-images.githubusercontent.com/67026548/209224885-f77caee8-ee6a-4342-b5cf-6e3581114e3b.png) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
