### PR TITLE
[Checkbox] Android tokens fixes

### DIFF
--- a/apps/fluent-tester/src/TestComponents/CheckboxV1/CheckboxV1Test.tsx
+++ b/apps/fluent-tester/src/TestComponents/CheckboxV1/CheckboxV1Test.tsx
@@ -22,6 +22,7 @@ const BasicCheckbox: React.FunctionComponent = () => {
       <Checkbox label="Checked checkbox (uncontrolled)" onChange={onChangeUncontrolled} defaultChecked accessibilityLabel="Hello there" />
       <Checkbox label="Disabled checkbox" disabled />
       <Checkbox label="Disabled checked checkbox" defaultChecked disabled />
+      <Checkbox label="A required checkbox" required />
     </View>
   );
 };
@@ -32,7 +33,6 @@ const DesktopSpecificCheckbox: React.FunctionComponent = () => {
       <Checkbox label="Checkbox will display a tooltip" tooltip="This is a tooltip" />
       <Checkbox label="A circular checkbox" shape="circular" />
       <Checkbox label="A checkbox with label placed before" labelPosition="before" />
-      <Checkbox label="A required checkbox" required />
     </>
   );
 };

--- a/change/@fluentui-react-native-checkbox-e8e98409-f2c4-4cf6-a72d-bd8692cea0e9.json
+++ b/change/@fluentui-react-native-checkbox-e8e98409-f2c4-4cf6-a72d-bd8692cea0e9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix checkbox android tokens",
+  "packageName": "@fluentui-react-native/checkbox",
+  "email": "rohanpd.work@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-a6471782-1946-4d9d-bc1e-79c7aaa7c486.json
+++ b/change/@fluentui-react-native-tester-a6471782-1946-4d9d-bc1e-79c7aaa7c486.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix checkbox android tokens",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "rohanpd.work@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Checkbox/src/CheckboxTokens.android.ts
+++ b/packages/components/Checkbox/src/CheckboxTokens.android.ts
@@ -7,6 +7,8 @@ import { CheckboxTokens } from './Checkbox.types';
 
 export const defaultCheckboxTokens: TokenSettings<CheckboxTokens, Theme> = (t: Theme) =>
   ({
+    requiredColor: globalTokens.color.darkRed.primary,
+    requiredPadding: globalTokens.size20,
     checkboxBorderWidth: globalTokens.stroke.width15,
     checkboxBorderRadius: globalTokens.corner.radius40,
     checkboxSize: globalTokens.size200,
@@ -26,9 +28,7 @@ export const defaultCheckboxTokens: TokenSettings<CheckboxTokens, Theme> = (t: T
       checkboxBackgroundColor: t.colors.neutralBackground1Pressed,
     },
     padding: globalTokens.size20,
-    fontSize: t.typography.variants.body1.size,
-    fontWeight: t.typography.variants.body1.weight,
-    fontLineHeight: t.typography.variants.body1.lineHeight,
+    variant: 'body1',
     checkboxBorderColor: t.colors.neutralStrokeAccessible,
     checkmarkOpacity: 0,
     disabled: {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [x] android

### Description of changes
This PR targets to fix the label token text variant to body1 as it was not available before. 
Modified the test app to show the same
### Verification

Visually verified on Android. 
 
| Before                                       | After                                      | Dark Mode - After                             |
|----------------------------------------------|--------------------------------------------|---------------------------------------------|
| ![Screenshot_1672902479](https://user-images.githubusercontent.com/30728574/210722864-e8afa998-3553-406b-a2e5-6a7105f319a1.png) | ![Screenshot_1672902486](https://user-images.githubusercontent.com/30728574/210722885-0ba3fdb3-da8e-4f11-9742-1e8d45de6a18.png) | ![Screenshot_1672902583](https://user-images.githubusercontent.com/30728574/210723656-84d5f93e-6ab9-4718-a52a-c822733eab23.png) |


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
