### PR TITLE
[Switch] Fix initial page load animation 

### DIFF
--- a/change/@fluentui-react-native-switch-e2c671fb-fdf2-44cd-aa57-270c2c56a58d.json
+++ b/change/@fluentui-react-native-switch-e2c671fb-fdf2-44cd-aa57-270c2c56a58d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "switch initial animation fix",
+  "packageName": "@fluentui-react-native/switch",
+  "email": "rohanpd.work@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Switch/src/__tests__/__snapshots__/Switch.test.tsx.snap
+++ b/packages/experimental/Switch/src/__tests__/__snapshots__/Switch.test.tsx.snap
@@ -168,7 +168,7 @@ exports[`Switch Disabled 1`] = `
         ],
       },
       "trackBackgroundStyle": Object {
-        "backgroundColor": "rgba(180, 214, 250, 1)",
+        "backgroundColor": "rgba(240, 240, 240, 1)",
       },
     }
   }
@@ -199,7 +199,7 @@ exports[`Switch Disabled 1`] = `
       style={
         Object {
           "alignItems": "center",
-          "backgroundColor": "rgba(180, 214, 250, 1)",
+          "backgroundColor": "rgba(240, 240, 240, 1)",
           "borderRadius": 100,
           "flexDirection": "row",
           "height": 32,

--- a/packages/experimental/Switch/src/useSwitch.ts
+++ b/packages/experimental/Switch/src/useSwitch.ts
@@ -58,25 +58,33 @@ export const useSwitch = (props: SwitchProps, animationConfig?: AnimationConfig)
   //Setting the initial position of the knob on track when page loads.
   React.useEffect(() => {
     if (isMobile) {
-      if (checkedState) {
-        startTrackAnimation(false, animationConfig, animation, checkedState);
-        startTrackBackgroundAnimation(true, trackBackgroundAnimation);
-      } else {
-        startTrackAnimation(true, animationConfig, animation, checkedState);
-        startTrackBackgroundAnimation(false, trackBackgroundAnimation);
-      }
+      Animated.timing(animation, {
+        toValue: checkedState ? animationConfig.trackWidth - (animationConfig.thumbWidth + animationConfig.thumbMargin * 2) : 0,
+        duration: 0,
+        useNativeDriver: false,
+      }).start();
+
+      const toValue = checkedState ? 0 : 1;
+      Animated.timing(trackBackgroundAnimation, {
+        toValue,
+        duration: 0,
+        useNativeDriver: false,
+      }).start();
     }
-  }, [checkedState, animationConfig]);
+  }, []);
 
   // Function to change background slowly over time when switch is toggled.
-  const startTrackBackgroundAnimation = React.useCallback((checked: boolean, animation: Animated.Value) => {
-    const toValue = checked ? 0 : 1;
-    Animated.timing(animation, {
-      toValue,
-      duration: 500,
-      useNativeDriver: false,
-    }).start();
-  }, []);
+  const startTrackBackgroundAnimation = React.useCallback(
+    (checked: boolean, animation: Animated.Value) => {
+      const toValue = checked ? 0 : 1;
+      Animated.timing(animation, {
+        toValue,
+        duration: 500,
+        useNativeDriver: false,
+      }).start();
+    },
+    [animation, checked],
+  );
 
   // Function to transform the knob over track in animated way when switch is toggled.
   const startTrackAnimation = React.useCallback(
@@ -86,12 +94,12 @@ export const useSwitch = (props: SwitchProps, animationConfig?: AnimationConfig)
           ? animationConfig.trackWidth - (animationConfig.thumbWidth + animationConfig.thumbMargin * 2)
           : onInit
           ? 0
-          : -(animationConfig.trackWidth + animationConfig.thumbWidth),
+          : -(animationConfig.trackWidth / 2 - animationConfig.thumbWidth),
         duration: 300,
         useNativeDriver: false,
       }).start();
     },
