### PR TITLE
chore: migrate to `@rnx-kit/align-deps`

### DIFF
--- a/apps/E2E/package.json
+++ b/apps/E2E/package.json
@@ -19,16 +19,18 @@
     "src/**/*",
     "dist/*"
   ],
+  "dependencies": {
+    "react": "17.0.2",
+    "react-native": "^0.68.0"
+  },
   "devDependencies": {
+    "@babel/core": "^7.8.0",
+    "@babel/runtime": "^7.8.0",
+    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
+    "@fluentui-react-native/focus-zone": "^0.11.26",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "@rnx-kit/cli": "^0.14.8",
     "@rnx-kit/metro-config": "^1.3.1",
-    "metro-config": "^0.67.0",
-    "metro-react-native-babel-preset": "^0.67.0",
-    "@fluentui-react-native/eslint-config-rules": "^0.1.1",
-    "@fluentui-react-native/scripts": "^0.1.1",
-    "ts-node": "^8.10.1",
-    "typescript": "4.5.4",
-    "webdriverio": "7.23.0",
     "@types/jasmine": "3.5.10",
     "@types/react": "^17.0.2",
     "@types/react-native": "^0.68.0",
@@ -39,21 +41,30 @@
     "@wdio/spec-reporter": "7.23.0",
     "appium": "2.0.0-beta.41",
     "appium-mac2-driver": "1.4.0",
+    "appium-uiautomator2-driver": "^2.10.2",
     "appium-windows-driver": "2.0.7",
     "appium-xcuitest-driver": "4.11.1",
-    "appium-uiautomator2-driver": "^2.10.2",
-    "@babel/core": "^7.8.0",
-    "@babel/runtime": "^7.8.0",
-    "@fluentui-react-native/focus-zone": "^0.11.26"
+    "metro-config": "^0.67.0",
+    "metro-react-native-babel-preset": "^0.67.0",
+    "ts-node": "^8.10.1",
+    "typescript": "4.5.4",
+    "webdriverio": "7.23.0"
   },
   "rnx-kit": {
-    "reactNativeVersion": "0.68",
-    "kitType": "library",
-    "capabilities": [
-      "core",
-      "react",
-      "metro-config",
-      "babel-preset-react-native"
-    ]
+    "kitType": "app",
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "react",
+        "metro-config",
+        "babel-preset-react-native"
+      ]
+    }
   }
 }

--- a/apps/fluent-tester/docs/android.md
+++ b/apps/fluent-tester/docs/android.md
@@ -53,26 +53,17 @@ yarn start
 ## Dependencies
 
 Dependencies are managed by
