### PR TITLE
Adding FRNAppearanceAdditions native module

### DIFF
--- a/apps/fluent-tester/ios/Podfile
+++ b/apps/fluent-tester/ios/Podfile
@@ -24,7 +24,8 @@ use_test_app! do |target|
   target.app do
     platform :ios, '14.0'
 
-    # There is a bug where autolinking isn't working, do specify these manually.
+    # There is a bug where autolinking isn't working, so specify these manually.
+    pod 'FRNAppearanceAdditions', :path => '../../../packages/experimental/AppearanceAdditions/FRNAppearanceAdditions.podspec'
     pod 'FRNFontMetrics', :path => '../../../packages/experimental/NativeFontMetrics/FRNFontMetrics.podspec'
 
     script_phase name: 'Start Packager',

--- a/apps/fluent-tester/ios/Podfile.lock
+++ b/apps/fluent-tester/ios/Podfile.lock
@@ -10,7 +10,9 @@ PODS:
     - React-jsi (= 0.68.5)
     - ReactCommon/turbomodule/core (= 0.68.5)
   - fmt (6.2.1)
-  - FRNAvatar (0.17.2):
+  - FRNAppearanceAdditions (0.1.0):
+    - React
+  - FRNAvatar (0.17.6):
     - MicrosoftFluentUI (= 0.10.0)
     - React
   - FRNDatePicker (0.7.4):
@@ -456,7 +458,7 @@ PODS:
     - React-jsi (= 0.68.5)
     - React-logger (= 0.68.5)
     - React-perflogger (= 0.68.5)
-  - ReactTestApp-DevSupport (2.1.1):
+  - ReactTestApp-DevSupport (2.2.4):
     - React-Core
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
@@ -471,6 +473,7 @@ DEPENDENCIES:
   - DoubleConversion (from `../../../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../../../node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../../../node_modules/react-native/React/FBReactNativeSpec`)
+  - FRNAppearanceAdditions (from `../../../packages/experimental/AppearanceAdditions/FRNAppearanceAdditions.podspec`)
   - FRNAvatar (from `../../../packages/experimental/Avatar`)
   - FRNDatePicker (from `../../../packages/experimental/NativeDatePicker`)
   - FRNFontMetrics (from `../../../packages/experimental/NativeFontMetrics/FRNFontMetrics.podspec`)
@@ -524,6 +527,8 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native/Libraries/FBLazyVector"
   FBReactNativeSpec:
     :path: "../../../node_modules/react-native/React/FBReactNativeSpec"
+  FRNAppearanceAdditions:
+    :path: "../../../packages/experimental/AppearanceAdditions/FRNAppearanceAdditions.podspec"
   FRNAvatar:
     :path: "../../../packages/experimental/Avatar"
   FRNDatePicker:
@@ -603,7 +608,8 @@ SPEC CHECKSUMS:
   FBLazyVector: 2b47ff52037bd9ae07cc9b051c9975797814b736
   FBReactNativeSpec: dd89c4a5591e20015aa55c6efbf9c7740a83efbf
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  FRNAvatar: 6b0c2d8a484aa0829f64397cf23ef5c56feefa63
+  FRNAppearanceAdditions: 88e8fdc98e8aef994df9ab0b04fc652c59a3b351
+  FRNAvatar: 8a93b612c82321d8dcebabbcaf738a6c29022fa0
   FRNDatePicker: 009ab6e4e003a9e5d720fb4aea27b94e6cc8a946
   FRNFontMetrics: c756b9bb1627909a7673b68caf7a7b14239c212e
   glog: 476ee3e89abb49e07f822b48323c51c57124b572
@@ -635,12 +641,12 @@ SPEC CHECKSUMS:
   React-RCTVibration: 9819a3bf6230e4b2a99877c21268b0b2416157a1
   React-runtimeexecutor: b1f1995089b90696dbc2a7ffe0059a80db5c8eb1
   ReactCommon: 149e2c0acab9bac61378da0db5b2880a1b5ff59b
-  ReactTestApp-DevSupport: 7ca8e4d798fce59f47adedd8f05a94d41d312921
+  ReactTestApp-DevSupport: 9d0767a4ae28efedbab6a281f880353288838339
   ReactTestApp-Resources: ecba662266ac5af3e30e1e3004c0fa8c0298b61a
   RNCPicker: 0bf8ef8f7800524f32d2bb2a8bcadd53eda0ecd1
   RNSVG: 6adc5c52d2488a476248413064b7f2832e639057
   Yoga: c4d61225a466f250c35c1ee78d2d0b3d41fe661c
 
-PODFILE CHECKSUM: 819f14a4e3e6e335a0b1993fe37edad50db02d86
+PODFILE CHECKSUM: b9fd154312c68d8d92a9ba6e8a2cac9fcf88b104
 
 COCOAPODS: 1.11.3

--- a/apps/fluent-tester/ios/Podfile.lock
+++ b/apps/fluent-tester/ios/Podfile.lock
@@ -12,7 +12,7 @@ PODS:
   - fmt (6.2.1)
   - FRNAppearanceAdditions (0.1.0):
     - React
-  - FRNAvatar (0.17.6):
+  - FRNAvatar (0.17.10):
     - MicrosoftFluentUI (= 0.10.0)
     - React
   - FRNDatePicker (0.7.4):
@@ -458,7 +458,7 @@ PODS:
     - React-jsi (= 0.68.5)
     - React-logger (= 0.68.5)
     - React-perflogger (= 0.68.5)
-  - ReactTestApp-DevSupport (2.2.4):
+  - ReactTestApp-DevSupport (2.3.2):
     - React-Core
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
@@ -609,7 +609,7 @@ SPEC CHECKSUMS:
   FBReactNativeSpec: dd89c4a5591e20015aa55c6efbf9c7740a83efbf
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   FRNAppearanceAdditions: 88e8fdc98e8aef994df9ab0b04fc652c59a3b351
-  FRNAvatar: 8a93b612c82321d8dcebabbcaf738a6c29022fa0
+  FRNAvatar: cbb9afacb90bcee65673e6d7a32eb63a900131eb
   FRNDatePicker: 009ab6e4e003a9e5d720fb4aea27b94e6cc8a946
   FRNFontMetrics: c756b9bb1627909a7673b68caf7a7b14239c212e
   glog: 476ee3e89abb49e07f822b48323c51c57124b572
@@ -641,7 +641,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: 9819a3bf6230e4b2a99877c21268b0b2416157a1
   React-runtimeexecutor: b1f1995089b90696dbc2a7ffe0059a80db5c8eb1
   ReactCommon: 149e2c0acab9bac61378da0db5b2880a1b5ff59b
-  ReactTestApp-DevSupport: 9d0767a4ae28efedbab6a281f880353288838339
+  ReactTestApp-DevSupport: 1646ce70be36400a60ca18608284f3f7099a35c1
   ReactTestApp-Resources: ecba662266ac5af3e30e1e3004c0fa8c0298b61a
   RNCPicker: 0bf8ef8f7800524f32d2bb2a8bcadd53eda0ecd1
   RNSVG: 6adc5c52d2488a476248413064b7f2832e639057

