### PR TITLE
Update Compressible inline documentation

### DIFF
--- a/change/@fluentui-react-native-framework-6950ec96-3368-404c-8cab-821eeb06e02f.json
+++ b/change/@fluentui-react-native-framework-6950ec96-3368-404c-8cab-821eeb06e02f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update Compressible documentation",
+  "packageName": "@fluentui-react-native/framework",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/framework/framework/src/compressible.ts
+++ b/packages/framework/framework/src/compressible.ts
@@ -5,7 +5,7 @@ import { UseTokens } from './useTokens';
 import { TokenSettings } from './useStyling';
 
 /**
- * Utility function which can create Function components that can be tree compressed (using the stagedRender pattern),
+ * Utility function which can create function components that can be tree compressed (using the stagedRender pattern),
  * and also have customize functionality exposed to swap out tokens.
  */
 export function compressible<TProps, TTokens>(

--- a/packages/framework/framework/src/compressible.ts
+++ b/packages/framework/framework/src/compressible.ts
@@ -1,12 +1,15 @@
 import { Theme } from '@fluentui-react-native/theme-types';
 import { stagedComponent, StagedRender } from '@fluentui-react-native/use-slot';
 import { CustomizableComponent } from '@fluentui-react-native/use-tokens';
-import { UseTokens } from './useTokens';
 import { TokenSettings } from './useStyling';
+import { UseTokens } from './useTokens';
 
 /**
  * Utility function which can create function components that can be tree compressed (using the stagedRender pattern),
- * and also have customize functionality exposed to swap out tokens.
+ * and also have customize functionality.
+ * @param fn StagedRender function that defines your component
+ * @param useTokens a hook function to build a set of tokens from a passed in theme as well as a cache object
+ * @returns A tree compressed function component with the `.customize` method exposed to it
  */
 export function compressible<TProps, TTokens>(
   fn: StagedRender<TProps>,

--- a/packages/framework/framework/src/compressible.ts
+++ b/packages/framework/framework/src/compressible.ts
@@ -4,6 +4,10 @@ import { CustomizableComponent } from '@fluentui-react-native/use-tokens';
 import { UseTokens } from './useTokens';
 import { TokenSettings } from './useStyling';
 
+/**
+ * Utility function which can create Function components that can be tree compressed (using the stagedRender pattern),
+ * and also have customize functionality exposed to swap out tokens.
+ */
 export function compressible<TProps, TTokens>(
   fn: StagedRender<TProps>,
   useTokens: UseTokens<TTokens>,

--- a/packages/framework/framework/src/useTokens.ts
+++ b/packages/framework/framework/src/useTokens.ts
@@ -5,6 +5,7 @@ import { TokenSettings } from './useStyling';
 
 export { applyTokenLayers, applyPropsToTokens, customizable, patchTokens } from '@fluentui-react-native/use-tokens';
 
+// A hook function to build a set of tokens from a passed in theme as well as a cache object
 export type UseTokens<TTokens> = UseTokensCore<TTokens, Theme>;
 
 export function buildUseTokens<TTokens>(...tokens: TokenSettings<TTokens>[]): UseTokens<TTokens> {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

Super simple change to add some inline documentation to compressible so that VS Code Intellisense can pick it up. The words I added are a rehash of the PR description of #819 (the PR that added compressible).

This is...  very little documentation, but better than nothing. 

### Verification

Hovering over compressible in VS Code works. 

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
