### PR TITLE
Add external svg icon packages test page

### DIFF
--- a/apps/E2E/src/Svg/consts.ts
+++ b/apps/E2E/src/Svg/consts.ts
@@ -1,4 +1,6 @@
 export const HOMEPAGE_SVG_BUTTON = 'Homepage_Svg_Button';
+export const HOMEPAGE_RNSVGIcons_BUTTON = 'Homepage_RNSVGIcons_Button';
+export const RNSVGIcons_TESTPAGE = 'RNSvgIcons_TestPage';
 export const SVG_TESTPAGE = 'Svg_TestPage';
 
 /* E2E Testing Svg 1 */

--- a/apps/E2E/src/common/NavigateAppPage.ts
+++ b/apps/E2E/src/common/NavigateAppPage.ts
@@ -26,7 +26,7 @@ import { HOMEPAGE_SHADOW_BUTTON } from '../Shadow/consts';
 import { HOMEPAGE_SHIMMER_BUTTON } from '../Shimmer/consts';
 import { HOMEPAGE_SPACING_BUTTON } from '../Spacing/consts';
 import { HOMEPAGE_STROKEWIDTH_BUTTON } from '../StrokeWidthTokens/consts';
-import { HOMEPAGE_SVG_BUTTON } from '../Svg/consts';
+import { HOMEPAGE_SVG_BUTTON, HOMEPAGE_RNSVGIcons_BUTTON } from '../Svg/consts';
 import { HOMEPAGE_SWITCH_BUTTON } from '../Switch/consts';
 import { HOMEPAGE_TEXT_BUTTON } from '../TextLegacy/consts';
 import { HOMEPAGE_TEXTV1_BUTTON } from '../TextV1/consts';
