### PR TITLE
Improve Error Messages + Refactor Switch E2E Tests

### DIFF
--- a/apps/E2E/src/Switch/pages/SwitchPageObject.ts
+++ b/apps/E2E/src/Switch/pages/SwitchPageObject.ts
@@ -1,10 +1,4 @@
-import {
-  SWITCH_TESTPAGE,
-  SWITCH_TEST_COMPONENT,
-  SWITCH_NO_A11Y_LABEL_COMPONENT,
-  HOMEPAGE_SWITCH_BUTTON,
-  SWITCH_ON_PRESS,
-} from '../consts';
+import { SWITCH_TESTPAGE, SWITCH_TEST_COMPONENT, SWITCH_NO_A11Y_LABEL_COMPONENT, HOMEPAGE_SWITCH_BUTTON, SWITCH_ON_PRESS } from '../consts';
 import { BasePage, By } from '../../common/BasePage';
 
 /* This enum gives the spec file an EASY way to interact with SPECIFIC UI elements on the page.
@@ -18,32 +12,29 @@ class SwitchPageObject extends BasePage {
   /******************************************************************/
   /**************** UI Element Interaction Methods ******************/
   /******************************************************************/
+  async setSwitchState(toggleState: boolean) {
+    const currState = await this.isSwitchChecked();
+    if (toggleState !== currState) {
+      await (await this._primaryComponent).click();
+      await this.waitForCondition(
+        async () => toggleState === (await this.isSwitchChecked()),
+        `Clicked the primary switch to turn it ${toggleState ? 'on' : 'off'}, but the switch failed to toggle.`,
+      );
+    }
+  }
+
   async isSwitchChecked(): Promise<boolean> {
     return await (await this._primaryComponent).isSelected();
   }
 