-[`@rnx-kit/dep-check`](https://github.com/microsoft/rnx-kit/tree/main/packages/dep-check).
-If you're looking to upgrade `react-native`, look for the `rnx-kit` section in
-`/apps/android/package.json`:
+[`@rnx-kit/align-deps`](https://github.com/microsoft/rnx-kit/tree/main/packages/align-deps).
+If you're looking to upgrade `react-native`, use the interactive upgrade command:
 
-```json
-{
-  ...
-  "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "kitType": "app",
-    "bundle": {
-  ...
-}
+```sh
+yarn rnx-align-deps --set-version
 ```
 
-Bump `reactNativeVersion`, and run `yarn rnx-dep-check --write`. This command
-will ensure that all relevant packages are bumped correctly.
+This command will ensure that all relevant packages are bumped correctly.
 
 You can read more about this tool here:
-[`@rnx-kit/dep-check` design document](https://github.com/microsoft/rnx-kit/blob/main/docsite/docs/architecture/dependency-management.md)
+[`@rnx-kit/align-deps` design document](https://github.com/microsoft/rnx-kit/blob/main/docsite/docs/architecture/dependency-management.md)
 
 ## Debugging
 

--- a/apps/fluent-tester/docs/ios.md
+++ b/apps/fluent-tester/docs/ios.md
@@ -32,26 +32,17 @@ yarn ios
 ## Dependencies
 
 Dependencies are managed by
-[`@rnx-kit/dep-check`](https://github.com/microsoft/rnx-kit/tree/main/packages/dep-check).
-If you're looking to upgrade `react-native`, look for the `rnx-kit` section in
-`/apps/fluent-tester/package.json`:
+[`@rnx-kit/align-deps`](https://github.com/microsoft/rnx-kit/tree/main/packages/align-deps).
+If you're looking to upgrade `react-native`, use the interactive upgrade command:
 
-```json
-{
-  ...
-  "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "kitType": "app",
-    "bundle": {
-  ...
-}
+```sh
+yarn rnx-align-deps --set-version
 ```
 
-Bump `reactNativeVersion`, and run `yarn rnx-dep-check --write`. This command
-will ensure that all relevant packages are bumped correctly.
+This command will ensure that all relevant packages are bumped correctly.
 
 You can read more about this tool here:
-[`@rnx-kit/dep-check` design document](https://github.com/microsoft/rnx-kit/blob/main/docsite/docs/architecture/dependency-management.md)
+[`@rnx-kit/align-deps` design document](https://github.com/microsoft/rnx-kit/blob/main/docsite/docs/architecture/dependency-management.md)
 
 ## Debugging
 

--- a/apps/fluent-tester/docs/macos.md
+++ b/apps/fluent-tester/docs/macos.md
@@ -41,26 +41,17 @@ You can debug native code in Xcode. To debug javascript code, you can either use
 ## Dependencies
 
 Dependencies are managed by
-[`@rnx-kit/dep-check`](https://github.com/microsoft/rnx-kit/tree/main/packages/dep-check).
-If you're looking to upgrade `react-native`, look for the `rnx-kit` section in
-`/apps/fluent-tester/package.json`:
+[`@rnx-kit/align-deps`](https://github.com/microsoft/rnx-kit/tree/main/packages/align-deps).
+If you're looking to upgrade `react-native`, use the interactive upgrade command:
 
-```json
-{
-  ...
-  "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "kitType": "app",
-    "bundle": {
-  ...
-}
+```sh
+yarn rnx-align-deps --set-version
 ```
 
-Bump `reactNativeVersion`, and run `yarn rnx-dep-check --write`. This command
-will ensure that all relevant packages are bumped correctly.
+This command will ensure that all relevant packages are bumped correctly.
 
 You can read more about this tool here:
-[`@rnx-kit/dep-check` design document](https://github.com/microsoft/rnx-kit/blob/main/docsite/docs/architecture/dependency-management.md)
+[`@rnx-kit/align-deps` design document](https://github.com/microsoft/rnx-kit/blob/main/docsite/docs/architecture/dependency-management.md)
 
 ## Troubleshooting
 

--- a/apps/fluent-tester/docs/windows.md
+++ b/apps/fluent-tester/docs/windows.md
@@ -30,26 +30,17 @@ You can debug native code in Visual Studio. To debug javascript code, you can ei
 ## Dependencies
 
 Dependencies are managed by
-[`@rnx-kit/dep-check`](https://github.com/microsoft/rnx-kit/tree/main/packages/dep-check).
-If you're looking to upgrade `react-native`, look for the `rnx-kit` section in
-`/apps/windows/package.json`:
+[`@rnx-kit/align-deps`](https://github.com/microsoft/rnx-kit/tree/main/packages/align-deps).
+If you're looking to upgrade `react-native`, use the interactive upgrade command:
 
-```json
-{
-  ...
-  "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "kitType": "app",
-    "bundle": {
-  ...
-}
+```sh
+yarn rnx-align-deps --set-version
 ```
 
-Bump `reactNativeVersion`, and run `yarn rnx-dep-check --write`. This command
-will ensure that all relevant packages are bumped correctly.
+This command will ensure that all relevant packages are bumped correctly.
 
 You can read more about this tool here:
-[`@rnx-kit/dep-check` design document](https://github.com/microsoft/rnx-kit/blob/main/docsite/docs/architecture/dependency-management.md)
+[`@rnx-kit/align-deps` design document](https://github.com/microsoft/rnx-kit/blob/main/docsite/docs/architecture/dependency-management.md)
 
 ## Troubleshooting
 

--- a/apps/fluent-tester/package.json
+++ b/apps/fluent-tester/package.json
@@ -82,7 +82,6 @@
     "@react-native-picker/picker": "^2.2.1",
     "@warren-ms/react-native-icons": "^0.0.13",
     "react": "17.0.2",
-    "react-dom": "17.0.2",
     "react-native": "^0.68.0",
     "react-native-macos": "^0.68.0",
     "react-native-svg": "^12.3.0",
@@ -167,7 +166,6 @@
         "babel-preset-react-native",
         "metro-config",
         "react",
-        "react-dom",
         "svg"
       ]
     }

--- a/apps/fluent-tester/package.json
+++ b/apps/fluent-tester/package.json
@@ -62,8 +62,8 @@
     "@fluentui-react-native/interactive-hooks": ">=0.22.14 <1.0.0",
     "@fluentui-react-native/menu": "^1.2.24",
     "@fluentui-react-native/merge-props": ">=0.5.1 <1.0.0",
-    "@fluentui-react-native/separator": "^0.14.11",
     "@fluentui-react-native/notification": "0.21.22",
+    "@fluentui-react-native/separator": "^0.14.11",
     "@fluentui-react-native/stack": ">=0.7.48 <1.0.0",
     "@fluentui-react-native/switch": "^0.8.20",
     "@fluentui-react-native/text": ">=0.19.16 <1.0.0",
@@ -80,19 +80,20 @@
     "@react-native-community/slider": "^4.2.0",
     "@react-native-menu/menu": "^0.1.2",
     "@react-native-picker/picker": "^2.2.1",
+    "@warren-ms/react-native-icons": "^0.0.13",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-native": "^0.68.0",
     "react-native-macos": "^0.68.0",
-    "react-native-svg": "12.5.0",
+    "react-native-svg": "^12.3.0",
     "react-native-windows": "^0.68.0",
-    "tslib": "^2.3.1",
-    "@warren-ms/react-native-icons": "^0.0.13"
+    "tslib": "^2.3.1"
   },
   "devDependencies": {
     "@babel/core": "^7.8.0",
     "@babel/runtime": "^7.8.0",
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
+    "@fluentui-react-native/focus-zone": "^0.11.26",
     "@fluentui-react-native/scripts": "^0.1.1",
     "@rnx-kit/cli": "^0.14.8",
     "@rnx-kit/metro-config": "^1.3.1",
@@ -101,8 +102,7 @@
     "metro-react-native-babel-preset": "^0.67.0",
     "react-native-svg-transformer": "^1.0.0",
     "react-native-test-app": "^2.0.2",
-    "react-test-renderer": "17.0.2",
-    "@fluentui-react-native/focus-zone": "^0.11.26"
+    "react-test-renderer": "17.0.2"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.68.0"
@@ -111,7 +111,6 @@
     "preset": "react-native"
   },
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
     "kitType": "app",
     "bundle": [
       {
@@ -152,17 +151,26 @@
         }
       }
     ],
-    "capabilities": [
-      "core-android",
-      "core-ios",
-      "core-macos",
-      "core-windows",
-      "babel-preset-react-native",
-      "metro-config",
-      "react",
-      "react-dom",
-      "svg"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native",
+        "@fluentui-react-native/scripts/align-deps-preset.js"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core-android",
+        "core-ios",
+        "core-macos",
+        "core-windows",
+        "babel-preset-react-native",
+        "metro-config",
+        "react",
+        "react-dom",
+        "svg"
+      ]
+    }
   },
   "depcheck": {
     "ignoreMatches": [

--- a/apps/win32/README.md
+++ b/apps/win32/README.md
@@ -85,23 +85,14 @@ yarn run-win32-web
 ## Dependencies
 
 Dependencies are managed by
-[`@rnx-kit/dep-check`](https://github.com/microsoft/rnx-kit/tree/main/packages/dep-check).
-If you're looking to upgrade `react-native`, look for the `rnx-kit` section in
-`/apps/win32/package.json`:
+[`@rnx-kit/align-deps`](https://github.com/microsoft/rnx-kit/tree/main/packages/align-deps).
+If you're looking to upgrade `react-native`, use the interactive upgrade command:
 
-```json
-{
-  ...
-  "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "kitType": "app",
-    "bundle": {
-  ...
-}
+```sh
+yarn rnx-align-deps --set-version
 ```
 
-Bump `reactNativeVersion`, and run `yarn rnx-dep-check --write`. This command
-will ensure that all relevant packages are bumped correctly.
+This command will ensure that all relevant packages are bumped correctly.
 
 You can read more about this tool here:
-[`@rnx-kit/dep-check` design document](https://github.com/microsoft/rnx-kit/blob/main/docsite/docs/architecture/dependency-management.md)
+[`@rnx-kit/align-deps` design document](https://github.com/microsoft/rnx-kit/blob/main/docsite/docs/architecture/dependency-management.md)

--- a/apps/win32/package.json
+++ b/apps/win32/package.json
@@ -33,8 +33,9 @@
   "dependencies": {
     "@fluentui-react-native/tester": "^0.128.3",
     "react": "17.0.2",
+    "react-dom": "17.0.2",
     "react-native": "^0.68.0",
-    "react-native-svg": "12.5.0",
+    "react-native-svg": "^12.3.0",
     "tslib": "^2.3.1"
   },
   "devDependencies": {
@@ -68,7 +69,6 @@
     "preset": "react-native"
   },
   "rnx-kit": {
-    "reactNativeVersion": "0.68",
     "kitType": "app",
     "bundle": [
       {
@@ -89,12 +89,20 @@
         "typescriptValidation": false
       }
     ],
-    "capabilities": [
-      "core",
-      "react",
-      "svg",
-      "metro-config",
-      "babel-preset-react-native"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "react",
+        "svg",
+        "metro-config",
+        "babel-preset-react-native"
+      ]
+    }
   }
 }

--- a/apps/win32/package.json
+++ b/apps/win32/package.json
@@ -33,7 +33,6 @@
   "dependencies": {
     "@fluentui-react-native/tester": "^0.128.3",
     "react": "17.0.2",
-    "react-dom": "17.0.2",
     "react-native": "^0.68.0",
     "react-native-svg": "^12.3.0",
     "tslib": "^2.3.1"

--- a/change/@fluentui-react-native-adapters-8694dd0a-72ca-44fc-9227-0107ce67c957.json
+++ b/change/@fluentui-react-native-adapters-8694dd0a-72ca-44fc-9227-0107ce67c957.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/adapters",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-android-theme-b65843ed-0834-4fda-a5ff-4765b947c8ab.json
+++ b/change/@fluentui-react-native-android-theme-b65843ed-0834-4fda-a5ff-4765b947c8ab.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/android-theme",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-apple-theme-fc3de142-5750-41f0-ab9c-f26a619a244e.json
+++ b/change/@fluentui-react-native-apple-theme-fc3de142-5750-41f0-ab9c-f26a619a244e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/apple-theme",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-avatar-ff91cbfe-7a25-4a9c-abfe-c919dab06992.json
+++ b/change/@fluentui-react-native-avatar-ff91cbfe-7a25-4a9c-abfe-c919dab06992.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/avatar",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-badge-cc52e43b-bafa-480f-ba8a-892b3fde4328.json
+++ b/change/@fluentui-react-native-badge-cc52e43b-bafa-480f-ba8a-892b3fde4328.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/badge",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-bfeda7bd-b8f5-4f6a-a59e-66f3deccd9e2.json
+++ b/change/@fluentui-react-native-bfeda7bd-b8f5-4f6a-a59e-66f3deccd9e2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui/react-native",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-button-68e839e0-b8ad-40c4-b31a-8a931196eed5.json
+++ b/change/@fluentui-react-native-button-68e839e0-b8ad-40c4-b31a-8a931196eed5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/button",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-callout-20b48f02-f819-4cf3-b5a0-29a58271adad.json
+++ b/change/@fluentui-react-native-callout-20b48f02-f819-4cf3-b5a0-29a58271adad.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/callout",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-checkbox-5b4496e8-76d0-4705-91fd-81a4cf9af70a.json
+++ b/change/@fluentui-react-native-checkbox-5b4496e8-76d0-4705-91fd-81a4cf9af70a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/checkbox",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-component-cache-b469df44-2b01-4c1f-8258-9ad1bb96a7ec.json
+++ b/change/@fluentui-react-native-component-cache-b469df44-2b01-4c1f-8258-9ad1bb96a7ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/component-cache",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-composition-1d40d8ac-d52a-4a82-83fe-4c7c09357a69.json
+++ b/change/@fluentui-react-native-composition-1d40d8ac-d52a-4a82-83fe-4c7c09357a69.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/composition",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-contextual-menu-c24e8aa0-a725-4ddd-bff2-17f2b1870e51.json
+++ b/change/@fluentui-react-native-contextual-menu-c24e8aa0-a725-4ddd-bff2-17f2b1870e51.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/contextual-menu",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-default-theme-63b180b7-f3af-4acc-a33a-97bbb07f5c5d.json
+++ b/change/@fluentui-react-native-default-theme-63b180b7-f3af-4acc-a33a-97bbb07f5c5d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/default-theme",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-dropdown-0e5631f1-6913-4271-8fb8-0db8648e28ce.json
+++ b/change/@fluentui-react-native-dropdown-0e5631f1-6913-4271-8fb8-0db8648e28ce.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/dropdown",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-e2e-testing-2a9da268-6ec3-4065-a0f6-be95d87864b4.json
+++ b/change/@fluentui-react-native-e2e-testing-2a9da268-6ec3-4065-a0f6-be95d87864b4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/e2e-testing",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-activity-indicator-8e0d5673-e107-4821-bc5f-d21d653c1508.json
+++ b/change/@fluentui-react-native-experimental-activity-indicator-8e0d5673-e107-4821-bc5f-d21d653c1508.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/experimental-activity-indicator",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-appearance-additions-8861279c-7592-4d6f-8a19-ac6320869a58.json
+++ b/change/@fluentui-react-native-experimental-appearance-additions-8861279c-7592-4d6f-8a19-ac6320869a58.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/experimental-appearance-additions",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-avatar-b5111caf-3ade-4884-9fb7-9c46b05d38fd.json
+++ b/change/@fluentui-react-native-experimental-avatar-b5111caf-3ade-4884-9fb7-9c46b05d38fd.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/experimental-avatar",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-button-3e33c98a-8776-41d4-9cef-0a78be3e3cbb.json
+++ b/change/@fluentui-react-native-experimental-button-3e33c98a-8776-41d4-9cef-0a78be3e3cbb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/experimental-button",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-checkbox-ba6478d7-4eb5-4ba5-9cc9-dd7f1411de29.json
+++ b/change/@fluentui-react-native-experimental-checkbox-ba6478d7-4eb5-4ba5-9cc9-dd7f1411de29.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/experimental-checkbox",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-drawer-bc309000-dddb-4915-80f9-ef8e14c42903.json
+++ b/change/@fluentui-react-native-experimental-drawer-bc309000-dddb-4915-80f9-ef8e14c42903.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/experimental-drawer",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-expander-554e36a5-a4f5-4fb6-8670-06e4e149a2c4.json
+++ b/change/@fluentui-react-native-experimental-expander-554e36a5-a4f5-4fb6-8670-06e4e149a2c4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/experimental-expander",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-link-c974fca6-c183-4f63-a107-0ba510b74428.json
+++ b/change/@fluentui-react-native-experimental-link-c974fca6-c183-4f63-a107-0ba510b74428.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/experimental-link",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-menu-button-172ca473-eaf1-496e-8bd7-565836968c56.json
+++ b/change/@fluentui-react-native-experimental-menu-button-172ca473-eaf1-496e-8bd7-565836968c56.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/experimental-menu-button",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-native-date-picker-383eb9ec-a6e3-4913-8fa1-e8f3b505b833.json
+++ b/change/@fluentui-react-native-experimental-native-date-picker-383eb9ec-a6e3-4913-8fa1-e8f3b505b833.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/experimental-native-date-picker",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-native-font-metrics-6b778d28-53ab-4f52-a24a-1e55eaa40940.json
+++ b/change/@fluentui-react-native-experimental-native-font-metrics-6b778d28-53ab-4f52-a24a-1e55eaa40940.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/experimental-native-font-metrics",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-radio-group-5586aad3-0d96-4143-9e76-ca2dce676fc4.json
+++ b/change/@fluentui-react-native-experimental-radio-group-5586aad3-0d96-4143-9e76-ca2dce676fc4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/experimental-radio-group",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-shadow-8b37c53f-1ba2-4a90-88e7-ee5b43fb9a33.json
+++ b/change/@fluentui-react-native-experimental-shadow-8b37c53f-1ba2-4a90-88e7-ee5b43fb9a33.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/experimental-shadow",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-shimmer-d0ea8543-fc81-46c9-a1b3-900427c61bdd.json
+++ b/change/@fluentui-react-native-experimental-shimmer-d0ea8543-fc81-46c9-a1b3-900427c61bdd.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/experimental-shimmer",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-tabs-7d8b6757-27b2-4bfd-9f04-b8f5f8f30604.json
+++ b/change/@fluentui-react-native-experimental-tabs-7d8b6757-27b2-4bfd-9f04-b8f5f8f30604.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/experimental-tabs",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-text-8b44eda9-3cac-4ab0-a604-96250daf1523.json
+++ b/change/@fluentui-react-native-experimental-text-8b44eda9-3cac-4ab0-a604-96250daf1523.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/experimental-text",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-focus-trap-zone-255adaff-facd-4af7-97a9-14b2c2f29cfd.json
+++ b/change/@fluentui-react-native-focus-trap-zone-255adaff-facd-4af7-97a9-14b2c2f29cfd.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/focus-trap-zone",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-focus-zone-df193691-d2c6-4b53-8c91-bf484e400c11.json
+++ b/change/@fluentui-react-native-focus-zone-df193691-d2c6-4b53-8c91-bf484e400c11.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/focus-zone",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-framework-f4e3199d-9e46-48ce-a9ef-f588e8f98b23.json
+++ b/change/@fluentui-react-native-framework-f4e3199d-9e46-48ce-a9ef-f588e8f98b23.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/framework",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-icon-c85204e5-cd88-49f7-ad31-1b851fd30be0.json
+++ b/change/@fluentui-react-native-icon-c85204e5-cd88-49f7-ad31-1b851fd30be0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/icon",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-interactive-hooks-603add24-0488-497f-a9e9-7dfd738222a7.json
+++ b/change/@fluentui-react-native-interactive-hooks-603add24-0488-497f-a9e9-7dfd738222a7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/interactive-hooks",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-link-5985986a-fb77-4442-be55-d84491a0537f.json
+++ b/change/@fluentui-react-native-link-5985986a-fb77-4442-be55-d84491a0537f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/link",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-menu-9d8ae5de-e7f2-4b24-9d73-b425c0cf7065.json
+++ b/change/@fluentui-react-native-menu-9d8ae5de-e7f2-4b24-9d73-b425c0cf7065.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-menu-button-8a842af7-1a3e-41c2-81bc-cabf6c237d86.json
+++ b/change/@fluentui-react-native-menu-button-8a842af7-1a3e-41c2-81bc-cabf6c237d86.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/menu-button",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-merge-props-ebe4375d-12de-44dc-bf1e-fb1f3f57a32e.json
+++ b/change/@fluentui-react-native-merge-props-ebe4375d-12de-44dc-bf1e-fb1f3f57a32e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/merge-props",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-notification-9bc80866-fe8d-4b66-979a-9ab2d43d937e.json
+++ b/change/@fluentui-react-native-notification-9bc80866-fe8d-4b66-979a-9ab2d43d937e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/notification",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-persona-coin-5122ff35-1533-4ee4-8404-1793bac9b636.json
+++ b/change/@fluentui-react-native-persona-coin-5122ff35-1533-4ee4-8404-1793bac9b636.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/persona-coin",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-persona-d9d86a21-0623-4253-80c7-ac183503aabc.json
+++ b/change/@fluentui-react-native-persona-d9d86a21-0623-4253-80c7-ac183503aabc.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/persona",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-popover-ec46d780-b768-44de-9c7c-a3c8690d0811.json
+++ b/change/@fluentui-react-native-popover-ec46d780-b768-44de-9c7c-a3c8690d0811.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/popover",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-pressable-423352db-67e3-47ec-b2c8-888a85ef55fa.json
+++ b/change/@fluentui-react-native-pressable-423352db-67e3-47ec-b2c8-888a85ef55fa.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/pressable",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-radio-group-6851b0ec-6674-4989-9cba-4568e5a79e9d.json
+++ b/change/@fluentui-react-native-radio-group-6851b0ec-6674-4989-9cba-4568e5a79e9d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/radio-group",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-separator-e1930d18-7582-4a4d-927f-726cc0f1684e.json
+++ b/change/@fluentui-react-native-separator-e1930d18-7582-4a4d-927f-726cc0f1684e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/separator",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-spinner-ac0c91ab-942e-4ada-b8e9-9f98b9e1373b.json
+++ b/change/@fluentui-react-native-spinner-ac0c91ab-942e-4ada-b8e9-9f98b9e1373b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/spinner",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-stack-34cc5bc2-79d7-47f7-a4a1-9b7161fe4c11.json
+++ b/change/@fluentui-react-native-stack-34cc5bc2-79d7-47f7-a4a1-9b7161fe4c11.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/stack",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-styling-utils-d2fae6ad-06b0-44a9-819d-e185f72a6bf8.json
+++ b/change/@fluentui-react-native-styling-utils-d2fae6ad-06b0-44a9-819d-e185f72a6bf8.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/styling-utils",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-switch-9040327b-b989-422e-b503-1cfa07fe8825.json
+++ b/change/@fluentui-react-native-switch-9040327b-b989-422e-b503-1cfa07fe8825.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/switch",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-tabs-9108d997-6b8c-4bfa-afd4-fd58733f371c.json
+++ b/change/@fluentui-react-native-tabs-9108d997-6b8c-4bfa-afd4-fd58733f371c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/tabs",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-tester-8ca29246-fe11-400d-b905-4265e2dec67d.json
+++ b/change/@fluentui-react-native-tester-8ca29246-fe11-400d-b905-4265e2dec67d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-tester-win32-810df1af-eca3-4400-a7f3-f45447e4f7bf.json
+++ b/change/@fluentui-react-native-tester-win32-810df1af-eca3-4400-a7f3-f45447e4f7bf.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/tester-win32",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-text-f9127c0d-cf73-44be-8a97-074aa17cc4ca.json
+++ b/change/@fluentui-react-native-text-f9127c0d-cf73-44be-8a97-074aa17cc4ca.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/text",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-theme-583f728b-13a8-4e4a-b2ae-6b00d396007b.json
+++ b/change/@fluentui-react-native-theme-583f728b-13a8-4e4a-b2ae-6b00d396007b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/theme",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-theme-tokens-a1d936fd-b605-4e49-996a-a84d26c5cca8.json
+++ b/change/@fluentui-react-native-theme-tokens-a1d936fd-b605-4e49-996a-a84d26c5cca8.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/theme-tokens",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-theme-types-3a1a4b5e-5ade-4794-88f1-14fb354e9f83.json
+++ b/change/@fluentui-react-native-theme-types-3a1a4b5e-5ade-4794-88f1-14fb354e9f83.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/theme-types",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-themed-stylesheet-a69607ab-3725-4947-ab03-adc771da6234.json
+++ b/change/@fluentui-react-native-themed-stylesheet-a69607ab-3725-4947-ab03-adc771da6234.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/themed-stylesheet",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-theming-utils-4cdcfc37-0169-47bf-adb7-bdbe4fd2aa4a.json
+++ b/change/@fluentui-react-native-theming-utils-4cdcfc37-0169-47bf-adb7-bdbe4fd2aa4a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/theming-utils",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-tokens-a0f5c32b-8654-4fae-a7a4-4a97c0ea9ac0.json
+++ b/change/@fluentui-react-native-tokens-a0f5c32b-8654-4fae-a7a4-4a97c0ea9ac0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/tokens",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-use-slot-5ebe5f05-354a-4e98-957f-7830e742e219.json
+++ b/change/@fluentui-react-native-use-slot-5ebe5f05-354a-4e98-957f-7830e742e219.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/use-slot",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-use-slots-957d0f0f-996d-4927-9546-c052b125ceb0.json
+++ b/change/@fluentui-react-native-use-slots-957d0f0f-996d-4927-9546-c052b125ceb0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/use-slots",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-use-styling-602a638d-47e6-440c-97c4-0b0fb2a47e3b.json
+++ b/change/@fluentui-react-native-use-styling-602a638d-47e6-440c-97c4-0b0fb2a47e3b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/use-styling",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-use-tokens-23d15827-9bda-4b3f-9f2d-39e65ff09ab2.json
+++ b/change/@fluentui-react-native-use-tokens-23d15827-9bda-4b3f-9f2d-39e65ff09ab2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/use-tokens",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-win32-theme-9cdf5fe1-e3ef-468e-97eb-d24f9d745aa3.json
+++ b/change/@fluentui-react-native-win32-theme-9cdf5fe1-e3ef-468e-97eb-d24f9d745aa3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@fluentui-react-native/win32-theme",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@uifabricshared-foundation-settings-eeb14807-27bb-4b66-86ff-c6ed978e7db4.json
+++ b/change/@uifabricshared-foundation-settings-eeb14807-27bb-4b66-86ff-c6ed978e7db4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@uifabricshared/foundation-settings",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@uifabricshared-foundation-tokens-439d7f68-31a8-4ddf-b12a-bb23cf4ed064.json
+++ b/change/@uifabricshared-foundation-tokens-439d7f68-31a8-4ddf-b12a-bb23cf4ed064.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@uifabricshared/foundation-tokens",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@uifabricshared-theme-registry-59fc35d0-33fe-4b8d-9ced-5edc01c40d3e.json
+++ b/change/@uifabricshared-theme-registry-59fc35d0-33fe-4b8d-9ced-5edc01c40d3e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@uifabricshared/theme-registry",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@uifabricshared-themed-settings-e15ab4be-dffb-4076-aba4-f642899ad7fc.json
+++ b/change/@uifabricshared-themed-settings-e15ab4be-dffb-4076-aba4-f642899ad7fc.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@uifabricshared/themed-settings",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@uifabricshared-theming-react-native-f75e234e-f1c3-4964-a709-78ae2a85b4bb.json
+++ b/change/@uifabricshared-theming-react-native-f75e234e-f1c3-4964-a709-78ae2a85b4bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Migrate to align-deps",
+  "packageName": "@uifabricshared/theming-react-native",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "change": "beachball change",
     "check-for-changed-files": "cd scripts && yarn fluentui-scripts checkForModifiedFiles",
     "checkchange": "beachball check --changehint \"Run 'yarn change' to generate a change file\"",
-    "depcheck": "rnx-dep-check && lage depcheck",
+    "align-deps": "rnx-align-deps --requirements react-native@0.68",
+    "depcheck": "yarn align-deps && lage depcheck",
     "lint": "lage lint",
     "preinstall": "node ./scripts/use-yarn-please.js",
     "prettier": "lage prettier",
@@ -37,18 +38,20 @@
     "@babel/preset-env": "^7.8.0",
     "@babel/preset-react": "^7.8.0",
     "@babel/preset-typescript": "^7.8.0",
-    "@rnx-kit/dep-check": "^1.10.1",
+    "@rnx-kit/align-deps": "^2.1.1",
     "babel-jest": "^24.9.0",
     "beachball": "^2.20.0",
     "lage": "^1.5.0",
     "markdown-link-check": "^3.8.7",
     "metro-react-native-babel-preset": "^0.67.0",
     "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "react-dom": "17.0.2",
+    "react-native": "^0.68.0"
   },
   "peerDependencies": {
     "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "react-dom": "17.0.2",
+    "react-native": "^0.68.0"
   },
   "workspaces": {
     "packages": [
@@ -75,11 +78,19 @@
     "@appium/types": "0.5.0"
   },
   "rnx-kit": {
-    "reactNativeVersion": "0.68",
     "kitType": "library",
-    "capabilities": [
-      "babel-preset-react-native",
-      "react-dom"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "babel-preset-react-native",
+        "core",
+        "react-dom"
+      ]
+    }
   }
 }

--- a/packages/components/Avatar/package.json
+++ b/packages/components/Avatar/package.json
@@ -35,8 +35,7 @@
     "@fluentui-react-native/icon": "^0.17.8",
     "@fluentui-react-native/theme-tokens": "^0.24.1",
     "@fluentui-react-native/tokens": "^0.20.6",
-    "@fluentui-react-native/use-styling": "^0.9.1",
-    "react-native-svg": "12.5.0"
+    "@fluentui-react-native/use-styling": "^0.9.1"
   },
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
@@ -44,22 +43,30 @@
     "@office-iss/react-native-win32": "^0.68.0",
     "@types/react-native": "^0.68.0",
     "react": "17.0.2",
-    "react-native": "^0.68.0"
+    "react-native": "^0.68.0",
+    "react-native-svg": "^12.3.0"
   },
   "peerDependencies": {
     "react": "17.0.2",
-    "react-native": "^0.68.0"
+    "react-native": "^0.68.0",
+    "react-native-svg": "^12.3.0"
   },
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react",
-      "svg"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react",
+        "svg"
+      ]
+    }
   }
 }

--- a/packages/components/Badge/package.json
+++ b/packages/components/Badge/package.json
@@ -32,8 +32,7 @@
     "@fluentui-react-native/theme-tokens": "^0.24.1",
     "@fluentui-react-native/theme-types": "^0.30.1",
     "@fluentui-react-native/tokens": "^0.20.6",
-    "@fluentui-react-native/use-styling": "^0.9.1",
-    "react-native-svg": "12.5.0"
+    "@fluentui-react-native/use-styling": "^0.9.1"
   },
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
@@ -42,22 +41,30 @@
     "@office-iss/react-native-win32": "^0.68.0",
     "@types/react-native": "^0.68.0",
     "react": "17.0.2",
-    "react-native": "^0.68.0"
+    "react-native": "^0.68.0",
+    "react-native-svg": "^12.3.0"
   },
   "peerDependencies": {
     "react": "17.0.2",
-    "react-native": "^0.68.0"
+    "react-native": "^0.68.0",
+    "react-native-svg": "^12.3.0"
   },
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react",
-      "svg"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react",
+        "svg"
+      ]
+    }
   }
 }

--- a/packages/components/Button/package.json
+++ b/packages/components/Button/package.json
@@ -60,14 +60,20 @@
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/components/Callout/package.json
+++ b/packages/components/Callout/package.json
@@ -50,14 +50,20 @@
     "react-native": "^0.68.0"
   },
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/components/Checkbox/package.json
+++ b/packages/components/Checkbox/package.json
@@ -38,7 +38,6 @@
     "@uifabricshared/foundation-compose": "^1.12.37",
     "@uifabricshared/foundation-composable": ">=0.11.1 <1.0.0",
     "@uifabricshared/foundation-settings": ">=0.12.1 <1.0.0",
-    "react-native-svg": "12.5.0",
     "tslib": "^2.3.1"
   },
   "devDependencies": {
@@ -48,24 +47,32 @@
     "@office-iss/react-native-win32": "^0.68.0",
     "@types/react-native": "^0.68.0",
     "react": "17.0.2",
-    "react-native": "^0.68.0"
+    "react-native": "^0.68.0",
+    "react-native-svg": "^12.3.0"
   },
   "peerDependencies": {
     "react": "17.0.2",
-    "react-native": "^0.68.0"
+    "react-native": "^0.68.0",
+    "react-native-svg": "^12.3.0"
   },
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react",
-      "svg"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react",
+        "svg"
+      ]
+    }
   }
 }

--- a/packages/components/ContextualMenu/package.json
+++ b/packages/components/ContextualMenu/package.json
@@ -38,8 +38,7 @@
     "@fluentui-react-native/tokens": ">=0.20.6 <1.0.0",
     "@uifabricshared/foundation-composable": ">=0.11.1 <1.0.0",
     "@uifabricshared/foundation-compose": "^1.12.37",
-    "@uifabricshared/foundation-settings": ">=0.12.1 <1.0.0",
-    "react-native-svg": "12.5.0"
+    "@uifabricshared/foundation-settings": ">=0.12.1 <1.0.0"
   },
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
@@ -49,22 +48,30 @@
     "@types/react-native": "^0.68.0",
     "react": "17.0.2",
     "react-native": "^0.68.0",
+    "react-native-svg": "^12.3.0",
     "react-native-svg-transformer": "^1.0.0"
   },
   "peerDependencies": {
     "react": "17.0.2",
-    "react-native": "^0.68.0"
+    "react-native": "^0.68.0",
+    "react-native-svg": "^12.3.0"
   },
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react",
-      "svg"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react",
+        "svg"
+      ]
+    }
   }
 }

--- a/packages/components/FocusTrapZone/package.json
+++ b/packages/components/FocusTrapZone/package.json
@@ -47,14 +47,20 @@
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/components/FocusZone/package.json
+++ b/packages/components/FocusZone/package.json
@@ -46,14 +46,20 @@
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/components/Icon/package.json
+++ b/packages/components/Icon/package.json
@@ -28,34 +28,41 @@
   "dependencies": {
     "@fluentui-react-native/adapters": "^0.10.0",
     "@fluentui-react-native/framework": ">=0.8.37 <1.0.0",
-    "@fluentui-react-native/text": "^0.19.16",
-    "react-native-svg": "12.5.0"
+    "@fluentui-react-native/text": "^0.19.16"
   },
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
-    "@fluentui-react-native/test-tools": ">=0.1.1 <1.0.0",
     "@fluentui-react-native/scripts": "^0.1.1",
+    "@fluentui-react-native/test-tools": ">=0.1.1 <1.0.0",
     "@office-iss/react-native-win32": "^0.68.0",
+    "@types/react-native": "^0.68.0",
     "react": "17.0.2",
     "react-native": "^0.68.0",
-    "@types/react-native": "^0.68.0"
+    "react-native-svg": "^12.3.0"
   },
   "peerDependencies": {
     "react": "17.0.2",
-    "react-native": "^0.68.0"
+    "react-native": "^0.68.0",
+    "react-native-svg": "^12.3.0"
   },
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react",
-      "svg"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react",
+        "svg"
+      ]
+    }
   }
 }

--- a/packages/components/Link/package.json
+++ b/packages/components/Link/package.json
@@ -52,14 +52,20 @@
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/components/Menu/package.json
+++ b/packages/components/Menu/package.json
@@ -35,7 +35,6 @@
     "@fluentui-react-native/theme-tokens": ">=0.24.1 <1.0.0",
     "@fluentui-react-native/tokens": ">=0.20.6 <1.0.0",
     "@fluentui-react-native/use-styling": ">=0.9.1 <1.0.0",
-    "react-native-svg": "12.5.0",
     "tslib": "^2.3.1"
   },
   "devDependencies": {
@@ -46,24 +45,32 @@
     "@office-iss/react-native-win32": "^0.68.0",
     "@types/react-native": "^0.68.0",
     "react": "17.0.2",
-    "react-native": "^0.68.0"
+    "react-native": "^0.68.0",
+    "react-native-svg": "^12.3.0"
   },
   "peerDependencies": {
     "react": "17.0.2",
-    "react-native": "^0.68.0"
+    "react-native": "^0.68.0",
+    "react-native-svg": "^12.3.0"
   },
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react",
-      "svg"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react",
+        "svg"
+      ]
+    }
   }
 }

--- a/packages/components/MenuButton/package.json
+++ b/packages/components/MenuButton/package.json
@@ -36,8 +36,7 @@
     "@fluentui-react-native/tokens": "^0.20.6",
     "@uifabricshared/foundation-composable": ">=0.11.1 <1.0.0",
     "@uifabricshared/foundation-compose": "^1.12.37",
-    "@uifabricshared/foundation-settings": ">=0.12.1 <1.0.0",
-    "react-native-svg": "12.5.0"
+    "@uifabricshared/foundation-settings": ">=0.12.1 <1.0.0"
   },
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
@@ -45,22 +44,30 @@
     "@office-iss/react-native-win32": "^0.68.0",
     "@types/react-native": "^0.68.0",
     "react": "17.0.2",
-    "react-native": "^0.68.0"
+    "react-native": "^0.68.0",
+    "react-native-svg": "^12.3.0"
   },
   "peerDependencies": {
     "react": "17.0.2",
-    "react-native": "^0.68.0"
+    "react-native": "^0.68.0",
+    "react-native-svg": "^12.3.0"
   },
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react",
-      "svg"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react",
+        "svg"
+      ]
+    }
   }
 }

--- a/packages/components/Notification/package.json
+++ b/packages/components/Notification/package.json
@@ -38,8 +38,7 @@
     "@fluentui-react-native/theme-tokens": "0.24.1",
     "@fluentui-react-native/theme-types": ">=0.30.1 <1.0.0",
     "@fluentui-react-native/tokens": ">=0.20.6 <1.0.0",
-    "@fluentui-react-native/use-styling": ">=0.9.1 <1.0.0",
-    "react-native-svg": "12.5.0"
+    "@fluentui-react-native/use-styling": ">=0.9.1 <1.0.0"
   },
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
@@ -48,24 +47,32 @@
     "@office-iss/react-native-win32": "^0.68.0",
     "@types/react-native": "^0.68.0",
     "react": "17.0.2",
-    "react-native": "^0.68.0"
+    "react-native": "^0.68.0",
+    "react-native-svg": "^12.3.0"
   },
   "peerDependencies": {
     "react": "17.0.2",
-    "react-native": "^0.68.0"
+    "react-native": "^0.68.0",
+    "react-native-svg": "^12.3.0"
   },
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react",
-      "svg"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react",
+        "svg"
+      ]
+    }
   }
 }

--- a/packages/components/Persona/package.json
+++ b/packages/components/Persona/package.json
@@ -49,14 +49,20 @@
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/components/PersonaCoin/package.json
+++ b/packages/components/PersonaCoin/package.json
@@ -50,14 +50,20 @@
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/components/Pressable/package.json
+++ b/packages/components/Pressable/package.json
@@ -45,14 +45,20 @@
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/components/RadioGroup/package.json
+++ b/packages/components/RadioGroup/package.json
@@ -53,14 +53,20 @@
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/components/Separator/package.json
+++ b/packages/components/Separator/package.json
@@ -45,14 +45,20 @@
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/components/Stack/package.json
+++ b/packages/components/Stack/package.json
@@ -36,9 +36,9 @@
   },
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "@fluentui-react-native/text": ">=0.19.16 <1.0.0",
     "@types/react-native": "^0.68.0",
-    "@fluentui-react-native/scripts": "^0.1.1",
     "react": "17.0.2",
     "react-native": "^0.68.0"
   },
@@ -49,14 +49,20 @@
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/components/Tabs/package.json
+++ b/packages/components/Tabs/package.json
@@ -54,14 +54,20 @@
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/components/text/package.json
+++ b/packages/components/text/package.json
@@ -50,14 +50,20 @@
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/deprecated/foundation-settings/package.json
+++ b/packages/deprecated/foundation-settings/package.json
@@ -47,13 +47,19 @@
     "react-native": "^0.68.0"
   },
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios"
+      ]
+    }
   }
 }

--- a/packages/deprecated/foundation-tokens/package.json
+++ b/packages/deprecated/foundation-tokens/package.json
@@ -48,13 +48,19 @@
     "react-native": "^0.68.0"
   },
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios"
+      ]
+    }
   }
 }

--- a/packages/deprecated/theme-registry/package.json
+++ b/packages/deprecated/theme-registry/package.json
@@ -40,14 +40,20 @@
     "react-native": "^0.68.0"
   },
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68.0",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios"
+      ]
+    }
   },
   "peerDependencies": {
     "react": "17.0.2",

--- a/packages/deprecated/themed-settings/package.json
+++ b/packages/deprecated/themed-settings/package.json
@@ -48,13 +48,19 @@
     "react-native": "^0.68.0"
   },
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios"
+      ]
+    }
   }
 }

--- a/packages/deprecated/theming-react-native/package.json
+++ b/packages/deprecated/theming-react-native/package.json
@@ -50,14 +50,20 @@
     "react-native": "^0.68.0"
   },
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/experimental/ActivityIndicator/package.json
+++ b/packages/experimental/ActivityIndicator/package.json
@@ -27,32 +27,39 @@
   },
   "dependencies": {
     "@fluentui-react-native/framework": "0.8.37",
-    "assert-never": "^1.2.1",
-    "react-native-svg": "12.5.0"
+    "assert-never": "^1.2.1"
   },
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/scripts": "^0.1.1",
     "@types/react-native": "^0.68.0",
     "react": "17.0.2",
-    "react-native": "^0.68.0"
+    "react-native": "^0.68.0",
+    "react-native-svg": "^12.3.0"
   },
   "peerDependencies": {
     "react": "17.0.2",
-    "react-native": "^0.68.0"
+    "react-native": "^0.68.0",
+    "react-native-svg": "^12.3.0"
   },
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react",
-      "svg"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react",
+        "svg"
+      ]
+    }
   }
 }

--- a/packages/experimental/AppearanceAdditions/package.json
+++ b/packages/experimental/AppearanceAdditions/package.json
@@ -43,13 +43,19 @@
     "react-native": "^0.68.0"
   },
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/experimental/Avatar/package.json
+++ b/packages/experimental/Avatar/package.json
@@ -44,14 +44,20 @@
     "react-native": "^0.68.0"
   },
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/experimental/Button/package.json
+++ b/packages/experimental/Button/package.json
@@ -42,14 +42,20 @@
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/experimental/Checkbox/package.json
+++ b/packages/experimental/Checkbox/package.json
@@ -47,14 +47,20 @@
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/experimental/Drawer/package.json
+++ b/packages/experimental/Drawer/package.json
@@ -44,14 +44,20 @@
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/experimental/Dropdown/package.json
+++ b/packages/experimental/Dropdown/package.json
@@ -33,7 +33,7 @@
     "@fluentui-react-native/interactive-hooks": ">=0.22.14 <1.0.0",
     "@fluentui-react-native/text": ">=0.19.16 <1.0.0",
     "@fluentui-react-native/theme-tokens": "^0.24.1",
-    "react-native-svg": "12.5.0"
+    "react-native-svg": "^12.3.0"
   },
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
@@ -50,14 +50,20 @@
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/experimental/Dropdown/package.json
+++ b/packages/experimental/Dropdown/package.json
@@ -32,8 +32,7 @@
     "@fluentui-react-native/framework": "0.8.37",
     "@fluentui-react-native/interactive-hooks": ">=0.22.14 <1.0.0",
     "@fluentui-react-native/text": ">=0.19.16 <1.0.0",
-    "@fluentui-react-native/theme-tokens": "^0.24.1",
-    "react-native-svg": "^12.3.0"
+    "@fluentui-react-native/theme-tokens": "^0.24.1"
   },
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
@@ -41,11 +40,13 @@
     "@fluentui-react-native/test-tools": ">=0.1.1 <1.0.0",
     "@types/react-native": "^0.68.0",
     "react": "17.0.2",
-    "react-native": "^0.68.0"
+    "react-native": "^0.68.0",
+    "react-native-svg": "^12.3.0"
   },
   "peerDependencies": {
     "react": "17.0.2",
-    "react-native": "^0.68.0"
+    "react-native": "^0.68.0",
+    "react-native-svg": "^12.3.0"
   },
   "author": "",
   "license": "MIT",
@@ -62,7 +63,8 @@
         "core",
         "core-android",
         "core-ios",
-        "react"
+        "react",
+        "svg"
       ]
     }
   }

--- a/packages/experimental/Expander/package.json
+++ b/packages/experimental/Expander/package.json
@@ -47,15 +47,21 @@
     "react-native-windows": "^0.68.0"
   },
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "core-windows",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "core-windows",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/experimental/Link/package.json
+++ b/packages/experimental/Link/package.json
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "react": ">=17.0.2",
-    "react-native": ">=0.68.0"
+    "react-native": ">=0.68.0-0"
   },
   "author": "",
   "license": "MIT"

--- a/packages/experimental/MenuButton/package.json
+++ b/packages/experimental/MenuButton/package.json
@@ -29,8 +29,7 @@
     "@fluentui-react-native/contextual-menu": "^0.21.22",
     "@fluentui-react-native/experimental-button": "^0.16.84",
     "@fluentui-react-native/framework": "0.8.37",
-    "@fluentui-react-native/tokens": ">=0.20.6 <1.0.0",
-    "react-native-svg": "12.5.0"
+    "@fluentui-react-native/tokens": ">=0.20.6 <1.0.0"
   },
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
@@ -38,24 +37,32 @@
     "@office-iss/react-native-win32": "^0.68.0",
     "@types/react-native": "^0.68.0",
     "react": "17.0.2",
-    "react-native": "^0.68.0"
+    "react-native": "^0.68.0",
+    "react-native-svg": "^12.3.0"
   },
   "peerDependencies": {
     "react": "17.0.2",
-    "react-native": "^0.68.0"
+    "react-native": "^0.68.0",
+    "react-native-svg": "^12.3.0"
   },
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react",
-      "svg"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react",
+        "svg"
+      ]
+    }
   }
 }

--- a/packages/experimental/NativeDatePicker/package.json
+++ b/packages/experimental/NativeDatePicker/package.json
@@ -40,14 +40,20 @@
     "react-native": "^0.68.0"
   },
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/experimental/NativeFontMetrics/package.json
+++ b/packages/experimental/NativeFontMetrics/package.json
@@ -42,13 +42,19 @@
     "react-native": "^0.68.0"
   },
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/experimental/Popover/package.json
+++ b/packages/experimental/Popover/package.json
@@ -44,14 +44,20 @@
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/experimental/RadioGroup/package.json
+++ b/packages/experimental/RadioGroup/package.json
@@ -51,14 +51,20 @@
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/experimental/Shadow/package.json
+++ b/packages/experimental/Shadow/package.json
@@ -44,14 +44,20 @@
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/experimental/Shimmer/package.json
+++ b/packages/experimental/Shimmer/package.json
@@ -30,8 +30,7 @@
     "@fluentui-react-native/tokens": ">=0.20.6 <1.0.0",
     "@fluentui-react-native/theming-utils": ">=0.23.1 <1.0.0",
     "@fluentui-react-native/component-cache": "^1.4.2",
-    "@fluentui-react-native/use-styling": "^0.9.1",
-    "react-native-svg": "12.5.0"
+    "@fluentui-react-native/use-styling": "^0.9.1"
   },
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
@@ -39,23 +38,31 @@
     "@types/react-native": "^0.68.0",
     "assert-never": "^1.2.1",
     "react": "17.0.2",
-    "react-native": "^0.68.0"
+    "react-native": "^0.68.0",
+    "react-native-svg": "^12.3.0"
   },
   "peerDependencies": {
     "react": "17.0.2",
-    "react-native": "^0.68.0"
+    "react-native": "^0.68.0",
+    "react-native-svg": "^12.3.0"
   },
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "svg"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "svg"
+      ]
+    }
   }
 }

--- a/packages/experimental/Spinner/package.json
+++ b/packages/experimental/Spinner/package.json
@@ -28,32 +28,39 @@
   "dependencies": {
     "@fluentui-react-native/component-cache": "^1.4.2",
     "@fluentui-react-native/framework": "0.8.37",
-    "@fluentui-react-native/text": ">=0.19.16 <1.0.0",
-    "react-native-svg": "12.5.0"
+    "@fluentui-react-native/text": ">=0.19.16 <1.0.0"
   },
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/scripts": "^0.1.1",
     "@types/react-native": "^0.68.0",
     "react": "17.0.2",
-    "react-native": "^0.68.0"
+    "react-native": "^0.68.0",
+    "react-native-svg": "^12.3.0"
   },
   "peerDependencies": {
     "react": "17.0.2",
-    "react-native": "^0.68.0"
+    "react-native": "^0.68.0",
+    "react-native-svg": "^12.3.0"
   },
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react",
-      "svg"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react",
+        "svg"
+      ]
+    }
   }
 }

--- a/packages/experimental/Stack/package.json
+++ b/packages/experimental/Stack/package.json
@@ -33,9 +33,9 @@
   },
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
+    "@fluentui-react-native/scripts": "^0.1.1",
     "@fluentui-react-native/text": ">=0.19.16 <1.0.0",
     "@types/react-native": "^0.68.0",
-    "@fluentui-react-native/scripts": "^0.1.1",
     "react": "17.0.2",
     "react-native": "^0.68.0",
     "tslib": "^2.3.1"
@@ -47,14 +47,20 @@
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/experimental/Switch/package.json
+++ b/packages/experimental/Switch/package.json
@@ -50,14 +50,20 @@
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/experimental/Tabs/package.json
+++ b/packages/experimental/Tabs/package.json
@@ -52,14 +52,20 @@
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/experimental/Text/package.json
+++ b/packages/experimental/Text/package.json
@@ -43,14 +43,20 @@
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/framework/component-cache/package.json
+++ b/packages/framework/component-cache/package.json
@@ -43,14 +43,20 @@
     "react-native": "^0.68.0"
   },
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/framework/composition/package.json
+++ b/packages/framework/composition/package.json
@@ -47,13 +47,19 @@
     "react-native": "^0.68.0"
   },
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios"
+      ]
+    }
   }
 }

--- a/packages/framework/framework/package.json
+++ b/packages/framework/framework/package.json
@@ -58,15 +58,21 @@
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react",
-      "react-dom"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react",
+        "react-dom"
+      ]
+    }
   }
 }

--- a/packages/framework/framework/package.json
+++ b/packages/framework/framework/package.json
@@ -47,12 +47,10 @@
     "@types/react": "^17.0.2",
     "@types/react-native": "^0.68.0",
     "react": "17.0.2",
-    "react-dom": "17.0.2",
     "react-native": "^0.68.0"
   },
   "peerDependencies": {
     "react": "17.0.2",
-    "react-dom": "17.0.2",
     "react-native": "^0.68.0"
   },
   "author": "",
@@ -70,8 +68,7 @@
         "core",
         "core-android",
         "core-ios",
-        "react",
-        "react-dom"
+        "react"
       ]
     }
   }

--- a/packages/framework/merge-props/package.json
+++ b/packages/framework/merge-props/package.json
@@ -48,13 +48,19 @@
     "react-native": "^0.68.0"
   },
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios"
+      ]
+    }
   }
 }

--- a/packages/framework/theme/package.json
+++ b/packages/framework/theme/package.json
@@ -45,14 +45,20 @@
     "react-native": "^0.68.0"
   },
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/framework/themed-stylesheet/package.json
+++ b/packages/framework/themed-stylesheet/package.json
@@ -45,13 +45,19 @@
     "react-native": "^0.68.0"
   },
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios"
+      ]
+    }
   }
 }

--- a/packages/framework/use-slot/package.json
+++ b/packages/framework/use-slot/package.json
@@ -44,14 +44,20 @@
     "react-native": "^0.68.0"
   },
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/framework/use-slots/package.json
+++ b/packages/framework/use-slots/package.json
@@ -44,14 +44,20 @@
     "react-native": "^0.68.0"
   },
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/framework/use-styling/package.json
+++ b/packages/framework/use-styling/package.json
@@ -43,15 +43,21 @@
     "react-native": "^0.68.0"
   },
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   },
   "peerDependencies": {
     "react": "17.0.2",

--- a/packages/framework/use-tokens/package.json
+++ b/packages/framework/use-tokens/package.json
@@ -43,15 +43,21 @@
     "react-native": "^0.68.0"
   },
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   },
   "peerDependencies": {
     "react": "17.0.2",

--- a/packages/libraries/core/package.json
+++ b/packages/libraries/core/package.json
@@ -59,14 +59,20 @@
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/theming/android-theme/package.json
+++ b/packages/theming/android-theme/package.json
@@ -49,14 +49,20 @@
     "react-native": "^0.68.0"
   },
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/theming/apple-theme/package.json
+++ b/packages/theming/apple-theme/package.json
@@ -57,15 +57,21 @@
     "react-native-macos": "^0.68.0"
   },
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "core-macos",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "core-macos",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/theming/default-theme/package.json
+++ b/packages/theming/default-theme/package.json
@@ -51,14 +51,20 @@
     "react-native": "^0.68.0"
   },
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/theming/theme-tokens/package.json
+++ b/packages/theming/theme-tokens/package.json
@@ -49,14 +49,20 @@
     "react-native": "^0.68.0"
   },
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/theming/theme-types/package.json
+++ b/packages/theming/theme-types/package.json
@@ -43,14 +43,20 @@
     "react-native": "^0.68.0"
   },
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/theming/theming-utils/package.json
+++ b/packages/theming/theming-utils/package.json
@@ -47,15 +47,21 @@
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "core-windows",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "core-windows",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/theming/win32-theme/package.json
+++ b/packages/theming/win32-theme/package.json
@@ -54,14 +54,20 @@
     "react-native": "^0.68.0"
   },
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/utils/adapters/package.json
+++ b/packages/utils/adapters/package.json
@@ -45,15 +45,21 @@
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "core-macos",
-      "core-windows"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "core-macos",
+        "core-windows"
+      ]
+    }
   }
 }

--- a/packages/utils/interactive-hooks/package.json
+++ b/packages/utils/interactive-hooks/package.json
@@ -52,14 +52,20 @@
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/utils/styling/package.json
+++ b/packages/utils/styling/package.json
@@ -38,14 +38,20 @@
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios",
-      "react"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
   }
 }

--- a/packages/utils/tokens/package.json
+++ b/packages/utils/tokens/package.json
@@ -44,13 +44,19 @@
   "author": "",
   "license": "MIT",
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "core",
-      "core-android",
-      "core-ios"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios"
+      ]
+    }
   }
 }

--- a/scripts/align-deps-preset.js
+++ b/scripts/align-deps-preset.js
@@ -1,0 +1,14 @@
+module.exports = {
+  0.68: {
+    jest: {
+      name: 'jest',
+      version: '^27.0.0',
+      devOnly: true,
+    },
+    'test-app': {
+      name: 'react-native-test-app',
+      version: '^2.0.2',
+      devOnly: true,
+    },
+  },
+};

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -65,12 +65,20 @@
     ]
   },
   "rnx-kit": {
-    "reactNativeVersion": "^0.68",
-    "reactNativeDevVersion": "^0.68",
     "kitType": "library",
-    "capabilities": [
-      "metro-config",
-      "metro-react-native-babel-transformer"
-    ]
+    "alignDeps": {
+      "presets": [
+        "microsoft/react-native",
+        "./align-deps-preset.js"
+      ],
+      "requirements": [
+        "react-native@0.68"
+      ],
+      "capabilities": [
+        "jest",
+        "metro-config",
+        "metro-react-native-babel-transformer"
+      ]
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2580,6 +2580,11 @@
   resolved "https://registry.yarnpkg.com/@react-native/polyfills/-/polyfills-2.0.0.tgz#4c40b74655c83982c8cf47530ee7dc13d957b6aa"
   integrity sha512-K0aGNn1TjalKj+65D7ycc1//H9roAQ51GJVk5ZJQFb2teECGmzd86bYDC0aYdbRf7gtovescq4Zt6FR0tgXiHQ==
 
+"@rnx-kit/align-deps@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@rnx-kit/align-deps/-/align-deps-2.1.1.tgz#f36f7512b4f0215b5664eb81fedbb2a9ffbb7d77"
+  integrity sha512-O6FXwL/TLUdpcbDB5rBaggOgxpAN6wKLqTd1+h0bYa31sQ2KlOBPlTwdK9N0M7TrbMu5nDqjeeIRYlpOmHyBtA==
+
 "@rnx-kit/babel-preset-metro-react-native@^1.1.4":
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/@rnx-kit/babel-preset-metro-react-native/-/babel-preset-metro-react-native-1.1.4.tgz#7c526987208547614f7fc43ed6e001b183083dd7"
@@ -2630,7 +2635,7 @@
   dependencies:
     chalk "^4.1.0"
 
-"@rnx-kit/dep-check@^1.10.1", "@rnx-kit/dep-check@^1.13.5":
+"@rnx-kit/dep-check@^1.13.5":
   version "1.14.0"
   resolved "https://registry.yarnpkg.com/@rnx-kit/dep-check/-/dep-check-1.14.0.tgz#208f8695616179a2042c87096d9eca17db1f0a74"
   integrity sha512-NGlSI+AEYcrzmCcwjUbtrsWTp9RR16sReq7jEjKblv1o/XgmOMXA6MZ87lj6VL28EUorbBXebQnRrA8E9Hza4A==
@@ -12414,7 +12419,7 @@ react-native-svg-transformer@^1.0.0:
     "@svgr/plugin-svgo" "^6.1.2"
     path-dirname "^1.0.2"
 
-react-native-svg@12.5.0, react-native-svg@^12.5.0:
+react-native-svg@^12.3.0, react-native-svg@^12.5.0:
   version "12.5.0"
   resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-12.5.0.tgz#61e4395eb5eb52bbd0511b3c227473f7dbf98a16"
   integrity sha512-xVMA6QjwU2E30DHLzjmewjHSmby4mMMlUaiKnFCYPWpsezsaB3zHS7eURwKNJLmcRYOPi3f6aBhxvFTNj/5j/A==


### PR DESCRIPTION
### Platforms Impacted

- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Migrate all packages to `@rnx-kit/align-deps`.

Note that `@rnx-kit/dep-check` still gets pulled in by `@rnx-kit/cli` 0.14. We will upgrade the cli in a separate PR.