### PR TITLE
[E2E Tests] Remove testPage fn overrides, add pageButtonName fn

### DIFF
--- a/apps/E2E/README.md
+++ b/apps/E2E/README.md
@@ -88,6 +88,20 @@ First check that iOS configs in wdio.conf.ios.js are updated to match your dev e
 
 _Note: It could take up to a minute to load the test app with WebDriverIO, don't panic, the tests will run :)_
 
+## Android Steps
+
+1. Follow step #1 from "Win32 Steps" section above.
+2. Start the server
+   - (from fluentui-react-native) `cd apps/fluent-tester`
+   - (from fluentui-react-native/apps/fluent-tester) `yarn start`
+3. Install and run the app from a new command prompt
+   - (from fluentui-react-native) `cd apps/fluent-tester`
+   - (from fluentui-react-native/apps/fluent-tester) `yarn android`
+4. Open a new command prompt and run the E2E tests
+   - (from fluentui-react-native/apps/E2E) `yarn e2etest:android`
+
+_Note: It could take up to a minute to load the test app with WebDriverIO, don't panic, the tests will run :)_
+
 # Authoring E2E Test
 
 You just added a new component to FURN... Awesome! Now we need to make sure we have proper regression testing to make sure we put the safest product out there (don't worry, it's not as hard as it sounds). Here's what we have to do:
@@ -145,9 +159,14 @@ class CheckboxPageObject extends BasePage {
     this._testPage.click();
   }
 
-  // This function selects a UI element with the prop `testID = CHECKBOX_TESTPAGE`
-  get _checkboxComponent() {
-    return By(CHECKBOX_TESTPAGE);
+  // This function gives the identifier of the test page's first section. This is used to test page load.
+  get _pageName() {
+    return CHECKBOX_TESTPAGE;
+  }
+
+  // This function gives the identifier of the button that navigates to the component's test page.
+  get _pageButtonName() {
+    return HOMEPAGE_CHECKBOX_BUTTON;
   }
 }
 
