### PR TITLE
[Switch] Disable state a11y fix

### DIFF
--- a/change/@fluentui-react-native-switch-e8fa82d1-7cc1-49f6-9610-b4bf1781f960.json
+++ b/change/@fluentui-react-native-switch-e8fa82d1-7cc1-49f6-9610-b4bf1781f960.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "switch disable state a11y fix",
+  "packageName": "@fluentui-react-native/switch",
+  "email": "rohanpd.work@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Switch/src/Switch.tsx
+++ b/packages/experimental/Switch/src/Switch.tsx
@@ -64,13 +64,12 @@ export const Switch = compose<SwitchType>({
     // now return the handler for finishing render
     return (final: SwitchProps) => {
       const { label, offText, onText, labelPosition, ...mergedProps } = mergeProps(switchInfo.props, final);
-      const { disabled } = mergedProps;
       const onOffText = switchInfo.state.toggled ? onText : offText;
       const displayOnOffText = !!offText || !!onText;
       const isReduceMotionEnabled = AccessibilityInfo.isReduceMotionEnabled;
       const thumbAnimation = isReduceMotionEnabled ? { animationClass: 'Ribbon_SwitchThumb' } : null;
       return (
-        <Slots.root {...mergedProps} {...(isMobile && { accessible: !disabled, focusable: !disabled })}>
+        <Slots.root {...mergedProps}>
           <Slots.label>{label}</Slots.label>
           <Slots.toggleContainer>
             {/* For the Mobile platform the animated styles are applied  */}

--- a/packages/experimental/Switch/src/Switch.tsx
+++ b/packages/experimental/Switch/src/Switch.tsx
@@ -64,12 +64,13 @@ export const Switch = compose<SwitchType>({
     // now return the handler for finishing render
     return (final: SwitchProps) => {
       const { label, offText, onText, labelPosition, ...mergedProps } = mergeProps(switchInfo.props, final);
+      const { disabled } = mergedProps;
       const onOffText = switchInfo.state.toggled ? onText : offText;
       const displayOnOffText = !!offText || !!onText;
       const isReduceMotionEnabled = AccessibilityInfo.isReduceMotionEnabled;
       const thumbAnimation = isReduceMotionEnabled ? { animationClass: 'Ribbon_SwitchThumb' } : null;
       return (
-        <Slots.root {...mergedProps}>
+        <Slots.root {...mergedProps} {...(isMobile && { accessible: !disabled, focusable: !disabled })}>
           <Slots.label>{label}</Slots.label>
           <Slots.toggleContainer>
             {/* For the Mobile platform the animated styles are applied  */}

--- a/packages/experimental/Switch/src/__tests__/__snapshots__/Switch.test.tsx.snap
+++ b/packages/experimental/Switch/src/__tests__/__snapshots__/Switch.test.tsx.snap
@@ -133,7 +133,7 @@ exports[`Switch Disabled 1`] = `
       "disabled": true,
     }
   }
-  accessible={true}
+  accessible={false}
   collapsable={false}
   focusable={false}
   onAccessibilityAction={[Function]}

--- a/packages/experimental/Switch/src/useSwitch.ts
+++ b/packages/experimental/Switch/src/useSwitch.ts
@@ -165,7 +165,7 @@ export const useSwitch = (props: SwitchProps, animationConfig?: AnimationConfig)
 
   return {
     props: {
-      accessible: true,
+      accessible: isMobile ? !disabled : true,
       accessibilityLabel: accessibilityLabel ?? label,
       accessibilityRole: accessibilityRole ?? 'switch',
       accessibilityActions: accessibilityActionsProp,


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [x] android

### Description of changes
This PR targets to fix the a11y issue where keyboard navigation also goes into disabled state switch which shouldn't happen. 
This fixes it for mobile platform - Android and iOS. 

This was already working on win32, hence verified that it doesn't break it and working as before. 

### Verification

Visually verified on Android, tested on win32 as well, it's working as before. 


| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| [Screen Recording (2).webm](https://user-images.githubusercontent.com/30728574/211253264-09dd856e-998c-4b9e-b2f1-a89a3ebfa623.webm) | [Screen Recording (1).webm](https://user-images.githubusercontent.com/30728574/211253237-e2d08847-7064-4995-bf0c-df798f4ef4d5.webm) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
