### PR TITLE
Notification: replace hardcoded colors with alias color tokens

### DIFF
--- a/change/@fluentui-react-native-notification-73702e85-e03e-4cd8-8c23-c39f3f918993.json
+++ b/change/@fluentui-react-native-notification-73702e85-e03e-4cd8-8c23-c39f3f918993.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Replace hardcoded colors with alias color tokens",
+  "packageName": "@fluentui-react-native/notification",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Notification/src/NotificationTokens.ios.ts
+++ b/packages/components/Notification/src/NotificationTokens.ios.ts
@@ -8,49 +8,17 @@ import { DynamicColorIOS } from 'react-native';
  * Fluent 2 colors are not yet in the token pipeline for iOS so DynamicColorIOS is necessary for dark mode
  */
 const notificationColors = {
-  background1: DynamicColorIOS({
-    light: '#FFFFFF',
-    dark: '#000000',
-  }),
-  background4: DynamicColorIOS({
-    light: '#FAFAFA',
-    dark: '#333333',
-  }),
-  background5: DynamicColorIOS({
-    light: '#F0F0F0',
-    dark: '#3D3D3D',
-  }),
   brandBackground4: DynamicColorIOS({
     light: '#EBF3FC',
     dark: '#082338',
-  }),
-  brandForeground1: DynamicColorIOS({
-    light: '#0F6CBD',
-    dark: '#479EF5',
   }),
   brandForeground4: DynamicColorIOS({
     light: '#0F6CBD',
     dark: '#77B7F7',
   }),
-  brandForegroundDisabled: DynamicColorIOS({
-    light: '#2886DE',
-    dark: '#2886DE', // not yet defined
-  }),
-  foreground2: DynamicColorIOS({
-    light: '#616161',
-    dark: '#D6D6D6',
-  }),
   foregroundDisabled2: DynamicColorIOS({
     light: '#FFFFFF',
     dark: '#3D3D3D',
-  }),
-  stroke2: DynamicColorIOS({
-    light: '#E0E0E0',
-    dark: '#3D3D3D',
-  }),
-  PaletteRedBackground1: DynamicColorIOS({
-    light: '#FDF6F6',
-    dark: '#3F1011',
   }),
   PaletteRedForeground1: DynamicColorIOS({
     light: '#9F282C',
@@ -111,12 +79,12 @@ export const defaultNotificationTokens: TokenSettings<NotificationTokens, Theme>
     primary: {
       backgroundColor: notificationColors.brandBackground4,
       color: notificationColors.brandForeground4,
-      disabledColor: notificationColors.brandForegroundDisabled,
+      disabledColor: t.colors.brandForegroundDisabled1,
       pressedColor: notificationColors.primaryPressed,
     },
     neutral: {
-      backgroundColor: notificationColors.background4,
-      color: notificationColors.foreground2,
+      backgroundColor: t.colors.neutralBackground4,
+      color: t.colors.neutralForeground2,
       disabledColor: notificationColors.foregroundDisabled2,
       pressedColor: notificationColors.neutralPressed,
     },
@@ -124,25 +92,25 @@ export const defaultNotificationTokens: TokenSettings<NotificationTokens, Theme>
       backgroundColor: notificationColors.brandBackground4,
       borderWidth: 0,
       color: notificationColors.brandForeground4,
-      disabledColor: notificationColors.brandForegroundDisabled,
+      disabledColor: t.colors.brandForegroundDisabled1,
       pressedColor: notificationColors.primaryPressed,
     },
     primaryOutlineBar: {
-      backgroundColor: notificationColors.background1,
-      borderColor: notificationColors.stroke2,
-      color: notificationColors.brandForeground1,
-      disabledColor: notificationColors.brandForegroundDisabled,
+      backgroundColor: t.colors.neutralBackground1,
+      borderColor: t.colors.neutralStroke2,
+      color: t.colors.brandForeground1,
+      disabledColor: t.colors.brandForegroundDisabled1,
       pressedColor: notificationColors.primaryPressed,
     },
     neutralBar: {
-      backgroundColor: notificationColors.background5,
+      backgroundColor: t.colors.neutralBackground5,
       borderWidth: 0,
-      color: notificationColors.foreground2,
+      color: t.colors.neutralForeground2,
       disabledColor: notificationColors.foregroundDisabled2,
       pressedColor: notificationColors.neutralPressed,
     },
     danger: {
-      backgroundColor: notificationColors.PaletteRedBackground1,
+      backgroundColor: t.colors.dangerBackground1,
       color: notificationColors.PaletteRedForeground1,
       pressedColor: notificationColors.dangerPressed,
     },

--- a/packages/components/Notification/src/NotificationTokens.ios.ts
+++ b/packages/components/Notification/src/NotificationTokens.ios.ts
@@ -34,8 +34,8 @@ export const defaultNotificationTokens: TokenSettings<NotificationTokens, Theme>
   ({
     backgroundColor: t.colors.background,
     borderColor: 'transparent',
-    borderRadius: 12,
-    borderWidth: 1,
+    borderRadius: globalTokens.corner.radius120,
+    borderWidth: globalTokens.stroke.width10,
     color: t.colors.brandForeground1,
     fontFamily: 'primary',
     fontLetterSpacing: -0.24,
@@ -47,7 +47,7 @@ export const defaultNotificationTokens: TokenSettings<NotificationTokens, Theme>
     paddingVertical: globalTokens.size120,
     shadowToken: t.shadows.shadow16,
     isBar: {
-      borderRadius: 0,
+      borderRadius: globalTokens.corner.radiusNone,
       fontWeight: '400',
       shadowToken: undefined,
     },
@@ -65,7 +65,7 @@ export const defaultNotificationTokens: TokenSettings<NotificationTokens, Theme>
     },
     primaryBar: {
       backgroundColor: t.colors.brandBackgroundTint,
-      borderWidth: 0,
+      borderWidth: globalTokens.stroke.widthNone,
       color: t.colors.brandForegroundTint,
       disabledColor: t.colors.brandForegroundDisabled1,
       pressedColor: notificationColors.primaryPressed,
@@ -79,7 +79,7 @@ export const defaultNotificationTokens: TokenSettings<NotificationTokens, Theme>
     },
     neutralBar: {
       backgroundColor: t.colors.neutralBackground5,
-      borderWidth: 0,
+      borderWidth: globalTokens.stroke.widthNone,
       color: t.colors.neutralForeground2,
       disabledColor: t.colors.neutralForegroundDisabled2,
       pressedColor: notificationColors.neutralPressed,

--- a/packages/components/Notification/src/NotificationTokens.ios.ts
+++ b/packages/components/Notification/src/NotificationTokens.ios.ts
@@ -8,31 +8,6 @@ import { DynamicColorIOS } from 'react-native';
  * Fluent 2 colors are not yet in the token pipeline for iOS so DynamicColorIOS is necessary for dark mode
  */
 const notificationColors = {
-  brandBackground4: DynamicColorIOS({
-    light: '#EBF3FC',
-    dark: '#082338',
-  }),
-  brandForeground4: DynamicColorIOS({
-    light: '#0F6CBD',
-    dark: '#77B7F7',
-  }),
-  foregroundDisabled2: DynamicColorIOS({
-    light: '#FFFFFF',
-    dark: '#3D3D3D',
-  }),
-  PaletteRedForeground1: DynamicColorIOS({
-    light: '#9F282C',
-    dark: '#E37D81',
-  }),
-  PaletteYellowBackground1: DynamicColorIOS({
-    light: '#FFFBD6',
-    dark: '#4C4400',
-  }),
-  PaletteYellowForeground1: DynamicColorIOS({
-    light: '#4C4400',
-    dark: '#FDEE65',
-  }),
-
   /**
    * None of the foreground tokens above have pressed versions so the foreground color with an alpha value is used.
    * The FluentUI Apple NotificationView was used to color match.
@@ -77,21 +52,21 @@ export const defaultNotificationTokens: TokenSettings<NotificationTokens, Theme>
       shadowToken: undefined,
     },
     primary: {
-      backgroundColor: notificationColors.brandBackground4,
-      color: notificationColors.brandForeground4,
+      backgroundColor: t.colors.brandBackgroundTint,
+      color: t.colors.brandForegroundTint,
       disabledColor: t.colors.brandForegroundDisabled1,
       pressedColor: notificationColors.primaryPressed,
     },
     neutral: {
       backgroundColor: t.colors.neutralBackground4,
       color: t.colors.neutralForeground2,
-      disabledColor: notificationColors.foregroundDisabled2,
+      disabledColor: t.colors.neutralForegroundDisabled2,
       pressedColor: notificationColors.neutralPressed,
     },
     primaryBar: {
-      backgroundColor: notificationColors.brandBackground4,
+      backgroundColor: t.colors.brandBackgroundTint,
       borderWidth: 0,
-      color: notificationColors.brandForeground4,
+      color: t.colors.brandForegroundTint,
       disabledColor: t.colors.brandForegroundDisabled1,
       pressedColor: notificationColors.primaryPressed,
     },
@@ -106,17 +81,17 @@ export const defaultNotificationTokens: TokenSettings<NotificationTokens, Theme>
       backgroundColor: t.colors.neutralBackground5,
       borderWidth: 0,
       color: t.colors.neutralForeground2,
-      disabledColor: notificationColors.foregroundDisabled2,
+      disabledColor: t.colors.neutralForegroundDisabled2,
       pressedColor: notificationColors.neutralPressed,
     },
     danger: {
       backgroundColor: t.colors.dangerBackground1,
-      color: notificationColors.PaletteRedForeground1,
+      color: t.colors.dangerForeground1,
       pressedColor: notificationColors.dangerPressed,
     },
     warning: {
-      backgroundColor: notificationColors.PaletteYellowBackground1,
-      color: notificationColors.PaletteYellowForeground1,
+      backgroundColor: t.colors.warningBackground1,
+      color: t.colors.warningForeground1,
       pressedColor: notificationColors.warningPressed,
     },
   } as NotificationTokens);

--- a/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
+++ b/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
@@ -153,16 +153,7 @@ exports[`Notification component tests Notification default 1`] = `
           },
         }
       }
-      disabledColor={
-        Object {
-          "dynamic": Object {
-            "dark": "#2886DE",
-            "highContrastDark": undefined,
-            "highContrastLight": undefined,
-            "light": "#2886DE",
-          },
-        }
-      }
+      disabledColor="#2886de"
       enableFocusRing={true}
       focusable={true}
       minWidth={0}

--- a/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
+++ b/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
@@ -5,14 +5,7 @@ exports[`Notification component tests Notification default 1`] = `
   style={
     Object {
       "alignSelf": "center",
-      "backgroundColor": Object {
-        "dynamic": Object {
-          "dark": "#082338",
-          "highContrastDark": undefined,
-          "highContrastLight": undefined,
-          "light": "#EBF3FC",
-        },
-      },
+      "backgroundColor": "#cfe4fa",
       "borderColor": "transparent",
       "borderRadius": 12,
       "bottom": undefined,
@@ -59,14 +52,7 @@ exports[`Notification component tests Notification default 1`] = `
       Object {
         "alignItems": undefined,
         "alignSelf": "center",
-        "backgroundColor": Object {
-          "dynamic": Object {
-            "dark": "#082338",
-            "highContrastDark": undefined,
-            "highContrastLight": undefined,
-            "light": "#EBF3FC",
-          },
-        },
+        "backgroundColor": "#cfe4fa",
         "borderBottomWidth": undefined,
         "borderColor": "transparent",
         "borderEndWidth": undefined,
@@ -117,14 +103,7 @@ exports[`Notification component tests Notification default 1`] = `
         style={
           Object {
             "alignSelf": "flex-start",
-            "color": Object {
-              "dynamic": Object {
-                "dark": "#77B7F7",
-                "highContrastDark": undefined,
-                "highContrastLight": undefined,
-                "light": "#0F6CBD",
-              },
-            },
+            "color": "#0f548c",
             "fontFamily": "System",
             "fontSize": 15,
             "fontWeight": "400",
@@ -143,16 +122,7 @@ exports[`Notification component tests Notification default 1`] = `
       accessible={true}
       appearance="subtle"
       collapsable={false}
-      color={
-        Object {
-          "dynamic": Object {
-            "dark": "#77B7F7",
-            "highContrastDark": undefined,
-            "highContrastLight": undefined,
-            "light": "#0F6CBD",
-          },
-        }
-      }
+      color="#0f548c"
       disabledColor="#2886de"
       enableFocusRing={true}
       focusable={true}
@@ -202,14 +172,7 @@ exports[`Notification component tests Notification default 1`] = `
         numberOfLines={0}
         style={
           Object {
-            "color": Object {
-              "dynamic": Object {
-                "dark": "#77B7F7",
-                "highContrastDark": undefined,
-                "highContrastLight": undefined,
-                "light": "#0F6CBD",
-              },
-            },
+            "color": "#0f548c",
             "fontFamily": "System",
             "fontSize": 15,
             "fontWeight": "600",


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

When Notification was implemented, iOS alias color tokens were not set up yet, so the colors were hardcoded into the tokens files. Now that alias color tokens are in, replace the hardcoded values with the actual tokens.

There have been some design changes since when the FURN notification was first implemented, so some colors/color names have changes. Below is a table mapping what the old hardcoded value was called to what alias token it was replaced with.

Also went ahead and updated Notification with stroke width/corner radius tokens.

Notes:
- Did not update the hardcoded values in NotificationTokens.ts. Wasn't sure if this should be updated or not - if it was updated then the Notification component will look strange on win32/macOS, it will only look the same for Android since Notification is using some tokens that are only present for iOS/Android

| Original color | Alias token color | Notes |
| - | - | - |
| background1 (light: #FFFFFF, dark: #000000) | neutralBackground1 | 
| background4 (light: #FAFAFA, dark: #333333) | neutralBackground4 |
| background5 (light: #F0F0F0, dark: #3D3D3D) | neutralBackground5 |
| brandBackground4 (light: #EBF3FC, dark: #082338) | brandBackgroundTint (light: #CFE4FA, dark: 0C3B5E)| **COLOR CHANGE |
| brandForeground1 \(light: #0F6CBD, dark: #479EF5) | brandForeground1 | 
| brandForeground4 (light: #0F6CBD, dark: #77B7F7) | brandForegroundTint (light: #0F548C, dark: #96C6FA) | **COLOR CHANGE |
| brandForegroundDisabled (light: #2886DE, dark: #2886DE) | brandForegroundDisabled1 |
| foreground2 (light: #616161, dark: #D6D6D6) | neutralForeground2 |
| foregroundDisabled2 (light: #FFFFFF, #3D3D3D) | neutralForegroundDisabled2 (light: #FFFFFF, dark: #2E2E2E) | **COLOR CHANGE | 
| stroke2 (light: #E0E0E0, dark: #3D3D3D) | neutralStroke2 |
| PaletteRedBackground1 (light: #FDF6F6, dark: #3F1011) | dangerBackground1 |
| PaletteRedForeground1 (light: #9F282C, dark: #E37D81) | dangerForeground1 (light: #BC2F32, dark: #E37D80) | **COLOR CHANGE |
| PaletteYellowBackground1 (light: #FFFBD6, dark: #4C4400) | warningBackground1 (light: #FFFEF5, dark: #4C4400) | ** COLOR CHANGE |
| PaletteYellowForeground1 (light: #4C4400, dark: #FDEE65) | warningForeground1 (light: #817400, dark: #FEEE66) | ** COLOR CHANGE | 
| primaryPressed (light: #0F6CBD30, dark: #77B7F756) | N/A, left hardcoded |
| neutralPressed (light: #61616145, dark: #D6D6D682 | N/A, left hardcoded |
| dangerPressed (light: #9F282C32, dark: #E37D8159 | N/A, left hardcoded |
| warningPressed (light: #4C440033, dark: #FDEE6564 | N/A, left hardcoded |

About the last four pressed state colors - planning to keep them hardcoded for now until either we create appropriate alias tokens for them or decide to not have pressed states altogether.

For reference, these are what those colors are for (default on left, pressed on right)

![image](https://user-images.githubusercontent.com/78454019/216123608-82ce3f1a-c6da-4281-8f2d-e3299dd514a2.png)


### Verification


https://user-images.githubusercontent.com/78454019/215622458-d8127a85-7518-4ab9-b47e-c7e1c218e797.mov


https://user-images.githubusercontent.com/78454019/215622694-fca12278-486b-45ea-8c1d-454e1113f015.mp4



### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
