### PR TITLE
Update all design-tokens packages to 0.42.0

### DIFF
--- a/change/@fluentui-react-native-apple-theme-71b4b9a3-0ce9-4f26-a87c-598bcc9efb8e.json
+++ b/change/@fluentui-react-native-apple-theme-71b4b9a3-0ce9-4f26-a87c-598bcc9efb8e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update all design-tokens packages to 0.42.0",
+  "packageName": "@fluentui-react-native/apple-theme",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-theme-tokens-80016b5b-e3de-4764-8bee-86350a2fc886.json
+++ b/change/@fluentui-react-native-theme-tokens-80016b5b-e3de-4764-8bee-86350a2fc886.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update all design-tokens packages to 0.42.0",
+  "packageName": "@fluentui-react-native/theme-tokens",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-theming-utils-e4f2dc51-7767-4a9d-94b0-e9153c558723.json
+++ b/change/@fluentui-react-native-theming-utils-e4f2dc51-7767-4a9d-94b0-e9153c558723.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update all design-tokens packages to 0.42.0",
+  "packageName": "@fluentui-react-native/theming-utils",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-win32-theme-7bb8eac0-8512-4cd5-baf6-c60e96f9df80.json
+++ b/change/@fluentui-react-native-win32-theme-7bb8eac0-8512-4cd5-baf6-c60e96f9df80.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update all design-tokens packages to 0.42.0",
+  "packageName": "@fluentui-react-native/win32-theme",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/theming/apple-theme/package.json
+++ b/packages/theming/apple-theme/package.json
@@ -32,8 +32,8 @@
   },
   "dependencies": {
     "@fluentui-react-native/default-theme": ">=0.16.24 <1.0.0",
-    "@fluentui-react-native/design-tokens-ios": "^0.40.0",
-    "@fluentui-react-native/design-tokens-macos": "^0.36.0",
+    "@fluentui-react-native/design-tokens-ios": "^0.42.0",
+    "@fluentui-react-native/design-tokens-macos": "^0.42.0",
     "@fluentui-react-native/memo-cache": "^1.1.7",
     "@fluentui-react-native/theme": ">=0.7.17 <1.0.0",
     "@fluentui-react-native/theme-tokens": "^0.23.1",

--- a/packages/theming/theme-tokens/package.json
+++ b/packages/theming/theme-tokens/package.json
@@ -31,10 +31,10 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@fluentui-react-native/design-tokens-android": "^0.37.0",
-    "@fluentui-react-native/design-tokens-ios": "^0.40.0",
-    "@fluentui-react-native/design-tokens-win32": "^0.36.0",
-    "@fluentui-react-native/design-tokens-windows": "^0.36.0",
+    "@fluentui-react-native/design-tokens-android": "^0.42.0",
+    "@fluentui-react-native/design-tokens-ios": "^0.42.0",
+    "@fluentui-react-native/design-tokens-win32": "^0.42.0",
+    "@fluentui-react-native/design-tokens-windows": "^0.42.0",
     "@fluentui-react-native/theme-types": ">=0.29.1 <1.0.0",
     "assert-never": "^1.2.1"
   },

