### PR TITLE
Add iOS shared color tokens (error, status, and presence)

### DIFF
--- a/change/@fluentui-react-native-apple-theme-a9f54f28-949a-4fb4-8571-e4bef08645b1.json
+++ b/change/@fluentui-react-native-apple-theme-a9f54f28-949a-4fb4-8571-e4bef08645b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add shared colors to AliasColorTokens and mapPipelineToTheme",
+  "packageName": "@fluentui-react-native/apple-theme",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-theme-tokens-1cb88617-12a8-403b-b427-6eea1cde80d3.json
+++ b/change/@fluentui-react-native-theme-tokens-1cb88617-12a8-403b-b427-6eea1cde80d3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add shared colors to AliasColorTokens and mapPipelineToTheme",
+  "packageName": "@fluentui-react-native/theme-tokens",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-theme-types-16022855-2015-40bd-b8cf-310da2f622d7.json
+++ b/change/@fluentui-react-native-theme-types-16022855-2015-40bd-b8cf-310da2f622d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add shared colors to AliasColorTokens and mapPipelineToTheme",
+  "packageName": "@fluentui-react-native/theme-types",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-theming-utils-36edff1c-19b0-4419-a00e-6d37b1fdcbb9.json
+++ b/change/@fluentui-react-native-theming-utils-36edff1c-19b0-4419-a00e-6d37b1fdcbb9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add shared colors to AliasColorTokens and mapPipelineToTheme",
+  "packageName": "@fluentui-react-native/theming-utils",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/theming/apple-theme/package.json
+++ b/packages/theming/apple-theme/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@fluentui-react-native/default-theme": ">=0.16.23 <1.0.0",
-    "@fluentui-react-native/design-tokens-ios": "^0.39.0",
+    "@fluentui-react-native/design-tokens-ios": "^0.40.0",
     "@fluentui-react-native/design-tokens-macos": "^0.36.0",
     "@fluentui-react-native/memo-cache": "^1.1.7",
     "@fluentui-react-native/theme": ">=0.7.16 <1.0.0",

--- a/packages/theming/apple-theme/package.json
+++ b/packages/theming/apple-theme/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@fluentui-react-native/default-theme": ">=0.16.23 <1.0.0",
-    "@fluentui-react-native/design-tokens-ios": "^0.38.0",
+    "@fluentui-react-native/design-tokens-ios": "^0.39.0",
     "@fluentui-react-native/design-tokens-macos": "^0.36.0",
     "@fluentui-react-native/memo-cache": "^1.1.7",
     "@fluentui-react-native/theme": ">=0.7.16 <1.0.0",

--- a/packages/theming/theme-tokens/package.json
+++ b/packages/theming/theme-tokens/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "@fluentui-react-native/design-tokens-android": "^0.37.0",
-    "@fluentui-react-native/design-tokens-ios": "^0.38.0",
+    "@fluentui-react-native/design-tokens-ios": "^0.39.0",
     "@fluentui-react-native/design-tokens-win32": "^0.36.0",
     "@fluentui-react-native/design-tokens-windows": "^0.36.0",
     "@fluentui-react-native/theme-types": ">=0.29.0 <1.0.0",

--- a/packages/theming/theme-tokens/package.json
+++ b/packages/theming/theme-tokens/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "@fluentui-react-native/design-tokens-android": "^0.37.0",
-    "@fluentui-react-native/design-tokens-ios": "^0.39.0",
+    "@fluentui-react-native/design-tokens-ios": "^0.40.0",
     "@fluentui-react-native/design-tokens-win32": "^0.36.0",
     "@fluentui-react-native/design-tokens-windows": "^0.36.0",
     "@fluentui-react-native/theme-types": ">=0.29.0 <1.0.0",

--- a/packages/theming/theme-types/src/Color.types.ts
+++ b/packages/theming/theme-types/src/Color.types.ts
@@ -876,6 +876,66 @@ export interface AliasColorTokens {
 
   /** @platform macOS, win32, windows */
   redBorder2?: ColorValue;
+
+  /** @platform ios  */
+  dangerBackground1?: ColorValue;
+
+  /** @platform ios  */
+  dangerBackground2?: ColorValue;
+
+  /** @platform ios  */
+  dangerForeground1?: ColorValue;
+
+  /** @platform ios  */
+  dangerForeground2?: ColorValue;
+
+  /** @platform ios  */
+  successBackground1?: ColorValue;
+
+  /** @platform ios  */
+  successBackground2?: ColorValue;
+
+  /** @platform ios  */
+  successForeground1?: ColorValue;
+
+  /** @platform ios  */
+  successForeground2?: ColorValue;
+
+  /** @platform ios  */
+  warningBackground1?: ColorValue;
+
+  /** @platform ios  */
+  warningBackground2?: ColorValue;
+
+  /** @platform ios  */
+  warningForeground1?: ColorValue;
+
+  /** @platform ios  */
+  warningForeground2?: ColorValue;
+
+  /** @platform ios  */
+  severeBackground1?: ColorValue;
+
+  /** @platform ios  */
+  severeBackground2?: ColorValue;
+
+  /** @platform ios  */
+  severeForeground1?: ColorValue;
+
+  /** @platform ios  */
+  severeForeground2?: ColorValue;
+
+  /** @platform ios  */
+  presenceAway?: ColorValue;
+
+  /** @platform ios  */
+  presenceDnd?: ColorValue;
+
+  /** @platform ios  */
+  presenceAvailable?: ColorValue;
+
+  /** @platform ios  */
+  presenceOof?: ColorValue;
 }
 
 /**

--- a/packages/theming/theme-types/src/Color.types.ts
+++ b/packages/theming/theme-types/src/Color.types.ts
@@ -877,63 +877,85 @@ export interface AliasColorTokens {
   /** @platform macOS, win32, windows */
   redBorder2?: ColorValue;
 
