### PR TITLE
Update IconV1 test names and add better test errors.

### DIFF
--- a/apps/E2E/src/IconV1/specs/IconV1.spec.win.ts
+++ b/apps/E2E/src/IconV1/specs/IconV1.spec.win.ts
@@ -1,7 +1,6 @@
 import NavigateAppPage from '../../common/NavigateAppPage';
 import IconV1PageObject from '../pages/IconV1PageObject';
-import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
-import { ComponentSelector } from '../../common/BasePage';
+import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT, Attribute, IMAGE_A11Y_ROLE } from '../../common/consts';
 import { ICON_ACCESSIBILITY_LABEL } from '../../IconLegacy/consts';
 
 // Before testing begins, allow up to 60 seconds for app to open
@@ -26,17 +25,26 @@ describe('IconV1 Accessibility Testing', () => {
     await IconV1PageObject.scrollToTestElement();
   });
 
-  it('Validate accessibilityLabel for SVG Icon', async () => {
-    await expect(await IconV1PageObject.getAccessibilityLabel(ComponentSelector.Primary)).toEqual(ICON_ACCESSIBILITY_LABEL);
+  it('Set SVG Icon "accessibilityLabel" prop. Validate "accessibilityLabel" value propagates to "Name" element attribute.', async () => {
+    await expect(
+      await IconV1PageObject.compareAttribute(IconV1PageObject._primaryComponent, Attribute.AccessibilityLabel, ICON_ACCESSIBILITY_LABEL),
+    ).toBeTruthy();
+
     await expect(await IconV1PageObject.didAssertPopup()).toBeFalsy(IconV1PageObject.ERRORMESSAGE_ASSERT);
   });
 
-  it('Validate accessibilityLabel for Font Icon', async () => {
-    await expect(await IconV1PageObject.getAccessibilityLabel(ComponentSelector.Secondary)).toEqual(ICON_ACCESSIBILITY_LABEL);
+  it('Set Font Icon "accessibilityLabel" prop. Validate "accessibilityLabel" value propagates to "Name" element attribute.', async () => {
+    await expect(
+      await IconV1PageObject.compareAttribute(IconV1PageObject._secondaryComponent, Attribute.AccessibilityLabel, ICON_ACCESSIBILITY_LABEL),
+    ).toBeTruthy();
+
     await expect(await IconV1PageObject.didAssertPopup()).toBeFalsy(IconV1PageObject.ERRORMESSAGE_ASSERT);
   });
 
-  it('Validate accessibilityRole for SVG Icon', async () => {
+  it('Validate IconV1\'s "accessibilityRole" defaults to "ControlType.Image".', async () => {
+    await expect(
+      await IconV1PageObject.compareAttribute(IconV1PageObject._primaryComponent, Attribute.AccessibilityRole, IMAGE_A11Y_ROLE),
+    ).toBeTruthy();
     await expect(await IconV1PageObject.getAccessibilityRole()).toEqual('ControlType.Image');
     await expect(await IconV1PageObject.didAssertPopup()).toBeFalsy(IconV1PageObject.ERRORMESSAGE_ASSERT);
   });

--- a/change/@fluentui-react-native-e2e-testing-372ce719-836d-4418-823a-ccb00221900f.json
+++ b/change/@fluentui-react-native-e2e-testing-372ce719-836d-4418-823a-ccb00221900f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Use better test names + new e2e methods on IconV1",
+  "packageName": "@fluentui-react-native/e2e-testing",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Currently, for most developers, it is difficult to figure out what the root issue is when a FURN E2E test fails because of opaque error messages. The existing E2E tests are also in need of some clean up in terms of code and PageObject design.

This commit is part of a larger effort to address the above. Here, I've updated error messages, use new BasePage methods, and did general cleanup for the following tests:

- IconV1

### Verification

Tests pass locally and in CI.

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
