### PR TITLE
Add missing eslint configs to various packages that were missing a config

### DIFF
--- a/change/@fluentui-react-native-avatar-66783c6e-18a0-4564-b8c7-2934323603f1.json
+++ b/change/@fluentui-react-native-avatar-66783c6e-18a0-4564-b8c7-2934323603f1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add eslint to packages missing a config",
+  "packageName": "@fluentui-react-native/avatar",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-codemods-772a4813-c372-42da-84ea-7e004a29e1b6.json
+++ b/change/@fluentui-react-native-codemods-772a4813-c372-42da-84ea-7e004a29e1b6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add eslint to packages missing a config",
+  "packageName": "@fluentui-react-native/codemods",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-composition-2d011c8d-189f-403d-a0c0-79e9638cd7d7.json
+++ b/change/@fluentui-react-native-composition-2d011c8d-189f-403d-a0c0-79e9638cd7d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add eslint to packages missing a config",
+  "packageName": "@fluentui-react-native/composition",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-activity-indicator-6dd7a58d-01bc-4936-b5c5-8c7ccb67d6ef.json
+++ b/change/@fluentui-react-native-experimental-activity-indicator-6dd7a58d-01bc-4936-b5c5-8c7ccb67d6ef.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add eslint to packages missing a config",
+  "packageName": "@fluentui-react-native/experimental-activity-indicator",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-appearance-additions-c991346d-23d9-4b9c-9539-146e066484c8.json
+++ b/change/@fluentui-react-native-experimental-appearance-additions-c991346d-23d9-4b9c-9539-146e066484c8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add eslint to packages missing a config",
+  "packageName": "@fluentui-react-native/experimental-appearance-additions",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-avatar-ab72a378-d1b2-4ade-bb62-1971237d3cf0.json
+++ b/change/@fluentui-react-native-experimental-avatar-ab72a378-d1b2-4ade-bb62-1971237d3cf0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add eslint to packages missing a config",
+  "packageName": "@fluentui-react-native/experimental-avatar",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-checkbox-6ad97e36-aca8-4b17-9d77-4ad9990e2893.json
+++ b/change/@fluentui-react-native-experimental-checkbox-6ad97e36-aca8-4b17-9d77-4ad9990e2893.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add eslint to packages missing a config",
+  "packageName": "@fluentui-react-native/experimental-checkbox",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-drawer-97982208-d1ee-4d8d-8929-0742471ffad4.json
+++ b/change/@fluentui-react-native-experimental-drawer-97982208-d1ee-4d8d-8929-0742471ffad4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add eslint to packages missing a config",
+  "packageName": "@fluentui-react-native/experimental-drawer",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-expander-6160c957-bd5d-4bea-a61c-2937647b51dd.json
+++ b/change/@fluentui-react-native-experimental-expander-6160c957-bd5d-4bea-a61c-2937647b51dd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add eslint to packages missing a config",
+  "packageName": "@fluentui-react-native/experimental-expander",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-native-date-picker-13fc0b07-4a02-4982-81b6-91750751b997.json
+++ b/change/@fluentui-react-native-experimental-native-date-picker-13fc0b07-4a02-4982-81b6-91750751b997.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add eslint to packages missing a config",
+  "packageName": "@fluentui-react-native/experimental-native-date-picker",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-native-font-metrics-36789b98-320a-4db4-b02e-b4a099c822da.json
+++ b/change/@fluentui-react-native-experimental-native-font-metrics-36789b98-320a-4db4-b02e-b4a099c822da.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add eslint to packages missing a config",
+  "packageName": "@fluentui-react-native/experimental-native-font-metrics",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-spinner-76ed880f-e944-4a0c-aa6a-2929b6c68ca3.json
+++ b/change/@fluentui-react-native-spinner-76ed880f-e944-4a0c-aa6a-2929b6c68ca3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add eslint to packages missing a config",
+  "packageName": "@fluentui-react-native/spinner",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-theme-b8741cec-4a53-4f80-9a96-de93e77acec8.json
+++ b/change/@fluentui-react-native-theme-b8741cec-4a53-4f80-9a96-de93e77acec8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add eslint to packages missing a config",
+  "packageName": "@fluentui-react-native/theme",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-use-slot-958d66dc-a110-4c76-ba0a-5ec3768b1848.json
+++ b/change/@fluentui-react-native-use-slot-958d66dc-a110-4c76-ba0a-5ec3768b1848.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add eslint to packages missing a config",
+  "packageName": "@fluentui-react-native/use-slot",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-use-slots-41333912-405f-4f7c-9284-f56acdcbb69c.json
+++ b/change/@fluentui-react-native-use-slots-41333912-405f-4f7c-9284-f56acdcbb69c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add eslint to packages missing a config",
+  "packageName": "@fluentui-react-native/use-slots",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-use-styling-5f60bebc-189c-4250-a8b9-ecb73fd36439.json
+++ b/change/@fluentui-react-native-use-styling-5f60bebc-189c-4250-a8b9-ecb73fd36439.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add eslint to packages missing a config",
+  "packageName": "@fluentui-react-native/use-styling",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-use-tokens-315d0410-96f3-459e-88a2-9e9474353967.json
+++ b/change/@fluentui-react-native-use-tokens-315d0410-96f3-459e-88a2-9e9474353967.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add eslint to packages missing a config",
+  "packageName": "@fluentui-react-native/use-tokens",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabricshared-foundation-tokens-c7b1db50-41d3-46bf-9b15-9a5e3e06e95c.json
+++ b/change/@uifabricshared-foundation-tokens-c7b1db50-41d3-46bf-9b15-9a5e3e06e95c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add eslint to packages missing a config",
+  "packageName": "@uifabricshared/foundation-tokens",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/codemods/.eslintrc.js
+++ b/packages/codemods/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/codemods/src/transforms/__testfixtures__/button-v0-to-v1.input.tsx
+++ b/packages/codemods/src/transforms/__testfixtures__/button-v0-to-v1.input.tsx
@@ -1,8 +1,8 @@
 import { Button, PrimaryButton, StealthButton } from '@fluentui/react-native';
-import { IFocusable } from '@fluentui-react-native/interactive-hooks';
+import type { IFocusable } from '@fluentui-react-native/interactive-hooks';
 import { Stack } from '@fluentui-react-native/stack';
 import * as React from 'react';