@@ -164,21 +183,22 @@ For example, a common task we want to perform is selecting a UI element and gett
 
 - In order for a Page Object to access a component from the test page, you must use [selectors](https://webdriver.io/docs/selectors.html). The WebDriver Protocol provides several selector strategies to query an element.
 
-- If [testID](https://reactnative.dev/docs/next/view#testid) is specified in React Native app for Windows, the locator strategy should choose accessibility id.
-  A unique accessiblity id/testID per Window is recommended for React Native Windows E2E testing when authoring the test app and test cases.
+- The underlying Android test drivers use [accessibilityLabel](https://reactnative.dev/docs/accessibility#accessibilitylabel) to find elements. However, all other platforms use [testID](https://reactnative.dev/docs/next/view#testid). Because of this, we're adding the testProps function that takes in a unique identifier and returns the correct prop based on the platform (testID for Win32, Windows, macOS, iOS; accessibilityId for Android).
+  If explict accessibilityLabel is being used for other platforms, apply testProps after it to override it for Android.
 
-- To use this, we must add a prop to our component or UI element in question called “testID”. In our test page, set the “testID” for the component, and we can then select it in our Page Object using the imported **_By_** method above from a base class.
+- If testProps is specified, the locator strategy should choose accessibility id.
+  A unique accessiblity id/testID per Window is recommended for E2E testing when authoring the test app and test cases.
+
+- To use this, we must add a prop to our component or UI element in question called "testProps". In our test page, set the “testProps” for the component after accessibilityLabel prop (if present), and we can then select it in our Page Object using the imported **_By_** method above from a base class.
 
 ## Setup your Component Test Page in the Test App
 
 In order to test the component, we need a test page in FURNs test app. Once you create that, you'll want to create a separate file for E2E testing (see pattern used by all other controls). Create
-an example and set `testID = {your_components_constant}` on your new control. Now, our automation framework can select this component using the constant you passed in to `testID`.
+an example and set `...{testProps(your_components_constant)}` on your new control. Now, our automation framework can select this component using the constant you passed in to `testProps`.
 
 ## Add to NavigateAppPage.ts
 
 This page object is responsible for navigating through the app to each test page. Here, you'll want to add integration for your new component. (Easily reproducible by looking at other components in the file).
-
-**If testID doesn't exist on your component, simply add it to your component's \_types.ts\_ file.**
 
 ## Write a Test Spec
 

--- a/apps/E2E/src/ActivityIndicator/pages/ActivityIndicatorPageObject.ts
+++ b/apps/E2E/src/ActivityIndicator/pages/ActivityIndicatorPageObject.ts
@@ -5,10 +5,6 @@ class ActivityIndicatorPageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(ACTIVITY_INDICATOR_TESTPAGE);
-  }
-
   get _pageName() {
     return ACTIVITY_INDICATOR_TESTPAGE;
   }
@@ -17,8 +13,8 @@ class ActivityIndicatorPageObject extends BasePage {
     return By(ACTIVITY_INDICATOR_TEST_COMPONENT);
   }
 
-  get _pageButton() {
-    return By(HOMEPAGE_ACTIVITY_INDICATOR_BUTTON);
+  get _pageButtonName() {
+    return HOMEPAGE_ACTIVITY_INDICATOR_BUTTON;
   }
 }
 

--- a/apps/E2E/src/Avatar/pages/AvatarPageObject.ts
+++ b/apps/E2E/src/Avatar/pages/AvatarPageObject.ts
@@ -1,22 +1,9 @@
-import {
-  AVATAR_TESTPAGE,
-  HOMEPAGE_AVATAR_BUTTON,
-  AVATAR_TEST_COMPONENT,
-  AVATAR_SECONDARY_TEST_COMPONENT,
-} from '../consts';
+import { AVATAR_TESTPAGE, HOMEPAGE_AVATAR_BUTTON, AVATAR_TEST_COMPONENT, AVATAR_SECONDARY_TEST_COMPONENT } from '../consts';
 import { BasePage, By } from '../../common/BasePage';
 class AvatarPageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(AVATAR_TESTPAGE);
-  }
-
-  get _pageButton() {
-    return By(HOMEPAGE_AVATAR_BUTTON);
-  }
-
   get _pageButtonName() {
     return HOMEPAGE_AVATAR_BUTTON;
   }

--- a/apps/E2E/src/Badge/pages/BasicBadgePageObject.ts
+++ b/apps/E2E/src/Badge/pages/BasicBadgePageObject.ts
@@ -1,9 +1,4 @@
-import {
-  BADGE_TESTPAGE,
-  HOMEPAGE_BADGE_BUTTON,
-  BADGE_TEST_COMPONENT,
-  BADGE_SECONDARY_TEST_COMPONENT,
-} from '../consts';
+import { BADGE_TESTPAGE, HOMEPAGE_BADGE_BUTTON, BADGE_TEST_COMPONENT, BADGE_SECONDARY_TEST_COMPONENT } from '../consts';
 import { BasePage, By } from '../../common/BasePage';
 
 export const enum BadgeComponentSelector {
@@ -23,12 +18,8 @@ class BasicBadgePageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(BADGE_TESTPAGE);
-  }
-
-  get _pageButton() {
-    return By(HOMEPAGE_BADGE_BUTTON);
+  get _pageButtonName() {
+    return HOMEPAGE_BADGE_BUTTON;
   }
 
   get _pageName() {

--- a/apps/E2E/src/ButtonLegacy/pages/ButtonLegacyPageObject.ts
+++ b/apps/E2E/src/ButtonLegacy/pages/ButtonLegacyPageObject.ts
@@ -44,10 +44,6 @@ class ButtonLegacyPageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(BUTTON_TESTPAGE);
-  }
-
   get _pageName() {
     return BUTTON_TESTPAGE;
   }
@@ -58,10 +54,6 @@ class ButtonLegacyPageObject extends BasePage {
 
   get _secondaryComponent() {
     return By(BUTTON_NO_A11Y_LABEL_COMPONENT_DEPRECATED);
-  }
-
-  get _pageButton() {
-    return By(HOMEPAGE_BUTTON_BUTTON);
   }
 
   get _pageButtonName() {

--- a/apps/E2E/src/ButtonV1/pages/ButtonV1PageObject.ts
+++ b/apps/E2E/src/ButtonV1/pages/ButtonV1PageObject.ts
@@ -24,10 +24,6 @@ class ButtonV1PageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(BUTTON_TESTPAGE);
-  }
-
   get _pageName() {
     return BUTTON_TESTPAGE;
   }
@@ -40,8 +36,8 @@ class ButtonV1PageObject extends BasePage {
     return By(BUTTON_NO_A11Y_LABEL_COMPONENT);
   }
 
-  get _pageButton() {
-    return By(HOMEPAGE_BUTTON_BUTTON);
+  get _pageButtonName() {
+    return HOMEPAGE_BUTTON_BUTTON;
   }
 }
 

--- a/apps/E2E/src/Callout/pages/CalloutPageObject.win.ts
+++ b/apps/E2E/src/Callout/pages/CalloutPageObject.win.ts
@@ -1,9 +1,4 @@
-import {
-  CALLOUT_TESTPAGE,
-  CALLOUT_TEST_COMPONENT,
-  HOMEPAGE_CALLOUT_BUTTON,
-  BUTTON_TO_OPEN_CALLOUT,
-} from '../consts';
+import { CALLOUT_TESTPAGE, CALLOUT_TEST_COMPONENT, HOMEPAGE_CALLOUT_BUTTON, BUTTON_TO_OPEN_CALLOUT } from '../consts';
 import { BasePage, By } from '../../common/BasePage';
 
 class CalloutPageObject extends BasePage {
@@ -33,10 +28,6 @@ class CalloutPageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(CALLOUT_TESTPAGE);
-  }
-
   get _pageName() {
     return CALLOUT_TESTPAGE;
   }
@@ -45,8 +36,8 @@ class CalloutPageObject extends BasePage {
     return By(CALLOUT_TEST_COMPONENT);
   }
 
-  get _pageButton() {
-    return By(HOMEPAGE_CALLOUT_BUTTON);
+  get _pageButtonName() {
+    return HOMEPAGE_CALLOUT_BUTTON;
   }
 
   get _buttonToOpenCallout() {

--- a/apps/E2E/src/CheckboxLegacy/pages/CheckboxLegacyPageObject.ts
+++ b/apps/E2E/src/CheckboxLegacy/pages/CheckboxLegacyPageObject.ts
@@ -63,10 +63,6 @@ class CheckboxLegacyPageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(CHECKBOX_TESTPAGE);
-  }
-
   get _pageName() {
     return CHECKBOX_TESTPAGE;
   }
@@ -79,8 +75,8 @@ class CheckboxLegacyPageObject extends BasePage {
     return By(CHECKBOX_NO_A11Y_LABEL_COMPONENT);
   }
 
-  get _pageButton() {
-    return By(HOMEPAGE_CHECKBOX_BUTTON);
+  get _pageButtonName() {
+    return HOMEPAGE_CHECKBOX_BUTTON;
   }
 }
 

--- a/apps/E2E/src/CheckboxV1/pages/CheckboxV1PageObject.ts
+++ b/apps/E2E/src/CheckboxV1/pages/CheckboxV1PageObject.ts
@@ -63,10 +63,6 @@ class CheckboxV1PageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(CHECKBOXV1_TESTPAGE);
-  }
-
   get _pageName() {
     return CHECKBOXV1_TESTPAGE;
   }
@@ -77,10 +73,6 @@ class CheckboxV1PageObject extends BasePage {
 
   get _secondaryComponent() {
     return By(CHECKBOXV1_NO_A11Y_LABEL_COMPONENT);
-  }
-
-  get _pageButton() {
-    return By(HOMEPAGE_CHECKBOXV1_BUTTON);
   }
 
   get _pageButtonName() {

--- a/apps/E2E/src/ContextualMenu/pages/ContextualMenuPageObject.win.ts
+++ b/apps/E2E/src/ContextualMenu/pages/ContextualMenuPageObject.win.ts
@@ -36,10 +36,6 @@ class ContextualMenuPageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(CONTEXTUALMENU_TESTPAGE);
-  }
-
   get _pageName() {
     return CONTEXTUALMENU_TESTPAGE;
   }
@@ -48,8 +44,8 @@ class ContextualMenuPageObject extends BasePage {
     return By(CONTEXTUALMENU_TEST_COMPONENT);
   }
 
-  get _pageButton() {
-    return By(HOMEPAGE_CONTEXTUALMENU_BUTTON);
+  get _pageButtonName() {
+    return HOMEPAGE_CONTEXTUALMENU_BUTTON;
   }
 
   get _contextualMenuItem() {

--- a/apps/E2E/src/CornerRadiusTokens/pages/CornerRadiusTokensPageObject.ts
+++ b/apps/E2E/src/CornerRadiusTokens/pages/CornerRadiusTokensPageObject.ts
@@ -1,5 +1,5 @@
 import { HOMEPAGE_CORNERRADIUS_TESTPAGE, HOMEPAGE_CORNERRADIUS_BUTTON } from '../consts';
-import { BasePage, By } from '../../common/BasePage';
+import { BasePage } from '../../common/BasePage';
 
 class CornerRadiusTokensPageObject extends BasePage {
   /*****************************************/

--- a/apps/E2E/src/CornerRadiusTokens/pages/CornerRadiusTokensPageObject.ts
+++ b/apps/E2E/src/CornerRadiusTokens/pages/CornerRadiusTokensPageObject.ts
@@ -1,23 +1,16 @@
-import {
-  HOMEPAGE_CORNERRADIUS_TESTPAGE,
-  HOMEPAGE_CORNERRADIUS_BUTTON,
-} from '../consts';
+import { HOMEPAGE_CORNERRADIUS_TESTPAGE, HOMEPAGE_CORNERRADIUS_BUTTON } from '../consts';
 import { BasePage, By } from '../../common/BasePage';
 
 class CornerRadiusTokensPageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(HOMEPAGE_CORNERRADIUS_TESTPAGE);
-  }
-
   get _pageName() {
     return HOMEPAGE_CORNERRADIUS_TESTPAGE;
   }
 
-  get _pageButton() {
-    return By(HOMEPAGE_CORNERRADIUS_BUTTON);
+  get _pageButtonName() {
+    return HOMEPAGE_CORNERRADIUS_BUTTON;
   }
 }
 

--- a/apps/E2E/src/FocusTrapZone/pages/FocusTrapZonePageObject.win.ts
+++ b/apps/E2E/src/FocusTrapZone/pages/FocusTrapZonePageObject.win.ts
@@ -1,18 +1,10 @@
-import {
-  FOCUSTRAPZONE_TESTPAGE,
-  FOCUSTRAPZONE_TEST_COMPONENT,
-  HOMEPAGE_FOCUSTRAPZONE_BUTTON,
-} from '../consts';
+import { FOCUSTRAPZONE_TESTPAGE, FOCUSTRAPZONE_TEST_COMPONENT, HOMEPAGE_FOCUSTRAPZONE_BUTTON } from '../consts';
 import { BasePage, By } from '../../common/BasePage';
 
 class FocusTrapZonePageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(FOCUSTRAPZONE_TESTPAGE);
-  }
-
   get _pageName() {
     return FOCUSTRAPZONE_TESTPAGE;
   }
@@ -21,8 +13,8 @@ class FocusTrapZonePageObject extends BasePage {
     return By(FOCUSTRAPZONE_TEST_COMPONENT);
   }
 
-  get _pageButton() {
-    return By(HOMEPAGE_FOCUSTRAPZONE_BUTTON);
+  get _pageButtonName() {
+    return HOMEPAGE_FOCUSTRAPZONE_BUTTON;
   }
 }
 

--- a/apps/E2E/src/FocusZone/pages/FocusZonePageObject.ts
+++ b/apps/E2E/src/FocusZone/pages/FocusZonePageObject.ts
@@ -90,10 +90,6 @@ class FocusZonePageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(FOCUSZONE_TESTPAGE);
-  }
-
   get _pageName() {
     return FOCUSZONE_TESTPAGE;
   }
@@ -102,8 +98,8 @@ class FocusZonePageObject extends BasePage {
     return By(FOCUSZONE_TEST_COMPONENT);
   }
 
-  get _pageButton() {
-    return By(HOMEPAGE_FOCUSZONE_BUTTON);
+  get _pageButtonName() {
+    return HOMEPAGE_FOCUSZONE_BUTTON;
   }
 
   get _directionPicker() {

--- a/apps/E2E/src/IconLegacy/pages/IconLegacyPageObject.ts
+++ b/apps/E2E/src/IconLegacy/pages/IconLegacyPageObject.ts
@@ -5,10 +5,6 @@ class IconLegacyPageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(ICON_TESTPAGE);
-  }
-
   get _pageName() {
     return ICON_TESTPAGE;
   }
@@ -21,8 +17,8 @@ class IconLegacyPageObject extends BasePage {
     return By(ICON_NO_A11Y_LABEL_COMPONENT);
   }
 
-  get _pageButton() {
-    return By(HOMEPAGE_ICON_BUTTON);
+  get _pageButtonName() {
+    return HOMEPAGE_ICON_BUTTON;
   }
 }
 

--- a/apps/E2E/src/IconV1/pages/IconV1PageObject.ts
+++ b/apps/E2E/src/IconV1/pages/IconV1PageObject.ts
@@ -5,10 +5,6 @@ class IconV1PageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(ICON_TESTPAGE);
-  }
-
   get _pageName() {
     return ICON_TESTPAGE;
   }
@@ -21,8 +17,8 @@ class IconV1PageObject extends BasePage {
     return By(ICON_FONT_TEST_COMPONENT);
   }
 
-  get _pageButton() {
-    return By(HOMEPAGE_ICON_BUTTON);
+  get _pageButtonName() {
+    return HOMEPAGE_ICON_BUTTON;
   }
 }
 

--- a/apps/E2E/src/LinkLegacy/pages/LinkLegacyPageObject.ts
+++ b/apps/E2E/src/LinkLegacy/pages/LinkLegacyPageObject.ts
@@ -5,10 +5,6 @@ class LinkLegacyPageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(LINK_TESTPAGE);
-  }
-
   get _pageName() {
     return LINK_TESTPAGE;
   }
@@ -21,8 +17,8 @@ class LinkLegacyPageObject extends BasePage {
     return By(LINK_NO_A11Y_LABEL_COMPONENT);
   }
 
-  get _pageButton() {
-    return By(HOMEPAGE_LINK_BUTTON);
+  get _pageButtonName() {
+    return HOMEPAGE_LINK_BUTTON;
   }
 }
 

--- a/apps/E2E/src/LinkV1/pages/LinkV1PageObject.ts
+++ b/apps/E2E/src/LinkV1/pages/LinkV1PageObject.ts
@@ -19,10 +19,6 @@ class LinkV1PageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(LINKV1_TESTPAGE);
-  }
-
   get _pageName() {
     return LINKV1_TESTPAGE;
   }
@@ -35,8 +31,8 @@ class LinkV1PageObject extends BasePage {
     return By(LINKV1_NO_A11Y_LABEL_COMPONENT);
   }
 
-  get _pageButton() {
-    return By(HOMEPAGE_LINKV1_BUTTON);
+  get _pageButtonName() {
+    return HOMEPAGE_LINKV1_BUTTON;
   }
 }
 

--- a/apps/E2E/src/Menu/pages/MenuPageObject.ts
+++ b/apps/E2E/src/Menu/pages/MenuPageObject.ts
@@ -116,10 +116,6 @@ class MenuPageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(MENU_TESTPAGE);
-  }
-
   get _pageName() {
     return MENU_TESTPAGE;
   }
@@ -128,8 +124,8 @@ class MenuPageObject extends BasePage {
     return By(MENUTRIGGER_TEST_COMPONENT);
   }
 
-  get _pageButton() {
-    return By(HOMEPAGE_MENU_BUTTON);
+  get _pageButtonName() {
+    return HOMEPAGE_MENU_BUTTON;
   }
 
   get _callbackResetButton() {

--- a/apps/E2E/src/MenuButtonLegacy/pages/MenuButtonLegacyPageObject.win.ts
+++ b/apps/E2E/src/MenuButtonLegacy/pages/MenuButtonLegacyPageObject.win.ts
@@ -47,10 +47,6 @@ class MenuButtonLegacyPageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(MENU_BUTTON_TESTPAGE);
-  }
-
   get _pageName() {
     return MENU_BUTTON_TESTPAGE;
   }
@@ -63,8 +59,8 @@ class MenuButtonLegacyPageObject extends BasePage {
     return By(MENU_BUTTON_NO_A11Y_LABEL_COMPONENT);
   }
 
-  get _pageButton() {
-    return By(HOMEPAGE_MENUBUTTON_BUTTON);
+  get _pageButtonName() {
+    return HOMEPAGE_MENUBUTTON_BUTTON;
   }
 
   get _menuItem() {

--- a/apps/E2E/src/MenuButtonV1/pages/MenuButtonV1PageObject.win.ts
+++ b/apps/E2E/src/MenuButtonV1/pages/MenuButtonV1PageObject.win.ts
@@ -10,10 +10,6 @@ class MenuButtonV1PageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(MENUBUTTONV1_TESTPAGE);
-  }
-
   get _pageName() {
     return MENUBUTTONV1_TESTPAGE;
   }
@@ -26,8 +22,8 @@ class MenuButtonV1PageObject extends BasePage {
     return By(MENUBUTTONV1_NO_A11Y_LABEL_COMPONENT);
   }
 
-  get _pageButton() {
-    return By(HOMEPAGE_MENUBUTTONV1_BUTTON);
+  get _pageButtonName() {
+    return HOMEPAGE_MENUBUTTONV1_BUTTON;
   }
 }
 

--- a/apps/E2E/src/Persona/pages/PersonaPageObject.ts
+++ b/apps/E2E/src/Persona/pages/PersonaPageObject.ts
@@ -1,18 +1,10 @@
-import {
-  PERSONA_TESTPAGE,
-  PERSONA_TEST_COMPONENT,
-  HOMEPAGE_PERSONA_BUTTON,
-} from '../consts';
+import { PERSONA_TESTPAGE, PERSONA_TEST_COMPONENT, HOMEPAGE_PERSONA_BUTTON } from '../consts';
 import { BasePage, By } from '../../common/BasePage';
 
 class PersonaPageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(PERSONA_TESTPAGE);
-  }
-
   get _pageName() {
     return PERSONA_TESTPAGE;
   }
@@ -21,8 +13,8 @@ class PersonaPageObject extends BasePage {
     return By(PERSONA_TEST_COMPONENT);
   }
 
-  get _pageButton() {
-    return By(HOMEPAGE_PERSONA_BUTTON);
+  get _pageButtonName() {
+    return HOMEPAGE_PERSONA_BUTTON;
   }
 }
 

--- a/apps/E2E/src/PersonaCoin/pages/PersonaCoinPageObject.ts
+++ b/apps/E2E/src/PersonaCoin/pages/PersonaCoinPageObject.ts
@@ -1,18 +1,10 @@
-import {
-  PERSONACOIN_TESTPAGE,
-  PERSONACOIN_TEST_COMPONENT,
-  HOMEPAGE_PERSONACOIN_BUTTON,
-} from '../consts';
+import { PERSONACOIN_TESTPAGE, PERSONACOIN_TEST_COMPONENT, HOMEPAGE_PERSONACOIN_BUTTON } from '../consts';
 import { BasePage, By } from '../../common/BasePage';
 
 class PersonaCoinPageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(PERSONACOIN_TESTPAGE);
-  }
-
   get _pageName() {
     return PERSONACOIN_TESTPAGE;
   }
@@ -21,8 +13,8 @@ class PersonaCoinPageObject extends BasePage {
     return By(PERSONACOIN_TEST_COMPONENT);
   }
 
-  get _pageButton() {
-    return By(HOMEPAGE_PERSONACOIN_BUTTON);
+  get _pageButtonName() {
+    return HOMEPAGE_PERSONACOIN_BUTTON;
   }
 }
 

--- a/apps/E2E/src/Pressable/pages/PressablePageObject.ts
+++ b/apps/E2E/src/Pressable/pages/PressablePageObject.ts
@@ -1,18 +1,10 @@
-import {
-  PRESSABLE_TESTPAGE,
-  PRESSABLE_TEST_COMPONENT,
-  HOMEPAGE_PRESSABLE_BUTTON,
-} from '../consts';
+import { PRESSABLE_TESTPAGE, PRESSABLE_TEST_COMPONENT, HOMEPAGE_PRESSABLE_BUTTON } from '../consts';
 import { BasePage, By } from '../../common/BasePage';
 
 class PressablePageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(PRESSABLE_TESTPAGE);
-  }
-
   get _pageName() {
     return PRESSABLE_TESTPAGE;
   }
