### PR TITLE
Changed jest config for win32 in Badge and Avatar

### DIFF
--- a/change/@fluentui-react-native-avatar-7a5d897b-9112-4d21-941f-9a2c6f4c861a.json
+++ b/change/@fluentui-react-native-avatar-7a5d897b-9112-4d21-941f-9a2c6f4c861a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated jest config for Avatar and Badge",
+  "packageName": "@fluentui-react-native/avatar",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-badge-a1efb260-bd84-4012-b090-3d985d5dd1dc.json
+++ b/change/@fluentui-react-native-badge-a1efb260-bd84-4012-b090-3d985d5dd1dc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated jest config for Avatar and Badge",
+  "packageName": "@fluentui-react-native/badge",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Avatar/jest.config.js
+++ b/packages/components/Avatar/jest.config.js
@@ -1,2 +1,2 @@
 const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
-module.exports = configureReactNativeJest('ios');
+module.exports = configureReactNativeJest('win32');

--- a/packages/components/Avatar/package.json
+++ b/packages/components/Avatar/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/scripts": "^0.1.1",
+    "@office-iss/react-native-win32": "^0.68.0",
     "@types/react-native": "^0.68.0",
     "react": "17.0.2",
     "react-native": "^0.68.0"

--- a/packages/components/Badge/jest.config.js
+++ b/packages/components/Badge/jest.config.js
@@ -1,2 +1,2 @@
 const { configureReactNativeJest } = require('@fluentui-react-native/scripts');
-module.exports = configureReactNativeJest('ios');
+module.exports = configureReactNativeJest('win32');

--- a/packages/components/Badge/package.json
+++ b/packages/components/Badge/package.json
@@ -39,6 +39,7 @@
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/scripts": "^0.1.1",
     "@fluentui-react-native/test-tools": ">=0.1.1 <1.0.0",
+    "@office-iss/react-native-win32": "^0.68.0",
     "@types/react-native": "^0.68.0",
     "react": "17.0.2",
     "react-native": "^0.68.0"

--- a/packages/components/Badge/src/__tests__/__snapshots__/Badge.test.tsx.snap
+++ b/packages/components/Badge/src/__tests__/__snapshots__/Badge.test.tsx.snap
@@ -42,11 +42,12 @@ exports[`Badge component tests Badge all props 1`] = `
     accessible={false}
     ellipsizeMode="tail"
     numberOfLines={0}
+    onAccessibilityTap={[Function]}
     style={
       Object {
         "color": "#ffffff",
-        "fontFamily": "System",
-        "fontSize": 13,
+        "fontFamily": "Segoe UI",
+        "fontSize": 12,
         "fontWeight": "400",
         "margin": 0,
         "marginEnd": 2,
@@ -84,11 +85,12 @@ exports[`Badge component tests Badge tokens 1`] = `
     accessible={false}
     ellipsizeMode="tail"
     numberOfLines={0}
+    onAccessibilityTap={[Function]}
     style={
       Object {
         "color": "#ffffff",
-        "fontFamily": "System",
-        "fontSize": 13,
+        "fontFamily": "Segoe UI",
+        "fontSize": 12,
         "fontWeight": "400",
         "margin": 0,
       }
@@ -163,11 +165,12 @@ exports[`CounterBadge component tests CounterBadge all props 1`] = `
   <Text
     ellipsizeMode="tail"
     numberOfLines={0}
+    onAccessibilityTap={[Function]}
     style={
       Object {
         "color": "#ffffff",
-        "fontFamily": "System",
-        "fontSize": 13,
+        "fontFamily": "Segoe UI",
+        "fontSize": 12,
         "fontStyle": undefined,
         "fontWeight": "400",
         "letterSpacing": undefined,
@@ -206,11 +209,12 @@ exports[`CounterBadge component tests CounterBadge shows 99+ 1`] = `
   <Text
     ellipsizeMode="tail"
     numberOfLines={0}
+    onAccessibilityTap={[Function]}
     style={
       Object {
         "color": "#ffffff",
-        "fontFamily": "System",
-        "fontSize": 13,
+        "fontFamily": "Segoe UI",
+        "fontSize": 12,
         "fontStyle": undefined,
         "fontWeight": "400",
         "letterSpacing": undefined,
@@ -249,11 +253,12 @@ exports[`CounterBadge component tests CounterBadge shows 1000+ 1`] = `
   <Text
     ellipsizeMode="tail"
     numberOfLines={0}
+    onAccessibilityTap={[Function]}
     style={
       Object {
         "color": "#ffffff",
-        "fontFamily": "System",
-        "fontSize": 13,
+        "fontFamily": "Segoe UI",
+        "fontSize": 12,
         "fontStyle": undefined,
         "fontWeight": "400",
         "letterSpacing": undefined,
@@ -293,11 +298,12 @@ exports[`CounterBadge component tests CounterBadge shows zero 1`] = `
   <Text
     ellipsizeMode="tail"
     numberOfLines={0}
+    onAccessibilityTap={[Function]}
     style={
       Object {
         "color": "#ffffff",
-        "fontFamily": "System",
-        "fontSize": 13,
+        "fontFamily": "Segoe UI",
+        "fontSize": 12,
         "fontStyle": undefined,
         "fontWeight": "400",
         "letterSpacing": undefined,
@@ -336,11 +342,12 @@ exports[`CounterBadge component tests CounterBadge tokens 1`] = `
   <Text
     ellipsizeMode="tail"
     numberOfLines={0}
+    onAccessibilityTap={[Function]}
     style={
       Object {
         "color": "#ffffff",
-        "fontFamily": "System",
-        "fontSize": 13,
+        "fontFamily": "Segoe UI",
+        "fontSize": 12,
         "fontStyle": undefined,
         "fontWeight": "400",
         "letterSpacing": undefined,


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
Changed jest config for win32 in Avatar and Badge

### Verification
Ran tests

### Pull request checklist

This PR has considered (when applicable):
- [X] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