@@ -147,6 +147,10 @@ class NavigateAppPage extends BasePage {
 
   async clickAndGoToSvgPage() {
     await (await this.svgPage).click();
+  }
+
+  async clickAndGoToRNSvgIconsPage() {
+    await (await this.rnSvgIconsPage).click();
   }
 
   async clickAndGoToSwitchPage() {
@@ -295,6 +299,10 @@ class NavigateAppPage extends BasePage {
 
   private get svgPage() {
     return By(HOMEPAGE_SVG_BUTTON);
+  }
+
+  private get rnSvgIconsPage() {
+    return By(HOMEPAGE_RNSVGIcons_BUTTON);
   }
 
   private get switchPage() {

--- a/apps/fluent-tester/package.json
+++ b/apps/fluent-tester/package.json
@@ -85,7 +85,8 @@
     "react-native-macos": "^0.68.0",
     "react-native-svg": "12.5.0",
     "react-native-windows": "^0.68.0",
-    "tslib": "^2.3.1"
+    "tslib": "^2.3.1",
+    "@warren-ms/react-native-icons": "^0.0.13"
   },
   "devDependencies": {
     "@babel/core": "^7.8.0",

--- a/apps/fluent-tester/src/TestComponents/Svg/RNSVGIcons.tsx
+++ b/apps/fluent-tester/src/TestComponents/Svg/RNSVGIcons.tsx
@@ -1,0 +1,1110 @@
+import * as React from 'react';
+import { RNSVGIcons_TESTPAGE } from '../../../../E2E/src/Svg/consts';
+import { /* Text, */ View } from 'react-native';
+import { Test, TestSection, PlatformStatus } from '../Test';
+import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
+import { faMugSaucer } from '@fortawesome/free-solid-svg-icons/faMugSaucer';
+import { faSquareCheck } from '@fortawesome/free-solid-svg-icons/faSquareCheck';
+import { faMugHot } from '@fortawesome/free-solid-svg-icons/faMugHot';
+import { faMountainCity } from '@fortawesome/free-solid-svg-icons/faMountainCity';
+import {
+  AccessTime20Filled,
+  AccessTime20Regular,
+  AccessTime24Filled,
+  AccessTime24Regular,
+  Accessibility16Filled,
+  Accessibility16Regular,
+  Accessibility20Filled,
+  Accessibility20Regular,
+  Accessibility24Filled,
+  Accessibility24Regular,
+  Accessibility28Filled,
+  Accessibility28Regular,
+  Accessibility32Filled,
+  Accessibility32Regular,
+  Accessibility48Filled,
+  Accessibility48Regular,
+  AccessibilityCheckmark20Filled,
+  AccessibilityCheckmark20Regular,
+  AccessibilityCheckmark24Filled,
+  AccessibilityCheckmark24Regular,
+  AccessibilityCheckmark28Filled,
+  AccessibilityCheckmark28Regular,
+  AccessibilityCheckmark32Filled,
+  AccessibilityCheckmark32Regular,
+  AccessibilityCheckmark48Filled,
+  AccessibilityCheckmark48Regular,
+  Add12Filled,
+  Add12Regular,
+  Add16Filled,
+  Add16Regular,
+  Add20Filled,
+  Add20Regular,
+  Add24Filled,
+  Add24Regular,
+  Add28Filled,
+  Add28Regular,
+  AddCircle12Filled,
+  AddCircle12Regular,
+  AddCircle16Filled,
+  AddCircle16Regular,
+  AddCircle20Filled,
+  AddCircle20Regular,
+  AddCircle24Filled,
+  AddCircle24Regular,
+  AddCircle28Filled,
+  AddCircle28Regular,
+  AddCircle32Filled,
+  AddCircle32Regular,
+  AddSquare20Filled,
+  AddSquare20Regular,
+  AddSquare24Filled,
+  AddSquare24Regular,
+  AddSquareMultiple16Filled,
+  AddSquareMultiple16Regular,
+  AddSquareMultiple20Filled,
+  AddSquareMultiple20Regular,
+  AddSubtractCircle16Filled,
+  AddSubtractCircle16Regular,
+  AddSubtractCircle20Filled,
+  AddSubtractCircle20Regular,
+  AddSubtractCircle24Filled,
+  AddSubtractCircle24Regular,
+  AddSubtractCircle28Filled,
+  AddSubtractCircle28Regular,
+  AddSubtractCircle48Filled,
+  AddSubtractCircle48Regular,
+  Airplane20Filled,
+  Airplane20Regular,
+  Airplane24Filled,
+  Airplane24Regular,
+  AirplaneTakeOff16Filled,
+  AirplaneTakeOff16Regular,
+  AirplaneTakeOff20Filled,
+  AirplaneTakeOff20Regular,
+  AirplaneTakeOff24Filled,
+  AirplaneTakeOff24Regular,
+  Album20Filled,
+  Album20Regular,
+  Album24Filled,
+  Album24Regular,
+  AlbumAdd20Filled,
+  AlbumAdd20Regular,
+  AlbumAdd24Filled,
+  AlbumAdd24Regular,
+  Alert12Filled,
+  Alert12Regular,
+  Alert16Filled,
+  Alert16Regular,
+  Alert20Filled,
+  Alert20Regular,
+  Alert24Filled,
+  Alert24Regular,
+  Alert28Filled,
+  Alert28Regular,
+  Alert32Filled,
+  Alert32Regular,
+  Alert48Filled,
+  Alert48Regular,
+  AlertBadge16Filled,
+  AlertBadge16Regular,
+  AlertBadge20Filled,
+  AlertBadge20Regular,
+  AlertBadge24Filled,
+  AlertBadge24Regular,
+  AlertOff16Filled,
+  AlertOff16Regular,
+  AlertOff20Filled,
+  AlertOff20Regular,
+  AlertOff24Filled,
+  AlertOff24Regular,
+  AlertOff28Filled,
+  AlertOff28Regular,
+  AlertOn20Filled,
+  AlertOn20Regular,
+  AlertOn24Filled,
+  AlertOn24Regular,
+  AlertSnooze12Filled,
+  AlertSnooze12Regular,
+  AlertSnooze16Filled,
+  AlertSnooze16Regular,
+  AlertSnooze20Filled,
+  AlertSnooze20Regular,
+  AlertSnooze24Filled,
+  AlertSnooze24Regular,
+  AlertUrgent16Filled,
+  AlertUrgent16Regular,
+  AlertUrgent20Filled,
+  AlertUrgent20Regular,
+  AlertUrgent24Filled,
+  AlertUrgent24Regular,
+  AlignBottom16Filled,
+  AlignBottom16Regular,
+  AlignBottom20Filled,
+  AlignBottom20Regular,
+  AlignBottom24Filled,
+  AlignBottom24Regular,
+  AlignBottom28Filled,
+  AlignBottom28Regular,
+  AlignBottom32Filled,
+  AlignBottom32Regular,
+  AlignBottom48Filled,
+  AlignBottom48Regular,
+  AlignCenterHorizontal16Filled,
+  AlignCenterHorizontal16Regular,
+  AlignCenterHorizontal20Filled,
+  AlignCenterHorizontal20Regular,
+  AlignCenterHorizontal24Filled,
+  AlignCenterHorizontal24Regular,
+  AlignCenterHorizontal28Filled,
+  AlignCenterHorizontal28Regular,
+  AlignCenterHorizontal32Filled,
+  AlignCenterHorizontal32Regular,
+  AlignCenterHorizontal48Filled,
+  AlignCenterHorizontal48Regular,
+  AlignCenterVertical16Filled,
+  AlignCenterVertical16Regular,
+  AlignCenterVertical20Filled,
+  AlignCenterVertical20Regular,
+  AlignCenterVertical24Filled,
+  AlignCenterVertical24Regular,
+  AlignCenterVertical28Filled,
+  AlignCenterVertical28Regular,
+  AlignCenterVertical32Filled,
+  AlignCenterVertical32Regular,
+  AlignCenterVertical48Filled,
+  AlignCenterVertical48Regular,
+  AlignDistributeBottom16Filled,
+  AlignDistributeBottom16Regular,
+  AlignDistributeLeft16Filled,
+  AlignDistributeLeft16Regular,
+  AlignDistributeRight16Filled,
+  AlignDistributeRight16Regular,
+  AlignDistributeTop16Filled,
+  AlignDistributeTop16Regular,
+  AlignEndHorizontal20Filled,
+  AlignEndHorizontal20Regular,
+  AlignEndVertical20Filled,
+  AlignEndVertical20Regular,
+  AlignLeft16Filled,
+  AlignLeft16Regular,
+  AlignLeft20Filled,
+  AlignLeft20Regular,
+  AlignLeft24Filled,
+  AlignLeft24Regular,
+  AlignLeft28Filled,
+  AlignLeft28Regular,
+  AlignLeft32Filled,
+  AlignLeft32Regular,
+  AlignLeft48Filled,
+  AlignLeft48Regular,
+  AlignRight16Filled,
+  AlignRight16Regular,
+  AlignRight20Filled,
+  AlignRight20Regular,
+  AlignRight24Filled,
+  AlignRight24Regular,
+  AlignRight28Filled,
+  AlignRight28Regular,
+  AlignRight32Filled,
+  AlignRight32Regular,
+  AlignRight48Filled,
+  AlignRight48Regular,
+  AlignSpaceAroundHorizontal20Filled,
+  AlignSpaceAroundHorizontal20Regular,
+  AlignSpaceAroundVertical20Filled,
+  AlignSpaceAroundVertical20Regular,
+  AlignSpaceBetweenHorizontal20Filled,
+  AlignSpaceBetweenHorizontal20Regular,
+  AlignSpaceBetweenVertical20Filled,
+  AlignSpaceBetweenVertical20Regular,
+  AlignSpaceEvenlyHorizontal20Filled,
+  AlignSpaceEvenlyHorizontal20Regular,
+  AlignSpaceEvenlyVertical20Filled,
+  AlignSpaceEvenlyVertical20Regular,
+  AlignSpaceFitVertical20Filled,
+  AlignSpaceFitVertical20Regular,
+  AlignStartHorizontal20Filled,
+  AlignStartHorizontal20Regular,
+  AlignStartVertical20Filled,
+  AlignStartVertical20Regular,
+  AlignStretchHorizontal16Filled,
+  AlignStretchHorizontal16Regular,
+  AlignStretchHorizontal20Filled,
+  AlignStretchHorizontal20Regular,
+  AlignStretchVertical16Filled,
+  AlignStretchVertical16Regular,
+  AlignStretchVertical20Filled,
+  AlignStretchVertical20Regular,
+  AlignTop16Filled,
+  AlignTop16Regular,
+  AlignTop20Filled,
+  AlignTop20Regular,
+  AlignTop24Filled,
+  AlignTop24Regular,
+  AlignTop28Filled,
+  AlignTop28Regular,
+  AlignTop32Filled,
+  AlignTop32Regular,
+  AlignTop48Filled,
+  AlignTop48Regular,
+  AnimalCat16Filled,
+  AnimalCat16Regular,
+  AnimalCat20Filled,
+  AnimalCat20Regular,
+  AnimalCat24Filled,
+  AnimalCat24Regular,
+  AnimalCat28Filled,
+  AnimalCat28Regular,
+  AnimalDog16Filled,
+  AnimalDog16Regular,
+  AnimalDog20Filled,
+  AnimalDog20Regular,
+  AnimalDog24Filled,
+  AnimalDog24Regular,
+  AnimalRabbit16Filled,
+  AnimalRabbit16Regular,
+  AnimalRabbit20Filled,
+  AnimalRabbit20Regular,
+  AnimalRabbit24Filled,
+  AnimalRabbit24Regular,
+  AnimalRabbit28Filled,
+  AnimalRabbit28Regular,
+  AnimalRabbit32Filled,
+  AnimalRabbit32Regular,
+  AnimalRabbitOff20Filled,
+  AnimalRabbitOff20Regular,
+  AnimalRabbitOff32Filled,
+  AnimalRabbitOff32Regular,
+  AnimalTurtle16Filled,
+  AnimalTurtle16Regular,
+  AnimalTurtle20Filled,
+  AnimalTurtle20Regular,
+  AnimalTurtle24Filled,
+  AnimalTurtle24Regular,
+  AnimalTurtle28Filled,
+  AnimalTurtle28Regular,
+  AppFolder16Filled,
+  AppFolder16Regular,
+  AppFolder20Filled,
+  AppFolder20Regular,
+  AppFolder24Filled,
+  AppFolder24Regular,
+  AppFolder28Filled,
+  AppFolder28Regular,
+  AppFolder32Filled,
+  AppFolder32Regular,
+  AppFolder48Filled,
+  AppFolder48Regular,
+  AppGeneric20Filled,
+  AppGeneric20Regular,
+  AppGeneric24Filled,
+  AppGeneric24Regular,
+  AppGeneric32Filled,
+  AppGeneric32Regular,
+  AppRecent20Filled,
+  AppRecent20Regular,
+  AppRecent24Filled,
+  AppRecent24Regular,
+  AppStore24Filled,
+  AppStore24Regular,
+  AppTitle20Filled,
+  AppTitle20Regular,
+  AppTitle24Filled,
+  AppTitle24Regular,
+  ApprovalsApp16Filled,
+  ApprovalsApp16Regular,
+  ApprovalsApp20Filled,
+  ApprovalsApp20Regular,
+  ApprovalsApp24Filled,
+  ApprovalsApp24Regular,
+  ApprovalsApp28Filled,
+  ApprovalsApp28Regular,
+  ApprovalsApp32Filled,
+  ApprovalsApp32Regular,
+  Apps16Filled,
+  Apps16Regular,
+  Apps20Filled,
+  Apps20Regular,
+  Apps24Filled,
+  Apps24Regular,
+  Apps28Filled,
+  Apps28Regular,
+  Apps32Filled,
+  Apps32Regular,
+  AppsAddIn16Filled,
+  AppsAddIn16Regular,
+  AppsAddIn20Filled,
+  AppsAddIn20Regular,
+  AppsAddIn24Filled,
+  AppsAddIn24Regular,
+  AppsAddIn28Filled,
+  AppsAddIn28Regular,
+  AppsList20Filled,
+  AppsList20Regular,
+  AppsList24Filled,
+  AppsList24Regular,
+  AppsListDetail20Filled,
+  AppsListDetail20Regular,
+  AppsListDetail24Filled,
+  AppsListDetail24Regular,
+  Archive16Filled,
+  Archive16Regular,
+  Archive20Filled,
+  Archive20Regular,
+  Archive24Filled,
+  Archive24Regular,
+  Archive28Filled,
+  Archive28Regular,
+  Archive32Filled,
+  Archive32Regular,
+  Archive48Filled,
+  Archive48Regular,
+  ArchiveArrowBack16Filled,
+  ArchiveArrowBack16Regular,
+  ArchiveArrowBack20Filled,
+  ArchiveArrowBack20Regular,
+  ArchiveArrowBack24Filled,
+  ArchiveArrowBack24Regular,
+  ArchiveArrowBack28Filled,
+  ArchiveArrowBack28Regular,
+  ArchiveArrowBack32Filled,
+  ArchiveArrowBack32Regular,
+  ArchiveArrowBack48Filled,
+  ArchiveArrowBack48Regular,
+  ArchiveMultiple16Filled,
+  ArchiveMultiple16Regular,
+  ArchiveMultiple20Filled,
+  ArchiveMultiple20Regular,
+  ArchiveMultiple24Filled,
+  ArchiveMultiple24Regular,
+  ArchiveSettings16Filled,
+  ArchiveSettings16Regular,
+  ArchiveSettings20Filled,
+  ArchiveSettings20Regular,
+  ArchiveSettings24Filled,
+  ArchiveSettings24Regular,
+  ArchiveSettings28Filled,
+  ArchiveSettings28Regular,
+  ArrowAutofitContent20Filled,
+  ArrowAutofitContent20Regular,
+  ArrowAutofitContent24Filled,
+  ArrowAutofitContent24Regular,
+  ArrowAutofitDown20Filled,
+  ArrowAutofitDown20Regular,
+  ArrowAutofitDown24Filled,
+  ArrowAutofitDown24Regular,
+  ArrowAutofitHeight20Filled,
+  ArrowAutofitHeight20Regular,
+  ArrowAutofitHeight24Filled,
+  ArrowAutofitHeight24Regular,
+  ArrowAutofitHeightDotted20Filled,
+  ArrowAutofitHeightDotted20Regular,
+  ArrowAutofitHeightDotted24Filled,
+  ArrowAutofitHeightDotted24Regular,
+  ArrowAutofitUp20Filled,
+  ArrowAutofitUp20Regular,
+  ArrowAutofitUp24Filled,
+  ArrowAutofitUp24Regular,
+  ArrowAutofitWidth20Filled,
+  ArrowAutofitWidth20Regular,
+  ArrowAutofitWidth24Filled,
+  ArrowAutofitWidth24Regular,
+  ArrowAutofitWidthDotted20Filled,
+  ArrowAutofitWidthDotted20Regular,
+  ArrowAutofitWidthDotted24Filled,
+  ArrowAutofitWidthDotted24Regular,
+  ArrowBetweenDown20Filled,
+  ArrowBetweenDown20Regular,
+  ArrowBetweenDown24Filled,
+  ArrowBetweenDown24Regular,
+  ArrowBetweenUp20Filled,
+  ArrowBetweenUp20Regular,
+  ArrowBidirectionalUpDown12Filled,
+  ArrowBidirectionalUpDown12Regular,
+  ArrowBidirectionalUpDown16Filled,
+  ArrowBidirectionalUpDown16Regular,
+  ArrowBidirectionalUpDown20Filled,
+  ArrowBidirectionalUpDown20Regular,
+  ArrowBidirectionalUpDown24Filled,
+  ArrowBidirectionalUpDown24Regular,
+  ArrowBounce16Filled,
+  ArrowBounce16Regular,
+  ArrowBounce20Filled,
+  ArrowBounce20Regular,
+  ArrowBounce24Filled,
+  ArrowBounce24Regular,
+  ArrowCircleDown12Filled,
+  ArrowCircleDown12Regular,
+  ArrowCircleDown16Filled,
+  ArrowCircleDown16Regular,
+  ArrowCircleDown20Filled,
+  ArrowCircleDown20Regular,
+  ArrowCircleDown24Filled,
+  ArrowCircleDown24Regular,
+  ArrowCircleDown28Filled,
+  ArrowCircleDown28Regular,
+  ArrowCircleDown32Filled,
+  ArrowCircleDown32Regular,
+  ArrowCircleDown48Filled,
+  ArrowCircleDown48Regular,
+  ArrowCircleDownDouble20Filled,
+  ArrowCircleDownDouble20Regular,
+  ArrowCircleDownDouble24Filled,
+  ArrowCircleDownDouble24Regular,
+  ArrowCircleDownRight16Filled,
+  ArrowCircleDownRight16Regular,
+  ArrowCircleDownRight20Filled,
+  ArrowCircleDownRight20Regular,
+  ArrowCircleDownRight24Filled,
+  ArrowCircleDownRight24Regular,
+  ArrowCircleDownSplit20Filled,
+  ArrowCircleDownSplit20Regular,
+  ArrowCircleDownSplit24Filled,
+  ArrowCircleDownSplit24Regular,
+  ArrowCircleDownUp20Filled,
+  ArrowCircleDownUp20Regular,
+  ArrowCircleLeft12Filled,
+  ArrowCircleLeft12Regular,
+  ArrowCircleLeft16Filled,
+  ArrowCircleLeft16Regular,
+  ArrowCircleLeft20Filled,
+  ArrowCircleLeft20Regular,
+  ArrowCircleLeft24Filled,
+  ArrowCircleLeft24Regular,
+  ArrowCircleLeft28Filled,
+  ArrowCircleLeft28Regular,
+  ArrowCircleLeft32Filled,
+  ArrowCircleLeft32Regular,
+  ArrowCircleLeft48Filled,
+  ArrowCircleLeft48Regular,
+  ArrowCircleRight12Filled,
+  ArrowCircleRight12Regular,
+  ArrowCircleRight16Filled,
+  ArrowCircleRight16Regular,
+  ArrowCircleRight20Filled,
+  ArrowCircleRight20Regular,
+  ArrowCircleRight24Filled,
+  ArrowCircleRight24Regular,
+  ArrowCircleRight28Filled,
+  ArrowCircleRight28Regular,
+  ArrowCircleRight32Filled,
+  ArrowCircleRight32Regular,
+  ArrowCircleRight48Filled,
+  ArrowCircleRight48Regular,
+  ArrowCircleUp12Filled,
+  ArrowCircleUp12Regular,
+  ArrowCircleUp16Filled,
+  ArrowCircleUp16Regular,
+  ArrowCircleUp20Filled,
+  ArrowCircleUp20Regular,
+  ArrowCircleUp24Filled,
+  ArrowCircleUp24Regular,
+  ArrowCircleUp28Filled,
+  ArrowCircleUp28Regular,
+  ArrowCircleUp32Filled,
+  ArrowCircleUp32Regular,
+  ArrowCircleUp48Filled,
+  ArrowCircleUp48Regular,
+  ArrowCircleUpLeft20Filled,
+  ArrowCircleUpLeft20Regular,
+} from '@warren-ms/react-native-icons';
+
+const FontAwesomeTest: React.FunctionComponent = () => {
+  return (
+    <React.Fragment>
+      <View style={{ flexDirection: 'column', alignItems: 'flex-start' }}>
+        <View style={{ flexDirection: 'row' }}>
+          <FontAwesomeIcon icon={faMugSaucer} color={'blue'} size={64} />
+          <FontAwesomeIcon icon={faSquareCheck} color={'blue'} size={64} />
+          <FontAwesomeIcon icon={faMugHot} color={'orange'} size={64} />
+          <FontAwesomeIcon icon={faMountainCity} color={'orange'} size={64} />
+        </View>
+      </View>
+    </React.Fragment>
+  );
+};
+const FluentIconsTest: React.FunctionComponent = () => {
+  return (
+    <React.Fragment>
+      <View style={{ flexDirection: 'column', alignItems: 'flex-start' }}>
+        <View style={{ flexDirection: 'row' }}>
+          <AccessTime20Filled />
+          <AccessTime20Regular />
+          <AccessTime24Filled />
+          <AccessTime24Regular />
+          <Accessibility16Filled />
+          <Accessibility16Regular />
+          <Accessibility20Filled />
+          <Accessibility20Regular />
+          <Accessibility24Filled />
+          <Accessibility24Regular />
+          <Accessibility28Filled />
+          <Accessibility28Regular />
+          <Accessibility32Filled />
+          <Accessibility32Regular />
+          <Accessibility48Filled />
+          <Accessibility48Regular />
+          <AccessibilityCheckmark20Filled />
+          <AccessibilityCheckmark20Regular />
+          <AccessibilityCheckmark24Filled />
+          <AccessibilityCheckmark24Regular />
+        </View>
+        <View style={{ flexDirection: 'row' }}>
+          <AccessibilityCheckmark28Filled />
+          <AccessibilityCheckmark28Regular />
+          <AccessibilityCheckmark32Filled />
+          <AccessibilityCheckmark32Regular />
+          <AccessibilityCheckmark48Filled />
+          <AccessibilityCheckmark48Regular />
+          <Add12Filled />
+          <Add12Regular />
+          <Add16Filled />
+          <Add16Regular />
+          <Add20Filled />
+          <Add20Regular />
+          <Add24Filled />
+          <Add24Regular />
+          <Add28Filled />
+          <Add28Regular />
+          <AddCircle12Filled />
+          <AddCircle12Regular />
+          <AddCircle16Filled />
+          <AddCircle16Regular />
+        </View>
+        <View style={{ flexDirection: 'row' }}>
+          <AddCircle20Filled />
+          <AddCircle20Regular />
+          <AddCircle24Filled />
+          <AddCircle24Regular />
+          <AddCircle28Filled />
+          <AddCircle28Regular />
+          <AddCircle32Filled />
+          <AddCircle32Regular />
+          <AddSquare20Filled />
+          <AddSquare20Regular />
+          <AddSquare24Filled />
+          <AddSquare24Regular />
+          <AddSquareMultiple16Filled />
+          <AddSquareMultiple16Regular />
+          <AddSquareMultiple20Filled />
+          <AddSquareMultiple20Regular />
+          <AddSubtractCircle16Filled />
+          <AddSubtractCircle16Regular />
+          <AddSubtractCircle20Filled />
+          <AddSubtractCircle20Regular />
+        </View>
+        <View style={{ flexDirection: 'row' }}>
+          <AddSubtractCircle24Filled />
+          <AddSubtractCircle24Regular />
+          <AddSubtractCircle28Filled />
+          <AddSubtractCircle28Regular />
+          <AddSubtractCircle48Filled />
+          <AddSubtractCircle48Regular />
+          <Airplane20Filled />
+          <Airplane20Regular />
+          <Airplane24Filled />
+          <Airplane24Regular />
+          <AirplaneTakeOff16Filled />
+          <AirplaneTakeOff16Regular />
+          <AirplaneTakeOff20Filled />
+          <AirplaneTakeOff20Regular />
+          <AirplaneTakeOff24Filled />
+          <AirplaneTakeOff24Regular />
+          <Album20Filled />
+          <Album20Regular />
+          <Album24Filled />
+          <Album24Regular />
+        </View>
+        <View style={{ flexDirection: 'row' }}>
+          <AlbumAdd20Filled />
+          <AlbumAdd20Regular />
+          <AlbumAdd24Filled />
+          <AlbumAdd24Regular />
+          <Alert12Filled />
+          <Alert12Regular />
+          <Alert16Filled />
+          <Alert16Regular />
+          <Alert20Filled />
+          <Alert20Regular />
+          <Alert24Filled />
+          <Alert24Regular />
+          <Alert28Filled />
+          <Alert28Regular />
+          <Alert32Filled />
+          <Alert32Regular />
+          <Alert48Filled />
+          <Alert48Regular />
+          <AlertBadge16Filled />
+          <AlertBadge16Regular />
+        </View>
+        <View style={{ flexDirection: 'row' }}>
+          <AlertBadge20Filled />
+          <AlertBadge20Regular />
+          <AlertBadge24Filled />
+          <AlertBadge24Regular />
+          <AlertOff16Filled />
+          <AlertOff16Regular />
+          <AlertOff20Filled />
+          <AlertOff20Regular />
+          <AlertOff24Filled />
+          <AlertOff24Regular />
+          <AlertOff28Filled />
+          <AlertOff28Regular />
+          <AlertOn20Filled />
+          <AlertOn20Regular />
+          <AlertOn24Filled />
+          <AlertOn24Regular />
+          <AlertSnooze12Filled />
+          <AlertSnooze12Regular />
+          <AlertSnooze16Filled />
+          <AlertSnooze16Regular />
+        </View>
+        <View style={{ flexDirection: 'row' }}>
+          <AlertSnooze20Filled />
+          <AlertSnooze20Regular />
+          <AlertSnooze24Filled />
+          <AlertSnooze24Regular />
+          <AlertUrgent16Filled />
+          <AlertUrgent16Regular />
+          <AlertUrgent20Filled />
+          <AlertUrgent20Regular />
+          <AlertUrgent24Filled />
+          <AlertUrgent24Regular />
+          <AlignBottom16Filled />
+          <AlignBottom16Regular />
+          <AlignBottom20Filled />
+          <AlignBottom20Regular />
+          <AlignBottom24Filled />
+          <AlignBottom24Regular />
+          <AlignBottom28Filled />
+          <AlignBottom28Regular />
+          <AlignBottom32Filled />
+          <AlignBottom32Regular />
+        </View>
+        <View style={{ flexDirection: 'row' }}>
+          <AlignBottom48Filled />
+          <AlignBottom48Regular />
+          <AlignCenterHorizontal16Filled />
+          <AlignCenterHorizontal16Regular />
+          <AlignCenterHorizontal20Filled />
+          <AlignCenterHorizontal20Regular />
+          <AlignCenterHorizontal24Filled />
+          <AlignCenterHorizontal24Regular />
+          <AlignCenterHorizontal28Filled />
+          <AlignCenterHorizontal28Regular />
+          <AlignCenterHorizontal32Filled />
+          <AlignCenterHorizontal32Regular />
+          <AlignCenterHorizontal48Filled />
+          <AlignCenterHorizontal48Regular />
+          <AlignCenterVertical16Filled />
+          <AlignCenterVertical16Regular />
+          <AlignCenterVertical20Filled />
+          <AlignCenterVertical20Regular />
+          <AlignCenterVertical24Filled />
+          <AlignCenterVertical24Regular />
+        </View>
+        <View style={{ flexDirection: 'row' }}>
+          <AlignCenterVertical28Filled />
+          <AlignCenterVertical28Regular />
+          <AlignCenterVertical32Filled />
+          <AlignCenterVertical32Regular />
+          <AlignCenterVertical48Filled />
+          <AlignCenterVertical48Regular />
+          <AlignDistributeBottom16Filled />
+          <AlignDistributeBottom16Regular />
+          <AlignDistributeLeft16Filled />
+          <AlignDistributeLeft16Regular />
+          <AlignDistributeRight16Filled />
+          <AlignDistributeRight16Regular />
+          <AlignDistributeTop16Filled />
+          <AlignDistributeTop16Regular />
+          <AlignEndHorizontal20Filled />
+          <AlignEndHorizontal20Regular />
+          <AlignEndVertical20Filled />
+          <AlignEndVertical20Regular />
+          <AlignLeft16Filled />
+          <AlignLeft16Regular />
+        </View>
+        <View style={{ flexDirection: 'row' }}>
+          <AlignLeft20Filled />
+          <AlignLeft20Regular />
+          <AlignLeft24Filled />
+          <AlignLeft24Regular />
+          <AlignLeft28Filled />
+          <AlignLeft28Regular />
+          <AlignLeft32Filled />
+          <AlignLeft32Regular />
+          <AlignLeft48Filled />
+          <AlignLeft48Regular />
+          <AlignRight16Filled />
+          <AlignRight16Regular />
+          <AlignRight20Filled />
+          <AlignRight20Regular />
+          <AlignRight24Filled />
+          <AlignRight24Regular />
+          <AlignRight28Filled />
+          <AlignRight28Regular />
+          <AlignRight32Filled />
+          <AlignRight32Regular />
+        </View>
+        <View style={{ flexDirection: 'row' }}>
+          <AlignRight48Filled />
+          <AlignRight48Regular />
+          <AlignSpaceAroundHorizontal20Filled />
+          <AlignSpaceAroundHorizontal20Regular />
+          <AlignSpaceAroundVertical20Filled />
+          <AlignSpaceAroundVertical20Regular />
+          <AlignSpaceBetweenHorizontal20Filled />
+          <AlignSpaceBetweenHorizontal20Regular />
+          <AlignSpaceBetweenVertical20Filled />
+          <AlignSpaceBetweenVertical20Regular />
+          <AlignSpaceEvenlyHorizontal20Filled />
+          <AlignSpaceEvenlyHorizontal20Regular />
+          <AlignSpaceEvenlyVertical20Filled />
+          <AlignSpaceEvenlyVertical20Regular />
+          <AlignSpaceFitVertical20Filled />
+          <AlignSpaceFitVertical20Regular />
+          <AlignStartHorizontal20Filled />
+          <AlignStartHorizontal20Regular />
+          <AlignStartVertical20Filled />
+          <AlignStartVertical20Regular />
+        </View>
+        <View style={{ flexDirection: 'row' }}>
+          <AlignStretchHorizontal16Filled />
+          <AlignStretchHorizontal16Regular />
+          <AlignStretchHorizontal20Filled />
+          <AlignStretchHorizontal20Regular />
+          <AlignStretchVertical16Filled />
+          <AlignStretchVertical16Regular />
+          <AlignStretchVertical20Filled />
+          <AlignStretchVertical20Regular />
+          <AlignTop16Filled />
+          <AlignTop16Regular />
+          <AlignTop20Filled />
+          <AlignTop20Regular />
+          <AlignTop24Filled />
+          <AlignTop24Regular />
+          <AlignTop28Filled />
+          <AlignTop28Regular />
+          <AlignTop32Filled />
+          <AlignTop32Regular />
+          <AlignTop48Filled />
+          <AlignTop48Regular />
+        </View>
+        <View style={{ flexDirection: 'row' }}>
+          <AnimalCat16Filled />
+          <AnimalCat16Regular />
+          <AnimalCat20Filled />
+          <AnimalCat20Regular />
+          <AnimalCat24Filled />
+          <AnimalCat24Regular />
+          <AnimalCat28Filled />
+          <AnimalCat28Regular />
+          <AnimalDog16Filled />
+          <AnimalDog16Regular />
+          <AnimalDog20Filled />
+          <AnimalDog20Regular />
+          <AnimalDog24Filled />
+          <AnimalDog24Regular />
+          <AnimalRabbit16Filled />
+          <AnimalRabbit16Regular />
+          <AnimalRabbit20Filled />
+          <AnimalRabbit20Regular />
+          <AnimalRabbit24Filled />
+          <AnimalRabbit24Regular />
+        </View>
+        <View style={{ flexDirection: 'row' }}>
+          <AnimalRabbit28Filled />
+          <AnimalRabbit28Regular />
+          <AnimalRabbit32Filled />
+          <AnimalRabbit32Regular />
+          <AnimalRabbitOff20Filled />
+          <AnimalRabbitOff20Regular />
+          <AnimalRabbitOff32Filled />
+          <AnimalRabbitOff32Regular />
+          <AnimalTurtle16Filled />
+          <AnimalTurtle16Regular />
+          <AnimalTurtle20Filled />
+          <AnimalTurtle20Regular />
+          <AnimalTurtle24Filled />
+          <AnimalTurtle24Regular />
+          <AnimalTurtle28Filled />
+          <AnimalTurtle28Regular />
+          <AppFolder16Filled />
+          <AppFolder16Regular />
+          <AppFolder20Filled />
+          <AppFolder20Regular />
+        </View>
+        <View style={{ flexDirection: 'row' }}>
+          <AppFolder24Filled />
+          <AppFolder24Regular />
+          <AppFolder28Filled />
+          <AppFolder28Regular />
+          <AppFolder32Filled />
+          <AppFolder32Regular />
+          <AppFolder48Filled />
+          <AppFolder48Regular />
+          <AppGeneric20Filled />
+          <AppGeneric20Regular />
+          <AppGeneric24Filled />
+          <AppGeneric24Regular />
+          <AppGeneric32Filled />
+          <AppGeneric32Regular />
+          <AppRecent20Filled />
+          <AppRecent20Regular />
+          <AppRecent24Filled />
+          <AppRecent24Regular />
+          <AppStore24Filled />
+          <AppStore24Regular />
+        </View>
+        <View style={{ flexDirection: 'row' }}>
+          <AppTitle20Filled />
+          <AppTitle20Regular />
+          <AppTitle24Filled />
+          <AppTitle24Regular />
+          <ApprovalsApp16Filled />
+          <ApprovalsApp16Regular />
+          <ApprovalsApp20Filled />
+          <ApprovalsApp20Regular />
+          <ApprovalsApp24Filled />
+          <ApprovalsApp24Regular />
+          <ApprovalsApp28Filled />
+          <ApprovalsApp28Regular />
+          <ApprovalsApp32Filled />
+          <ApprovalsApp32Regular />
+          <Apps16Filled />
+          <Apps16Regular />
+          <Apps20Filled />
+          <Apps20Regular />
+          <Apps24Filled />
+          <Apps24Regular />
+        </View>
+        <View style={{ flexDirection: 'row' }}>
+          <Apps28Filled />
+          <Apps28Regular />
+          <Apps32Filled />
+          <Apps32Regular />
+          <AppsAddIn16Filled />
+          <AppsAddIn16Regular />
+          <AppsAddIn20Filled />
+          <AppsAddIn20Regular />
+          <AppsAddIn24Filled />
+          <AppsAddIn24Regular />
+          <AppsAddIn28Filled />
+          <AppsAddIn28Regular />
+          <AppsList20Filled />
+          <AppsList20Regular />
+          <AppsList24Filled />
+          <AppsList24Regular />
+          <AppsListDetail20Filled />
+          <AppsListDetail20Regular />
+          <AppsListDetail24Filled />
+          <AppsListDetail24Regular />
+        </View>
+        <View style={{ flexDirection: 'row' }}>
+          <Archive16Filled />
+          <Archive16Regular />
+          <Archive20Filled />
+          <Archive20Regular />
+          <Archive24Filled />
+          <Archive24Regular />
+          <Archive28Filled />
+          <Archive28Regular />
+          <Archive32Filled />
+          <Archive32Regular />
+          <Archive48Filled />
+          <Archive48Regular />
+          <ArchiveArrowBack16Filled />
+          <ArchiveArrowBack16Regular />
+          <ArchiveArrowBack20Filled />
+          <ArchiveArrowBack20Regular />
+          <ArchiveArrowBack24Filled />
+          <ArchiveArrowBack24Regular />
+          <ArchiveArrowBack28Filled />
+          <ArchiveArrowBack28Regular />
+        </View>
+        <View style={{ flexDirection: 'row' }}>
+          <ArchiveArrowBack32Filled />
+          <ArchiveArrowBack32Regular />
+          <ArchiveArrowBack48Filled />
+          <ArchiveArrowBack48Regular />
+          <ArchiveMultiple16Filled />
+          <ArchiveMultiple16Regular />
+          <ArchiveMultiple20Filled />
+          <ArchiveMultiple20Regular />
+          <ArchiveMultiple24Filled />
+          <ArchiveMultiple24Regular />
+          <ArchiveSettings16Filled />
+          <ArchiveSettings16Regular />
+          <ArchiveSettings20Filled />
+          <ArchiveSettings20Regular />
+          <ArchiveSettings24Filled />
+          <ArchiveSettings24Regular />
+          <ArchiveSettings28Filled />
+          <ArchiveSettings28Regular />
+          <ArrowAutofitContent20Filled />
+          <ArrowAutofitContent20Regular />
+        </View>
+        <View style={{ flexDirection: 'row' }}>
+          <ArrowAutofitContent24Filled />
+          <ArrowAutofitContent24Regular />
+          <ArrowAutofitDown20Filled />
+          <ArrowAutofitDown20Regular />
+          <ArrowAutofitDown24Filled />
+          <ArrowAutofitDown24Regular />
+          <ArrowAutofitHeight20Filled />
+          <ArrowAutofitHeight20Regular />
+          <ArrowAutofitHeight24Filled />
+          <ArrowAutofitHeight24Regular />
+          <ArrowAutofitHeightDotted20Filled />
+          <ArrowAutofitHeightDotted20Regular />
+          <ArrowAutofitHeightDotted24Filled />
+          <ArrowAutofitHeightDotted24Regular />
+          <ArrowAutofitUp20Filled />
+          <ArrowAutofitUp20Regular />
+          <ArrowAutofitUp24Filled />
+          <ArrowAutofitUp24Regular />
+          <ArrowAutofitWidth20Filled />
+          <ArrowAutofitWidth20Regular />
+        </View>
+        <View style={{ flexDirection: 'row' }}>
+          <ArrowAutofitWidth24Filled />
+          <ArrowAutofitWidth24Regular />
+          <ArrowAutofitWidthDotted20Filled />
+          <ArrowAutofitWidthDotted20Regular />
+          <ArrowAutofitWidthDotted24Filled />
+          <ArrowAutofitWidthDotted24Regular />
+          <ArrowBetweenDown20Filled />
+          <ArrowBetweenDown20Regular />
+          <ArrowBetweenDown24Filled />
+          <ArrowBetweenDown24Regular />
+          <ArrowBetweenUp20Filled />
+          <ArrowBetweenUp20Regular />
+          <ArrowBidirectionalUpDown12Filled />
+          <ArrowBidirectionalUpDown12Regular />
+          <ArrowBidirectionalUpDown16Filled />
+          <ArrowBidirectionalUpDown16Regular />
+          <ArrowBidirectionalUpDown20Filled />
+          <ArrowBidirectionalUpDown20Regular />
+          <ArrowBidirectionalUpDown24Filled />
+          <ArrowBidirectionalUpDown24Regular />
+        </View>
+        <View style={{ flexDirection: 'row' }}>
+          <ArrowBounce16Filled />
+          <ArrowBounce16Regular />
+          <ArrowBounce20Filled />
+          <ArrowBounce20Regular />
+          <ArrowBounce24Filled />
+          <ArrowBounce24Regular />
+          <ArrowCircleDown12Filled />
+          <ArrowCircleDown12Regular />
+          <ArrowCircleDown16Filled />
+          <ArrowCircleDown16Regular />
+          <ArrowCircleDown20Filled />
+          <ArrowCircleDown20Regular />
+          <ArrowCircleDown24Filled />
+          <ArrowCircleDown24Regular />
+          <ArrowCircleDown28Filled />
+          <ArrowCircleDown28Regular />
+          <ArrowCircleDown32Filled />
+          <ArrowCircleDown32Regular />
+          <ArrowCircleDown48Filled />
+          <ArrowCircleDown48Regular />
+        </View>
+        <View style={{ flexDirection: 'row' }}>
+          <ArrowCircleDownDouble20Filled />
+          <ArrowCircleDownDouble20Regular />
+          <ArrowCircleDownDouble24Filled />
+          <ArrowCircleDownDouble24Regular />
+          <ArrowCircleDownRight16Filled />
+          <ArrowCircleDownRight16Regular />
+          <ArrowCircleDownRight20Filled />
+          <ArrowCircleDownRight20Regular />
+          <ArrowCircleDownRight24Filled />
+          <ArrowCircleDownRight24Regular />
+          <ArrowCircleDownSplit20Filled />
+          <ArrowCircleDownSplit20Regular />
+          <ArrowCircleDownSplit24Filled />
+          <ArrowCircleDownSplit24Regular />
+          <ArrowCircleDownUp20Filled />
+          <ArrowCircleDownUp20Regular />
+          <ArrowCircleLeft12Filled />
+          <ArrowCircleLeft12Regular />
+          <ArrowCircleLeft16Filled />
+          <ArrowCircleLeft16Regular />
+        </View>
+        <View style={{ flexDirection: 'row' }}>
+          <ArrowCircleLeft20Filled />
+          <ArrowCircleLeft20Regular />
+          <ArrowCircleLeft24Filled />
+          <ArrowCircleLeft24Regular />
+          <ArrowCircleLeft28Filled />
+          <ArrowCircleLeft28Regular />
+          <ArrowCircleLeft32Filled />
+          <ArrowCircleLeft32Regular />
+          <ArrowCircleLeft48Filled />
+          <ArrowCircleLeft48Regular />
+          <ArrowCircleRight12Filled />
+          <ArrowCircleRight12Regular />
+          <ArrowCircleRight16Filled />
+          <ArrowCircleRight16Regular />
+          <ArrowCircleRight20Filled />
+          <ArrowCircleRight20Regular />
+          <ArrowCircleRight24Filled />
+          <ArrowCircleRight24Regular />
+          <ArrowCircleRight28Filled />
+          <ArrowCircleRight28Regular />
+        </View>
+        <View style={{ flexDirection: 'row' }}>
+          <ArrowCircleRight32Filled />
+          <ArrowCircleRight32Regular />
+          <ArrowCircleRight48Filled />
+          <ArrowCircleRight48Regular />
+          <ArrowCircleUp12Filled />
+          <ArrowCircleUp12Regular />
+          <ArrowCircleUp16Filled />
+          <ArrowCircleUp16Regular />
+          <ArrowCircleUp20Filled />
+          <ArrowCircleUp20Regular />
+          <ArrowCircleUp24Filled />
+          <ArrowCircleUp24Regular />
+          <ArrowCircleUp28Filled />
+          <ArrowCircleUp28Regular />
+          <ArrowCircleUp32Filled />
+          <ArrowCircleUp32Regular />
+          <ArrowCircleUp48Filled />
+          <ArrowCircleUp48Regular />
+          <ArrowCircleUpLeft20Filled />
+          <ArrowCircleUpLeft20Regular />
+        </View>
+      </View>
+    </React.Fragment>
+  );
+};
+
+const svgSections: TestSection[] = [
+  {
+    name: 'FontAwesome RNSVG Icons package',
+    testID: RNSVGIcons_TESTPAGE,
+    component: FontAwesomeTest,
+  },
+  {
+    name: 'Fluent-UI Icons package',
+    component: FluentIconsTest,
+  },
+];
+
+export const RNSVGIconsTest: React.FunctionComponent = () => {
+  const status: PlatformStatus = {
+    win32Status: 'Production',
+    uwpStatus: 'Production',
+    iosStatus: 'Production',
+    macosStatus: 'Production',
+    androidStatus: 'Production',
+  };
+
+  const description = 'Playground for testing various popular icon packages we are compatible with.';
+
+  return <Test name="RNSVG Icon packages" description={description} sections={svgSections} status={status} />;
+};

--- a/apps/fluent-tester/src/TestComponents/Svg/SvgTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Svg/SvgTest.tsx
@@ -5,31 +5,12 @@ import { Circle, Defs, G, Line, Path, Polygon, LinearGradient, RadialGradient, R
 import TestSvg from './Assets/accessible-icon-brands.svg';
 import { SVG_TESTPAGE } from '../../../../E2E/src/Svg/consts';
 import { Test, TestSection, PlatformStatus } from '../Test';
-import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
-import { faMugSaucer } from '@fortawesome/free-solid-svg-icons/faMugSaucer';
-import { faSquareCheck } from '@fortawesome/free-solid-svg-icons/faSquareCheck';
-import { faMugHot } from '@fortawesome/free-solid-svg-icons/faMugHot';
-import { faMountainCity } from '@fortawesome/free-solid-svg-icons/faMountainCity';
-
 const styles = StyleSheet.create({
   svg: {
     backgroundColor: 'green',
     color: 'purple',
   },
 });
-
-const FontAwesomeTest: React.FunctionComponent = () => {
-  return (
-    <React.Fragment>
-      <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-        <FontAwesomeIcon icon={faMugSaucer} color={'blue'} size={64} />
-        <FontAwesomeIcon icon={faSquareCheck} color={'blue'} size={64} />
-        <FontAwesomeIcon icon={faMugHot} color={'orange'} size={64} />
-        <FontAwesomeIcon icon={faMountainCity} color={'orange'} size={64} />
-      </View>
-    </React.Fragment>
-  );
-};
 
 const RectTest: React.FunctionComponent = () => {
   const [useColorA, setUseColorA] = React.useState(false);
@@ -169,10 +150,6 @@ const svgSections: TestSection[] = [
     name: 'Rect',
     testID: SVG_TESTPAGE,
     component: RectTest,
-  },
-  {
-    name: 'FontAwesome Test',
-    component: FontAwesomeTest,
   },
   {
     name: 'Circle',

--- a/apps/fluent-tester/src/TestComponents/Svg/index.ts
+++ b/apps/fluent-tester/src/TestComponents/Svg/index.ts
@@ -1,1 +1,2 @@
 export * from './SvgTest';
+export * from './RNSVGIcons';

--- a/apps/fluent-tester/src/testPages.ts
+++ b/apps/fluent-tester/src/testPages.ts
@@ -31,7 +31,7 @@ import { ShadowTest } from './TestComponents/Shadow';
 import { ShimmerTest } from './TestComponents/Shimmer';
 import { SpacingTokensTest } from './TestComponents/Spacing';
 import { StrokeWidthTest } from './TestComponents/StrokeWidth';
-import { SvgTest } from './TestComponents/Svg';
+import { SvgTest, RNSVGIconsTest } from './TestComponents/Svg';
 import { SwitchTest } from './TestComponents/Switch';
 import { TabsLegacyTest } from './TestComponents/TabsLegacy';
 import { TabsV1Test } from './TestComponents/TabsV1';
@@ -242,9 +242,15 @@ export const tests: TestDescription[] = [
     platforms: ['android', 'ios', 'macos', 'win32', 'windows'],
   },
   {
-    name: 'Svg',
+    name: 'Svg rendering',
     component: SvgTest,
     testPageButton: Constants.HOMEPAGE_SVG_BUTTON,
+    platforms: ['android', 'ios', 'macos', 'win32'],
+  },
+  {
+    name: 'Svg Icon packages',
+    component: RNSVGIconsTest,
+    testPageButton: Constants.HOMEPAGE_RNSVGIcons_BUTTON,
     platforms: ['android', 'ios', 'macos', 'win32'],
   },
   {

--- a/apps/win32/package.json
+++ b/apps/win32/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@fluentui-react-native/tester": "^0.126.35",
+    "@warren-ms/react-native-icons": "^0.0.11",
     "react": "17.0.2",
     "react-native": "^0.68.0",
     "react-native-svg": "12.5.0",

--- a/apps/win32/package.json
+++ b/apps/win32/package.json
@@ -32,7 +32,6 @@
   },
   "dependencies": {
     "@fluentui-react-native/tester": "^0.126.35",
-    "@warren-ms/react-native-icons": "^0.0.11",
     "react": "17.0.2",
     "react-native": "^0.68.0",
     "react-native-svg": "12.5.0",

--- a/change/@fluentui-react-native-e2e-testing-d18b150f-9fd9-4ec2-a665-cc86de1b3346.json
+++ b/change/@fluentui-react-native-e2e-testing-d18b150f-9fd9-4ec2-a665-cc86de1b3346.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add test page as a playground for various icon packages available on the internet.",
+  "packageName": "@fluentui-react-native/e2e-testing",
+  "email": "warleu@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-tester-af193f7c-43cb-4582-a8ce-e621ccd0bb5b.json
+++ b/change/@fluentui-react-native-tester-af193f7c-43cb-4582-a8ce-e621ccd0bb5b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add test page as a playground for various icon packages available on the internet.",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "warleu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1347,7 +1347,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.0", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.0", "@babel/runtime@^7.8.4":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.7.tgz#fcb41a5a70550e04a7b708037c7c32f7f356d8fd"
   integrity sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==
@@ -1414,6 +1414,11 @@
     colorspace "1.1.x"
     enabled "2.0.x"
     kuler "^2.0.0"
+
+"@emotion/hash@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
+  integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
 "@esbuild/android-arm@0.15.16":
   version "0.15.16"
@@ -1491,6 +1496,25 @@
   dependencies:
     humps "^2.0.1"
     prop-types "^15.7.2"
+
+"@griffel/core@^1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@griffel/core/-/core-1.9.0.tgz#53ff246ace962fc156151a87129145e8121491db"
+  integrity sha512-fiPf/mfcO6B96n4qgRFwA6TBEkPu8x2nWCHEGPnB+RrSttbiwzgsxuy+ojsf6QVeeS+i9qQegRbK2rIow+238Q==
+  dependencies:
+    "@emotion/hash" "^0.8.0"
+    csstype "^3.0.10"
+    rtl-css-js "^1.16.0"
+    stylis "^4.0.13"
+    tslib "^2.1.0"
+
+"@griffel/react@^1.0.0":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@griffel/react/-/react-1.5.2.tgz#c3bb743653f57a4f99b2c25fe6d0b56b4aa4f772"
+  integrity sha512-y27CVUYIFuJue18AiSnaocfhXvbkjDvH5oafJY+3zdcY7hx17oaGQZ2qdKegRkZJlyKcMU//J/1HJ4SrIDrXRA==
+  dependencies:
+    "@griffel/core" "^1.9.0"
+    tslib "^2.1.0"
 
 "@hapi/hoek@^9.0.0":
   version "9.3.0"
@@ -3780,6 +3804,16 @@
   version "3.2.45"
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.2.45.tgz#a3fffa7489eafff38d984e23d0236e230c818bc2"
   integrity sha512-Ewzq5Yhimg7pSztDV+RH1UDKBzmtqieXQlpTVm2AwraoRL/Rks96mvd8Vgi7Lj+h+TH8dv7mXD3FRZR3TUvbSg==
+
+"@warren-ms/react-native-icons@^0.0.13":
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/@warren-ms/react-native-icons/-/react-native-icons-0.0.13.tgz#8909cce08ba3751cbcb9e763907d5a02d169e17d"
+  integrity sha512-1HGR40cxIlYWNAhgl5OaAXsMgU5iOvK5NR0WZfjA6s6TkV1giFqYXWECtE8Zz4JMMQDLMFaPNQjrnpZf4LCvXg==
+  dependencies:
+    "@griffel/react" "^1.0.0"
+    "@types/react-native" "^0.68.0"
+    react-native-svg "^12.5.0"
+    tslib "^2.1.0"
 
 "@wdio/allure-reporter@7.23.0":
   version "7.23.0"
@@ -6218,7 +6252,7 @@ cssstyle@^2.3.0:
   dependencies:
     cssom "~0.3.6"
 
-csstype@^3.0.2:
+csstype@^3.0.10, csstype@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.1.tgz#841b532c45c758ee546a11d5bd7b7b473c8c30b9"
   integrity sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==
@@ -12380,7 +12414,7 @@ react-native-svg-transformer@^1.0.0:
     "@svgr/plugin-svgo" "^6.1.2"
     path-dirname "^1.0.2"
 
-react-native-svg@12.5.0:
+react-native-svg@12.5.0, react-native-svg@^12.5.0:
   version "12.5.0"
   resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-12.5.0.tgz#61e4395eb5eb52bbd0511b3c227473f7dbf98a16"
   integrity sha512-xVMA6QjwU2E30DHLzjmewjHSmby4mMMlUaiKnFCYPWpsezsaB3zHS7eURwKNJLmcRYOPi3f6aBhxvFTNj/5j/A==
@@ -12945,6 +12979,13 @@ rsvp@^4.8.4:
   version "4.8.5"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
+
+rtl-css-js@^1.16.0:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/rtl-css-js/-/rtl-css-js-1.16.1.tgz#4b48b4354b0ff917a30488d95100fbf7219a3e80"
+  integrity sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
 
 run-async@^2.4.0:
   version "2.4.1"
@@ -13660,6 +13701,11 @@ strnum@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.0.5.tgz#5c4e829fe15ad4ff0d20c3db5ac97b73c9b072db"
   integrity sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==
+
+stylis@^4.0.13:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.1.3.tgz#fd2fbe79f5fed17c55269e16ed8da14c84d069f7"
+  integrity sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA==
 
 sudo-prompt@^9.0.0:
   version "9.2.1"


### PR DESCRIPTION
Add test page as a playground for various icon packages publicly available to try and ensure that we are broadly compatible.

### Initial package sources:
FontAwesome is used in a pretty large percentage of all websites and has a rnsvg package of their font icons.

Microsofts fluentui-system-icons are svg icons meant for use with web react. They use SVGR to do the conversion process for web react but SVGR can also do the conversion for react-native-svg. I'm currently working on publishing a rnsvg package from my personal github fork. Some more advanced features will not be available like css styling since RNSVG does not readily support this. The icons themselves will be available though.

![image](https://user-images.githubusercontent.com/63264034/213157930-6bc44921-8c98-4385-a633-54f75a843729.png)

### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

(a summary of the changes made, often organized by file)

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
