### PR TITLE
Fix MenuPopover props not getting called

### DIFF
--- a/change/@fluentui-react-native-menu-46d26763-b9e1-4dc6-a860-2a2a9840585f.json
+++ b/change/@fluentui-react-native-menu-46d26763-b9e1-4dc6-a860-2a2a9840585f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix MenuPopover props not getting called",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
+++ b/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
@@ -26,7 +26,7 @@ export const useMenuPopover = (props: MenuPopoverProps): MenuPopoverState => {
   const onDismiss = React.useCallback(() => {
     props.onDismiss();
     setOpen(undefined, false /* isOpen */), [setOpen];
-  });
+  }, [props.onDismiss, setOpen]);
   const dismissBehaviors = isControlled ? controlledDismissBehaviors : undefined;
   const directionalHint = getDirectionalHint(isSubmenu, I18nManager.isRTL);
 

--- a/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
+++ b/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
@@ -101,7 +101,8 @@ export const useMenuPopover = (props: MenuPopoverProps): MenuPopoverState => {
     props: {
       accessibilityRole,
       target: triggerRef,
-      onDismiss,
+      onDismiss: props.onDismiss ?? onDismiss,
+      onShow: props.onShow,
       directionalHint,
       dismissBehaviors,
       doNotTakePointerCapture,

--- a/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
+++ b/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
@@ -23,7 +23,7 @@ export const useMenuPopover = (props: MenuPopoverProps): MenuPopoverState => {
 
   const { onKeyDown: onKeyDownProp, onKeyUp: onKeyUpProp } = props;
 
-  const onDismiss = React.useCallback(() => setOpen(undefined, false /* isOpen */), [setOpen]);
+  const onDismiss = props.onDismiss ?? React.useCallback(() => setOpen(undefined, false /* isOpen */), [setOpen]);
   const dismissBehaviors = isControlled ? controlledDismissBehaviors : undefined;
   const directionalHint = getDirectionalHint(isSubmenu, I18nManager.isRTL);
 
@@ -101,7 +101,7 @@ export const useMenuPopover = (props: MenuPopoverProps): MenuPopoverState => {
     props: {
       accessibilityRole,
       target: triggerRef,
-      onDismiss: props.onDismiss ?? onDismiss,
+      onDismiss: onDismiss,
       onShow: props.onShow,
       directionalHint,
       dismissBehaviors,

--- a/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
+++ b/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
@@ -104,7 +104,7 @@ export const useMenuPopover = (props: MenuPopoverProps): MenuPopoverState => {
     props: {
       accessibilityRole,
       target: triggerRef,
-      onDismiss: onDismiss,
+      onDismiss,
       onShow: props.onShow,
       directionalHint,
       dismissBehaviors,

--- a/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
+++ b/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
@@ -24,7 +24,7 @@ export const useMenuPopover = (props: MenuPopoverProps): MenuPopoverState => {
   const { onKeyDown: onKeyDownProp, onKeyUp: onKeyUpProp } = props;
 
   const onDismiss = React.useCallback(() => {
-    props.onDismiss();
+    props.onDismiss?.();
     setOpen(undefined, false /* isOpen */), [setOpen];
   }, [props.onDismiss, setOpen]);
   const dismissBehaviors = isControlled ? controlledDismissBehaviors : undefined;

--- a/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
+++ b/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
@@ -23,7 +23,10 @@ export const useMenuPopover = (props: MenuPopoverProps): MenuPopoverState => {
 
   const { onKeyDown: onKeyDownProp, onKeyUp: onKeyUpProp } = props;
 
-  const onDismiss = props.onDismiss ?? React.useCallback(() => setOpen(undefined, false /* isOpen */), [setOpen]);
+  const onDismiss = React.useCallback(() => {
+    props.onDismiss();
+    setOpen(undefined, false /* isOpen */), [setOpen];
+  });
   const dismissBehaviors = isControlled ? controlledDismissBehaviors : undefined;
   const directionalHint = getDirectionalHint(isSubmenu, I18nManager.isRTL);
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS
- [X] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

onDismiss/onShow overrides aren't getting called, let's make sure we map them in the useMenuPopover hook.
### Verification
Overrides are getting called (macOS & win32)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