@@ -21,8 +13,8 @@ class PressablePageObject extends BasePage {
     return By(PRESSABLE_TEST_COMPONENT);
   }
 
-  get _pageButton() {
-    return By(HOMEPAGE_PRESSABLE_BUTTON);
+  get _pageButtonName() {
+    return HOMEPAGE_PRESSABLE_BUTTON;
   }
 }
 

--- a/apps/E2E/src/RadioGroupLegacy/pages/RadioGroupLegacyPageObject.ts
+++ b/apps/E2E/src/RadioGroupLegacy/pages/RadioGroupLegacyPageObject.ts
@@ -76,10 +76,6 @@ class RadioGroupLegacyPage extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(RADIOGROUP_TESTPAGE);
-  }
-
   get _pageName() {
     return RADIOGROUP_TESTPAGE;
   }
@@ -92,8 +88,8 @@ class RadioGroupLegacyPage extends BasePage {
     return By(RADIOGROUP_NO_A11Y_LABEL_COMPONENT);
   }
 
-  get _pageButton() {
-    return By(HOMEPAGE_RADIOGROUP_BUTTON);
+  get _pageButtonName() {
+    return HOMEPAGE_RADIOGROUP_BUTTON;
   }
 
   /***************/

--- a/apps/E2E/src/RadioGroupV1/pages/RadioGroupV1PageObject.ts
+++ b/apps/E2E/src/RadioGroupV1/pages/RadioGroupV1PageObject.ts
@@ -93,10 +93,6 @@ class RadioGroupV1Page extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(RADIOGROUPV1_TESTPAGE);
-  }
-
   get _pageName() {
     return RADIOGROUPV1_TESTPAGE;
   }