-  async waitForSwitchChecked(timeout?: number): Promise<void> {
-    browser.waitUntil(async () => await this.isSwitchChecked(), {
-      timeout: timeout ?? this.waitForUiEvent,
-      timeoutMsg: 'The Switch was not toggled correctly',
-      interval: 1000,
-    });
+  async waitForSwitchStateChange(newState: boolean, errorMsg: string, timeout?: number): Promise<boolean> {
+    this.waitForCondition(async () => (await this.isSwitchChecked()) === newState, errorMsg, timeout);
+    return (await this.isSwitchChecked()) === newState;
   }
 
-  async toggleSwitchToUnchecked(): Promise<void> {
-    if (await this.isSwitchChecked()) {
-      await (await this._primaryComponent).click();
-    }
-  }
-
-  async didOnChangeCallbackFire(): Promise<boolean> {
-    const callbackText = await By(SWITCH_ON_PRESS);
-    browser.waitUntil(async () => await callbackText.isDisplayed(), {
-      timeout: this.waitForUiEvent,
-      timeoutMsg: 'The OnChange callback did not fire.',
-      interval: 1000,
-    });
-
+  async waitForOnChangeCallbackToFire(errorMsg: string): Promise<boolean> {
+    const callbackText = await this._callbackText;
+    this.waitForCondition(async () => await callbackText.isDisplayed(), errorMsg);
     return await callbackText.isDisplayed();
   }
 
@@ -83,6 +74,10 @@ class SwitchPageObject extends BasePage {
 
   get _pageButton() {
     return By(HOMEPAGE_SWITCH_BUTTON);
+  }
+
+  get _callbackText() {
+    return By(SWITCH_ON_PRESS);
   }
 }
 

--- a/apps/E2E/src/Switch/pages/SwitchPageObject.ts
+++ b/apps/E2E/src/Switch/pages/SwitchPageObject.ts
@@ -16,9 +16,9 @@ class SwitchPageObject extends BasePage {
     const currState = await this.isSwitchChecked();
     if (toggleState !== currState) {
       await (await this._primaryComponent).click();
-      await this.waitForCondition(
-        async () => toggleState === (await this.isSwitchChecked()),
-        `Clicked the primary switch to turn it ${toggleState ? 'on' : 'off'}, but the switch failed to toggle.`,
+      await this.waitForSwitchStateChange(
+        toggleState,
+        `Clicked primary switch to turn it ${toggleState ? 'on' : 'off'}, but it failed to toggle.`,
       );
     }
   }

--- a/apps/E2E/src/Switch/pages/SwitchPageObject.ts
+++ b/apps/E2E/src/Switch/pages/SwitchPageObject.ts
@@ -27,30 +27,15 @@ class SwitchPageObject extends BasePage {
     return await (await this._primaryComponent).isSelected();
   }
 
-  async waitForSwitchStateChange(newState: boolean, errorMsg: string, timeout?: number): Promise<boolean> {
-    this.waitForCondition(async () => (await this.isSwitchChecked()) === newState, errorMsg, timeout);
+  async waitForSwitchStateChange(newState: boolean, errorMsg: string): Promise<boolean> {
+    await this.waitForCondition(async () => (await this.isSwitchChecked()) === newState, errorMsg);
     return (await this.isSwitchChecked()) === newState;
   }
 
   async waitForOnChangeCallbackToFire(errorMsg: string): Promise<boolean> {
     const callbackText = await this._callbackText;
-    this.waitForCondition(async () => await callbackText.isDisplayed(), errorMsg);
+    await this.waitForCondition(async () => await callbackText.isDisplayed(), errorMsg);
     return await callbackText.isDisplayed();
-  }
-
-  /* Sends a Keyboarding command on a specific UI element */
-  async sendKey(switchSelector: SwitchComponentSelector, key: string): Promise<void> {
-    await (await this.getButtonSelector(switchSelector)).addValue(key);
-  }
-
-  /* Returns the correct WebDriverIO element from the Button Selector */
-  async getButtonSelector(switchSelector?: SwitchComponentSelector): Promise<WebdriverIO.Element> {
-    if (switchSelector == SwitchComponentSelector.PrimaryComponent) {
-      return await this._primaryComponent;
-    } else if (switchSelector === SwitchComponentSelector.SecondaryComponent) {
-      return await this._secondaryComponent;
-    }
-    return await this._primaryComponent;
   }
 
   /*****************************************/

--- a/apps/E2E/src/Switch/specs/Switch.spec.win.ts
+++ b/apps/E2E/src/Switch/specs/Switch.spec.win.ts
@@ -75,7 +75,7 @@ describe('Switch Functional Testing', () => {
 
     /* Validate the Switch is toggled ON */
     await expect(
-      await SwitchPageObject.waitForSwitchStateChange(true, 'Clicked the primary switch to turn it on, but it remained on.'),
+      await SwitchPageObject.waitForSwitchStateChange(true, 'Clicked the primary switch to turn it on, but it remained off.'),
     ).toBeTruthy();
 
     await expect(

--- a/apps/E2E/src/Switch/specs/Switch.spec.win.ts
+++ b/apps/E2E/src/Switch/specs/Switch.spec.win.ts
@@ -16,6 +16,7 @@ describe('Switch Testing Initialization', function () {
     await SwitchPageObject.waitForPageDisplayed(PAGE_TIMEOUT);
 
     await expect(await SwitchPageObject.isPageLoaded()).toBeTruthy(SwitchPageObject.ERRORMESSAGE_PAGELOAD);
+
     await expect(await SwitchPageObject.didAssertPopup()).toBeFalsy(SwitchPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
   });
 });
@@ -26,7 +27,7 @@ describe('Switch Accessibility Testing', () => {
     await SwitchPageObject.scrollToTestElement();
   });
 
-  it('Switch - Validate accessibilityRole is correct', async () => {
+  it('Validate "accessibilityRole" defaults to Button "ControlType" element attribute.', async () => {
     await expect(
       await SwitchPageObject.compareAttribute(SwitchPageObject._primaryComponent, Attribute.AccessibilityRole, BUTTON_A11Y_ROLE),
     ).toBeTruthy();
@@ -34,7 +35,7 @@ describe('Switch Accessibility Testing', () => {
     await expect(await SwitchPageObject.didAssertPopup()).toBeFalsy(SwitchPageObject.ERRORMESSAGE_ASSERT);
   });
 
-  it('Switch - Set accessibilityLabel', async () => {
+  it('Set "accessibilityLabel" prop. Validate "accessibilityLabel" value propagates to "Name" element attribute.', async () => {
     await expect(
       await SwitchPageObject.compareAttribute(SwitchPageObject._primaryComponent, Attribute.AccessibilityLabel, SWITCH_ACCESSIBILITY_LABEL),
     ).toBeTruthy();
@@ -42,7 +43,7 @@ describe('Switch Accessibility Testing', () => {
     await expect(await SwitchPageObject.didAssertPopup()).toBeFalsy(SwitchPageObject.ERRORMESSAGE_ASSERT);
   });
 
-  it('Switch - Do not set accessibilityLabel -> Default to Switch label', async () => {
+  it('Do not set "accessibilityLabel" prop. Validate "Name" element attribute defaults to current Switch label.', async () => {
     await expect(
       await SwitchPageObject.compareAttribute(
         SwitchPageObject._secondaryComponent,
@@ -63,7 +64,7 @@ describe('Switch Functional Testing', () => {
     await SwitchPageObject.setSwitchState(false);
   });
 
-  it("Click on a Switch -> Validate it toggles correctly AND calls the user's onChange", async () => {
+  it("Click on primary Switch. Validate it toggles correctly AND calls the user's onChange() callback.", async () => {
     /* Validate the Switch is initially toggled OFF */
     await expect(await SwitchPageObject.isSwitchChecked()).toBeFalsy(
       'Primary switch should be off on test start, but it was initially on.',
@@ -93,7 +94,7 @@ describe('Switch Functional Testing', () => {
     await expect(await SwitchPageObject.didAssertPopup()).toBeFalsy(SwitchPageObject.ERRORMESSAGE_ASSERT);
   });
 
-  it("Click the 'Enter' on a Switch and verify it toggles correctly AND calls the user's onChange", async () => {
+  it('Press "ENTER" on primary Switch. Validate it toggles correctly AND calls the user\'s onChange() callback.', async () => {
     /* Validate the Switch is initially toggled OFF */
     await expect(await SwitchPageObject.isSwitchChecked()).toBeFalsy(
       'Primary switch should be off on test start, but it was initially on.',
@@ -123,7 +124,7 @@ describe('Switch Functional Testing', () => {
     await expect(await SwitchPageObject.didAssertPopup()).toBeFalsy(SwitchPageObject.ERRORMESSAGE_ASSERT);
   });
 
-  it("Click the 'SPACE' on a Switch and verify it toggles correctly AND calls the user's onChange", async () => {
+  it('Press "SPACE" on primary Switch. Validate it toggles correctly AND calls the user\'s onChange() callback.', async () => {
     /* Validate the Switch is initially toggled OFF */
     await expect(await SwitchPageObject.isSwitchChecked()).toBeFalsy(
       'Primary switch should be off on test start, but it was initially on.',

--- a/apps/E2E/src/Switch/specs/Switch.spec.win.ts
+++ b/apps/E2E/src/Switch/specs/Switch.spec.win.ts
@@ -47,7 +47,7 @@ describe('Switch Accessibility Testing', () => {
     await expect(
       await SwitchPageObject.compareAttribute(
         SwitchPageObject._secondaryComponent,
-        Attribute.AccessibilityRole,
+        Attribute.AccessibilityLabel,
         SWITCH_TEST_COMPONENT_LABEL,
       ),
     ).toBeTruthy();
@@ -89,7 +89,7 @@ describe('Switch Functional Testing', () => {
     /* Validate the Switch is toggled OFF */
     await expect(
       await SwitchPageObject.waitForSwitchStateChange(false, 'Clicked the primary switch to turn it off, but it remained on.'),
-    ).toBeFalsy();
+    ).toBeTruthy();
 
     await expect(await SwitchPageObject.didAssertPopup()).toBeFalsy(SwitchPageObject.ERRORMESSAGE_ASSERT);
   });
@@ -119,7 +119,7 @@ describe('Switch Functional Testing', () => {
     /* Validate the Switch is toggled OFF */
     await expect(
       await SwitchPageObject.waitForSwitchStateChange(false, 'Pressed "ENTER" on the primary switch to turn it off, but it remained on.'),
-    ).toBeFalsy();
+    ).toBeTruthy();
 
     await expect(await SwitchPageObject.didAssertPopup()).toBeFalsy(SwitchPageObject.ERRORMESSAGE_ASSERT);
   });
@@ -149,7 +149,7 @@ describe('Switch Functional Testing', () => {
     /* Validate the Switch is toggled OFF */
     await expect(
       await SwitchPageObject.waitForSwitchStateChange(false, 'Pressed "SPACE" on the primary switch to turn it off, but it remained on.'),
-    ).toBeFalsy();
+    ).toBeTruthy();
 
     await expect(await SwitchPageObject.didAssertPopup()).toBeFalsy(SwitchPageObject.ERRORMESSAGE_ASSERT);
   });

--- a/apps/E2E/src/Switch/specs/Switch.spec.win.ts
+++ b/apps/E2E/src/Switch/specs/Switch.spec.win.ts
@@ -27,7 +27,7 @@ describe('Switch Accessibility Testing', () => {
     await SwitchPageObject.scrollToTestElement();
   });
 
-  it('Validate "accessibilityRole" defaults to Button "ControlType" element attribute.', async () => {
+  it('Validate "accessibilityRole" defaults to "ControlType.Button".', async () => {
     await expect(
       await SwitchPageObject.compareAttribute(SwitchPageObject._primaryComponent, Attribute.AccessibilityRole, BUTTON_A11Y_ROLE),
     ).toBeTruthy();

--- a/change/@fluentui-react-native-e2e-testing-219e8a16-e512-405c-8d39-a45c4ba905fb.json
+++ b/change/@fluentui-react-native-e2e-testing-219e8a16-e512-405c-8d39-a45c4ba905fb.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Update Switch E2E tests with better error messages + refactored code",
+  "packageName": "@fluentui-react-native/e2e-testing",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Currently, for most developers, it is difficult to figure out what the root issue is when a FURN E2E test fails because of opaque error messages. The existing E2E tests are also in need of some clean up in terms of code and PageObject design.

This commit is part of a larger effort to address the above. Here, I've updated error messages, use new BasePage methods, and did general cleanup for the following tests:

- Switch

### Verification

Tests pass locally and in CI.

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
