### PR TITLE
macOS: Update Menu font

### DIFF
--- a/change/@fluentui-react-native-menu-0d402e72-8daf-4d85-9263-91b711cb5a1c.json
+++ b/change/@fluentui-react-native-menu-0d402e72-8daf-4d85-9263-91b711cb5a1c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update Menu font",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "amchiu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/MenuItem/MenuItemTokens.macos.ts
+++ b/packages/components/Menu/src/MenuItem/MenuItemTokens.macos.ts
@@ -9,7 +9,7 @@ export const defaultMenuItemTokens: TokenSettings<MenuItemTokens, Theme> = (t: T
   checkmarkSize: 16,
   color: t.colors.menuItemText, // matches ContextualMenu
   fontFamily: t.typography.families.primary,
-  fontSize: 13, // aligning with ContextualMenu font size
+  fontSize: 13, // aligning with NSMenu font size
   fontWeight: globalTokens.font.weight.regular as FontWeightValue,
   gap: globalTokens.size40,
   paddingHorizontal: 5, // hardcoded for now to match ContextualMenu

--- a/packages/components/Menu/src/MenuItem/MenuItemTokens.macos.ts
+++ b/packages/components/Menu/src/MenuItem/MenuItemTokens.macos.ts
@@ -9,7 +9,7 @@ export const defaultMenuItemTokens: TokenSettings<MenuItemTokens, Theme> = (t: T
   checkmarkSize: 16,
   color: t.colors.menuItemText, // matches ContextualMenu
   fontFamily: t.typography.families.primary,
-  fontSize: globalTokens.font.size300,
+  fontSize: 13, // aligning with ContextualMenu font size
   fontWeight: globalTokens.font.weight.regular as FontWeightValue,
   gap: globalTokens.size40,
   paddingHorizontal: 5, // hardcoded for now to match ContextualMenu


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Updating the font token value for MenuItem to align with ContextualMenu visuals.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/67026167/212430453-5d611a10-e4ee-410e-a462-e1d039d50bd3.png) |![image](https://user-images.githubusercontent.com/67026167/212430528-0a2825f3-9ef1-4b42-98a8-c0ee554956d8.png) |
ContextualMenu:
![image](https://user-images.githubusercontent.com/67026167/212430589-ff951e6c-ef0c-4d3e-99d3-bca60b5f70ce.png)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