--- a/packages/theming/theming-utils/package.json
+++ b/packages/theming/theming-utils/package.json
@@ -30,8 +30,8 @@
     "@fluentui-react-native/tokens": ">=0.20.4 <1.0.0"
   },
   "devDependencies": {
-    "@fluentui-react-native/design-tokens-win32": "^0.36.0",
-    "@fluentui-react-native/design-tokens-windows": "^0.36.0",
+    "@fluentui-react-native/design-tokens-win32": "^0.42.0",
+    "@fluentui-react-native/design-tokens-windows": "^0.42.0",
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/scripts": "^0.1.1",
     "@types/react-native": "^0.68.0",

--- a/packages/theming/win32-theme/package.json
+++ b/packages/theming/win32-theme/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "@fluentui-react-native/default-theme": ">=0.16.24 <1.0.0",
-    "@fluentui-react-native/design-tokens-win32": "^0.36.0",
+    "@fluentui-react-native/design-tokens-win32": "^0.42.0",
     "@fluentui-react-native/memo-cache": "^1.1.7",
     "@fluentui-react-native/theme-tokens": ">=0.23.1 <1.0.0",
     "@fluentui-react-native/theme-types": ">=0.29.1 <1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1440,30 +1440,30 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@fluentui-react-native/design-tokens-android@^0.37.0":
-  version "0.37.0"
-  resolved "https://registry.yarnpkg.com/@fluentui-react-native/design-tokens-android/-/design-tokens-android-0.37.0.tgz#c1479a10bb10a939db8effac98988ff2859110a9"
-  integrity sha512-qh1i195poQu/Zvabk/VsLZw+U1zwN5WQn9JAJgk1ZCWLwKfc24HRx+zpnSBdbWcOSI5b6kEDffwq8nPKUAN3QQ==
+"@fluentui-react-native/design-tokens-android@^0.42.0":
+  version "0.42.0"
+  resolved "https://registry.yarnpkg.com/@fluentui-react-native/design-tokens-android/-/design-tokens-android-0.42.0.tgz#5b4c24bbd248219e17908e6cd24f54d799a1fffc"
+  integrity sha512-pF8kUUURH5vzMGLL5gsx6rM8e5dsLemo17230SRIxxWVvLGkbO8RRoo5kU9Nxi1yuUfaNvWylt3kLlfoeC5flw==
 
-"@fluentui-react-native/design-tokens-ios@^0.40.0":
-  version "0.40.0"
-  resolved "https://registry.yarnpkg.com/@fluentui-react-native/design-tokens-ios/-/design-tokens-ios-0.40.0.tgz#6e4ec6968dffec0307cb3c90bf5fbe45f476c04a"
-  integrity sha512-BB5kjSdynGfequ5LFKzUgIwHjNZd3YZSGkTeRdyy0ibVZNQZdPOK2jSffvIq4DjNhLiIEN7chG0343+S+o3zEw==
+"@fluentui-react-native/design-tokens-ios@^0.42.0":
+  version "0.42.0"
+  resolved "https://registry.yarnpkg.com/@fluentui-react-native/design-tokens-ios/-/design-tokens-ios-0.42.0.tgz#3639e67b7749a504e6b27215d31257f469f460bd"
+  integrity sha512-qAvVfQtrpx71B0RM7W2I8BazBlYWIXExmcCqSvBoUhRlNCfKSLz4Ry1cecm1ldtEnykhnMTYrNtBwzRJ/99CEA==
 
-"@fluentui-react-native/design-tokens-macos@^0.36.0":
-  version "0.36.0"
-  resolved "https://registry.yarnpkg.com/@fluentui-react-native/design-tokens-macos/-/design-tokens-macos-0.36.0.tgz#2609266b37f8486864c6d0b5db1a963a49121363"
-  integrity sha512-MuxBgTj5FNk1s3PjRxTQOksa5sLjRX5p4qSMbigkWs3p913jzBkcU5wg36DeADIklAUGgORFmL5qPyTYMsK26A==
+"@fluentui-react-native/design-tokens-macos@^0.42.0":
+  version "0.42.0"
+  resolved "https://registry.yarnpkg.com/@fluentui-react-native/design-tokens-macos/-/design-tokens-macos-0.42.0.tgz#bc9f0f61c82078637b4013653d98f22da673b962"
+  integrity sha512-l7tpf+kjyXt+5kplnV/ftVeKf1Mz3u8JVMXUK6V2jiDPOlFBCkhMZkU/mEHbA26eFuyoRwBRKkH5NgiKqH41vA==
 
-"@fluentui-react-native/design-tokens-win32@^0.36.0":
-  version "0.36.0"
-  resolved "https://registry.yarnpkg.com/@fluentui-react-native/design-tokens-win32/-/design-tokens-win32-0.36.0.tgz#0fa6706bbd4caeaac5ba562a01bbd52fa453ba13"
-  integrity sha512-DO2H2eBHoGHiheTxK253KyUWxmk31gW9Ge9Ks+eyMoxOmLz431rI7/HZXhDrNeTqNJbtK3kEOoVkot+T2Em+xQ==
+"@fluentui-react-native/design-tokens-win32@^0.42.0":
+  version "0.42.0"
+  resolved "https://registry.yarnpkg.com/@fluentui-react-native/design-tokens-win32/-/design-tokens-win32-0.42.0.tgz#b67bc3474bcaab4aa69affcb297b37999379b29c"
+  integrity sha512-JU5HH2XmM2qhgqS4Onws1Wq6zgt9L+WEllXAwq0/QEeiLciKWlF4PQ5WIcxqFfrvTeC4ogImuslMAbsHeTSI9Q==
 
-"@fluentui-react-native/design-tokens-windows@^0.36.0":
-  version "0.36.0"
-  resolved "https://registry.yarnpkg.com/@fluentui-react-native/design-tokens-windows/-/design-tokens-windows-0.36.0.tgz#d0ad552c0176af5596896b96ee8029952f5f4415"
-  integrity sha512-sz2a+LtcJSn1fL4mydeE8NL5kKnWfLkk5kgkRKxO3DKCMghDMf0Yp0e0+a9oHSZrFemhJv8oZSok10VKjqeWAw==
+"@fluentui-react-native/design-tokens-windows@^0.42.0":
+  version "0.42.0"
+  resolved "https://registry.yarnpkg.com/@fluentui-react-native/design-tokens-windows/-/design-tokens-windows-0.42.0.tgz#6b7ca87ed30a92634e72cbe8fc1280fd21db50b8"
+  integrity sha512-hBPCikSDJ3Rgw+mAbTgnNB83dn3SeSKPo4XNli22tbV08fN8P5mEaEg8Uw0cbVMN3D138ykNeAaK/lZjO9KIqA==
 
 "@fortawesome/fontawesome-common-types@6.2.1":
   version "6.2.1"


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

Update design-tokens repos to 0.42.0. Changes includes
- Adding dark elevated colors for iOS
- Removing grey0/grey100 for all platforms (redundant with white/black)
- Adding shared (error/presence/etc. ) colors to Android

### Verification

CI should pass

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
