### PR TITLE
Update Basics.md with correct example

### DIFF
--- a/docs/pages/Theming/Basics.md
+++ b/docs/pages/Theming/Basics.md
@@ -57,7 +57,7 @@ import { Text } from 'react-native';
 export const AppContent = () => {
   const theme = useFluentTheme();
 
-  return <Text color={theme.colors.bodyText}>Hello World!</Text>;
+  return <Text style={{ color: theme.colors.bodyText }}>Hello World!</Text>;
 };
 ```
 


### PR DESCRIPTION
Made an update to the Accessing theme properties example, where it was not using the stock RN styling prop, and instead trying to use a color prop that doesn't exist on stock RN Text component.

### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Made an update to the Accessing theme properties example, where it was not using the stock RN styling prop, and instead trying to use a color prop that doesn't exist on stock RN Text component.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
