### PR TITLE
Add underline to Link component

### DIFF
--- a/change/@fluentui-react-native-link-e4ee89e3-2559-4525-b78f-8367e489bfa6.json
+++ b/change/@fluentui-react-native-link-e4ee89e3-2559-4525-b78f-8367e489bfa6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add underline to Link",
+  "packageName": "@fluentui-react-native/link",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Link/src/LinkTokens.ts
+++ b/packages/components/Link/src/LinkTokens.ts
@@ -7,9 +7,7 @@ export const defaultLinkTokens: TokenSettings<LinkTokens, Theme> = (t: Theme) =>
     color: t.colors.brandForegroundLink,
     alignSelf: 'flex-start',
     variant: 'body1',
-    inline: {
-      textDecorationLine: 'underline',
-    },
+    textDecorationLine: 'underline',
     disabled: {
       color: t.colors.neutralForegroundDisabled,
       textDecorationLine: 'none',
@@ -19,7 +17,6 @@ export const defaultLinkTokens: TokenSettings<LinkTokens, Theme> = (t: Theme) =>
     },
     hovered: {
       color: t.colors.brandForegroundLinkHover,
-      textDecorationLine: 'underline',
     },
     pressed: {
       color: t.colors.brandForegroundLinkPressed,


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [ ] android

### Description of changes

The design on the Link has changed to add an underline for all Links, not just inline Links.
Adding underline for all Links.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/4602628/210661014-6778b788-6da0-43fd-9aee-917c75de8da4.png) ![image](https://user-images.githubusercontent.com/4602628/210661051-2ba4456a-baea-471d-a9c3-3dd2591f1126.png) | ![image](https://user-images.githubusercontent.com/4602628/210660665-6078e42f-91fd-48eb-a918-93e7e676ee6a.png) ![image](https://user-images.githubusercontent.com/4602628/210660602-0e9bf629-7fc6-4b67-82b2-ecd5fd14eabd.png) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
