### PR TITLE
Fix build failing on radiogroup android tests

### DIFF
--- a/apps/E2E/src/RadioGroupV1/specs/RadioGroupV1.spec.android.ts
+++ b/apps/E2E/src/RadioGroupV1/specs/RadioGroupV1.spec.android.ts
@@ -1,5 +1,5 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
-import RadioGroupV1Page, { RadioSelector } from '../pages/RadioGroupV1PageObject';
+import RadioGroupV1Page, { Radio } from '../pages/RadioGroupV1PageObject';
 import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT, AndroidAttribute, ANDROID_RADIOBUTTON } from '../../common/consts';
 import { RADIOGROUPV1_TEST_COMPONENT } from '../consts';
 
@@ -42,7 +42,7 @@ describe('RadioGroupV1/RadioV1 Accessibility Testing', () => {
 
   it('Validate Radio Group Class on Android', async () => {
     await expect(
-      await RadioGroupV1Page.compareAttribute(RadioGroupV1Page._firstRadio, AndroidAttribute.Class, ANDROID_RADIOBUTTON),
+      await RadioGroupV1Page.compareAttribute(RadioGroupV1Page.getRadio(Radio.First), AndroidAttribute.Class, ANDROID_RADIOBUTTON),
     ).toBeTruthy();
 
     await expect(await RadioGroupV1Page.didAssertPopup()).toBeFalsy(RadioGroupV1Page.ERRORMESSAGE_ASSERT);
@@ -59,14 +59,13 @@ describe('RadioGroupV1 Functional Testing', async () => {
 
   it('Click on a Radio and ensure it changes state from unselected -> selected', async () => {
     /* Validate the Radio is not initially selected */
-    await expect(await RadioGroupV1Page.isRadioSelected(RadioSelector.Second)).toBeFalsy();
+    await expect(await RadioGroupV1Page.isRadioSelected(Radio.Second)).toBeFalsy();
 
     /* Click on the Radio to select it */
-    await RadioGroupV1Page.clickRadio(RadioSelector.Second);
-    await RadioGroupV1Page.waitForRadioSelected(RadioSelector.Second, PAGE_TIMEOUT);
+    await RadioGroupV1Page.click(RadioGroupV1Page.getRadio(Radio.Second));
 
     /* Validate the Radio is selected */
-    await expect(await RadioGroupV1Page.isRadioSelected(RadioSelector.Second)).toBeTruthy();
+    await expect(await RadioGroupV1Page.waitForRadioSelected(Radio.Second, 'Expected radio #2 to be selected by click.')).toBeTruthy();
     await expect(await RadioGroupV1Page.didAssertPopup()).toBeFalsy(RadioGroupV1Page.ERRORMESSAGE_ASSERT);
   });
 });

--- a/change/@fluentui-react-native-e2e-testing-67ee8543-292d-438c-ae56-df3581a4b66d.json
+++ b/change/@fluentui-react-native-e2e-testing-67ee8543-292d-438c-ae56-df3581a4b66d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix build failing on radiogroup android tests",
+  "packageName": "@fluentui-react-native/e2e-testing",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [x] android

### Description of changes

When merging changes from #2514, these conflicted with the new RadioGroup Android E2E tests from #2511. Due to no merge conflicts between #2514 and #2511, these were not caught in the pipeline and thus caused subsequent build errors on main.

This fixes the errors by using correct refactored methods in the `RadioGroupV1PageObject` introduced in #2514 in the android spec. 

### Verification

CI should pass for build and for E2E.

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