@@ -109,8 +105,8 @@ class RadioGroupV1Page extends BasePage {
     return By(RADIOGROUPV1_NO_A11Y_LABEL_COMPONENT);
   }
 
-  get _pageButton() {
-    return By(HOMEPAGE_RADIOGROUPV1_BUTTON);
+  get _pageButtonName() {
+    return HOMEPAGE_RADIOGROUPV1_BUTTON;
   }
 
   /***************/

--- a/apps/E2E/src/Separator/pages/SeparatorPageObject.ts
+++ b/apps/E2E/src/Separator/pages/SeparatorPageObject.ts
@@ -1,18 +1,10 @@
-import {
-  SEPARATOR_TESTPAGE,
-  SEPARATOR_TEST_COMPONENT,
-  HOMEPAGE_SEPARATOR_BUTTON,
-} from '../consts';
+import { SEPARATOR_TESTPAGE, SEPARATOR_TEST_COMPONENT, HOMEPAGE_SEPARATOR_BUTTON } from '../consts';
 import { BasePage, By } from '../../common/BasePage';
 
 class SeparatorPageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(SEPARATOR_TESTPAGE);
-  }
-
   get _pageName() {
     return SEPARATOR_TESTPAGE;
   }
@@ -21,8 +13,8 @@ class SeparatorPageObject extends BasePage {
     return By(SEPARATOR_TEST_COMPONENT);
   }
 