-    [],
+    [animation, animationConfig],
   );
 
   const switchAnimationStyles = React.useMemo(() => {

--- a/packages/experimental/Switch/src/useSwitch.ts
+++ b/packages/experimental/Switch/src/useSwitch.ts
@@ -1,11 +1,5 @@
 import * as React from 'react';
-import {
-  usePressableState,
-  useKeyProps,
-  useOnPressWithFocus,
-  useViewCommandFocus,
-  InteractionEvent,
-} from '@fluentui-react-native/interactive-hooks';
+import { usePressableState, useKeyProps, useOnPressWithFocus, useViewCommandFocus } from '@fluentui-react-native/interactive-hooks';
 import { SwitchProps, SwitchInfo, AnimationConfig } from './Switch.types';
 import { AccessibilityState, AccessibilityActionEvent, Animated, Platform } from 'react-native';
 import { memoize } from '@fluentui-react-native/framework';
@@ -19,7 +13,7 @@ export const useSwitch = (props: SwitchProps, animationConfig?: AnimationConfig)
   const defaultComponentRef = React.useRef(null);
   const [trackBackgroundAnimation] = React.useState(new Animated.Value(0));
   const animation = React.useRef(new Animated.Value(0)).current;
-
+  const [isInit, setIsInit] = React.useState(true);
   const {
     onChange,
     checked,
@@ -37,70 +31,27 @@ export const useSwitch = (props: SwitchProps, animationConfig?: AnimationConfig)
     ...rest
   } = props;
 
-  const onChangeWithAnimation = React.useCallback(
-    (e: InteractionEvent, checked?: boolean) => {
-      onChange && onChange(e, checked);
-      if (isMobile) {
-        if (checked) {
-          startTrackBackgroundAnimation(checked, trackBackgroundAnimation);
-          startTrackAnimation(false, animationConfig, animation, checked);
-        } else {
-          startTrackBackgroundAnimation(checked, trackBackgroundAnimation);
-          startTrackAnimation(false, animationConfig, animation, checked);
-        }
-      }
-    },
-    [onChange, trackBackgroundAnimation, animationConfig, animation],
-  );
-
-  const [checkedState, toggleCallback] = useAsToggleWithEvent(defaultChecked, checked, onChangeWithAnimation);
+  const [checkedState, toggleCallback] = useAsToggleWithEvent(defaultChecked, checked, onChange);
 
   //Setting the initial position of the knob on track when page loads.
   React.useEffect(() => {
     if (isMobile) {
       Animated.timing(animation, {
         toValue: checkedState ? animationConfig.trackWidth - (animationConfig.thumbWidth + animationConfig.thumbMargin * 2) : 0,
-        duration: 0,
+        duration: isInit ? 0 : 300,
         useNativeDriver: false,
       }).start();
 
       const toValue = checkedState ? 0 : 1;
       Animated.timing(trackBackgroundAnimation, {
         toValue,
-        duration: 0,
+        duration: isInit ? 0 : 500,
         useNativeDriver: false,
       }).start();
+
+      setIsInit(false);
     }
-  }, []);
-
-  // Function to change background slowly over time when switch is toggled.
-  const startTrackBackgroundAnimation = React.useCallback(
-    (checked: boolean, animation: Animated.Value) => {
-      const toValue = checked ? 0 : 1;
-      Animated.timing(animation, {
-        toValue,
-        duration: 500,
-        useNativeDriver: false,
-      }).start();
-    },
-    [animation, checked],
-  );
-
-  // Function to transform the knob over track in animated way when switch is toggled.
-  const startTrackAnimation = React.useCallback(
-    (onInit = false, animationConfig: AnimationConfig, animation: Animated.Value, toggled: boolean) => {
-      Animated.timing(animation, {
-        toValue: toggled
-          ? animationConfig.trackWidth - (animationConfig.thumbWidth + animationConfig.thumbMargin * 2)
-          : onInit
-          ? 0
-          : -(animationConfig.trackWidth / 2 - animationConfig.thumbWidth),
-        duration: 300,
-        useNativeDriver: false,
-      }).start();
-    },
-    [animation, animationConfig],
-  );
+  }, [checked, checkedState]);
 
   const switchAnimationStyles = React.useMemo(() => {
     // transform over toggled on position to toggled off position and vice versa


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [x] android

### Description of changes

This PR targets to fix the animation behavior that was seen on page load itself which was not expected. 
Animation should only occur when the switch changes the state from ON to OFF & vice-versa.  

This also target to clean up some functions and reduce few code. 


Adding the videos below. 

### Verification


| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| https://user-images.githubusercontent.com/30728574/213670626-b76b982b-6841-4218-97d0-6cc32aa24f37.mov | https://user-images.githubusercontent.com/30728574/213670678-8380a6c0-7475-49ee-b14e-8600d323b2f8.mov |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
