### PR TITLE
Fix MenuDividerTokens import

### DIFF
--- a/change/@fluentui-react-native-menu-15d9bfb4-507c-4c82-affe-8abfe80707b9.json
+++ b/change/@fluentui-react-native-menu-15d9bfb4-507c-4c82-affe-8abfe80707b9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix MenuDividerTokens import",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "amchiu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/MenuDivider/MenuDivider.styling.ts
+++ b/packages/components/Menu/src/MenuDivider/MenuDivider.styling.ts
@@ -1,5 +1,5 @@
 import { UseStylingOptions, buildProps } from '@fluentui-react-native/framework';
-import { defaultMenuDividerTokens } from './MenuDividerTokens.win32';
+import { defaultMenuDividerTokens } from './MenuDividerTokens';
 import { menuDividerName, MenuDividerProps, MenuDividerTokens, MenuDividerSlotProps } from './MenuDivider.types';
 
 export const stylingSettings: UseStylingOptions<MenuDividerProps, MenuDividerSlotProps, MenuDividerTokens> = {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Updating the defaultMenuDividerTokens import to grab the respective platform tokens. This fixes the MenuDivider background color on macOS. 

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/67026167/211651679-178262e5-f98b-4e33-9d83-5e7662d04b37.png) | ![image](https://user-images.githubusercontent.com/67026167/211651712-a41bde25-5e66-4ada-b8ee-7c466d552e0c.png) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