-  get _pageButton() {
-    return By(HOMEPAGE_SEPARATOR_BUTTON);
+  get _pageButtonName() {
+    return HOMEPAGE_SEPARATOR_BUTTON;
   }
 }
 

--- a/apps/E2E/src/Shadow/pages/ShadowPageObject.ts
+++ b/apps/E2E/src/Shadow/pages/ShadowPageObject.ts
@@ -5,16 +5,12 @@ class ShadowTestPage extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(SHADOW_TESTPAGE);
-  }
-
   get _pageName() {
     return SHADOW_TESTPAGE;
   }
 
-  get _pageButton() {
-    return By(HOMEPAGE_SHADOW_BUTTON);
+  get _pageButtonName() {
+    return HOMEPAGE_SHADOW_BUTTON;
   }
 }
 

--- a/apps/E2E/src/Shadow/pages/ShadowPageObject.ts
+++ b/apps/E2E/src/Shadow/pages/ShadowPageObject.ts
@@ -1,5 +1,5 @@
 import { SHADOW_TESTPAGE, HOMEPAGE_SHADOW_BUTTON } from '../consts';
-import { BasePage, By } from '../../common/BasePage';
+import { BasePage } from '../../common/BasePage';
 
 class ShadowTestPage extends BasePage {
   /*****************************************/

--- a/apps/E2E/src/Shimmer/pages/ShimmerPageObject.win.ts
+++ b/apps/E2E/src/Shimmer/pages/ShimmerPageObject.win.ts
@@ -1,18 +1,10 @@
-import {
-  HOMEPAGE_SHIMMER_BUTTON,
-  SHIMMER_TESTPAGE,
-  SHIMMER_TEST_COMPONENT,
-} from '../consts';
+import { HOMEPAGE_SHIMMER_BUTTON, SHIMMER_TESTPAGE, SHIMMER_TEST_COMPONENT } from '../consts';
 import { BasePage, By } from '../../common/BasePage';
 
 class ShimmerPageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(SHIMMER_TESTPAGE);
-  }
-
   get _pageName() {
     return SHIMMER_TESTPAGE;
   }