+  /// Error, status, and presence tokens
+
+  // TODO #2440: Add to android
   /** @platform ios  */
   dangerBackground1?: ColorValue;
 
+  // TODO #2440: Add to android
   /** @platform ios  */
   dangerBackground2?: ColorValue;
 
+  // TODO #2440: Add to android
   /** @platform ios  */
   dangerForeground1?: ColorValue;
 
+  // TODO #2440: Add to android
   /** @platform ios  */
   dangerForeground2?: ColorValue;
 
+  // TODO #2440: Add to android
   /** @platform ios  */
   successBackground1?: ColorValue;
 
+  // TODO #2440: Add to android
   /** @platform ios  */
   successBackground2?: ColorValue;
 
+  // TODO #2440: Add to android
   /** @platform ios  */
   successForeground1?: ColorValue;
 
+  // TODO #2440: Add to android
   /** @platform ios  */
   successForeground2?: ColorValue;
 
+  // TODO #2440: Add to android
   /** @platform ios  */
   warningBackground1?: ColorValue;
 
+  // TODO #2440: Add to android
   /** @platform ios  */
   warningBackground2?: ColorValue;
 
+  // TODO #2440: Add to android
   /** @platform ios  */
   warningForeground1?: ColorValue;
 
+  // TODO #2440: Add to android
   /** @platform ios  */
   warningForeground2?: ColorValue;
 
+  // TODO #2440: Add to android
   /** @platform ios  */
   severeBackground1?: ColorValue;
 
+  // TODO #2440: Add to android
   /** @platform ios  */
   severeBackground2?: ColorValue;
 
+  // TODO #2440: Add to android
   /** @platform ios  */
   severeForeground1?: ColorValue;
 
+  // TODO #2440: Add to android
   /** @platform ios  */
   severeForeground2?: ColorValue;
 
+  // TODO #2440: Add to android
   /** @platform ios  */
   presenceAway?: ColorValue;
 
+  // TODO #2440: Add to android
   /** @platform ios  */
   presenceDnd?: ColorValue;
 
+  // TODO #2440: Add to android
   /** @platform ios  */
   presenceAvailable?: ColorValue;
 
+  // TODO #2440: Add to android
   /** @platform ios  */
   presenceOof?: ColorValue;
 }

--- a/packages/theming/theming-utils/src/mapPipelineToTheme.ios.ts
+++ b/packages/theming/theming-utils/src/mapPipelineToTheme.ios.ts
@@ -109,6 +109,33 @@ export function mapPipelineToTheme(pipelineOutput: any): AliasColorTokens {
     brandStroke1: pipelineOutput.brandStroke1.strokeColorRest,
     brandStroke1Pressed: pipelineOutput.brandStroke1.strokeColorPressed,
     brandStroke1Selected: pipelineOutput.brandStroke1.strokeColorSelected,
+
+    /// Error, status, and presence tokens
+
+    dangerBackground1: pipelineOutput.dangerBackground1.fillColorRest,
+    dangerBackground2: pipelineOutput.dangerBackground2.fillColorRest,
+    dangerForeground1: pipelineOutput.dangerForeground1.fillColorRest,
+    dangerForeground2: pipelineOutput.dangerForeground2.fillColorRest,
+
+    successBackground1: pipelineOutput.successBackground1.fillColorRest,
+    successBackground2: pipelineOutput.successBackground2.fillColorRest,
+    successForeground1: pipelineOutput.successForeground1.fillColorRest,
+    successForeground2: pipelineOutput.successForeground2.fillColorRest,
+
+    warningBackground1: pipelineOutput.warningBackground1.fillColorRest,
+    warningBackground2: pipelineOutput.warningBackground2.fillColorRest,
+    warningForeground1: pipelineOutput.warningForeground1.fillColorRest,
+    warningForeground2: pipelineOutput.warningForeground2.fillColorRest,
+
+    severeBackground1: pipelineOutput.severeBackground1.fillColorRest,
+    severeBackground2: pipelineOutput.severeBackground2.fillColorRest,
+    severeForeground1: pipelineOutput.severeForeground1.fillColorRest,
+    severeForeground2: pipelineOutput.severeForeground1.fillColorRest,
+
+    presenceAway: pipelineOutput.presenceAway.fillColorRest,
+    presenceDnd: pipelineOutput.presenceDnd.fillColorRest,
+    presenceAvailable: pipelineOutput.presenceAvailable.fillColorRest,
+    presenceOof: pipelineOutput.presenceOof.fillColorRest,
   };
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1445,10 +1445,10 @@
   resolved "https://registry.yarnpkg.com/@fluentui-react-native/design-tokens-android/-/design-tokens-android-0.37.0.tgz#c1479a10bb10a939db8effac98988ff2859110a9"
   integrity sha512-qh1i195poQu/Zvabk/VsLZw+U1zwN5WQn9JAJgk1ZCWLwKfc24HRx+zpnSBdbWcOSI5b6kEDffwq8nPKUAN3QQ==
 
