### PR TITLE
Change `console.error` calls thrown in `BasePage` to `console.warn` calls. 

### DIFF
--- a/apps/E2E/src/common/BasePage.ts
+++ b/apps/E2E/src/common/BasePage.ts
@@ -371,7 +371,7 @@ export abstract class BasePage {
   // Returns the identifier of the secondary UI element used for testing on the given test page. Often times, we'll want to set a
   // prop on one component, and not set it on another to verify certain behaviors. This is why we have this secondary component.
   get _secondaryComponentName(): string {
-    console.warn('Please verify whether or not your page object should implement secondaryComponentName.');
+    console.warn('Please verify whether or not your page object should implement _secondaryComponentName.');
     return DUMMY_CHAR;
   }
 

--- a/apps/E2E/src/common/BasePage.ts
+++ b/apps/E2E/src/common/BasePage.ts
@@ -363,7 +363,7 @@ export abstract class BasePage {
   // Returns: String
   // Returns the identifier of the primary UI element used for testing on the given test page.
   get _primaryComponentName(): string {
-    console.error('Each class extending BasePage must implement its own _primaryComponentName method.');
+    console.warn('Each class extending BasePage must implement its own _primaryComponentName method.');
     return DUMMY_CHAR;
   }
 
@@ -371,7 +371,7 @@ export abstract class BasePage {
   // Returns the identifier of the secondary UI element used for testing on the given test page. Often times, we'll want to set a
   // prop on one component, and not set it on another to verify certain behaviors. This is why we have this secondary component.
   get _secondaryComponentName(): string {
-    console.error('Each class extending BasePage must implement its own _secondaryComponentName method.');
+    console.warn('Each class extending BasePage must implement its own _secondaryComponentName method.');
     return DUMMY_CHAR;
   }
 

--- a/apps/E2E/src/common/BasePage.ts
+++ b/apps/E2E/src/common/BasePage.ts
@@ -363,7 +363,7 @@ export abstract class BasePage {
   // Returns: String
   // Returns the identifier of the primary UI element used for testing on the given test page.
   get _primaryComponentName(): string {
-    console.warn('Each class extending BasePage must implement its own _primaryComponentName method.');
+    console.warn('Please verify whether or not your page object should implement _primaryComponentName.');
     return DUMMY_CHAR;
   }
 
@@ -371,7 +371,7 @@ export abstract class BasePage {
   // Returns the identifier of the secondary UI element used for testing on the given test page. Often times, we'll want to set a
   // prop on one component, and not set it on another to verify certain behaviors. This is why we have this secondary component.
   get _secondaryComponentName(): string {
-    console.warn('Each class extending BasePage must implement its own _secondaryComponentName method.');
+    console.warn('Please verify whether or not your page object should implement secondaryComponentName.');
     return DUMMY_CHAR;
   }
 

--- a/change/@fluentui-react-native-e2e-testing-3c978817-4969-45f0-b1ec-2f90a903e3c0.json
+++ b/change/@fluentui-react-native-e2e-testing-3c978817-4969-45f0-b1ec-2f90a903e3c0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Change console.error -> console.warn in BasePage",
+  "packageName": "@fluentui-react-native/e2e-testing",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

For PageObjects used in E2E tests, calling an unimplemented `._primaryComponent` / `._secondaryComponent` getter outputs a warning using `console.error`.

This PR switches the `console.error` calls to `console.warn` calls during E2E tests.

### Verification

Tests pass.

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