@@ -21,8 +13,8 @@ class ShimmerPageObject extends BasePage {
     return By(SHIMMER_TEST_COMPONENT);
   }
 
-  get _pageButton() {
-    return By(HOMEPAGE_SHIMMER_BUTTON);
+  get _pageButtonName() {
+    return HOMEPAGE_SHIMMER_BUTTON;
   }
 }
 

--- a/apps/E2E/src/Spacing/pages/SpacingTokensPageObject.ts
+++ b/apps/E2E/src/Spacing/pages/SpacingTokensPageObject.ts
@@ -5,16 +5,12 @@ class SpacingTokensPageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(SPACING_TESTPAGE);
-  }
-
   get _pageName() {
     return SPACING_TESTPAGE;
   }
 
-  get _pageButton() {
-    return By(HOMEPAGE_SPACING_BUTTON);
+  get _pageButtonName() {
+    return HOMEPAGE_SPACING_BUTTON;
   }
 }
 

--- a/apps/E2E/src/Spacing/pages/SpacingTokensPageObject.ts
+++ b/apps/E2E/src/Spacing/pages/SpacingTokensPageObject.ts
@@ -1,5 +1,5 @@
 import { SPACING_TESTPAGE, HOMEPAGE_SPACING_BUTTON } from '../consts';
-import { BasePage, By } from '../../common/BasePage';
+import { BasePage } from '../../common/BasePage';
 
 class SpacingTokensPageObject extends BasePage {
   /*****************************************/

--- a/apps/E2E/src/StrokeWidthTokens/pages/StrokeWidthTokensPageObject.ts
+++ b/apps/E2E/src/StrokeWidthTokens/pages/StrokeWidthTokensPageObject.ts
@@ -5,16 +5,12 @@ class StrokeWidthTokensPageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(STROKEWIDTH_TESTPAGE);
-  }
-
   get _pageName() {
     return STROKEWIDTH_TESTPAGE;
   }
 
-  get _pageButton() {
-    return By(HOMEPAGE_STROKEWIDTH_BUTTON);
+  get _pageButtonName() {
+    return HOMEPAGE_STROKEWIDTH_BUTTON;
   }
 }
 