-import { SvgIconProps } from '@fluentui-react-native/icon';
+import type { SvgIconProps } from '@fluentui-react-native/icon';
 
 export const ButtonFocusTest_deprecated: React.FunctionComponent = () => {
   const [state, setState] = React.useState({

--- a/packages/codemods/src/transforms/__testfixtures__/button-v0-to-v1.output.tsx
+++ b/packages/codemods/src/transforms/__testfixtures__/button-v0-to-v1.output.tsx
@@ -1,8 +1,8 @@
 import { ButtonV1 as Button } from '@fluentui/react-native';
-import { IFocusable } from '@fluentui-react-native/interactive-hooks';
+import type { IFocusable } from '@fluentui-react-native/interactive-hooks';
 import { Stack } from '@fluentui-react-native/stack';
 import * as React from 'react';
-import { SvgIconProps } from '@fluentui-react-native/icon';
+import type { SvgIconProps } from '@fluentui-react-native/icon';
 
 export const ButtonFocusTest_deprecated: React.FunctionComponent = () => {
   const [state, setState] = React.useState({

--- a/packages/codemods/src/transforms/__testfixtures__/deprecate-exports.input.tsx
+++ b/packages/codemods/src/transforms/__testfixtures__/deprecate-exports.input.tsx
@@ -1,6 +1,6 @@
-import { IPartialTheme, ITheme, ThemeRegistry } from './Theme.types';
+import type { IPartialTheme, ITheme, ThemeRegistry } from './Theme.types';
 import { createPlatformThemeRegistry } from './platform';
-import { IProcessTheme, IThemeEventListener, IThemeRegistry } from '@uifabricshared/theme-registry';
+import type { IProcessTheme, IThemeEventListener, IThemeRegistry } from '@uifabricshared/theme-registry';
 
 export { ITheme, IPartialTheme } from '@uifabricshared/theming-ramp';
 export type IThemeDefinition = IPartialTheme | IProcessTheme<ITheme, IPartialTheme>;

--- a/packages/codemods/src/transforms/__testfixtures__/deprecate-exports.output.tsx
+++ b/packages/codemods/src/transforms/__testfixtures__/deprecate-exports.output.tsx
@@ -1,6 +1,6 @@
-import { IPartialTheme, ITheme, ThemeRegistry } from './Theme.types';
+import type { IPartialTheme, ITheme, ThemeRegistry } from './Theme.types';
 import { createPlatformThemeRegistry } from './platform';
-import { IProcessTheme, IThemeEventListener, IThemeRegistry } from '@uifabricshared/theme-registry';
+import type { IProcessTheme, IThemeEventListener, IThemeRegistry } from '@uifabricshared/theme-registry';
 
 /**
  * @deprecated

--- a/packages/codemods/src/transforms/button-v0-to-v1.ts
+++ b/packages/codemods/src/transforms/button-v0-to-v1.ts
@@ -1,4 +1,4 @@
-import { Transform, JSCodeshift, FileInfo, API, Options, ImportDeclaration, ASTPath, JSXElement } from 'jscodeshift';
+import type { Transform, JSCodeshift, FileInfo, API, Options, ImportDeclaration, ASTPath, JSXElement } from 'jscodeshift';
 
 export const transform: Transform = (fileInfo: FileInfo, api: API, options: Options) => {
   const j: JSCodeshift = api.jscodeshift;

--- a/packages/codemods/src/transforms/deprecate-exports.ts
+++ b/packages/codemods/src/transforms/deprecate-exports.ts
@@ -1,4 +1,4 @@
-import { Transform, JSCodeshift, FileInfo, API, Options } from 'jscodeshift';
+import type { Transform, JSCodeshift, FileInfo, API, Options } from 'jscodeshift';
 
 export const transform: Transform = (fileInfo: FileInfo, api: API, options: Options) => {
   const j: JSCodeshift = api.jscodeshift;

--- a/packages/components/Avatar/.eslintrc.js
+++ b/packages/components/Avatar/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/components/Avatar/src/Avatar.styling.ts
+++ b/packages/components/Avatar/src/Avatar.styling.ts
@@ -1,17 +1,15 @@
-import {
-  AvatarName,
+import type {
   AvatarTokens,
   AvatarConfigurableProps,
   AvatarSlotProps,
   AvatarProps,
-  AvatarColors,
-  AvatarSizesForTokens,
   AvatarNamedColor,
-  ColorSchemes,
   AvatarColorSchemes,
 } from './Avatar.types';
+import { AvatarName, AvatarColors, AvatarSizesForTokens, ColorSchemes } from './Avatar.types';
 import { Platform } from 'react-native';
-import { Theme, UseStylingOptions, buildProps } from '@fluentui-react-native/framework';
+import type { Theme, UseStylingOptions } from '@fluentui-react-native/framework';
+import { buildProps } from '@fluentui-react-native/framework';
 import { defaultAvatarTokens } from './AvatarTokens';
 import { borderStyles, fontStyles } from '@fluentui-react-native/tokens';
 import { getRingConfig, getRingSpacing, getIconStyles } from './stylingUtils';

--- a/packages/components/Avatar/src/Avatar.tsx
+++ b/packages/components/Avatar/src/Avatar.tsx
@@ -1,9 +1,11 @@
 /** @jsx withSlots */
 import { Image, View, Text, Platform } from 'react-native';
 import { Fragment } from 'react';
-import { AvatarProps, AvatarType, AvatarName, AvatarState, AvatarSlotProps } from './Avatar.types';
+import type { AvatarProps, AvatarType, AvatarState, AvatarSlotProps } from './Avatar.types';
+import { AvatarName } from './Avatar.types';
 import { stylingSettings } from './Avatar.styling';
-import { compose, UseSlots, mergeProps, withSlots, Slots } from '@fluentui-react-native/framework';
+import type { UseSlots, Slots } from '@fluentui-react-native/framework';
+import { compose, mergeProps, withSlots } from '@fluentui-react-native/framework';
 import { useAvatar } from './useAvatar';
 import { PresenceBadge } from '@fluentui-react-native/badge';
 import { Icon } from '@fluentui-react-native/icon';

--- a/packages/components/Avatar/src/Avatar.types.ts
+++ b/packages/components/Avatar/src/Avatar.types.ts
@@ -1,9 +1,9 @@
 import type { IViewProps } from '@fluentui-react-native/adapters';
-import { ImageProps, ViewProps, TextProps, ColorValue } from 'react-native';
-import { IBackgroundColorTokens, IForegroundColorTokens, IBorderTokens, FontTokens } from '@fluentui-react-native/tokens';
-import { PresenceBadgeProps, BadgeSize, PresenceBadgeStatus } from '@fluentui-react-native/badge';
-import { IconProps, IconSourcesType } from '@fluentui-react-native/icon';
-import { SvgProps } from 'react-native-svg';
+import type { ImageProps, ViewProps, TextProps, ColorValue } from 'react-native';
+import type { IBackgroundColorTokens, IForegroundColorTokens, IBorderTokens, FontTokens } from '@fluentui-react-native/tokens';
+import type { PresenceBadgeProps, BadgeSize, PresenceBadgeStatus } from '@fluentui-react-native/badge';
+import type { IconProps, IconSourcesType } from '@fluentui-react-native/icon';
+import type { SvgProps } from 'react-native-svg';
 
 export const AvatarName = 'Avatar';
 export const AvatarSizesForTokens = [

--- a/packages/components/Avatar/src/AvatarTokens.android.ts
+++ b/packages/components/Avatar/src/AvatarTokens.android.ts
@@ -1,6 +1,6 @@
-import { Theme } from '@fluentui-react-native/framework';
-import { TokenSettings } from '@fluentui-react-native/use-styling';
-import { AvatarTokens } from '.';
+import type { Theme } from '@fluentui-react-native/framework';
+import type { TokenSettings } from '@fluentui-react-native/use-styling';
+import type { AvatarTokens } from '.';
 import { globalTokens } from '@fluentui-react-native/theme-tokens';
 
 export const defaultAvatarTokens: TokenSettings<AvatarTokens, Theme> = (t: Theme) =>

--- a/packages/components/Avatar/src/AvatarTokens.ts
+++ b/packages/components/Avatar/src/AvatarTokens.ts
@@ -1,6 +1,6 @@
-import { Theme } from '@fluentui-react-native/framework';
-import { TokenSettings } from '@fluentui-react-native/use-styling';
-import { AvatarTokens } from '.';
+import type { Theme } from '@fluentui-react-native/framework';
+import type { TokenSettings } from '@fluentui-react-native/use-styling';
+import type { AvatarTokens } from '.';
 import { globalTokens } from '@fluentui-react-native/theme-tokens';
 
 export const defaultAvatarTokens: TokenSettings<AvatarTokens, Theme> = (t: Theme) =>

--- a/packages/components/Avatar/src/AvatarTokens.win32.ts
+++ b/packages/components/Avatar/src/AvatarTokens.win32.ts
@@ -1,6 +1,6 @@
-import { Theme } from '@fluentui-react-native/framework';
-import { TokenSettings } from '@fluentui-react-native/use-styling';
-import { AvatarTokens } from '.';
+import type { Theme } from '@fluentui-react-native/framework';
+import type { TokenSettings } from '@fluentui-react-native/use-styling';
+import type { AvatarTokens } from '.';
 import { globalTokens } from '@fluentui-react-native/theme-tokens';
 
 export const defaultAvatarTokens: TokenSettings<AvatarTokens, Theme> = (t: Theme) =>

--- a/packages/components/Avatar/src/index.ts
+++ b/packages/components/Avatar/src/index.ts
@@ -1,3 +1,20 @@
-export * from './Avatar';
-export * from './Avatar.types';
+export { Avatar, avatarLookup } from './Avatar';
+export { AvatarColors, AvatarName, AvatarSizes, AvatarSizesForTokens, ColorSchemes } from './Avatar.types';
+export type {
+  AvatarActive,
+  AvatarActiveAppearance,
+  AvatarColor,
+  AvatarColorSchemes,
+  AvatarConfigurableProps,
+  AvatarInfo,
+  AvatarNamedColor,
+  AvatarProps,
+  AvatarShape,
+  AvatarSize,
+  AvatarSlotProps,
+  AvatarState,
+  AvatarTokens,
+  AvatarType,
+  RingConfig,
+} from './Avatar.types';
 export { useAvatar } from './useAvatar';

--- a/packages/components/Avatar/src/stylingUtils.android.ts
+++ b/packages/components/Avatar/src/stylingUtils.android.ts
@@ -1,5 +1,5 @@
 import { globalTokens } from '@fluentui-react-native/theme-tokens';
-import { RingConfig, AvatarTokens } from './Avatar.types';
+import type { RingConfig, AvatarTokens } from './Avatar.types';
 
 export function getRingConfig(tokens: AvatarTokens): RingConfig {
   const { size, ringThickness } = tokens;

--- a/packages/components/Avatar/src/stylingUtils.ts
+++ b/packages/components/Avatar/src/stylingUtils.ts
@@ -1,5 +1,5 @@
 import { globalTokens } from '@fluentui-react-native/theme-tokens';
-import { RingConfig, AvatarTokens } from './Avatar.types';
+import type { RingConfig, AvatarTokens } from './Avatar.types';
 
 export function getRingConfig(tokens: AvatarTokens): RingConfig {
   const { size, ringThickness } = tokens;

--- a/packages/components/Avatar/src/useAvatar.ts
+++ b/packages/components/Avatar/src/useAvatar.ts
@@ -1,6 +1,7 @@
-import { ImageProps, ImageSourcePropType } from 'react-native';
-import { AvatarProps, AvatarInfo, AvatarState, AvatarColors, AvatarSize, AvatarColor } from './Avatar.types';
-import { PresenceBadgeProps } from '@fluentui-react-native/badge';
+import type { ImageProps, ImageSourcePropType } from 'react-native';
+import type { AvatarProps, AvatarInfo, AvatarState, AvatarSize, AvatarColor } from './Avatar.types';
+import { AvatarColors } from './Avatar.types';
+import type { PresenceBadgeProps } from '@fluentui-react-native/badge';
 import { titles, multiWordTitles } from './titles';
 import { getHashCodeWeb } from './getHashCode';
 import { createIconProps } from '@fluentui-react-native/icon';

--- a/packages/deprecated/foundation-tokens/.eslintrc.js
+++ b/packages/deprecated/foundation-tokens/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/deprecated/foundation-tokens/src/MockButton.ts
+++ b/packages/deprecated/foundation-tokens/src/MockButton.ts
@@ -1,17 +1,20 @@
-import {
+import type {
   IMockTextTokens,
   IMockColorTokens,
   IMockBorderTokens,
   IMockForegroundColorTokens,
   IMockCaptionTextTokens,
+} from './MockTokens';
+import {
   standardTextTokens,
   standardForegroundColorTokens,
   standardBackgroundColorTokens,
   standardBorderTokens,
   standardCaptionTokens,
 } from './MockTokens';
-import { IMockBaseProps, mockCreate, stockFakeComponent } from './MockComponent';
-import { IComponentSettings } from '@uifabricshared/foundation-settings';
+import type { IMockBaseProps } from './MockComponent';
+import { mockCreate, stockFakeComponent } from './MockComponent';
+import type { IComponentSettings } from '@uifabricshared/foundation-settings';
 
 export type IMockTextProps = IMockTextTokens & IMockForegroundColorTokens & IMockBaseProps;
 export type IMockViewProps = IMockBaseProps;

--- a/packages/deprecated/foundation-tokens/src/MockComponent.ts
+++ b/packages/deprecated/foundation-tokens/src/MockComponent.ts
@@ -1,10 +1,11 @@
-import { IMockTheme } from './MockTheme';
-import { ITargetHasToken, IComponentTokens, IStyleFactories } from './Token.types';
-import { mergeSettings, ISlotProps, IComponentSettings } from '@uifabricshared/foundation-settings';
-import { StyleProp } from '@fluentui-react-native/merge-props';
+import type { IMockTheme } from './MockTheme';
+import type { ITargetHasToken, IComponentTokens, IStyleFactories } from './Token.types';
+import type { ISlotProps, IComponentSettings } from '@uifabricshared/foundation-settings';
+import { mergeSettings } from '@uifabricshared/foundation-settings';
+import type { StyleProp } from '@fluentui-react-native/merge-props';
 import { processTokens } from './Token';
 import { buildComponentTokens } from './Token.function';
-import { GetMemoValue } from '@fluentui-react-native/memo-cache';
+import type { GetMemoValue } from '@fluentui-react-native/memo-cache';
 
 export type ICSSStyle = React.CSSProperties;
 

--- a/packages/deprecated/foundation-tokens/src/MockTheme.ts
+++ b/packages/deprecated/foundation-tokens/src/MockTheme.ts
@@ -1,4 +1,4 @@
-import { ColorValue } from 'react-native';
+import type { ColorValue } from 'react-native';
 
 export interface IMockTheme {
   textSizes: {

--- a/packages/deprecated/foundation-tokens/src/MockTokens.ts
+++ b/packages/deprecated/foundation-tokens/src/MockTokens.ts
@@ -1,6 +1,6 @@
-import { IMockTheme } from './MockTheme';
-import { IStyleFactoryOperation, ILookupThemePart } from './Token.types';
-import { ColorValue } from 'react-native';
+import type { IMockTheme } from './MockTheme';
+import type { IStyleFactoryOperation, ILookupThemePart } from './Token.types';
+import type { ColorValue } from 'react-native';
 
 export interface IMockTextTokens {
   fontSize?: string | number;

--- a/packages/deprecated/foundation-tokens/src/Token.function.ts
+++ b/packages/deprecated/foundation-tokens/src/Token.function.ts
@@ -1,6 +1,6 @@
-import { ISlotProps } from '@uifabricshared/foundation-settings';
+import type { ISlotProps } from '@uifabricshared/foundation-settings';
 import { mergeProps } from '@fluentui-react-native/merge-props';
-import {
+import type {
   ITargetHasToken,
   IStyleFactoryOperation,
   IComponentTokens,
@@ -8,8 +8,8 @@ import {
   IStyleFinalizer,
   IStyleFactoryFunction,
 } from './Token.types';
-import { ITokenPropInfo, ICachedPropHandlers } from './Token.internal';
-import { GetMemoValue } from '@fluentui-react-native/memo-cache';
+import type { ITokenPropInfo, ICachedPropHandlers } from './Token.internal';
+import type { GetMemoValue } from '@fluentui-react-native/memo-cache';
 
 interface ITokensForSlot<TProps, TTokens, TTheme> {
   toStyle: IStyleFactoryOperation<TTokens, TTheme>[];

--- a/packages/deprecated/foundation-tokens/src/Token.internal.ts
+++ b/packages/deprecated/foundation-tokens/src/Token.internal.ts
@@ -1,4 +1,4 @@
-import { GetMemoValue } from '@fluentui-react-native/memo-cache';
+import type { GetMemoValue } from '@fluentui-react-native/memo-cache';
 
 export interface ITokenPropInfo<TTokens> {
   /** token props, aggregated from settings and user props */

--- a/packages/deprecated/foundation-tokens/src/Token.test.ts
+++ b/packages/deprecated/foundation-tokens/src/Token.test.ts
@@ -1,4 +1,5 @@
-import { MockButton, IButtonSettings } from './MockButton';
+import type { IButtonSettings } from './MockButton';
+import { MockButton } from './MockButton';
 import { theme } from './MockTheme';
 import { getMemoCache } from '@fluentui-react-native/memo-cache';
 

--- a/packages/deprecated/foundation-tokens/src/Token.ts
+++ b/packages/deprecated/foundation-tokens/src/Token.ts
@@ -1,7 +1,7 @@
-import { IComponentTokens } from './Token.types';
-import { ISlotProps, IComponentSettings } from '@uifabricshared/foundation-settings';
-import { ITokenPropInfo } from './Token.internal';
-import { GetMemoValue } from '@fluentui-react-native/memo-cache';
+import type { IComponentTokens } from './Token.types';
+import type { ISlotProps, IComponentSettings } from '@uifabricshared/foundation-settings';
+import type { ITokenPropInfo } from './Token.internal';
+import type { GetMemoValue } from '@fluentui-react-native/memo-cache';
 
 /**
  * Take the input props and props from settings and return a merged set of token props (a single source

--- a/packages/deprecated/foundation-tokens/src/Token.types.ts
+++ b/packages/deprecated/foundation-tokens/src/Token.types.ts
@@ -1,11 +1,11 @@
-import {
+import type {
   LookupThemePart,
   OperationSet,
   StyleFactoryFunction,
   StyleFactoryFunctionRaw,
   StyleFactoryOperation,
 } from '@fluentui-react-native/tokens';
-import { ICachedPropHandlers } from './Token.internal';
+import type { ICachedPropHandlers } from './Token.internal';
 
 export type ILookupThemePart<TTheme> = LookupThemePart<TTheme>;
 export type IStyleFactoryOperation<TTokens, TTheme> = StyleFactoryOperation<TTokens, TTheme>;

--- a/packages/deprecated/foundation-tokens/src/index.ts
+++ b/packages/deprecated/foundation-tokens/src/index.ts
@@ -1,4 +1,15 @@
-export * from './Token.types';
-export * from './Token';
-export * from './Token.function';
+export type {
+  IComponentTokens,
+  ILookupThemePart,
+  IOperationSet,
+  IStyleFactories,
+  IStyleFactoryEntry,
+  IStyleFactoryFunction,
+  IStyleFactoryFunctionRaw,
+  IStyleFactoryOperation,
+  IStyleFinalizer,
+  ITargetHasToken,
+} from './Token.types';
+export { processTokens } from './Token';
+export { buildComponentTokens } from './Token.function';
 export { styleFunction } from '@fluentui-react-native/tokens';

--- a/packages/experimental/ActivityIndicator/.eslintrc.js
+++ b/packages/experimental/ActivityIndicator/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/experimental/ActivityIndicator/src/ActivityIndicator.mobile.tsx
+++ b/packages/experimental/ActivityIndicator/src/ActivityIndicator.mobile.tsx
@@ -2,8 +2,10 @@
 import { useRef, useEffect, useCallback } from 'react';
 import { Animated, Easing, View } from 'react-native';
 import { Svg, Path } from 'react-native-svg';
-import { compose, mergeProps, withSlots, UseSlots, buildUseStyling } from '@fluentui-react-native/framework';
-import { activityIndicatorName, ActivityIndicatorProps, FluentActivityIndicatorType } from './ActivityIndicator.types';
+import type { UseSlots } from '@fluentui-react-native/framework';
+import { compose, mergeProps, withSlots, buildUseStyling } from '@fluentui-react-native/framework';
+import type { ActivityIndicatorProps, FluentActivityIndicatorType } from './ActivityIndicator.types';
+import { activityIndicatorName } from './ActivityIndicator.types';
 import { diameterSizeMap, lineThicknessSizeMap, stylingSettings } from './ActivityIndicator.styling';
 
 const getActivityIndicatorPath = (diameter: number, width: number, color: string) => {

--- a/packages/experimental/ActivityIndicator/src/ActivityIndicator.styling.tsx
+++ b/packages/experimental/ActivityIndicator/src/ActivityIndicator.styling.tsx
@@ -1,13 +1,15 @@
-import { UseStylingOptions, buildProps } from '@fluentui-react-native/framework';
-import { ActivityIndicatorProps as CoreActivityIndicatorProps, Appearance } from 'react-native';
-import {
-  activityIndicatorName,
+import type { UseStylingOptions } from '@fluentui-react-native/framework';
+import { buildProps } from '@fluentui-react-native/framework';
+import type { ActivityIndicatorProps as CoreActivityIndicatorProps } from 'react-native';
+import { Appearance } from 'react-native';
+import type {
   ActivityIndicatorProps,
   FluentActivityIndicatorSlotProps,
   ActivityIndicatorTokens,
   CoreActivityIndicatorSlotProps,
   ActivityIndicatorSize,
 } from './ActivityIndicator.types';
+import { activityIndicatorName } from './ActivityIndicator.types';
 import assertNever from 'assert-never';
 
 export const diameterSizeMap: { [key: string]: number } = {

--- a/packages/experimental/ActivityIndicator/src/ActivityIndicator.types.tsx
+++ b/packages/experimental/ActivityIndicator/src/ActivityIndicator.types.tsx
@@ -1,5 +1,5 @@
-import { Animated, ActivityIndicatorProps as CoreActivityIndicatorProps } from 'react-native';
-import { SvgProps } from 'react-native-svg';
+import type { Animated, ActivityIndicatorProps as CoreActivityIndicatorProps } from 'react-native';
+import type { SvgProps } from 'react-native-svg';
 
 export const activityIndicatorName = 'ActivityIndicator';
 /**

--- a/packages/experimental/ActivityIndicator/src/CoreActivityIndicator.tsx
+++ b/packages/experimental/ActivityIndicator/src/CoreActivityIndicator.tsx
@@ -1,9 +1,11 @@
 /** @jsx withSlots */
 
 import { ActivityIndicator as CoreActivityIndicator } from 'react-native';
-import { activityIndicatorName, CoreActivityIndicatorType, ActivityIndicatorProps } from './ActivityIndicator.types';
+import type { CoreActivityIndicatorType, ActivityIndicatorProps } from './ActivityIndicator.types';
+import { activityIndicatorName } from './ActivityIndicator.types';
 import { coreStylingSettings } from './ActivityIndicator.styling';
-import { compose, withSlots, UseSlots } from '@fluentui-react-native/framework';
+import type { UseSlots } from '@fluentui-react-native/framework';
+import { compose, withSlots } from '@fluentui-react-native/framework';
 
 /**
  * Wrapper around React Native Core's ActivityIndicator for platforms we do not

--- a/packages/experimental/ActivityIndicator/src/index.ts
+++ b/packages/experimental/ActivityIndicator/src/index.ts
@@ -1,1 +1,1 @@
-export * from './ActivityIndicator';
+export { ActivityIndicator } from './ActivityIndicator';

--- a/packages/experimental/AppearanceAdditions/.eslintrc.js
+++ b/packages/experimental/AppearanceAdditions/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/experimental/AppearanceAdditions/src/NativeAppearanceAdditions.ts
+++ b/packages/experimental/AppearanceAdditions/src/NativeAppearanceAdditions.ts
@@ -1,4 +1,4 @@
-import { SizeClass, UserInterfaceLevel } from './NativeAppearanceAdditions.types';
+import type { SizeClass, UserInterfaceLevel } from './NativeAppearanceAdditions.types';
 
 export const NativeAppearanceAdditions = {
   // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/packages/experimental/AppearanceAdditions/src/appearanceAdditions.ios.ts
+++ b/packages/experimental/AppearanceAdditions/src/appearanceAdditions.ios.ts
@@ -1,12 +1,7 @@
 import { NativeEventEmitter } from 'react-native';
 import NativeAppearanceAdditions from './NativeAppearanceAdditions.ios';
-import {
-  HorizontalSizeClassKey,
-  AppearanceAdditions,
-  SizeClass,
-  UserInterfaceLevel,
-  UserInterfaceLevelKey,
-} from './NativeAppearanceAdditions.types';
+import type { AppearanceAdditions, SizeClass, UserInterfaceLevel } from './NativeAppearanceAdditions.types';
+import { HorizontalSizeClassKey, UserInterfaceLevelKey } from './NativeAppearanceAdditions.types';
 import { memoize } from '@fluentui-react-native/framework';
 
 class AppearanceAdditionsImpl implements AppearanceAdditions {

--- a/packages/experimental/AppearanceAdditions/src/appearanceAdditions.ts
+++ b/packages/experimental/AppearanceAdditions/src/appearanceAdditions.ts
@@ -1,5 +1,5 @@
 import { memoize } from '@fluentui-react-native/framework';
-import { AppearanceAdditions } from './NativeAppearanceAdditions.types';
+import type { AppearanceAdditions } from './NativeAppearanceAdditions.types';
 
 // Default values for non-iOS clients.
 function getAppearanceAdditionsWorker() {

--- a/packages/experimental/AppearanceAdditions/src/getSizeClass.ios.ts
+++ b/packages/experimental/AppearanceAdditions/src/getSizeClass.ios.ts
@@ -4,7 +4,7 @@ import { useSubscription } from 'use-subscription';
 import { appearanceAdditions } from './appearanceAdditions';
 
 import NativeAppearanceAdditions from './NativeAppearanceAdditions';
-import { SizeClass } from './NativeAppearanceAdditions.types';
+import type { SizeClass } from './NativeAppearanceAdditions.types';
 
 const eventEmitter = NativeAppearanceAdditions ? new NativeEventEmitter(NativeAppearanceAdditions as any) : undefined;
 
@@ -13,6 +13,8 @@ export function useHorizontalSizeClass(): SizeClass {
     return 'regular';
   }
 
+  // Early return on eventEmitter will either always or never return within a single instance
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   const subscription = useMemo(
     () => ({
       getCurrentValue: () => appearanceAdditions().horizontalSizeClass,
@@ -26,5 +28,7 @@ export function useHorizontalSizeClass(): SizeClass {
     [],
   );
 
+  // Early return on eventEmitter will either always or never return within a single instance
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   return useSubscription(subscription);
 }

--- a/packages/experimental/AppearanceAdditions/src/getSizeClass.ts
+++ b/packages/experimental/AppearanceAdditions/src/getSizeClass.ts
@@ -1,4 +1,4 @@
-import { SizeClass } from './NativeAppearanceAdditions.types';
+import type { SizeClass } from './NativeAppearanceAdditions.types';
 
 export function useHorizontalSizeClass(): SizeClass {
   // Stubbed out for non-iOS platforms

--- a/packages/experimental/AppearanceAdditions/src/index.ts
+++ b/packages/experimental/AppearanceAdditions/src/index.ts
@@ -2,4 +2,4 @@ export { NativeAppearanceAdditions } from './NativeAppearanceAdditions';
 export { appearanceAdditions } from './appearanceAdditions';
 export type { AppearanceAdditions, SizeClass as SizeClassIOS } from './NativeAppearanceAdditions.types';
 
-export * from './getSizeClass';
+export { useHorizontalSizeClass } from './getSizeClass';

--- a/packages/experimental/Avatar/.eslintrc.js
+++ b/packages/experimental/Avatar/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/experimental/Avatar/src/NativeAvatar.tsx
+++ b/packages/experimental/Avatar/src/NativeAvatar.tsx
@@ -1,6 +1,8 @@
 /** @jsx withSlots */
-import { compose, UseSlots, buildProps, mergeProps, withSlots } from '@fluentui-react-native/framework';
-import { ImageURISource, NativeModules, ViewProps, ColorValue } from 'react-native';
+import type { UseSlots } from '@fluentui-react-native/framework';
+import { compose, buildProps, mergeProps, withSlots } from '@fluentui-react-native/framework';
+import type { ImageURISource, ViewProps, ColorValue } from 'react-native';
+import { NativeModules } from 'react-native';
 import { ensureNativeComponent } from '@fluentui-react-native/component-cache';
 
 const avatarName = 'NativeAvatar';

--- a/packages/experimental/Avatar/src/index.ts
+++ b/packages/experimental/Avatar/src/index.ts
@@ -1,1 +1,2 @@
-export * from './NativeAvatar';
+export { NativeAvatar, Sizes } from './NativeAvatar';
+export type { AvatarStyle, NativeAvatarProps, NativeAvatarTokens, NativeAvatarViewProps, Presence, Size } from './NativeAvatar';

--- a/packages/experimental/Checkbox/.eslintrc.js
+++ b/packages/experimental/Checkbox/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/experimental/Checkbox/src/Checkbox.macos.tsx
+++ b/packages/experimental/Checkbox/src/Checkbox.macos.tsx
@@ -1,8 +1,10 @@
 /** @jsx withSlots */
-import { checkboxName, CheckboxTokens, CheckboxProps, CheckboxState } from '@fluentui-react-native/checkbox';
-import { compose, mergeProps, withSlots, UseSlots, buildProps } from '@fluentui-react-native/framework';
+import type { CheckboxTokens, CheckboxProps, CheckboxState } from '@fluentui-react-native/checkbox';
+import { checkboxName } from '@fluentui-react-native/checkbox';
+import type { UseSlots } from '@fluentui-react-native/framework';
+import { compose, mergeProps, withSlots, buildProps } from '@fluentui-react-native/framework';
 import { ensureNativeComponent } from '@fluentui-react-native/component-cache';
-import { IViewProps } from '@fluentui-react-native/adapters';
+import type { IViewProps } from '@fluentui-react-native/adapters';
 
 const NativeCheckboxView = ensureNativeComponent('FRNCheckboxView');
 

--- a/packages/experimental/Drawer/.eslintrc.js
+++ b/packages/experimental/Drawer/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/experimental/Drawer/src/Drawer.tsx
+++ b/packages/experimental/Drawer/src/Drawer.tsx
@@ -1,7 +1,9 @@
 /** @jsx withSlots */
 import * as React from 'react';
-import { drawerName, DrawerTokens, DrawerProps, DrawerType } from './Drawer.types';
-import { compose, UseSlots, buildProps, mergeProps, withSlots } from '@fluentui-react-native/framework';
+import type { DrawerTokens, DrawerProps, DrawerType } from './Drawer.types';
+import { drawerName } from './Drawer.types';
+import type { UseSlots } from '@fluentui-react-native/framework';
+import { compose, buildProps, mergeProps, withSlots } from '@fluentui-react-native/framework';
 import { ensureNativeComponent } from '@fluentui-react-native/component-cache';
 
 const FRNDrawer = ensureNativeComponent('FRNDrawer');

--- a/packages/experimental/Drawer/src/Drawer.types.ts
+++ b/packages/experimental/Drawer/src/Drawer.types.ts
@@ -1,4 +1,4 @@
-import { ViewProps } from 'react-native';
+import type { ViewProps } from 'react-native';
 
 export const drawerName = 'Drawer';
 

--- a/packages/experimental/Drawer/src/index.ts
+++ b/packages/experimental/Drawer/src/index.ts
@@ -1,1 +1,1 @@
-export * from './Drawer';
+export { Drawer } from './Drawer';

--- a/packages/experimental/Expander/.eslintrc.js
+++ b/packages/experimental/Expander/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/experimental/Expander/src/Expander.tsx
+++ b/packages/experimental/Expander/src/Expander.tsx
@@ -1,7 +1,9 @@
 /** @jsx withSlots */
 import * as React from 'react';
-import { expanderName, ExpanderType, ExpanderProps, ExpanderViewProps } from './Expander.types';
-import { compose, mergeProps, withSlots, UseSlots, buildProps } from '@fluentui-react-native/framework';
+import type { ExpanderType, ExpanderProps, ExpanderViewProps } from './Expander.types';
+import { expanderName } from './Expander.types';
+import type { UseSlots} from '@fluentui-react-native/framework';
+import { compose, mergeProps, withSlots, buildProps } from '@fluentui-react-native/framework';
 import { ensureNativeComponent } from '@fluentui-react-native/component-cache';
 
 const ExpanderComponent = ensureNativeComponent('ExpanderView');

--- a/packages/experimental/Expander/src/Expander.types.ts
+++ b/packages/experimental/Expander/src/Expander.types.ts
@@ -1,4 +1,4 @@
-import { ColorValue } from 'react-native';
+import type { ColorValue } from 'react-native';
 
 export const expanderName = 'Expander';
 
@@ -96,7 +96,7 @@ export interface ExpanderTokens {
   /**
    * Header border thickness
    */
-  headerBorderThickness?: Number;
+  headerBorderThickness?: number;
   /**
    * Content background color
    */
@@ -132,7 +132,7 @@ export interface ExpanderTokens {
   /**
    * Chevron border thickness
    */
-  chevronBorderThickness?: Number;
+  chevronBorderThickness?: number;
   /**
    * Chevron border color at rest
    */

--- a/packages/experimental/Expander/src/index.ts
+++ b/packages/experimental/Expander/src/index.ts
@@ -1,2 +1,3 @@
-export * from './Expander';
-export * from './Expander.types';
+export { Expander } from './Expander';
+export { expanderName } from './Expander.types';
+export type { ExpandDirection, ExpanderProps, ExpanderTokens, ExpanderType, ExpanderViewProps, HorizontalAlignment, VerticalAlignment } from './Expander.types';

--- a/packages/experimental/NativeDatePicker/.eslintrc.js
+++ b/packages/experimental/NativeDatePicker/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/experimental/NativeDatePicker/src/NativeDatePicker.ios.tsx
+++ b/packages/experimental/NativeDatePicker/src/NativeDatePicker.ios.tsx
@@ -26,6 +26,7 @@ interface DatePickerParameterObject {
   dateSubtitle?: string;
   timeTitle?: string;
   timeSubtitle?: string;
+  // eslint-disable-next-line @typescript-eslint/ban-types
   callback: Function;
 }
 
@@ -77,9 +78,9 @@ NativeDatePicker.parseISOString = (dateISOString: string): Date => {
   if (dateISOString == null) {
     return null;
   }
-  var dateParts: number[] = dateISOString.split(/\D+/).map((x) => parseInt(x, 10));
+  const dateParts: number[] = dateISOString.split(/\D+/).map((x) => parseInt(x, 10));
   dateParts[1]--; // Date.UTC's `month` arg is zero-based
-  var dateUTC = Date.UTC.apply(null, dateParts);
+  const dateUTC = Date.UTC.apply(null, dateParts);
   return new Date(dateUTC);
 };
 

--- a/packages/experimental/NativeDatePicker/src/index.ts
+++ b/packages/experimental/NativeDatePicker/src/index.ts
@@ -1,1 +1,1 @@
-export * from './NativeDatePicker';
+export { NativeDatePicker } from './NativeDatePicker';

--- a/packages/experimental/NativeFontMetrics/.eslintrc.js
+++ b/packages/experimental/NativeFontMetrics/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/experimental/NativeFontMetrics/src/NativeFontMetrics.ios.ts
+++ b/packages/experimental/NativeFontMetrics/src/NativeFontMetrics.ios.ts
@@ -1,5 +1,5 @@
 import { NativeModules } from 'react-native';
-import { ScaleFactors, TextStyle } from './NativeFontMetrics.types';
+import type { ScaleFactors, TextStyle } from './NativeFontMetrics.types';
 
 export const NativeFontMetrics = NativeModules.FRNFontMetrics;
 

--- a/packages/experimental/NativeFontMetrics/src/NativeFontMetrics.ts
+++ b/packages/experimental/NativeFontMetrics/src/NativeFontMetrics.ts
@@ -1,4 +1,4 @@
-import { TextStyle } from './NativeFontMetrics.types';
+import type { TextStyle } from './NativeFontMetrics.types';
 
 const NativeFontMetrics = {
   // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/packages/experimental/NativeFontMetrics/src/fontMetrics.ios.ts
+++ b/packages/experimental/NativeFontMetrics/src/fontMetrics.ios.ts
@@ -1,6 +1,6 @@
 import { NativeEventEmitter } from 'react-native';
 import NativeFontMetrics from './NativeFontMetrics';
-import { FontMetrics, ScaleFactors } from './NativeFontMetrics.types';
+import type { FontMetrics, ScaleFactors } from './NativeFontMetrics.types';
 
 class FontMetricsImpl implements FontMetrics {
   _scaleFactors: ScaleFactors;

--- a/packages/experimental/NativeFontMetrics/src/fontMetrics.ts
+++ b/packages/experimental/NativeFontMetrics/src/fontMetrics.ts
@@ -1,3 +1,3 @@
-import { FontMetrics } from './NativeFontMetrics.types';
+import type { FontMetrics } from './NativeFontMetrics.types';
 
 export const fontMetrics = { scaleFactors: {} } as FontMetrics;

--- a/packages/experimental/NativeFontMetrics/src/index.ts
+++ b/packages/experimental/NativeFontMetrics/src/index.ts
@@ -1,1 +1,1 @@
-export * from './useFontMetrics';
+export { useFontMetricsScaleFactors } from './useFontMetrics';

--- a/packages/experimental/NativeFontMetrics/src/useFontMetrics.ios.ts
+++ b/packages/experimental/NativeFontMetrics/src/useFontMetrics.ios.ts
@@ -3,7 +3,7 @@ import { NativeEventEmitter } from 'react-native';
 import { useSubscription } from 'use-subscription';
 import { fontMetrics } from './fontMetrics';
 import NativeFontMetrics from './NativeFontMetrics';
-import { ScaleFactors } from './NativeFontMetrics.types';
+import type { ScaleFactors } from './NativeFontMetrics.types';
 
 const eventEmitter = NativeFontMetrics ? new NativeEventEmitter(NativeFontMetrics as any) : undefined;
 
@@ -12,6 +12,8 @@ export function useFontMetricsScaleFactors(): ScaleFactors {
     return {};
   }
 
+  // Early return on eventEmitter will either always or never return within a single instance
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   const subscription = useMemo(
     () => ({
       getCurrentValue: () => fontMetrics.scaleFactors,
@@ -25,5 +27,7 @@ export function useFontMetricsScaleFactors(): ScaleFactors {
     [],
   );
 
+  // Early return on eventEmitter will either always or never return within a single instance
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   return useSubscription(subscription);
 }

--- a/packages/experimental/NativeFontMetrics/src/useFontMetrics.ts
+++ b/packages/experimental/NativeFontMetrics/src/useFontMetrics.ts
@@ -1,4 +1,4 @@
-import { ScaleFactors } from './NativeFontMetrics.types';
+import type { ScaleFactors } from './NativeFontMetrics.types';
 
 export function useFontMetricsScaleFactors(): ScaleFactors {
   // Stubbed out for non-iOS platforms

--- a/packages/experimental/Spinner/.eslintrc.js
+++ b/packages/experimental/Spinner/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/experimental/Spinner/src/Spinner.tsx
+++ b/packages/experimental/Spinner/src/Spinner.tsx
@@ -2,8 +2,10 @@
 import { View } from 'react-native';
 import { TextV1 as Text } from '@fluentui-react-native/text';
 import { Svg } from 'react-native-svg';
-import { compose, mergeProps, withSlots, UseSlots } from '@fluentui-react-native/framework';
-import { spinnerName, SpinnerProps, SpinnerType } from './Spinner.types';
+import type { UseSlots } from '@fluentui-react-native/framework';
+import { compose, mergeProps, withSlots } from '@fluentui-react-native/framework';
+import type { SpinnerProps, SpinnerType } from './Spinner.types';
+import { spinnerName } from './Spinner.types';
 import { RCTNativeAnimatedSpinner } from './consts.win32';
 
 /* TODO: Implement Spinner with following slots */

--- a/packages/experimental/Spinner/src/Spinner.types.tsx
+++ b/packages/experimental/Spinner/src/Spinner.types.tsx
@@ -1,4 +1,4 @@
-import { TextProps, ViewProps } from 'react-native';
+import type { TextProps, ViewProps } from 'react-native';
 
 export const spinnerName = 'Spinner';
 /**

--- a/packages/experimental/Spinner/src/index.ts
+++ b/packages/experimental/Spinner/src/index.ts
@@ -1,1 +1,1 @@
-export * from './Spinner';
+export { ActivityIndicator } from './Spinner';

--- a/packages/framework/composition/.eslintrc.js
+++ b/packages/framework/composition/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/framework/composition/src/composeFactory.test.tsx
+++ b/packages/framework/composition/src/composeFactory.test.tsx
@@ -1,9 +1,11 @@
 /** @jsx withSlots */
 import { withSlots } from '@fluentui-react-native/use-slot';
 import * as renderer from 'react-test-renderer';
-import { composeFactory, UseStyledSlots } from './composeFactory';
-import { ViewProps, View, Text, TextProps, ColorValue } from 'react-native';
-import { ThemeHelper } from '@fluentui-react-native/use-styling';
+import type { UseStyledSlots } from './composeFactory';
+import { composeFactory } from './composeFactory';
+import type { ViewProps, TextProps, ColorValue } from 'react-native';
+import { View, Text } from 'react-native';
+import type { ThemeHelper } from '@fluentui-react-native/use-styling';
 
 type Theme = {
   values: {

--- a/packages/framework/composition/src/composeFactory.ts
+++ b/packages/framework/composition/src/composeFactory.ts
@@ -1,7 +1,11 @@
-import { UseStylingOptions, TokenSettings, ThemeHelper, HasLayer, buildUseStyling } from '@fluentui-react-native/use-styling';
-import { ComposableFunction, stagedComponent } from '@fluentui-react-native/use-slot';
-import { UseSlotOptions, buildUseSlots, Slots } from '@fluentui-react-native/use-slots';
-import { immutableMergeCore, MergeOptions } from '@fluentui-react-native/immutable-merge';
+import type { UseStylingOptions, TokenSettings, ThemeHelper, HasLayer } from '@fluentui-react-native/use-styling';
+import { buildUseStyling } from '@fluentui-react-native/use-styling';
+import type { ComposableFunction } from '@fluentui-react-native/use-slot';
+import { stagedComponent } from '@fluentui-react-native/use-slot';
+import type { UseSlotOptions, Slots } from '@fluentui-react-native/use-slots';
+import { buildUseSlots } from '@fluentui-react-native/use-slots';
+import type { MergeOptions } from '@fluentui-react-native/immutable-merge';
+import { immutableMergeCore } from '@fluentui-react-native/immutable-merge';
 
 export type UseStyledSlots<TProps, TSlotProps> = (props: TProps, lookup?: HasLayer) => Slots<TSlotProps>;
 

--- a/packages/framework/composition/src/index.ts
+++ b/packages/framework/composition/src/index.ts
@@ -1,1 +1,2 @@
-export * from './composeFactory';
+export { composeFactory } from './composeFactory';
+export type { ComposeFactoryComponent, ComposeFactoryOptions, UseStyledSlots } from './composeFactory';

--- a/packages/framework/theme/.eslintrc.js
+++ b/packages/framework/theme/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/framework/theme/src/ThemeProvider.tsx
+++ b/packages/framework/theme/src/ThemeProvider.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { ThemeReference } from './themeReference';
+import type { ThemeReference } from './themeReference';
 import { ThemeContext } from '@fluentui-react-native/theme-types';
 
-export interface ThemeProviderProps extends React.PropsWithChildren<{}> {
+export interface ThemeProviderProps extends React.PropsWithChildren<Record<string, unknown>> {
   /**
    * to set themes into the provider wrap them in a reference
    */

--- a/packages/framework/theme/src/index.ts
+++ b/packages/framework/theme/src/index.ts
@@ -1,2 +1,4 @@
-export * from './ThemeProvider';
-export * from './themeReference';
+export { ThemeProvider } from './ThemeProvider';
+export type { ThemeProviderProps } from './ThemeProvider';
+export { ThemeReference } from './themeReference';
+export type { OnThemeChange, ThemeRecipe, ThemeTransform } from './themeReference';

--- a/packages/framework/theme/src/mergeTheme.ts
+++ b/packages/framework/theme/src/mergeTheme.ts
@@ -1,5 +1,5 @@
 import { immutableMerge } from '@fluentui-react-native/immutable-merge';
-import { Theme, PartialTheme } from '@fluentui-react-native/theme-types';
+import type { Theme, PartialTheme } from '@fluentui-react-native/theme-types';
 
 export function mergeTheme<TTheme extends Theme, TPartial extends PartialTheme>(base: TTheme, partial: TPartial): TTheme {
   return immutableMerge(base, partial as unknown as TTheme);

--- a/packages/framework/theme/src/themeReference.test.ts
+++ b/packages/framework/theme/src/themeReference.test.ts
@@ -1,4 +1,4 @@
-import { Theme, Spacing, PartialTheme } from '@fluentui-react-native/theme-types';
+import type { Theme, Spacing, PartialTheme } from '@fluentui-react-native/theme-types';
 import { ThemeReference } from './themeReference';
 import { mockTheme } from '@fluentui-react-native/test-tools';
 

--- a/packages/framework/theme/src/themeReference.ts
+++ b/packages/framework/theme/src/themeReference.ts
@@ -1,4 +1,4 @@
-import { Theme, PartialTheme } from '@fluentui-react-native/theme-types';
+import type { Theme, PartialTheme } from '@fluentui-react-native/theme-types';
 import { mergeTheme } from './mergeTheme';
 
 /**

--- a/packages/framework/use-slot/.eslintrc.js
+++ b/packages/framework/use-slot/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/framework/use-slot/src/index.ts
+++ b/packages/framework/use-slot/src/index.ts
@@ -1,4 +1,6 @@
-export * from './renderSlot';
-export * from './stagedComponent';
-export * from './useSlot';
-export * from './withSlots';
+export { renderSlot } from './renderSlot';
+export type { NativeReactType, SlotFn } from './renderSlot';
+export { stagedComponent } from './stagedComponent';
+export type { ComposableFunction, FinalRender, StagedRender } from './stagedComponent';
+export { useSlot } from './useSlot';
+export { withSlots } from './withSlots';

--- a/packages/framework/use-slot/src/useSlot.test.tsx
+++ b/packages/framework/use-slot/src/useSlot.test.tsx
@@ -1,12 +1,13 @@
 /** @jsx withSlots */
-import { TextProps, Text, View } from 'react-native';
+import type { TextProps } from 'react-native';
+import { Text, View } from 'react-native';
 import toJson from 'enzyme-to-json';
 import * as React from 'react';
 import { mount } from 'enzyme';
 import { useSlot } from './useSlot';
 import { withSlots } from './withSlots';
 import { mergeStyles } from '@fluentui-react-native/merge-props';
-import { NativeReactType } from './renderSlot';
+import type { NativeReactType } from './renderSlot';
 import { stagedComponent } from './stagedComponent';
 
 type PluggableTextProps = React.PropsWithChildren<TextProps> & { inner?: NativeReactType | React.FunctionComponent<TextProps> };

--- a/packages/framework/use-slot/src/useSlot.ts
+++ b/packages/framework/use-slot/src/useSlot.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { SlotFn, NativeReactType } from './renderSlot';
+import type { SlotFn, NativeReactType } from './renderSlot';
 import { mergeProps } from '@fluentui-react-native/merge-props';
-import { ComposableFunction, StagedRender } from './stagedComponent';
+import type { ComposableFunction, StagedRender } from './stagedComponent';
 
 /**
  *
@@ -52,6 +52,7 @@ export function useSlot<TProps>(
       }
 
       // now if result was a function then call it directly, if not go through the standard React.createElement process
+      // eslint-disable-next-line @typescript-eslint/ban-types
       return typeof result === 'function' ? (result as Function)(props, ...children) : React.createElement(component, props, ...children);
     };
     // mark the slotFn so that withSlots knows to handle it differently

--- a/packages/framework/use-slot/src/withSlots.tsx
+++ b/packages/framework/use-slot/src/withSlots.tsx
@@ -1,4 +1,5 @@
-import { NativeReactType, renderSlot } from './renderSlot';
+import type { NativeReactType } from './renderSlot';
+import { renderSlot } from './renderSlot';
 
 /**
  * This function is required for any module that uses slots.

--- a/packages/framework/use-slots/.eslintrc.js
+++ b/packages/framework/use-slots/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/framework/use-slots/src/buildUseSlots.test.tsx
+++ b/packages/framework/use-slots/src/buildUseSlots.test.tsx
@@ -2,7 +2,8 @@
 import { withSlots, stagedComponent } from '@fluentui-react-native/use-slot';
 import * as renderer from 'react-test-renderer';
 import { buildUseSlots } from './buildUseSlots';
-import { ViewProps, View, Text, TextProps } from 'react-native';
+import type { ViewProps, TextProps } from 'react-native';
+import { View, Text } from 'react-native';
 
 type SlotProps1 = {
   outer: ViewProps;

--- a/packages/framework/use-slots/src/buildUseSlots.ts
+++ b/packages/framework/use-slots/src/buildUseSlots.ts
@@ -1,4 +1,5 @@
-import { useSlot, ComposableFunction, SlotFn, NativeReactType } from '@fluentui-react-native/use-slot';
+import type { ComposableFunction, SlotFn, NativeReactType } from '@fluentui-react-native/use-slot';
+import { useSlot } from '@fluentui-react-native/use-slot';
 
 // type AsObject<T> = T extends object ? T : never
 
@@ -18,6 +19,7 @@ export function buildUseSlots<TSlotProps>(options: UseSlotOptions<TSlotProps>): 
   const { slots, filters = {}, useStyling } = options;
   return (...args: any[]) => {
     // get the baseline slot props to render with the slots
+    // eslint-disable-next-line @typescript-eslint/ban-types
     const slotProps: TSlotProps = typeof useStyling === 'function' ? (useStyling as Function)(...args) : ((useStyling || {}) as TSlotProps);
 
     // build up a set of slots closures and store them in props

--- a/packages/framework/use-slots/src/index.ts
+++ b/packages/framework/use-slots/src/index.ts
@@ -1,1 +1,2 @@
-export * from './buildUseSlots';
+export { buildUseSlots } from './buildUseSlots';
+export type { GetSlotProps, Slots, UseSlotOptions, UseSlotsBase } from './buildUseSlots';

--- a/packages/framework/use-slots/src/useSlots.samples.test.tsx
+++ b/packages/framework/use-slots/src/useSlots.samples.test.tsx
@@ -4,7 +4,7 @@ import { mergeProps } from '@fluentui-react-native/merge-props';
 import { buildUseSlots } from './buildUseSlots';
 import toJson from 'enzyme-to-json';
 import { mount } from 'enzyme';
-import { CSSProperties } from 'react';
+import type { CSSProperties } from 'react';
 
 // types for web
 type TextProps = { style?: CSSProperties };

--- a/packages/framework/use-styling/.eslintrc.js
+++ b/packages/framework/use-styling/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/framework/use-styling/src/buildProps.ts
+++ b/packages/framework/use-styling/src/buildProps.ts
@@ -1,4 +1,4 @@
-import { GetMemoValue } from '@fluentui-react-native/memo-cache';
+import type { GetMemoValue } from '@fluentui-react-native/memo-cache';
 
 /**
  * Informs the framework of any tokens that also appear as props for the component.

--- a/packages/framework/use-styling/src/buildUseStyling.test.ts
+++ b/packages/framework/use-styling/src/buildUseStyling.test.ts
@@ -1,4 +1,5 @@
-import { buildUseStyling, ThemeHelper, UseStylingOptions } from './buildUseStyling';
+import type { ThemeHelper, UseStylingOptions } from './buildUseStyling';
+import { buildUseStyling } from './buildUseStyling';
 import { getMemoCache } from '@fluentui-react-native/memo-cache';
 import { buildProps } from './buildProps';
 

--- a/packages/framework/use-styling/src/buildUseStyling.ts
+++ b/packages/framework/use-styling/src/buildUseStyling.ts
@@ -1,6 +1,8 @@
-import { GetMemoValue } from '@fluentui-react-native/memo-cache';
-import { TokensThatAreAlsoProps, BuildSlotProps, refinePropsFunctions } from './buildProps';
-import { applyPropsToTokens, applyTokenLayers, buildUseTokens, HasLayer, TokenSettings } from '@fluentui-react-native/use-tokens';
+import type { GetMemoValue } from '@fluentui-react-native/memo-cache';
+import type { TokensThatAreAlsoProps, BuildSlotProps } from './buildProps';
+import { refinePropsFunctions } from './buildProps';
+import type { HasLayer, TokenSettings } from '@fluentui-react-native/use-tokens';
+import { applyPropsToTokens, applyTokenLayers, buildUseTokens } from '@fluentui-react-native/use-tokens';
 
 /**
  * Options used to build up a useStyling hook

--- a/packages/framework/use-styling/src/index.ts
+++ b/packages/framework/use-styling/src/index.ts
@@ -1,3 +1,5 @@
-export * from './buildUseStyling';
-export * from './buildProps';
+export { buildUseStyling } from './buildUseStyling';
+export type { ThemeHelper, UseStyling, UseStylingOptions } from './buildUseStyling';
+export { buildProps, refinePropsFunctions } from './buildProps';
+export type { BuildPropsBase, BuildSlotProps, RefinableBuildPropsBase, RefineFunctionBase, TokensThatAreAlsoProps } from './buildProps';
 export { HasLayer, applyTokenLayers, TokenSettings, TokensFromTheme } from '@fluentui-react-native/use-tokens';

--- a/packages/framework/use-styling/src/useStyling.samples.test.tsx
+++ b/packages/framework/use-styling/src/useStyling.samples.test.tsx
@@ -1,5 +1,7 @@
-import { ThemeHelper, buildUseStyling, UseStylingOptions } from './buildUseStyling';
-import { TextProps, Text, View, ColorValue } from 'react-native';
+import type { ThemeHelper, UseStylingOptions } from './buildUseStyling';
+import { buildUseStyling } from './buildUseStyling';
+import type { TextProps, ColorValue } from 'react-native';
+import { Text, View } from 'react-native';
 import { buildProps } from './buildProps';
 import toJson from 'enzyme-to-json';
 import * as React from 'react';

--- a/packages/framework/use-tokens/.eslintrc.js
+++ b/packages/framework/use-tokens/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/packages/framework/use-tokens/src/applyPropsToTokens.ts
+++ b/packages/framework/use-tokens/src/applyPropsToTokens.ts
@@ -1,4 +1,4 @@
-import { GetMemoValue } from '@fluentui-react-native/memo-cache';
+import type { GetMemoValue } from '@fluentui-react-native/memo-cache';
 
 export function applyPropsToTokens<TProps, TTokens>(
   props: TProps,

--- a/packages/framework/use-tokens/src/applyTokenLayers.ts
+++ b/packages/framework/use-tokens/src/applyTokenLayers.ts
@@ -1,4 +1,4 @@
-import { GetMemoValue } from '@fluentui-react-native/memo-cache';
+import type { GetMemoValue } from '@fluentui-react-native/memo-cache';
 import { immutableMerge } from '@fluentui-react-native/immutable-merge';
 
 /**

--- a/packages/framework/use-tokens/src/buildUseTokens.ts
+++ b/packages/framework/use-tokens/src/buildUseTokens.ts
@@ -1,4 +1,5 @@
-import { getMemoCache, GetMemoValue } from '@fluentui-react-native/memo-cache';
+import type { GetMemoValue } from '@fluentui-react-native/memo-cache';
+import { getMemoCache } from '@fluentui-react-native/memo-cache';
 import { immutableMerge } from '@fluentui-react-native/immutable-merge';
 
 /** A function to generate tokens based on a theme */

--- a/packages/framework/use-tokens/src/customizable.ts
+++ b/packages/framework/use-tokens/src/customizable.ts
@@ -1,5 +1,5 @@
-import React from 'react';
-import { TokenSettings, UseTokens } from './buildUseTokens';
+import type React from 'react';
+import type { TokenSettings, UseTokens } from './buildUseTokens';
 
 /**
  * A component implementation, with a use tokens hook passed in. Implementing it this way allows the useTokens hook to be

--- a/packages/framework/use-tokens/src/index.ts
+++ b/packages/framework/use-tokens/src/index.ts
@@ -1,5 +1,8 @@
-export * from './applyPropsToTokens';
-export * from './applyTokenLayers';
-export * from './buildUseTokens';
-export * from './customizable';
-export * from './patchTokens';
+export { applyPropsToTokens } from './applyPropsToTokens';
+export { applyTokenLayers } from './applyTokenLayers';
+export type { HasLayer } from './applyTokenLayers';
+export { buildUseTokens } from './buildUseTokens';
+export type { GetComponentInfo, TokenSettings, TokensFromTheme, UseTokens, UseTokensCore } from './buildUseTokens';
+export { customizable } from './customizable';
+export type { CustomizableComponent, InjectableComponent } from './customizable';
+export { patchTokens } from './patchTokens';

--- a/packages/framework/use-tokens/src/patchTokens.ts
+++ b/packages/framework/use-tokens/src/patchTokens.ts
@@ -1,4 +1,4 @@
-import { GetMemoValue } from '@fluentui-react-native/memo-cache';
+import type { GetMemoValue } from '@fluentui-react-native/memo-cache';
 
 /**
  * Take a set of tokens (and a memo-cache) and apply changes to those tokens from an additional set of tokens. Only keys which are

--- a/packages/framework/use-tokens/src/useTokens.samples.test.tsx
+++ b/packages/framework/use-tokens/src/useTokens.samples.test.tsx
@@ -1,4 +1,5 @@
-import { TextProps, Text, View } from 'react-native';
+import type { TextProps } from 'react-native';
+import { Text, View } from 'react-native';
 import toJson from 'enzyme-to-json';
 import * as React from 'react';
 import { mount } from 'enzyme';


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
Added the standard eslint config to packages that were missing an eslint config, and ran `lint --fix`.

I manually suppressed a few lint errors.  In particular in:
/packages/experimental/NativeFontMetrics/src/useFontMetrics.ios.ts
/packages/experimental/AppearanceAdditions/src/getSizeClass.ios.ts
/packages/framework/use-slots/src/buildUseSlots.ts

In /packages/framework/theme/src/ThemeProvider.tsx
I changed the type of ThemeProviderProps  from `extends React.PropsWithChildren<{}> {` to `extends React.PropsWithChildren<Record<string, unknown>> {`


### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
