### PR TITLE
macOS: Update MenuDivider margin

### DIFF
--- a/change/@fluentui-react-native-menu-b7437920-ce21-4dc8-a398-c802734fe769.json
+++ b/change/@fluentui-react-native-menu-b7437920-ce21-4dc8-a398-c802734fe769.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update MenuDivider margin",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "amchiu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/MenuDivider/MenuDividerTokens.macos.ts
+++ b/packages/components/Menu/src/MenuDivider/MenuDividerTokens.macos.ts
@@ -6,5 +6,5 @@ import { MenuDividerTokens } from './MenuDivider.types';
 export const defaultMenuDividerTokens: TokenSettings<MenuDividerTokens, Theme> = (t: Theme): MenuDividerTokens => ({
   backgroundColor: t.colors.neutralStroke2,
   height: globalTokens.stroke.width10,
-  margin: globalTokens.size20,
+  margin: globalTokens.size40,
 });


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Updating the MenuDivider margin size to better align with NSMenu. size20 -> size40

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/67026167/211664845-875f216f-8c25-486c-aea8-6c573e172303.png) | ![image](https://user-images.githubusercontent.com/67026167/211664883-094bdc40-a005-4a1d-aadc-c1d4c1292372.png) |

NSMenu:
![image](https://user-images.githubusercontent.com/67026167/211665023-2112dd4c-06cd-41a2-a5ac-98b1755b755a.png)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