-"@fluentui-react-native/design-tokens-ios@^0.39.0":
-  version "0.39.0"
-  resolved "https://registry.yarnpkg.com/@fluentui-react-native/design-tokens-ios/-/design-tokens-ios-0.39.0.tgz#11b05c4a5cb47de888b1a25eb94e1e3937a3a6e7"
-  integrity sha512-31aI5ELiCK8vhkqC4j9VIm5edbcUSQAbMw1a/nmkXbgAGimNHd+OmEN+ZQ1uGcL9FspZyqULlw7X9BespOKH+Q==
+"@fluentui-react-native/design-tokens-ios@^0.40.0":
+  version "0.40.0"
+  resolved "https://registry.yarnpkg.com/@fluentui-react-native/design-tokens-ios/-/design-tokens-ios-0.40.0.tgz#6e4ec6968dffec0307cb3c90bf5fbe45f476c04a"
+  integrity sha512-BB5kjSdynGfequ5LFKzUgIwHjNZd3YZSGkTeRdyy0ibVZNQZdPOK2jSffvIq4DjNhLiIEN7chG0343+S+o3zEw==
 
 "@fluentui-react-native/design-tokens-macos@^0.36.0":
   version "0.36.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1445,10 +1445,10 @@
   resolved "https://registry.yarnpkg.com/@fluentui-react-native/design-tokens-android/-/design-tokens-android-0.37.0.tgz#c1479a10bb10a939db8effac98988ff2859110a9"
   integrity sha512-qh1i195poQu/Zvabk/VsLZw+U1zwN5WQn9JAJgk1ZCWLwKfc24HRx+zpnSBdbWcOSI5b6kEDffwq8nPKUAN3QQ==
 
-"@fluentui-react-native/design-tokens-ios@^0.38.0":
-  version "0.38.0"
-  resolved "https://registry.yarnpkg.com/@fluentui-react-native/design-tokens-ios/-/design-tokens-ios-0.38.0.tgz#9008f08064c5d822c49a4b342c81816d99caba29"
-  integrity sha512-NCe8NgxCtjA9FYZtTCpu7Llw0PO/sZ0pCNAZvebwZo+anrlI33LG3+dw8Ea8NB53mmBXOBVWDbzEH4k35CC6RA==
+"@fluentui-react-native/design-tokens-ios@^0.39.0":
+  version "0.39.0"
+  resolved "https://registry.yarnpkg.com/@fluentui-react-native/design-tokens-ios/-/design-tokens-ios-0.39.0.tgz#11b05c4a5cb47de888b1a25eb94e1e3937a3a6e7"
+  integrity sha512-31aI5ELiCK8vhkqC4j9VIm5edbcUSQAbMw1a/nmkXbgAGimNHd+OmEN+ZQ1uGcL9FspZyqULlw7X9BespOKH+Q==
 
 "@fluentui-react-native/design-tokens-macos@^0.36.0":
   version "0.36.0"


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Follow up to https://github.com/microsoft/fluentui-react-native/pull/2481

In the change above we added neutral and brand alias color tokens. There was still some ongoing discussion on shared color tokens (i.e. error, status, and presence tokens) at the time, but that's been resolved and those tokens have been added to the design-tokens repo. Updating iOS alias color tokens to include these new tokens. 

After this change, the full set of the iOS alias tokens will be available.

### Verification

Realized that the existing Tokens test page was actually getting updated with the iOS alias tokens changes - videos for light/dark mode below, the new shared colors that were added are at the bottom: 

https://user-images.githubusercontent.com/78454019/212396302-48bf3fde-16d5-4ddc-b37a-2af8f0ee4c8b.mp4

https://user-images.githubusercontent.com/78454019/212396283-18a0306e-b588-44a5-ad1c-56e8ee8e29db.mp4



### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
