### PR TITLE
Memoize theme creation for iOS, macOS, android

### DIFF
--- a/change/@fluentui-react-native-android-theme-1da7f8cb-7739-4ae7-9758-7460a965cb58.json
+++ b/change/@fluentui-react-native-android-theme-1da7f8cb-7739-4ae7-9758-7460a965cb58.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Memoize theme creation for android, ios, macOS",
+  "packageName": "@fluentui-react-native/android-theme",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-apple-theme-33349529-0eec-44de-be81-f0d749691fe9.json
+++ b/change/@fluentui-react-native-apple-theme-33349529-0eec-44de-be81-f0d749691fe9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Memoize theme creation for android, ios, macOS",
+  "packageName": "@fluentui-react-native/apple-theme",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/theming/android-theme/src/androidTheme.ts
+++ b/packages/theming/android-theme/src/androidTheme.ts
@@ -4,6 +4,7 @@ import { paletteFromAndroidColors } from './colorsTokens';
 import { androidTypography } from './androidTypography';
 import { getAndroidPalette } from './colorsBase';
 import { androidShadows } from './androidShadows';
+import { memoize } from '@fluentui-react-native/memo-cache';
 
 export function androidSpacing(): Spacing {
   return {
@@ -35,7 +36,7 @@ export const androidComponents = {
   },
 };
 
-export function getAndroidTheme(appearance: 'light' | 'dark'): Theme {
+function getAndroidThemeWorker(appearance: 'light' | 'dark'): Theme {
   return {
     colors: paletteFromAndroidColors(getFluentUIAndroidPalette(getAndroidPalette(appearance))),
     typography: androidTypography(),
@@ -45,3 +46,5 @@ export function getAndroidTheme(appearance: 'light' | 'dark'): Theme {
     host: { appearance },
   };
 }
+
+export const getAndroidTheme = memoize(getAndroidThemeWorker);

--- a/packages/theming/apple-theme/src/appleColors.macos.ts
+++ b/packages/theming/apple-theme/src/appleColors.macos.ts
@@ -1,5 +1,4 @@
 import { ThemeColorDefinition, AppearanceOptions } from '@fluentui-react-native/theme-types';
-import { getCurrentAppearance } from '@fluentui-react-native/theming-utils';
 import { AppleSemanticPalette, FluentUIApplePalette } from './appleColors.types.macos';
 import { PlatformColor, DynamicColorMacOS, ColorWithSystemEffectMacOS } from 'react-native-macos';
 import { createMacOSColorAliasTokens } from './createMacOSAliasTokens';

--- a/packages/theming/apple-theme/src/appleColors.macos.ts
+++ b/packages/theming/apple-theme/src/appleColors.macos.ts
@@ -1,8 +1,7 @@
-import { ThemeColorDefinition, AliasColorTokens } from '@fluentui-react-native/theme-types';
+import { ThemeColorDefinition, AppearanceOptions } from '@fluentui-react-native/theme-types';
 import { getCurrentAppearance } from '@fluentui-react-native/theming-utils';
 import { AppleSemanticPalette, FluentUIApplePalette } from './appleColors.types.macos';
 import { PlatformColor, DynamicColorMacOS, ColorWithSystemEffectMacOS } from 'react-native-macos';
-import { Appearance } from 'react-native';
 import { createMacOSColorAliasTokens } from './createMacOSAliasTokens';
 import { getIsHighContrast } from './appleHighContrast.macos';
 
@@ -255,18 +254,14 @@ function getFluentUIApplePalette(): FluentUIApplePalette {
   };
 }
 
-function getMacOSAliasTokens(): AliasColorTokens {
-  const appearance = Appearance.getColorScheme();
-  const mode = getCurrentAppearance(appearance, 'light');
-  return createMacOSColorAliasTokens(mode, getIsHighContrast());
-}
 /** Creates a palette of colors for the apple theme, given the FluentUI Apple Palette and Apple Semantic Palette
  * The fallback palette is loaded while we wait for  the native theming module to load, or if the module is not found
  */
-export function fallbackApplePalette(): ThemeColorDefinition {
+export function fallbackApplePalette(mode: AppearanceOptions): ThemeColorDefinition {
   const fluentUIApple = getFluentUIApplePalette();
   const applePlatform = getAppleSemanticPalette();
-  const macOSAliasColorTokens = getMacOSAliasTokens();
+  const macOSAliasColorTokens = createMacOSColorAliasTokens(mode, getIsHighContrast());
+
   return {
     /* PaletteBackgroundColors & PaletteTextColors */
 

--- a/packages/theming/apple-theme/src/appleShadows.macos.ts
+++ b/packages/theming/apple-theme/src/appleShadows.macos.ts
@@ -1,11 +1,7 @@
-import { ThemeShadowDefinition } from '@fluentui-react-native/theme-types';
-import { getCurrentAppearance } from '@fluentui-react-native/theming-utils';
-import { Appearance } from 'react-native';
+import { ThemeShadowDefinition, AppearanceOptions } from '@fluentui-react-native/theme-types';
 import { getIsHighContrast } from './appleHighContrast.macos';
 import { createMacOSShadowAliasTokens } from './createMacOSAliasTokens';
 
-export function fallbackAppleShadows(): ThemeShadowDefinition {
-  const appearance = Appearance.getColorScheme();
-  const mode = getCurrentAppearance(appearance, 'light');
+export function fallbackAppleShadows(mode: AppearanceOptions): ThemeShadowDefinition {
   return createMacOSShadowAliasTokens(mode, getIsHighContrast());
 }

--- a/packages/theming/apple-theme/src/appleTheme.ios.ts
+++ b/packages/theming/apple-theme/src/appleTheme.ios.ts
@@ -2,6 +2,7 @@ import { Theme, Spacing } from '@fluentui-react-native/theme-types';
 import { paletteFromAppleColors } from './appleColors.ios';
 import { appleTypography } from './appleTypography.ios';
 import { iOSShadows } from './appleShadows.ios';
+import { memoize } from '@fluentui-react-native/memo-cache';
 
 function appleSpacing(): Spacing {
   return {
@@ -127,7 +128,7 @@ const appleComponents = {
   },
 };
 
-export function getBaseAppleThemeIOS(isLightMode: boolean): Theme {
+function getBaseAppleThemeIOSWorker(isLightMode: boolean): Theme {
   return {
     colors: paletteFromAppleColors(isLightMode),
     typography: appleTypography(),
@@ -137,3 +138,5 @@ export function getBaseAppleThemeIOS(isLightMode: boolean): Theme {
     host: { appearance: isLightMode ? 'light' : 'dark' },
   };
 }
+
+export const getBaseAppleThemeIOS = memoize(getBaseAppleThemeIOSWorker);

--- a/packages/theming/apple-theme/src/appleTheme.macos.ts
+++ b/packages/theming/apple-theme/src/appleTheme.macos.ts
@@ -2,6 +2,7 @@ import { Spacing, Theme } from '@fluentui-react-native/theme-types';
 import { fallbackApplePalette } from './appleColors.macos';
 import { fallbackAppleShadows } from './appleShadows.macos';
 import { fallbackAppleTypography } from './appleTypography.macos';
+import { memoize } from '@fluentui-react-native/memo-cache';
 
 export function appleSpacing(): Spacing {
   return {
@@ -71,7 +72,7 @@ export const appleComponents = {
   },
 };
 
-export function getBaseAppleThemeMacOS(): Theme {
+function getBaseAppleThemeMacOSWorker(): Theme {
   return {
     colors: fallbackApplePalette(),
     typography: fallbackAppleTypography(),
@@ -81,3 +82,5 @@ export function getBaseAppleThemeMacOS(): Theme {
     host: { appearance: 'dynamic' },
   };
 }
+
+export const getBaseAppleThemeMacOS = memoize(getBaseAppleThemeMacOSWorker);

--- a/packages/theming/apple-theme/src/appleTheme.macos.ts
+++ b/packages/theming/apple-theme/src/appleTheme.macos.ts
@@ -1,4 +1,4 @@
-import { Spacing, Theme } from '@fluentui-react-native/theme-types';
+import { Spacing, Theme, AppearanceOptions } from '@fluentui-react-native/theme-types';
 import { fallbackApplePalette } from './appleColors.macos';
 import { fallbackAppleShadows } from './appleShadows.macos';
 import { fallbackAppleTypography } from './appleTypography.macos';
@@ -72,11 +72,11 @@ export const appleComponents = {
   },
 };
 
-function getBaseAppleThemeMacOSWorker(): Theme {
+function getBaseAppleThemeMacOSWorker(mode: AppearanceOptions): Theme {
   return {
-    colors: fallbackApplePalette(),
+    colors: fallbackApplePalette(mode),
     typography: fallbackAppleTypography(),
-    shadows: fallbackAppleShadows(),
+    shadows: fallbackAppleShadows(mode),
     spacing: appleSpacing(),
     components: appleComponents,
     host: { appearance: 'dynamic' },

--- a/packages/theming/apple-theme/src/createAppleTheme.macos.ts
+++ b/packages/theming/apple-theme/src/createAppleTheme.macos.ts
@@ -1,5 +1,6 @@
 import { ThemeReference } from '@fluentui-react-native/theme';
 import { Theme } from '@fluentui-react-native/theme-types';
+import { getCurrentAppearance } from '@fluentui-react-native/theming-utils';
 import { Appearance } from 'react-native';
 import { getBaseAppleThemeMacOS } from './appleTheme.macos';
 import { AccessibilityInfo } from 'react-native-macos';
@@ -9,7 +10,9 @@ let appleThemeReference: ThemeReference;
 
 export function createAppleTheme(): ThemeReference {
   appleThemeReference = new ThemeReference({} as Theme, () => {
-    return getBaseAppleThemeMacOS();
+    const appearance = Appearance.getColorScheme();
+    const mode = getCurrentAppearance(appearance, 'light');
+    return getBaseAppleThemeMacOS(mode);
   });
   // Fetch initial system settings for high contrast mode
   highContrastHandler();


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [x] android

### Description of changes

There was a suggestion in PR #2483 to memoize the method creating the default theme to prevent the method from creating a new theme object every time it's called. This PR is just making the same change for the iOS, macOS, and android themes.

### Verification

CI/automated tests should pass. No visual changes.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