--- a/apps/fluent-tester/macos/Podfile.lock
+++ b/apps/fluent-tester/macos/Podfile.lock
@@ -1,25 +1,25 @@
 PODS:
   - boost (1.76.0)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.68.59)
-  - FBReactNativeSpec (0.68.59):
+  - FBLazyVector (0.68.62)
+  - FBReactNativeSpec (0.68.62):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.59)
-    - RCTTypeSafety (= 0.68.59)
-    - React-Core (= 0.68.59)
-    - React-jsi (= 0.68.59)
-    - ReactCommon/turbomodule/core (= 0.68.59)
+    - RCTRequired (= 0.68.62)
+    - RCTTypeSafety (= 0.68.62)
+    - React-Core (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - ReactCommon/turbomodule/core (= 0.68.62)
   - fmt (6.2.1)
-  - FRNAvatar (0.16.30):
+  - FRNAvatar (0.17.10):
     - MicrosoftFluentUI (= 0.10.0)
     - React
-  - FRNCallout (0.21.43):
+  - FRNCallout (0.21.55):
     - React
-  - FRNCheckbox (0.13.14):
+  - FRNCheckbox (0.13.32):
     - React
-  - FRNMenuButton (0.10.4):
+  - FRNMenuButton (0.10.22):
     - React
-  - FRNRadioButton (0.16.14):
+  - FRNRadioButton (0.16.29):
     - React
   - glog (0.3.5)
   - MicrosoftFluentUI (0.10.0):
@@ -102,270 +102,270 @@ PODS:
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
-  - RCTFocusZone (0.11.13):
+  - RCTFocusZone (0.11.25):
     - React
-  - RCTRequired (0.68.59)
-  - RCTTypeSafety (0.68.59):
-    - FBLazyVector (= 0.68.59)
+  - RCTRequired (0.68.62)
+  - RCTTypeSafety (0.68.62):
+    - FBLazyVector (= 0.68.62)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.59)
-    - React-Core (= 0.68.59)
-  - React (0.68.59):
-    - React-Core (= 0.68.59)
-    - React-Core/DevSupport (= 0.68.59)
-    - React-Core/RCTWebSocket (= 0.68.59)
-    - React-RCTActionSheet (= 0.68.59)
-    - React-RCTAnimation (= 0.68.59)
-    - React-RCTBlob (= 0.68.59)
-    - React-RCTImage (= 0.68.59)
-    - React-RCTLinking (= 0.68.59)
-    - React-RCTNetwork (= 0.68.59)
-    - React-RCTSettings (= 0.68.59)
-    - React-RCTText (= 0.68.59)
-    - React-RCTVibration (= 0.68.59)
-  - React-callinvoker (0.68.59)
-  - React-Codegen (0.68.59):
-    - FBReactNativeSpec (= 0.68.59)
+    - RCTRequired (= 0.68.62)
+    - React-Core (= 0.68.62)
+  - React (0.68.62):
+    - React-Core (= 0.68.62)
+    - React-Core/DevSupport (= 0.68.62)
+    - React-Core/RCTWebSocket (= 0.68.62)
+    - React-RCTActionSheet (= 0.68.62)
+    - React-RCTAnimation (= 0.68.62)
+    - React-RCTBlob (= 0.68.62)
+    - React-RCTImage (= 0.68.62)
+    - React-RCTLinking (= 0.68.62)
+    - React-RCTNetwork (= 0.68.62)
+    - React-RCTSettings (= 0.68.62)
+    - React-RCTText (= 0.68.62)
+    - React-RCTVibration (= 0.68.62)
+  - React-callinvoker (0.68.62)
+  - React-Codegen (0.68.62):
+    - FBReactNativeSpec (= 0.68.62)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.59)
-    - RCTTypeSafety (= 0.68.59)
-    - React-Core (= 0.68.59)
-    - React-jsi (= 0.68.59)
-    - React-jsiexecutor (= 0.68.59)
-    - ReactCommon/turbomodule/core (= 0.68.59)
-  - React-Core (0.68.59):
+    - RCTRequired (= 0.68.62)
+    - RCTTypeSafety (= 0.68.62)
+    - React-Core (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-jsiexecutor (= 0.68.62)
+    - ReactCommon/turbomodule/core (= 0.68.62)
+  - React-Core (0.68.62):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.59)
-    - React-cxxreact (= 0.68.59)
-    - React-jsi (= 0.68.59)
-    - React-jsiexecutor (= 0.68.59)
-    - React-perflogger (= 0.68.59)
+    - React-Core/Default (= 0.68.62)
+    - React-cxxreact (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-jsiexecutor (= 0.68.62)
+    - React-perflogger (= 0.68.62)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.68.59):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default
-    - React-cxxreact (= 0.68.59)
-    - React-jsi (= 0.68.59)
-    - React-jsiexecutor (= 0.68.59)
-    - React-perflogger (= 0.68.59)
-    - Yoga
-  - React-Core/Default (0.68.59):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.68.59)
-    - React-jsi (= 0.68.59)
-    - React-jsiexecutor (= 0.68.59)
-    - React-perflogger (= 0.68.59)
-    - Yoga
-  - React-Core/DevSupport (0.68.59):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.59)
-    - React-Core/RCTWebSocket (= 0.68.59)
-    - React-cxxreact (= 0.68.59)
-    - React-jsi (= 0.68.59)
-    - React-jsiexecutor (= 0.68.59)
-    - React-jsinspector (= 0.68.59)
-    - React-perflogger (= 0.68.59)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.68.59):
+  - React-Core/CoreModulesHeaders (0.68.62):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.59)
-    - React-jsi (= 0.68.59)
-    - React-jsiexecutor (= 0.68.59)
-    - React-perflogger (= 0.68.59)
+    - React-cxxreact (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-jsiexecutor (= 0.68.62)
+    - React-perflogger (= 0.68.62)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.68.59):
+  - React-Core/Default (0.68.62):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-cxxreact (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-jsiexecutor (= 0.68.62)
+    - React-perflogger (= 0.68.62)
+    - Yoga
+  - React-Core/DevSupport (0.68.62):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-Core/Default (= 0.68.62)
+    - React-Core/RCTWebSocket (= 0.68.62)
+    - React-cxxreact (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-jsiexecutor (= 0.68.62)
+    - React-jsinspector (= 0.68.62)
+    - React-perflogger (= 0.68.62)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.68.62):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.59)
-    - React-jsi (= 0.68.59)
-    - React-jsiexecutor (= 0.68.59)
-    - React-perflogger (= 0.68.59)
+    - React-cxxreact (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-jsiexecutor (= 0.68.62)
+    - React-perflogger (= 0.68.62)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.68.59):
+  - React-Core/RCTAnimationHeaders (0.68.62):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.59)
-    - React-jsi (= 0.68.59)
-    - React-jsiexecutor (= 0.68.59)
-    - React-perflogger (= 0.68.59)
+    - React-cxxreact (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-jsiexecutor (= 0.68.62)
+    - React-perflogger (= 0.68.62)
     - Yoga
-  - React-Core/RCTImageHeaders (0.68.59):
+  - React-Core/RCTBlobHeaders (0.68.62):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.59)
-    - React-jsi (= 0.68.59)
-    - React-jsiexecutor (= 0.68.59)
-    - React-perflogger (= 0.68.59)
+    - React-cxxreact (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-jsiexecutor (= 0.68.62)
+    - React-perflogger (= 0.68.62)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.68.59):
+  - React-Core/RCTImageHeaders (0.68.62):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.59)
-    - React-jsi (= 0.68.59)
-    - React-jsiexecutor (= 0.68.59)
-    - React-perflogger (= 0.68.59)
+    - React-cxxreact (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-jsiexecutor (= 0.68.62)
+    - React-perflogger (= 0.68.62)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.68.59):
+  - React-Core/RCTLinkingHeaders (0.68.62):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.59)
-    - React-jsi (= 0.68.59)
-    - React-jsiexecutor (= 0.68.59)
-    - React-perflogger (= 0.68.59)
+    - React-cxxreact (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-jsiexecutor (= 0.68.62)
+    - React-perflogger (= 0.68.62)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.68.59):
+  - React-Core/RCTNetworkHeaders (0.68.62):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.59)
-    - React-jsi (= 0.68.59)
-    - React-jsiexecutor (= 0.68.59)
-    - React-perflogger (= 0.68.59)
+    - React-cxxreact (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-jsiexecutor (= 0.68.62)
+    - React-perflogger (= 0.68.62)
     - Yoga
-  - React-Core/RCTTextHeaders (0.68.59):
+  - React-Core/RCTSettingsHeaders (0.68.62):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.59)
-    - React-jsi (= 0.68.59)
-    - React-jsiexecutor (= 0.68.59)
-    - React-perflogger (= 0.68.59)
+    - React-cxxreact (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-jsiexecutor (= 0.68.62)
+    - React-perflogger (= 0.68.62)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.68.59):
+  - React-Core/RCTTextHeaders (0.68.62):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.59)
-    - React-jsi (= 0.68.59)
-    - React-jsiexecutor (= 0.68.59)
-    - React-perflogger (= 0.68.59)
+    - React-cxxreact (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-jsiexecutor (= 0.68.62)
+    - React-perflogger (= 0.68.62)
     - Yoga
-  - React-Core/RCTWebSocket (0.68.59):
+  - React-Core/RCTVibrationHeaders (0.68.62):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.59)
-    - React-cxxreact (= 0.68.59)
-    - React-jsi (= 0.68.59)
-    - React-jsiexecutor (= 0.68.59)
-    - React-perflogger (= 0.68.59)
+    - React-Core/Default
+    - React-cxxreact (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-jsiexecutor (= 0.68.62)
+    - React-perflogger (= 0.68.62)
     - Yoga
-  - React-CoreModules (0.68.59):
+  - React-Core/RCTWebSocket (0.68.62):
+    - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.59)
-    - React-Codegen (= 0.68.59)
-    - React-Core/CoreModulesHeaders (= 0.68.59)
-    - React-jsi (= 0.68.59)
-    - React-RCTImage (= 0.68.59)
-    - ReactCommon/turbomodule/core (= 0.68.59)
-  - React-cxxreact (0.68.59):
+    - React-Core/Default (= 0.68.62)
+    - React-cxxreact (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-jsiexecutor (= 0.68.62)
+    - React-perflogger (= 0.68.62)
+    - Yoga
+  - React-CoreModules (0.68.62):
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - RCTTypeSafety (= 0.68.62)
+    - React-Codegen (= 0.68.62)
+    - React-Core/CoreModulesHeaders (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-RCTImage (= 0.68.62)
+    - ReactCommon/turbomodule/core (= 0.68.62)
+  - React-cxxreact (0.68.62):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.68.59)
-    - React-jsi (= 0.68.59)
-    - React-jsinspector (= 0.68.59)
-    - React-logger (= 0.68.59)
-    - React-perflogger (= 0.68.59)
-    - React-runtimeexecutor (= 0.68.59)
-  - React-jsi (0.68.59):
+    - React-callinvoker (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-jsinspector (= 0.68.62)
+    - React-logger (= 0.68.62)
+    - React-perflogger (= 0.68.62)
+    - React-runtimeexecutor (= 0.68.62)
+  - React-jsi (0.68.62):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-jsi/Default (= 0.68.59)
-  - React-jsi/Default (0.68.59):
+    - React-jsi/Default (= 0.68.62)
+  - React-jsi/Default (0.68.62):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-  - React-jsiexecutor (0.68.59):
+  - React-jsiexecutor (0.68.62):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.68.59)
-    - React-jsi (= 0.68.59)
-    - React-perflogger (= 0.68.59)
-  - React-jsinspector (0.68.59)
-  - React-logger (0.68.59):
+    - React-cxxreact (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-perflogger (= 0.68.62)
+  - React-jsinspector (0.68.62)
+  - React-logger (0.68.62):
     - glog
-  - React-perflogger (0.68.59)
-  - React-RCTActionSheet (0.68.59):
-    - React-Core/RCTActionSheetHeaders (= 0.68.59)
-  - React-RCTAnimation (0.68.59):
+  - React-perflogger (0.68.62)
+  - React-RCTActionSheet (0.68.62):
+    - React-Core/RCTActionSheetHeaders (= 0.68.62)
+  - React-RCTAnimation (0.68.62):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.59)
-    - React-Codegen (= 0.68.59)
-    - React-Core/RCTAnimationHeaders (= 0.68.59)
-    - React-jsi (= 0.68.59)
-    - ReactCommon/turbomodule/core (= 0.68.59)
-  - React-RCTBlob (0.68.59):
+    - RCTTypeSafety (= 0.68.62)
+    - React-Codegen (= 0.68.62)
+    - React-Core/RCTAnimationHeaders (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - ReactCommon/turbomodule/core (= 0.68.62)
+  - React-RCTBlob (0.68.62):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Codegen (= 0.68.59)
-    - React-Core/RCTBlobHeaders (= 0.68.59)
-    - React-Core/RCTWebSocket (= 0.68.59)
-    - React-jsi (= 0.68.59)
-    - React-RCTNetwork (= 0.68.59)
-    - ReactCommon/turbomodule/core (= 0.68.59)
-  - React-RCTImage (0.68.59):
+    - React-Codegen (= 0.68.62)
+    - React-Core/RCTBlobHeaders (= 0.68.62)
+    - React-Core/RCTWebSocket (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-RCTNetwork (= 0.68.62)
+    - ReactCommon/turbomodule/core (= 0.68.62)
+  - React-RCTImage (0.68.62):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.59)
-    - React-Codegen (= 0.68.59)
-    - React-Core/RCTImageHeaders (= 0.68.59)
-    - React-jsi (= 0.68.59)
-    - React-RCTNetwork (= 0.68.59)
-    - ReactCommon/turbomodule/core (= 0.68.59)
-  - React-RCTLinking (0.68.59):
-    - React-Codegen (= 0.68.59)
-    - React-Core/RCTLinkingHeaders (= 0.68.59)
-    - React-jsi (= 0.68.59)
-    - ReactCommon/turbomodule/core (= 0.68.59)
-  - React-RCTNetwork (0.68.59):
+    - RCTTypeSafety (= 0.68.62)
+    - React-Codegen (= 0.68.62)
+    - React-Core/RCTImageHeaders (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-RCTNetwork (= 0.68.62)
+    - ReactCommon/turbomodule/core (= 0.68.62)
+  - React-RCTLinking (0.68.62):
+    - React-Codegen (= 0.68.62)
+    - React-Core/RCTLinkingHeaders (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - ReactCommon/turbomodule/core (= 0.68.62)
+  - React-RCTNetwork (0.68.62):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.59)
-    - React-Codegen (= 0.68.59)
-    - React-Core/RCTNetworkHeaders (= 0.68.59)
-    - React-jsi (= 0.68.59)
-    - ReactCommon/turbomodule/core (= 0.68.59)
-  - React-RCTSettings (0.68.59):
+    - RCTTypeSafety (= 0.68.62)
+    - React-Codegen (= 0.68.62)
+    - React-Core/RCTNetworkHeaders (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - ReactCommon/turbomodule/core (= 0.68.62)
+  - React-RCTSettings (0.68.62):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.59)
-    - React-Codegen (= 0.68.59)
-    - React-Core/RCTSettingsHeaders (= 0.68.59)
-    - React-jsi (= 0.68.59)
-    - ReactCommon/turbomodule/core (= 0.68.59)
-  - React-RCTText (0.68.59):
-    - React-Core/RCTTextHeaders (= 0.68.59)
-  - React-RCTVibration (0.68.59):
+    - RCTTypeSafety (= 0.68.62)
+    - React-Codegen (= 0.68.62)
+    - React-Core/RCTSettingsHeaders (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - ReactCommon/turbomodule/core (= 0.68.62)
+  - React-RCTText (0.68.62):
+    - React-Core/RCTTextHeaders (= 0.68.62)
+  - React-RCTVibration (0.68.62):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Codegen (= 0.68.59)
-    - React-Core/RCTVibrationHeaders (= 0.68.59)
-    - React-jsi (= 0.68.59)
-    - ReactCommon/turbomodule/core (= 0.68.59)
-  - React-runtimeexecutor (0.68.59):
-    - React-jsi (= 0.68.59)
-  - ReactCommon/turbomodule/core (0.68.59):
+    - React-Codegen (= 0.68.62)
+    - React-Core/RCTVibrationHeaders (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - ReactCommon/turbomodule/core (= 0.68.62)
+  - React-runtimeexecutor (0.68.62):
+    - React-jsi (= 0.68.62)
+  - ReactCommon/turbomodule/core (0.68.62):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.68.59)
-    - React-Core (= 0.68.59)
-    - React-cxxreact (= 0.68.59)
-    - React-jsi (= 0.68.59)
-    - React-logger (= 0.68.59)
-    - React-perflogger (= 0.68.59)
-  - ReactTestApp-DevSupport (2.1.1):
+    - React-callinvoker (= 0.68.62)
+    - React-Core (= 0.68.62)
+    - React-cxxreact (= 0.68.62)
+    - React-jsi (= 0.68.62)
+    - React-logger (= 0.68.62)
+    - React-perflogger (= 0.68.62)
+  - ReactTestApp-DevSupport (2.3.2):
     - React-Core
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
@@ -512,47 +512,47 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: 613e39eac4239cc72b15421247b5ab05361266a2
   DoubleConversion: ed15e075aa758ac0e4c1f8b830bd4e4d40d669e8
-  FBLazyVector: 6cffa71e5650b5cb43db82d8f0ba09faba2880ca
-  FBReactNativeSpec: f81567c045ac83ecbe6f21eb778a759986274955
+  FBLazyVector: 476cc84f9fec4a6988871e6af22fc484de505767
+  FBReactNativeSpec: 2936b6cdfd7e1f964105666fdb2e2d917ca38a86
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  FRNAvatar: b57500ffd4955a077c6318e7485de44f4a663042
-  FRNCallout: fb2db03b402f59b4b8bbf8738a8ec17bd25db2da
-  FRNCheckbox: 2fc8c5cd67f8ef2b82dae2eef14bb0e42ffa64fe
-  FRNMenuButton: 86cc9e8f25b2593478de59c81bdc67b70881c893
-  FRNRadioButton: 51e6d490bdcc60ab4e0310d545cec8f9bdf81b01
+  FRNAvatar: cbb9afacb90bcee65673e6d7a32eb63a900131eb
+  FRNCallout: 0c30f8dcff541722151a4b74fab7e60ba63d3529
+  FRNCheckbox: bf387cb0c207f6f127b3673d98007d3cbdedb1f3
+  FRNMenuButton: c3b16b95b0ebd169d4ef4476b5988da5135d859b
+  FRNRadioButton: 6e86a5810c21d3f1938596c9e413a5d34e07d97a
   glog: 20113a0d46931b6f096cf8302c68691d75a456ff
   MicrosoftFluentUI: f6db695718efb93f4ca9bdc366c00b80a1f91dba
   RCT-Folly: 5544a3ff21f4406e70e92a8711598e97fc81517c
-  RCTFocusZone: 44f158f3332829d5c2895e1bf2dc29ce03a9aa53
-  RCTRequired: b95cf30b8216e43c6c409af3bf8cb1662f611553
-  RCTTypeSafety: 59e5eb122ec87d02fabf90aa1ce5ba3294e782e3
-  React: 7a33419f3df43edc47a72557921d714469a843e0
-  React-callinvoker: ca9726c44669c0f4839cd7ee24b13ee4a0d9b4f5
-  React-Codegen: 21f1da14c226e09685069972527b1043bdd0a4d5
-  React-Core: 9117908c9e819d11501d993596915be616e7e198
-  React-CoreModules: 50a564ffba9ed156ca43107bb6f3be6038250fcc
-  React-cxxreact: 503fc094a735da2e41cf53b2cbc36d1ee41545c8
-  React-jsi: e2c06ced7ad1f6a0bbb97aa82012f531fb08e6bd
-  React-jsiexecutor: c4d4de8fc5562df2e1bb0b49ca5152d72ba5ae44
-  React-jsinspector: d0913ee975ac48f0a6f025adf18763857993bb8d
-  React-logger: d511b77d33a96bf771d558fdf7d32db7939890ba
-  React-perflogger: a70044daee607dae27c5e3c829a9b85fcc46f816
-  React-RCTActionSheet: 4dfc5c1880dfac4348dd6dfaf08e2fc282f18040
-  React-RCTAnimation: cc4351fe1ae4f45c273b7cf01013a24458b9a3cf
-  React-RCTBlob: 3005fd95a831b30847403537d41d561a4ccc624c
-  React-RCTImage: f57cb0a88b74baf5ede093e8bb5a1118dfbe75a0
-  React-RCTLinking: b4831cc5c57dc3f9c731580dbf94b063548af72a
-  React-RCTNetwork: b8781bdfcbf0adaac7eee89eb69ef4d6d8445afa
-  React-RCTSettings: c50254e6db9800d64bea38808cc50b5921b4b453
-  React-RCTText: e1234cd32a880eb29aaf44f3bf7f59d1066b0767
-  React-RCTVibration: 7d6ce1162b543b837347b8e1989ac4f44b4a7427
-  React-runtimeexecutor: 6c80fffe5267158c59786907e93079ac6e2ade46
-  ReactCommon: 83ac4fac05c1604a59b8f404a233908f3bc09a57
-  ReactTestApp-DevSupport: 7ca8e4d798fce59f47adedd8f05a94d41d312921
+  RCTFocusZone: 7caf73a4751d23644070dcab259e699ece705bbd
+  RCTRequired: 023a1e179ee2f19716f408aa6139ab1519ca7c2a
+  RCTTypeSafety: 82dd668bad65235631a88afc7767a5a2975710f6
+  React: 7aeda534cd94a13bfe4ee41c54873b6e94e4dd5c
+  React-callinvoker: 92923c7c5728d0cf923edf28993aac12ff950bdd
+  React-Codegen: c9605b3292a3089a6c08d81a4ce91f56865de6fe
+  React-Core: bbc4cd945153924b7fdd561f65848ce939781390
+  React-CoreModules: 36ef084a60778dd7e6a475bd554c8f64afc05d84
+  React-cxxreact: d778321f58d8743f6f663f5ac6da9009130931b7
+  React-jsi: 4fd996624ef520667e114fcc3d2f1867196d0f47
+  React-jsiexecutor: 1862151d3f809499c82d7f66a3ca624b4d6b49d9
+  React-jsinspector: 39348b9a3417419aea646f41cba625e1a7bbbd30
+  React-logger: 7a2e45e85d0fe59edb6d4fb2cbcbb9981ab9486e
+  React-perflogger: 20ae52b52ce2c0e1e257e0c0502f8f08a0b43ff9
+  React-RCTActionSheet: 2a62f3135a621bbf90504a28205cf5ef05b27bea
+  React-RCTAnimation: 219eb987ed34c38cbf13096062da7ddc142f0fac
+  React-RCTBlob: e3fb25043782acd848669cac9a15270f5702256c
+  React-RCTImage: fd5acd0da73155da5d3af967987861ab8296abe5
+  React-RCTLinking: 0bc10a82b83569e85c0f971e5adf5a53856989b6
+  React-RCTNetwork: 72cf76e577b16ceb90964bbbda07b2f22817de57
+  React-RCTSettings: 83d48be06041a57485e59820f23b1050560dabe6
+  React-RCTText: 79b5b9221fceb445d4299003628c0dd0300fa8e2
+  React-RCTVibration: c25bc2b1d5bea3f2fd8bd1931c3a23df604c7a57
+  React-runtimeexecutor: 71d892141f53ed18c108d97ce49083d7792c8cca
+  ReactCommon: 2ac737725b34d197ba527a4055a842374633de3d
+  ReactTestApp-DevSupport: 1646ce70be36400a60ca18608284f3f7099a35c1
   ReactTestApp-Resources: 8c0164a3cc5052418c92018e2af0e05d564aa307
   RNCPicker: 0bf8ef8f7800524f32d2bb2a8bcadd53eda0ecd1
   RNSVG: 6adc5c52d2488a476248413064b7f2832e639057
-  Yoga: 89eab6ce9fcb1fb5d498ac606c4315a3d6290297
+  Yoga: 6c7edb98bf534779ae3d0af1790018da859047c9
 
 PODFILE CHECKSUM: d3fe834dea1e24594a8ba545f70b5250bbc25c91
 

--- a/change/@fluentui-react-native-dependency-profiles-30b0d6dc-1802-4066-b916-f77a68f917af.json
+++ b/change/@fluentui-react-native-dependency-profiles-30b0d6dc-1802-4066-b916-f77a68f917af.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update lock files",
+  "packageName": "@fluentui-react-native/dependency-profiles",
+  "email": "mischreiber@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-appearance-additions-fa13e589-038a-4274-8457-572dde2dc048.json
+++ b/change/@fluentui-react-native-experimental-appearance-additions-fa13e589-038a-4274-8457-572dde2dc048.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Adding a new native module, `AppearanceAdditions`",
+  "packageName": "@fluentui-react-native/experimental-appearance-additions",
+  "email": "mischreiber@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-5a0c243e-f833-4c5b-918a-68a08821d25f.json
+++ b/change/@fluentui-react-native-tester-5a0c243e-f833-4c5b-918a-68a08821d25f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adding a new native module, `AppearanceAdditions`",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "mischreiber@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/dependency-profiles/src/index.js
+++ b/packages/dependency-profiles/src/index.js
@@ -134,6 +134,10 @@ module.exports = {
       "name": "@fluentui-react-native/experimental-activity-indicator",
       "version": "0.7.13"
     },
+    "@fluentui-react-native/experimental-appearance-additions": {
+      "name": "@fluentui-react-native/experimental-appearance-additions",
+      "version": "0.1.0"
+    },
     "@fluentui-react-native/experimental-avatar": {
       "name": "@fluentui-react-native/experimental-avatar",
       "version": "0.17.10"

--- a/packages/experimental/AppearanceAdditions/CHANGELOG.json
+++ b/packages/experimental/AppearanceAdditions/CHANGELOG.json
@@ -1,0 +1,4 @@
+{
+  "name": "@fluentui-react-native/experimental-appearance-additions",
+  "entries": []
+}

--- a/packages/experimental/AppearanceAdditions/FRNAppearanceAdditions.podspec
+++ b/packages/experimental/AppearanceAdditions/FRNAppearanceAdditions.podspec
@@ -1,0 +1,22 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = 'FRNAppearanceAdditions'
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.license      = package['license']
+
+  s.authors      = package['author']
+  s.homepage     = "https://github.com/microsoft/fluentui-react-native"
+
+  s.source           = { :git => "https://github.com/microsoft/fluentui-react-native.git", :tag => "#{s.version}" }
+  s.swift_version    = "5"
+
+  s.dependency 'React'
+
+  s.ios.deployment_target = "14.0"
+  s.ios.source_files      = "ios/*.{swift,h,m}"
+
+end

--- a/packages/experimental/AppearanceAdditions/babel.config.js
+++ b/packages/experimental/AppearanceAdditions/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = require('@fluentui-react-native/scripts/babel.config');

--- a/packages/experimental/AppearanceAdditions/ios/FRNAppearanceAdditions.h
+++ b/packages/experimental/AppearanceAdditions/ios/FRNAppearanceAdditions.h
@@ -1,0 +1,10 @@
+#import <React/RCTEventEmitter.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+RCT_EXTERN NSString * _Nonnull RCTHorizontalSizeClassPreference(UITraitCollection * _Nullable traitCollection);
+
+@interface FRNAppearanceAdditions : RCTEventEmitter <RCTBridgeModule>
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/experimental/AppearanceAdditions/ios/FRNAppearanceAdditions.m
+++ b/packages/experimental/AppearanceAdditions/ios/FRNAppearanceAdditions.m
@@ -1,0 +1,119 @@
+#import "FRNAppearanceAdditions.h"
+
+#import <React/RCTBridgeModule.h>
+#import <React/RCTConstants.h>
+#import <React/RCTUtils.h>
+
+NSString *const FRNAppearanceSizeClassCompact = @"compact";
+NSString *const FRNAppearanceSizeClassRegular = @"regular";
+NSString *const FRNUserInterfaceLevelBase = @"base";
+NSString *const FRNUserInterfaceLevelElevated = @"elevated";
+
+NSString *RCTHorizontalSizeClassPreference(UITraitCollection *traitCollection) {
+    static NSDictionary *sizeClasses;
+    static dispatch_once_t onceToken;
+
+    dispatch_once(&onceToken, ^{
+        sizeClasses = @{
+        @(UIUserInterfaceSizeClassCompact) : FRNAppearanceSizeClassCompact,
+        @(UIUserInterfaceSizeClassRegular) : FRNAppearanceSizeClassRegular
+      };
+    });
+
+    traitCollection = traitCollection ?: [UITraitCollection currentTraitCollection];
+
+    NSString *sizeClass = sizeClasses[@(traitCollection.horizontalSizeClass)];
+    if (sizeClass == nil) {
+        sizeClass = [traitCollection userInterfaceIdiom] == UIUserInterfaceIdiomPhone ? FRNAppearanceSizeClassCompact : FRNAppearanceSizeClassRegular;
+    }
+    return sizeClass;
+}
+
+NSString *RCTUserInterfaceLevelPreference(UITraitCollection *traitCollection) {
+    static NSDictionary *userInterfaceLevels;
+    static dispatch_once_t onceToken;
+
+    dispatch_once(&onceToken, ^{
+        userInterfaceLevels = @{
+        @(UIUserInterfaceLevelBase) : FRNUserInterfaceLevelBase,
+        @(UIUserInterfaceLevelElevated) : FRNUserInterfaceLevelElevated
+      };
+    });
+
+    traitCollection = traitCollection ?: [UITraitCollection currentTraitCollection];
+
+    NSString *sizeClass = userInterfaceLevels[@(traitCollection.userInterfaceLevel)];
+    if (sizeClass == nil) {
+        sizeClass = FRNUserInterfaceLevelBase;
+    }
+    return sizeClass;
+}
+
+@implementation FRNAppearanceAdditions {
+    BOOL _hasListeners;
+    NSString *_horizontalSizeClass;
+    NSString *_userInterfaceLevel;
+}
+
++ (BOOL)requiresMainQueueSetup {
+    return YES;
+}
+
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(horizontalSizeClass)
+{
+    return _horizontalSizeClass;
+}
+
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(userInterfaceLevel)
+{
+    return _userInterfaceLevel;
+}
+
+#pragma mark - RCTEventEmitter
+
+- (NSArray<NSString *> *)supportedEvents {
+    return @[ @"appearanceChanged" ];
+}
+
+- (void)startObserving {
+    _hasListeners = YES;
+    _horizontalSizeClass = RCTHorizontalSizeClassPreference(nil);
+    _userInterfaceLevel = RCTUserInterfaceLevelPreference(nil);
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(appearanceChanged:)
+                                                 name:RCTUserInterfaceStyleDidChangeNotification
+                                               object:nil];
+}
+
+- (void)stopObserving {
+    _hasListeners = NO;
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+#pragma mark - Event processing
+
+- (void)appearanceChanged:(NSNotification *)notification {
+    if (_hasListeners) {
+        UITraitCollection *traitCollection = [[notification userInfo] valueForKey:RCTUserInterfaceStyleDidChangeNotificationTraitCollectionKey];
+        if (![traitCollection isKindOfClass:[UITraitCollection class]]) {
+            traitCollection = nil;
+        }
+
+        NSString *horizontalSizeClass = RCTHorizontalSizeClassPreference(traitCollection);
+        NSString *userInterfaceLevel = RCTUserInterfaceLevelPreference(traitCollection);
+        if (![horizontalSizeClass isEqualToString:_horizontalSizeClass] ||
+            ![userInterfaceLevel isEqualToString:_userInterfaceLevel]) {
+            _horizontalSizeClass = horizontalSizeClass;
+            _userInterfaceLevel = userInterfaceLevel;
+            [self sendEventWithName:@"appearanceChanged"
+                               body:@{
+                                        @"horizontalSizeClass": _horizontalSizeClass,
+                                        @"userInterfaceLevel": _userInterfaceLevel
+                                    }];
+        }
+    }
+}
+
+RCT_EXPORT_MODULE();
+
+@end

--- a/packages/experimental/AppearanceAdditions/ios/FRNAppearanceAdditions.xcodeproj/project.pbxproj
+++ b/packages/experimental/AppearanceAdditions/ios/FRNAppearanceAdditions.xcodeproj/project.pbxproj
@@ -1,0 +1,1 @@
+// This dummy project file is required for @react-native-community/cli <8.0 to recognize this package as a native module

--- a/packages/experimental/AppearanceAdditions/just.config.js
+++ b/packages/experimental/AppearanceAdditions/just.config.js
@@ -1,0 +1,3 @@
+const { preset } = require('@fluentui-react-native/scripts');
+
+preset();

--- a/packages/experimental/AppearanceAdditions/package.json
+++ b/packages/experimental/AppearanceAdditions/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@fluentui-react-native/experimental-appearance-additions",
+  "version": "0.1.0",
+  "description": "A module to expose callbacks for additional traitCollection changes.",
+  "license": "MIT",
+  "author": "Microsoft <fluentuinativeowners@microsoft.com>",
+  "homepage": "https://github.com/microsoft/fluentui-react-native",
+  "main": "src/index.ts",
+  "module": "src/index.ts",
+  "typings": "lib/index.d.ts",
+  "onPublish": {
+    "main": "lib-commonjs/index.js",
+    "module": "lib/index.js"
+  },
+  "scripts": {
+    "build": "fluentui-scripts build",
+    "just": "fluentui-scripts",
+    "clean": "fluentui-scripts clean",
+    "lint": "fluentui-scripts eslint",
+    "depcheck": "fluentui-scripts depcheck",
+    "test": "fluentui-scripts jest",
+    "update-snapshots": "fluentui-scripts jest -u",
+    "prettier": "fluentui-scripts prettier",
+    "prettier-fix": "fluentui-scripts prettier --fix true"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/fluentui-react-native.git",
+    "directory": "packages/experimental/AppearanceAdditions"
+  },
+  "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
+    "@types/react-native": "^0.68.0",
+    "@types/use-subscription": "1.0.0",
+    "react": "17.0.2",
+    "react-native": "^0.68.0",
+    "use-subscription": ">=1.0.0 <1.6.0"
+  },
+  "peerDependencies": {
+    "react": "17.0.2",
+    "react-native": "^0.68.0"
+  },
+  "rnx-kit": {
+    "reactNativeVersion": "^0.68",
+    "reactNativeDevVersion": "^0.68",
+    "kitType": "library",
+    "capabilities": [
+      "core",
+      "core-ios",
+      "react"
+    ]
+  }
+}

--- a/packages/experimental/AppearanceAdditions/src/NativeAppearanceAdditions.ios.ts
+++ b/packages/experimental/AppearanceAdditions/src/NativeAppearanceAdditions.ios.ts
@@ -1,0 +1,9 @@
+import { NativeModules } from 'react-native';
+
+export const NativeAppearanceAdditions = NativeModules.FRNAppearanceAdditions;
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface NativeAppearanceAdditionsInterface {}
+
+// export default NativeFontMetrics as NativeFontMetricsInterface;
+export default NativeAppearanceAdditions as NativeAppearanceAdditionsInterface;

--- a/packages/experimental/AppearanceAdditions/src/NativeAppearanceAdditions.ts
+++ b/packages/experimental/AppearanceAdditions/src/NativeAppearanceAdditions.ts
@@ -1,0 +1,19 @@
+import { SizeClass, UserInterfaceLevel } from './NativeAppearanceAdditions.types';
+
+export const NativeAppearanceAdditions = {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  addListener: (_: string) => {},
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  removeListeners: (_: number) => {},
+  horizontalSizeClass: () => {
+    console.warn('NativeAppearanceAdditions is only available on iOS');
+    return 'regular' as SizeClass;
+  },
+  userInterfaceLevel: () => {
+    console.warn('NativeAppearanceAdditions is only available on iOS');
+    return 'base' as UserInterfaceLevel;
+  },
+};
+
+// export default NativeFontMetrics;
+export default NativeAppearanceAdditions;

--- a/packages/experimental/AppearanceAdditions/src/NativeAppearanceAdditions.types.ts
+++ b/packages/experimental/AppearanceAdditions/src/NativeAppearanceAdditions.types.ts
@@ -1,4 +1,4 @@
-export interface IAppearanceAdditions {
+export interface AppearanceAdditions {
   readonly horizontalSizeClass: SizeClass;
   readonly userInterfaceLevel: UserInterfaceLevel;
 }

--- a/packages/experimental/AppearanceAdditions/src/NativeAppearanceAdditions.types.ts
+++ b/packages/experimental/AppearanceAdditions/src/NativeAppearanceAdditions.types.ts
@@ -1,0 +1,10 @@
+export interface IAppearanceAdditions {
+  readonly horizontalSizeClass: SizeClass;
+  readonly userInterfaceLevel: UserInterfaceLevel;
+}
+
+export const HorizontalSizeClassKey = 'horizontalSizeClass';
+export type SizeClass = 'compact' | 'regular';
+
+export const UserInterfaceLevelKey = 'userInterfaceLevel';
+export type UserInterfaceLevel = 'base' | 'elevated';

--- a/packages/experimental/AppearanceAdditions/src/appearanceAdditions.ios.ts
+++ b/packages/experimental/AppearanceAdditions/src/appearanceAdditions.ios.ts
@@ -2,13 +2,13 @@ import { NativeEventEmitter } from 'react-native';
 import NativeAppearanceAdditions from './NativeAppearanceAdditions.ios';
 import {
   HorizontalSizeClassKey,
-  IAppearanceAdditions,
+  AppearanceAdditions,
   SizeClass,
   UserInterfaceLevel,
   UserInterfaceLevelKey,
 } from './NativeAppearanceAdditions.types';
 
-class AppearanceAdditionsImpl implements IAppearanceAdditions {
+class AppearanceAdditionsImpl implements AppearanceAdditions {
   _horizontalSizeClass: SizeClass;
   _userInterfaceLevel: UserInterfaceLevel;
 
@@ -29,4 +29,4 @@ class AppearanceAdditionsImpl implements IAppearanceAdditions {
   }
 }
 
-export const appearanceAdditions = new AppearanceAdditionsImpl() as IAppearanceAdditions;
+export const appearanceAdditions = new AppearanceAdditionsImpl() as AppearanceAdditions;

--- a/packages/experimental/AppearanceAdditions/src/appearanceAdditions.ios.ts
+++ b/packages/experimental/AppearanceAdditions/src/appearanceAdditions.ios.ts
@@ -1,0 +1,32 @@
+import { NativeEventEmitter } from 'react-native';
+import NativeAppearanceAdditions from './NativeAppearanceAdditions.ios';
+import {
+  HorizontalSizeClassKey,
+  IAppearanceAdditions,
+  SizeClass,
+  UserInterfaceLevel,
+  UserInterfaceLevelKey,
+} from './NativeAppearanceAdditions.types';
+
+class AppearanceAdditionsImpl implements IAppearanceAdditions {
+  _horizontalSizeClass: SizeClass;
+  _userInterfaceLevel: UserInterfaceLevel;
+
+  get horizontalSizeClass(): SizeClass {
+    return this._horizontalSizeClass;
+  }
+
+  get userInterfaceLevel(): UserInterfaceLevel {
+    return this._userInterfaceLevel;
+  }
+
+  constructor() {
+    const eventEmitter = new NativeEventEmitter(NativeAppearanceAdditions as any);
+    eventEmitter.addListener('appearanceChanged', (newValue) => {
+      this._horizontalSizeClass = newValue[HorizontalSizeClassKey];
+      this._userInterfaceLevel = newValue[UserInterfaceLevelKey];
+    });
+  }
+}
+
+export const appearanceAdditions = new AppearanceAdditionsImpl() as IAppearanceAdditions;

--- a/packages/experimental/AppearanceAdditions/src/appearanceAdditions.ts
+++ b/packages/experimental/AppearanceAdditions/src/appearanceAdditions.ts
@@ -1,7 +1,7 @@
-import { IAppearanceAdditions } from './NativeAppearanceAdditions.types';
+import { AppearanceAdditions } from './NativeAppearanceAdditions.types';
 
 // Default values for non-iOS clients.
 export const appearanceAdditions = {
   horizontalSizeClass: 'regular',
   userInterfaceLevel: 'base',
-} as IAppearanceAdditions;
+} as AppearanceAdditions;

--- a/packages/experimental/AppearanceAdditions/src/appearanceAdditions.ts
+++ b/packages/experimental/AppearanceAdditions/src/appearanceAdditions.ts
@@ -1,0 +1,7 @@
+import { IAppearanceAdditions } from './NativeAppearanceAdditions.types';
+
+// Default values for non-iOS clients.
+export const appearanceAdditions = {
+  horizontalSizeClass: 'regular',
+  userInterfaceLevel: 'base',
+} as IAppearanceAdditions;

--- a/packages/experimental/AppearanceAdditions/src/getSizeClass.ios.ts
+++ b/packages/experimental/AppearanceAdditions/src/getSizeClass.ios.ts
@@ -1,0 +1,30 @@
+import { useMemo } from 'react';
+import { NativeEventEmitter } from 'react-native';
+import { useSubscription } from 'use-subscription';
+import { appearanceAdditions } from './appearanceAdditions';
+
+import NativeAppearanceAdditions from './NativeAppearanceAdditions';
+import { SizeClass } from './NativeAppearanceAdditions.types';
+
+const eventEmitter = NativeAppearanceAdditions ? new NativeEventEmitter(NativeAppearanceAdditions as any) : undefined;
+
+export function useHorizontalSizeClass(): SizeClass {
+  if (!eventEmitter) {
+    return 'regular';
+  }
+
+  const subscription = useMemo(
+    () => ({
+      getCurrentValue: () => appearanceAdditions.horizontalSizeClass,
+      subscribe: (callback) => {
+        const appearanceSubscription = eventEmitter.addListener('appearanceChanged', callback);
+        return () => {
+          appearanceSubscription.remove();
+        };
+      },
+    }),
+    [],
+  );
+
+  return useSubscription(subscription);
+}

--- a/packages/experimental/AppearanceAdditions/src/getSizeClass.ts
+++ b/packages/experimental/AppearanceAdditions/src/getSizeClass.ts
@@ -1,0 +1,6 @@
+import { SizeClass } from './NativeAppearanceAdditions.types';
+
+export function useHorizontalSizeClass(): SizeClass {
+  // Stubbed out for non-iOS platforms
+  return 'regular';
+}

--- a/packages/experimental/AppearanceAdditions/src/index.ts
+++ b/packages/experimental/AppearanceAdditions/src/index.ts
@@ -1,5 +1,5 @@
 export { NativeAppearanceAdditions } from './NativeAppearanceAdditions';
 export { appearanceAdditions } from './appearanceAdditions';
-export type { IAppearanceAdditions, SizeClass as SizeClassIOS } from './NativeAppearanceAdditions.types';
+export type { AppearanceAdditions, SizeClass as SizeClassIOS } from './NativeAppearanceAdditions.types';
 
 export * from './getSizeClass';

--- a/packages/experimental/AppearanceAdditions/src/index.ts
+++ b/packages/experimental/AppearanceAdditions/src/index.ts
@@ -1,0 +1,5 @@
+export { NativeAppearanceAdditions } from './NativeAppearanceAdditions';
+export { appearanceAdditions } from './appearanceAdditions';
+export type { IAppearanceAdditions, SizeClass as SizeClassIOS } from './NativeAppearanceAdditions.types';
+
+export * from './getSizeClass';

--- a/packages/experimental/AppearanceAdditions/tsconfig.json
+++ b/packages/experimental/AppearanceAdditions/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@fluentui-react-native/scripts/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "lib"
+  },
+  "include": ["src"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1470,24 +1470,6 @@
   resolved "https://registry.yarnpkg.com/@fluentui-react-native/design-tokens-windows/-/design-tokens-windows-0.42.0.tgz#6b7ca87ed30a92634e72cbe8fc1280fd21db50b8"
   integrity sha512-hBPCikSDJ3Rgw+mAbTgnNB83dn3SeSKPo4XNli22tbV08fN8P5mEaEg8Uw0cbVMN3D138ykNeAaK/lZjO9KIqA==
 
-"@fluentui-react-native/framework@0.8.31":
-  version "0.8.31"
-  resolved "https://registry.yarnpkg.com/@fluentui-react-native/framework/-/framework-0.8.31.tgz#0e0dc6f7943ba05ab16814f78363ed385dba4815"
-  integrity sha512-o8JSxZ5dzHuFK8hXP8hfBFcJhp/V/QbcIYIXPuawmSK+vko25frZ1o4C1gzVbD4itqfp2ykCr2B+7q9UwM7fJw==
-  dependencies:
-    "@fluentui-react-native/composition" ">=0.8.1 <1.0.0"
-    "@fluentui-react-native/default-theme" ">=0.16.21 <1.0.0"
-    "@fluentui-react-native/immutable-merge" "^1.1.7"
-    "@fluentui-react-native/memo-cache" "^1.1.7"
-    "@fluentui-react-native/merge-props" ">=0.5.1 <1.0.0"
-    "@fluentui-react-native/theme-types" ">=0.28.0 <1.0.0"
-    "@fluentui-react-native/tokens" ">=0.20.2 <1.0.0"
-    "@fluentui-react-native/use-slot" ">=0.3.1 <1.0.0"
-    "@fluentui-react-native/use-slots" ">=0.7.1 <1.0.0"
-    "@fluentui-react-native/use-styling" ">=0.9.1 <1.0.0"
-    "@fluentui-react-native/use-tokens" ">=0.3.1 <1.0.0"
-    tslib "^2.3.1"
-
 "@fortawesome/fontawesome-common-types@6.2.1":
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.2.1.tgz#411e02a820744d3f7e0d8d9df9d82b471beaa073"


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Adding a new native module to iOS, `FRNAppearanceAdditions`. This will be a hosting ground for APIs that wish were part of `react-native/appearance`, but aren't yet. The medium-term goal is to move equivalent logic from here upstream, but this will unblock FURN scenarios in the meantime.

### Verification

This code is not part of this PR (coming next), but here's some future code that rely on this native module, each doing their thing:

#### Switching betweek dark and dark-elevated at runtime, before:

https://user-images.githubusercontent.com/4934719/214698307-1ff4cbf3-3ae3-42a4-9717-1670e3900d93.mov

#### Switching betweek dark and dark-elevated at runtime, after:

https://user-images.githubusercontent.com/4934719/214698265-d72767d8-7c44-47c8-85f4-e37721f8ed9d.mov

#### Notification responding to size classes, before:

https://user-images.githubusercontent.com/4934719/214698302-f557f421-569b-4dcb-a915-3bfe1de8515a.mov

#### Notification responding to size classes, after:

https://user-images.githubusercontent.com/4934719/214698305-2d7b0fd2-597e-4331-9cea-f7531ca5659c.mov

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