--- a/apps/E2E/src/StrokeWidthTokens/pages/StrokeWidthTokensPageObject.ts
+++ b/apps/E2E/src/StrokeWidthTokens/pages/StrokeWidthTokensPageObject.ts
@@ -1,5 +1,5 @@
 import { STROKEWIDTH_TESTPAGE, HOMEPAGE_STROKEWIDTH_BUTTON } from '../consts';
-import { BasePage, By } from '../../common/BasePage';
+import { BasePage } from '../../common/BasePage';
 
 class StrokeWidthTokensPageObject extends BasePage {
   /*****************************************/

--- a/apps/E2E/src/Svg/pages/SvgPageObject.ts
+++ b/apps/E2E/src/Svg/pages/SvgPageObject.ts
@@ -5,10 +5,6 @@ class SvgPageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(SVG_TESTPAGE);
-  }
-
   get _pageName() {
     return SVG_TESTPAGE;
   }
@@ -17,8 +13,8 @@ class SvgPageObject extends BasePage {
     return By(SVG_TEST_COMPONENT);
   }
 
-  get _pageButton() {
-    return By(HOMEPAGE_SVG_BUTTON);
+  get _pageButtonName() {
+    return HOMEPAGE_SVG_BUTTON;
   }
 }
 

--- a/apps/E2E/src/Switch/pages/SwitchPageObject.ts
+++ b/apps/E2E/src/Switch/pages/SwitchPageObject.ts
@@ -1,10 +1,4 @@
-import {
-  SWITCH_TESTPAGE,
-  SWITCH_TEST_COMPONENT,
-  SWITCH_NO_A11Y_LABEL_COMPONENT,
-  HOMEPAGE_SWITCH_BUTTON,
-  SWITCH_ON_PRESS,
-} from '../consts';
+import { SWITCH_TESTPAGE, SWITCH_TEST_COMPONENT, SWITCH_NO_A11Y_LABEL_COMPONENT, HOMEPAGE_SWITCH_BUTTON, SWITCH_ON_PRESS } from '../consts';
 import { BasePage, By } from '../../common/BasePage';
 
 /* This enum gives the spec file an EASY way to interact with SPECIFIC UI elements on the page.
@@ -65,10 +59,6 @@ class SwitchPageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(SWITCH_TESTPAGE);
-  }
-
   get _pageName() {
     return SWITCH_TESTPAGE;
   }
@@ -81,8 +71,8 @@ class SwitchPageObject extends BasePage {
     return By(SWITCH_NO_A11Y_LABEL_COMPONENT);
   }
 
-  get _pageButton() {
-    return By(HOMEPAGE_SWITCH_BUTTON);
+  get _pageButtonName() {
+    return HOMEPAGE_SWITCH_BUTTON;
   }
 }
 

--- a/apps/E2E/src/TabsLegacy/pages/TabsLegacyPageObject.ts
+++ b/apps/E2E/src/TabsLegacy/pages/TabsLegacyPageObject.ts
@@ -75,10 +75,6 @@ class TabsLegacyPageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(TABS_TESTPAGE);
-  }
-
   get _pageName() {
     return TABS_TESTPAGE;
   }
@@ -87,8 +83,8 @@ class TabsLegacyPageObject extends BasePage {
     return By(TABS_TEST_COMPONENT);
   }
 
-  get _pageButton() {
-    return By(HOMEPAGE_TABS_BUTTON);
+  get _pageButtonName() {
+    return HOMEPAGE_TABS_BUTTON;
   }
 
   /* The first tab group has 3 Tab item headers, all listed below */

--- a/apps/E2E/src/TabsV1/pages/TabsV1PageObject.ts
+++ b/apps/E2E/src/TabsV1/pages/TabsV1PageObject.ts
@@ -12,10 +12,6 @@ class TabsV1PageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(TABSV1_TESTPAGE);
-  }
-
   get _pageName() {
     return TABSV1_TESTPAGE;
   }
@@ -24,8 +20,8 @@ class TabsV1PageObject extends BasePage {
     return By(TABSV1_TEST_COMPONENT);
   }
 
-  get _pageButton() {
-    return By(HOMEPAGE_TABSV1_BUTTON);
+  get _pageButtonName() {
+    return HOMEPAGE_TABSV1_BUTTON;
   }
 
   /***********/

--- a/apps/E2E/src/TextLegacy/pages/TextLegacyPageObject.ts
+++ b/apps/E2E/src/TextLegacy/pages/TextLegacyPageObject.ts
@@ -32,10 +32,6 @@ class TextLegacyPageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(TEXT_TESTPAGE);
-  }
-
   get _pageName() {
     return TEXT_TESTPAGE;
   }
@@ -48,8 +44,8 @@ class TextLegacyPageObject extends BasePage {
     return By(DEPRECATED_TEXT_SECOND_COMPONENT);
   }
 
-  get _pageButton() {
-    return By(HOMEPAGE_TEXT_BUTTON);
+  get _pageButtonName() {
+    return HOMEPAGE_TEXT_BUTTON;
   }
 }
 

--- a/apps/E2E/src/TextV1/pages/TextV1PageObject.win.ts
+++ b/apps/E2E/src/TextV1/pages/TextV1PageObject.win.ts
@@ -5,10 +5,6 @@ class TextV1PageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(TEXTV1_TESTPAGE);
-  }
-
   get _pageName() {
     return TEXTV1_TESTPAGE;
   }
