### PR TITLE
[Checkbox] fix checkbox & regression

### DIFF
--- a/change/@fluentui-react-native-checkbox-e33c4114-27b1-42d8-a2f0-d4e44b822a54.json
+++ b/change/@fluentui-react-native-checkbox-e33c4114-27b1-42d8-a2f0-d4e44b822a54.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix checkbox & regression",
+  "packageName": "@fluentui-react-native/checkbox",
+  "email": "rohanpd.work@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Checkbox/src/Checkbox.tsx
+++ b/packages/components/Checkbox/src/Checkbox.tsx
@@ -54,7 +54,7 @@ export const Checkbox = compose<CheckboxType>({
       return (
         <Slots.root {...mergedProps} {...(Platform.OS == 'android' && { accessible: !disabled, focusable: !disabled })}>
           {Checkbox.state.labelIsBefore && labelComponent}
-          <Slots.checkbox accessible={false} onPress={onPress} disabled focusable={false}>
+          <Slots.checkbox accessible={false} onPress={onPress} disabled={disabled} focusable={false}>
             <Slots.checkmark key="checkmark" viewBox="0 0 12 12">
               {checkmarkPath}
             </Slots.checkmark>


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes
This is PR to fix a regression. 
The PR https://github.com/microsoft/fluentui-react-native/pull/2467 which targeted to fix a regression on win32 had impact on Android ripple. 
Seems passing disabled directly had an effect on the ripple area, hence made a small fix. 
Verified on win32 as well so be sure it doesn't break it again.



Current fix : 
Clicking on checkbox should bring only ripple on checkbox , and clicking on label should bring ripple on entire area.


https://user-images.githubusercontent.com/30728574/209975663-c307c2e9-1982-4e5d-840e-e80eb80b2db3.mov

Previously : Clicking on checkbox was bringing ripple on entire area. 

https://user-images.githubusercontent.com/30728574/209975675-670d0405-a04d-40b7-ae16-cfa5aa26236a.mov


### Verification

Adding a video for win32 platform. On Android verified visually and seems working as expected. 

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
