### PR TITLE
[Checkbox] Fix regression on win32

### DIFF
--- a/change/@fluentui-react-native-checkbox-a1ee3952-b272-40e5-9131-ba47501c063c.json
+++ b/change/@fluentui-react-native-checkbox-a1ee3952-b272-40e5-9131-ba47501c063c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix regression on win32",
+  "packageName": "@fluentui-react-native/checkbox",
+  "email": "rohanpd.work@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Checkbox/src/Checkbox.tsx
+++ b/packages/components/Checkbox/src/Checkbox.tsx
@@ -54,7 +54,7 @@ export const Checkbox = compose<CheckboxType>({
       return (
         <Slots.root {...mergedProps} {...(Platform.OS == 'android' && { accessible: !disabled, focusable: !disabled })}>
           {Checkbox.state.labelIsBefore && labelComponent}
-          <Slots.checkbox {...(Platform.OS == 'android' && { onPress, disabled })} accessible={false} focusable={false}>
+          <Slots.checkbox accessible={false} onPress={onPress} disabled focusable={false}>
             <Slots.checkmark key="checkmark" viewBox="0 0 12 12">
               {checkmarkPath}
             </Slots.checkmark>


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes


https://github.com/microsoft/fluentui-react-native/pull/2416 , in this PR there was a change from View to Pressable to accommodate ripple behavior on Android as View doesn't support ripple. 

But there was an regression on win32 ,  https://github.com/microsoft/fluentui-react-native/pull/2466 . 
I have provided a fix for the same in this PR. 


### Verification
Ran win32 tester as well and verified with pre-existing behavior of keyboard navigation and click points. 

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
