### PR TITLE
Show focus on Submenu item for keyboard access

### DIFF
--- a/change/@fluentui-react-native-menu-6e8f4812-f534-4202-926f-e3a9b54d4fb0.json
+++ b/change/@fluentui-react-native-menu-6e8f4812-f534-4202-926f-e3a9b54d4fb0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Show focus on Submenu item for keyboard access",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "amchiu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/MenuItem/useMenuItem.ts
+++ b/packages/components/Menu/src/MenuItem/useMenuItem.ts
@@ -38,6 +38,7 @@ export const useMenuItem = (props: MenuItemProps): MenuItemInfo => {
         ((isRtl && e.nativeEvent.key === 'ArrowLeft') || (!isRtl && e.nativeEvent.key === 'ArrowRight'));
 
       if (!disabled && (!isArrowKey || isArrowOpen)) {
+        componentRef?.current?.blur();
         onClick?.(e);
       }
 
@@ -51,7 +52,7 @@ export const useMenuItem = (props: MenuItemProps): MenuItemInfo => {
         onArrowClose?.(e);
       }
     },
-    [disabled, hasSubmenu, onArrowClose, onClick, setOpen, shouldPersist],
+    [componentRef, disabled, hasSubmenu, onArrowClose, onClick, setOpen, shouldPersist],
   );
 
   const pressable = usePressableState({ ...rest, onPress: onInvoke });

--- a/packages/components/Menu/src/MenuList/MenuList.tsx
+++ b/packages/components/Menu/src/MenuList/MenuList.tsx
@@ -9,6 +9,7 @@ import { useMenuList } from './useMenuList';
 import { useMenuListContextValue } from './useMenuListContextValue';
 import { IViewProps } from '@fluentui-react-native/adapters';
 import { FocusZone } from '@fluentui-react-native/focus-zone';
+import { useMenuContext } from '../context';
 
 const MenuStack = stagedComponent((props: React.PropsWithRef<IViewProps> & { gap?: number }) => {
   const { gap, ...rest } = props;
@@ -39,6 +40,7 @@ export const MenuList = compose<MenuListType>({
   },
   useRender: (userProps: MenuListProps, useSlots: UseSlots<MenuListType>) => {
     const menuList = useMenuList(userProps);
+    const context = useMenuContext();
     const contextValue = useMenuListContextValue(menuList);
     const Slots = useSlots(menuList.props);
 
@@ -56,7 +58,7 @@ export const MenuList = compose<MenuListType>({
               <Slots.focusZone
                 componentRef={focusZoneRef}
                 focusZoneDirection={'vertical'}
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                defaultTabbableElement={context.isSubmenu ? null : focusZoneRef} // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                 // @ts-ignore FocusZone takes ViewProps, but that isn't defined on it's type.
                 enableFocusRing={false}
               >

--- a/packages/components/Menu/src/MenuList/MenuList.tsx
+++ b/packages/components/Menu/src/MenuList/MenuList.tsx
@@ -40,8 +40,8 @@ export const MenuList = compose<MenuListType>({
   },
   useRender: (userProps: MenuListProps, useSlots: UseSlots<MenuListType>) => {
     const menuList = useMenuList(userProps);
-    const context = useMenuContext();
-    const contextValue = useMenuListContextValue(menuList);
+    const menuContext = useMenuContext();
+    const menuListContextValue = useMenuListContextValue(menuList);
     const Slots = useSlots(menuList.props);
 
     const focusZoneRef = React.useRef<View>();
@@ -58,7 +58,7 @@ export const MenuList = compose<MenuListType>({
               <Slots.focusZone
                 componentRef={focusZoneRef}
                 focusZoneDirection={'vertical'}
-                defaultTabbableElement={context.isSubmenu ? null : focusZoneRef} // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                defaultTabbableElement={menuContext.isSubmenu ? null : focusZoneRef} // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                 // @ts-ignore FocusZone takes ViewProps, but that isn't defined on it's type.
                 enableFocusRing={false}
               >
@@ -70,7 +70,7 @@ export const MenuList = compose<MenuListType>({
           <Slots.root>{children}</Slots.root>
         );
 
-      return <MenuListProvider value={contextValue}>{content}</MenuListProvider>;
+      return <MenuListProvider value={menuListContextValue}>{content}</MenuListProvider>;
     };
   },
 });

--- a/packages/components/Menu/src/MenuList/MenuList.tsx
+++ b/packages/components/Menu/src/MenuList/MenuList.tsx
@@ -58,6 +58,8 @@ export const MenuList = compose<MenuListType>({
               <Slots.focusZone
                 componentRef={focusZoneRef}
                 focusZoneDirection={'vertical'}
+                // For submenus, setting defaultTabbableElement to null will let FZ set focus on the first key view.
+                // For root menu, let's set focus on the container to block FZ setting focus on the first key view.
                 defaultTabbableElement={menuContext.isSubmenu ? null : focusZoneRef} // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                 // @ts-ignore FocusZone takes ViewProps, but that isn't defined on it's type.
                 enableFocusRing={false}

--- a/packages/components/Menu/src/MenuList/MenuList.tsx
+++ b/packages/components/Menu/src/MenuList/MenuList.tsx
@@ -56,7 +56,6 @@ export const MenuList = compose<MenuListType>({
               <Slots.focusZone
                 componentRef={focusZoneRef}
                 focusZoneDirection={'vertical'}
-                defaultTabbableElement={focusZoneRef}
                 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                 // @ts-ignore FocusZone takes ViewProps, but that isn't defined on it's type.
                 enableFocusRing={false}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This PR refines the focus behavior for Submenu item to align with the native experience. 

1. When opening a menu(via keyboard/mouse), the first menu item should not get focus. 
            - Covered.
2. When opening a submenu via mouse, the first menu item should not get focus. 
            - Regressed by this change, created a task for followup.
3. When opening a submenu via keyboard, the first menu item should get focus and the parent submenu item should lose focus/ fades to a gray color background.
            - This change achieves the first part, a task has been filed to followup on the second part.



### Verification

Tested Submenus on win32, didn't notice any behavioral changes. 

Before:

https://user-images.githubusercontent.com/67026167/211050743-78ec34af-8fea-4c57-aa58-9d31324f49bd.mov


After:

https://user-images.githubusercontent.com/67026167/211050712-02f2f912-8c40-4f60-823e-2693f08e284a.mov



### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [X] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
