### PR TITLE
Fix incorrect docs in iOS `fluent-tester` README

### DIFF
--- a/apps/fluent-tester/docs/ios.md
+++ b/apps/fluent-tester/docs/ios.md
@@ -13,16 +13,16 @@ yarn
 yarn build
 ```
 
-2. Then go into `apps/fluent-tester/ios` folder and run pod install to pull in the project-level Cocoapod dependencies defined in the podfile, and to generate a valid xcworkspace:
+2. Then go into `apps/fluent-tester/ios` folder and run `pod install` to pull in the project-level Cocoapod dependencies defined in the podfile, and to generate a valid xcworkspace:
 
 ```sh
-apps/fluent-tester/ios
+cd apps/fluent-tester/ios
 pod install
 ```
 
 Note: if you get the error: "CocoaPods could not find compatible versions for pod "MicrosoftFluentUI"," you may need to run `pod install --repo-update`.
 
-3. Return to the ios directory and run yarn ios to launch the FluentUI Tester app:
+3. Return to the `fluentui-tester` directory and run `yarn ios` to launch the FluentUI Tester app:
 
 ```sh
 cd ..

--- a/change/@fluentui-react-native-tester-328cdb3d-866e-464b-964a-a42ac3085320.json
+++ b/change/@fluentui-react-native-tester-328cdb3d-866e-464b-964a-a42ac3085320.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Updating README for iOS Fluent Tester",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "mischreiber@microsoft.com",
+  "dependentChangeType": "none"
+}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Updating a few minor issues with the iOS Fluent Tester documentation.

### Verification

Looked at the updated README markdown -- it looks good!

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