@@ -21,8 +17,8 @@ class TextV1PageObject extends BasePage {
     return By(TEXTV1_NO_A11Y_LABEL_COMPONENT);
   }
 
-  get _pageButton() {
-    return By(HOMEPAGE_TEXTV1_BUTTON);
+  get _pageButtonName() {
+    return HOMEPAGE_TEXTV1_BUTTON;
   }
 }
 

--- a/apps/E2E/src/Theme/pages/ThemePageObject.win.ts
+++ b/apps/E2E/src/Theme/pages/ThemePageObject.win.ts
@@ -5,10 +5,6 @@ class ThemePageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(THEME_TESTPAGE);
-  }
-
   get _pageName() {
     return THEME_TESTPAGE;
   }
@@ -17,8 +13,8 @@ class ThemePageObject extends BasePage {
     return By(THEME_TEST_COMPONENT);
   }
 
-  get _pageButton() {
-    return By(HOMEPAGE_THEME_BUTTON);
+  get _pageButtonName() {
+    return HOMEPAGE_THEME_BUTTON;
   }
 }
 

--- a/apps/E2E/src/Tokens/pages/TokensPageObject.win.ts
+++ b/apps/E2E/src/Tokens/pages/TokensPageObject.win.ts
@@ -5,10 +5,6 @@ class TokenPageObject extends BasePage {
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/
-  get _testPage() {
-    return By(TOKEN_TESTPAGE);
-  }
-
   get _pageName() {
     return TOKEN_TESTPAGE;
   }
@@ -17,8 +13,8 @@ class TokenPageObject extends BasePage {
     return By(TOKENS_TEST_COMPONENT);
   }
 
-  get _pageButton() {
-    return By(HOMEPAGE_TOKEN_BUTTON);
+  get _pageButtonName() {
+    return HOMEPAGE_TOKEN_BUTTON;
   }
 }
 

--- a/apps/E2E/src/common/BasePage.ts
+++ b/apps/E2E/src/common/BasePage.ts
@@ -278,7 +278,9 @@ export abstract class BasePage {
 
   // Returns: UI Element
   // The Text component on each test page containing the title of that page. We can use this to determine if a test page has loaded correctly.
-  abstract get _testPage(): Promise<WebdriverIO.Element>;
+  get _testPage(): Promise<WebdriverIO.Element> {
+    return By(this._pageName);
+  }
 
   // Returns: UI Element
   // The primary UI element used for testing on the given test page.
@@ -297,7 +299,9 @@ export abstract class BasePage {
 
   // Returns: UI Element
   // The button that navigates you to the component's test page.
-  abstract get _pageButton(): Promise<WebdriverIO.Element>;
+  get _pageButton(): Promise<WebdriverIO.Element> {
+    return By(this._pageButtonName);
+  }
 
   // Returns: String
   // Returns the name of the test page. Useful for error messages (see above).
@@ -305,9 +309,7 @@ export abstract class BasePage {
 
   // Returns: String
   // Returns the name of the button that navigates to the test page.
-  get _pageButtonName(): string {
-    return DUMMY_CHAR;
-  }
+  abstract get _pageButtonName(): string;
 
   // The scrollviewer containing the list of buttons to navigate to each test page
   get _testPageButtonScrollViewer() {

--- a/apps/E2E/src/common/NativeTesting/pages/NativeTestingPageObject.win.ts
+++ b/apps/E2E/src/common/NativeTesting/pages/NativeTestingPageObject.win.ts
@@ -53,6 +53,10 @@ class NativeTestingPageObject extends BasePage {
     throw new Error('You are trying to read the _pageButton getter for NativeTestingPageObject, which is not implemented.');
   }
 
+  get _pageButtonName(): string {
+    throw new Error('You are trying to read the _pageButtonName getter for NativeTestingPageObject, which is not implemented.');
+  }
+
   get _pageName(): string {
     throw new Error('You are trying to read the _pageName getter for NativeTestingPageObject, which is not implemented.');
   }

--- a/apps/E2E/src/common/NavigateAppPage.ts
+++ b/apps/E2E/src/common/NavigateAppPage.ts
@@ -333,6 +333,10 @@ class NavigateAppPage extends BasePage {
   get _pageButton(): Promise<WebdriverIO.Element> {
     throw new Error('You are trying to read the _pageButton getter for NavigateAppPage, which is not implemented.');
   }
+
+  get _pageButtonName(): string {
+    throw new Error('You are trying to read the _pageButtonName getter for NavigateAppPage, which is not implemented.');
+  }
 }
 
 export default new NavigateAppPage();

--- a/change/@fluentui-react-native-e2e-testing-d7833867-a143-47cf-8329-6839566f34db.json
+++ b/change/@fluentui-react-native-e2e-testing-d7833867-a143-47cf-8329-6839566f34db.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Remove need to override testPage, add pageButtonName fn",
+  "packageName": "@fluentui-react-native/e2e-testing",
+  "email": "ayushsinghs@yahoo.in",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

- _testPage() and _pageName() had redundancy. Updated _testPage() to use _pageName() internally removing the need to override it.
- _pageButtonName() added in PR [#2399](https://github.com/microsoft/fluentui-react-native/pull/2399) to provide support for Android E2E and _pageButton() had a similar dependency. Made _pageButtonName() abstract to ensure its implementation and updated _pageButton() to use it internally. 
- Update readme for these changes and PR [#2399](https://github.com/microsoft/fluentui-react-native/pull/2399)

### Verification

The PR Pipeline works as expected.

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
