### PR TITLE
Revert Checkbox back to using View instead of Pressable

### DIFF
--- a/change/@fluentui-react-native-checkbox-27225660-45fe-4215-aa25-6a06e0cbfc6d.json
+++ b/change/@fluentui-react-native-checkbox-27225660-45fe-4215-aa25-6a06e0cbfc6d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Revert checkbox back to using View from Pressable",
+  "packageName": "@fluentui-react-native/checkbox",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Checkbox/src/Checkbox.tsx
+++ b/packages/components/Checkbox/src/Checkbox.tsx
@@ -1,6 +1,6 @@
 /** @jsx withSlots */
 import * as React from 'react';
-import { Pressable, Platform } from 'react-native';
+import { Pressable, Platform, View } from 'react-native';
 import { checkboxName, CheckboxType, CheckboxProps } from './Checkbox.types';
 import { TextV1 as Text } from '@fluentui-react-native/text';
 import { stylingSettings, getDefaultSize } from './Checkbox.styling';
@@ -13,7 +13,7 @@ export const Checkbox = compose<CheckboxType>({
   ...stylingSettings,
   slots: {
     root: Pressable,
-    checkbox: Pressable,
+    checkbox: View,
     checkmark: Svg,
     label: Text,
     required: Text,


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

This change reverts Checkbox back to using View instead of Pressable (which was introduced by #2416). This change caused a regression on win32 where the user is unable to toggle a checkbox via click if they clicked on the checkbox itself (not the label). Clicking on the label still toggles the checkbox which is why E2E test did not catch this. The click() function clicks the test element at the top center of the element. 

I'm working on adding an additional test which will test if we can toggle a checkbox via click on a checkbox without a label which should catch this regression if it ever occurs in the future. The additional test will come in a future commit.

This change was manually tested in the Fluent Tester on win32.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
