### PR TITLE
chore: enable `@rnx-kit/no-const-enum`

### DIFF
--- a/apps/E2E/.eslintrc.js
+++ b/apps/E2E/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@fluentui-react-native/eslint-config-rules'],
+};

--- a/apps/E2E/package.json
+++ b/apps/E2E/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "scripts": {
     "build": "fluentui-scripts build",
+    "lint": "fluentui-scripts eslint",
     "e2etest:android": "wdio run wdio.conf.android.js",
     "e2etest:ios": "wdio run wdio.conf.ios.js",
     "e2etest:macos": "wdio run wdio.conf.macos.js",

--- a/apps/E2E/src/Badge/pages/BasicBadgePageObject.ts
+++ b/apps/E2E/src/Badge/pages/BasicBadgePageObject.ts
@@ -1,10 +1,5 @@
-import { BADGE_TESTPAGE, HOMEPAGE_BADGE_BUTTON, BADGE_TEST_COMPONENT, BADGE_SECONDARY_TEST_COMPONENT } from '../consts';
 import { BasePage } from '../../common/BasePage';
-
-export const enum BadgeComponentSelector {
-  PrimaryComponent, //this._primaryComponent
-  SecondaryComponent, //this._secondaryComponent
-}
+import { BADGE_SECONDARY_TEST_COMPONENT, BADGE_TESTPAGE, BADGE_TEST_COMPONENT, HOMEPAGE_BADGE_BUTTON } from '../consts';
 
 class BasicBadgePageObject extends BasePage {
   async getPrimaryComponentAttribute(attribute: string): Promise<string> {

--- a/apps/E2E/src/CheckboxLegacy/pages/CheckboxLegacyPageObject.ts
+++ b/apps/E2E/src/CheckboxLegacy/pages/CheckboxLegacyPageObject.ts
@@ -1,12 +1,12 @@
+import { BasePage, By } from '../../common/BasePage';
+import { Attribute, AttributeValue } from '../../common/consts';
 import {
+  CHECKBOX_NO_A11Y_LABEL_COMPONENT,
+  CHECKBOX_ON_PRESS,
   CHECKBOX_TESTPAGE,
   CHECKBOX_TEST_COMPONENT,
-  CHECKBOX_NO_A11Y_LABEL_COMPONENT,
   HOMEPAGE_CHECKBOX_BUTTON,
-  CHECKBOX_ON_PRESS,
 } from '../consts';
-import { BasePage, By, DesktopPlatform } from '../../common/BasePage';
-import { Attribute, AttributeValue } from '../../common/consts';
 
 class CheckboxLegacyPageObject extends BasePage {
   /******************************************************************/
@@ -14,7 +14,7 @@ class CheckboxLegacyPageObject extends BasePage {
   /******************************************************************/
   async isCheckboxChecked(): Promise<boolean> {
     const checkbox = await this._primaryComponent;
-    if (this.platform === DesktopPlatform.Windows) {
+    if (this.platform === 'windows') {
       // for native windows, .isSelected() always returns false. this is a workaround
       return (await checkbox.getAttribute(Attribute.ToggleState)) === AttributeValue.on;
     } else {

--- a/apps/E2E/src/FocusZone/consts.ts
+++ b/apps/E2E/src/FocusZone/consts.ts
@@ -1,4 +1,5 @@
-import { FocusZoneDirection } from '@fluentui-react-native/focus-zone';
+import type { FocusZoneDirection } from '@fluentui-react-native/focus-zone';
+import type { GridButton } from './pages/FocusZonePageObject';
 
 export const HOMEPAGE_FOCUSZONE_BUTTON = 'Homepage_FocusZone_Button';
 export const FOCUSZONE_TESTPAGE = 'FocusZone_TestPage';
@@ -14,7 +15,7 @@ export const FOCUSZONE_GRID_BEFORE = 'FocusZone_Grid_Before';
 export const FOCUSZONE_GRID_AFTER = 'FocusZone_Grid_After';
 
 /* Grid Button Test IDs */
-export const FOCUSZONE_GRID_BUTTON = (idx: number) => `FocusZone_GridButton_${idx}`;
+export const FOCUSZONE_GRID_BUTTON = (idx: GridButton) => `FocusZone_GridButton_${idx}`;
 
 export const FOCUSZONE_TWO_DIM_SWITCH = 'FocusZone_2D_Switch';
 export const FOCUSZONE_DISABLED_SWITCH = 'FocusZone_Disabled_Switch';

--- a/apps/E2E/src/FocusZone/pages/FocusZonePageObject.ts
+++ b/apps/E2E/src/FocusZone/pages/FocusZonePageObject.ts
@@ -1,4 +1,5 @@
-import { FocusZoneDirection } from '@fluentui-react-native/focus-zone';
+import type { FocusZoneDirection } from '@fluentui-react-native/focus-zone';
+import { BasePage, By } from '../../common/BasePage';
 import {
   FOCUSZONE_CIRCLE_NAV_SWITCH,
   FOCUSZONE_DEFAULT_TABBABLE_SWITCH,
@@ -13,62 +14,39 @@ import {
   FOCUSZONE_TWO_DIM_SWITCH,
   HOMEPAGE_FOCUSZONE_BUTTON,
 } from '../consts';
-import { BasePage, By } from '../../common/BasePage';
 
-export const enum GridButton {
-  One = 1,
-  Two,
-  Three,
-  Four,
-  Five,
-  Six,
-  Seven,
-  Eight,
-  Nine,
-}
+export type GridButton = '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9';
 
-export const enum GridFocusZoneOption {
-  SetDirection = 0,
-  Set2DNavigation,
-  SetCircularNavigation,
-  UseDefaultTabbableElement,
-  Disable,
-}
-
-type BooleanGridFocusZoneOption =
-  | GridFocusZoneOption.UseDefaultTabbableElement
-  | GridFocusZoneOption.Set2DNavigation
-  | GridFocusZoneOption.SetCircularNavigation
-  | GridFocusZoneOption.Disable;
+type GridFocusZoneOption = 'SetDirection' | 'Set2DNavigation' | 'SetCircularNavigation' | 'UseDefaultTabbableElement' | 'Disable';
 
 class FocusZonePageObject extends BasePage {
   async resetTest() {
-    await this.configureGridFocusZone(GridFocusZoneOption.SetDirection, 'bidirectional');
-    await this.configureGridFocusZone(GridFocusZoneOption.Set2DNavigation, false);
-    await this.configureGridFocusZone(GridFocusZoneOption.SetCircularNavigation, false);
-    await this.configureGridFocusZone(GridFocusZoneOption.Disable, false);
+    await this.configureGridFocusZone('SetDirection', 'bidirectional');
+    await this.configureGridFocusZone('Set2DNavigation', false);
+    await this.configureGridFocusZone('SetCircularNavigation', false);
+    await this.configureGridFocusZone('Disable', false);
   }
 
-  async configureGridFocusZone(option: GridFocusZoneOption.SetDirection, direction: FocusZoneDirection);
-  async configureGridFocusZone(option: BooleanGridFocusZoneOption, value: boolean);
+  async configureGridFocusZone(option: 'SetDirection', direction: FocusZoneDirection);
+  async configureGridFocusZone(option: GridFocusZoneOption, value: boolean);
   async configureGridFocusZone(option: GridFocusZoneOption, arg: any): Promise<void> {
     let switchElement: WebdriverIO.Element;
     switch (option) {
-      case GridFocusZoneOption.SetDirection:
+      case 'SetDirection':
         await (await this._directionPicker).click();
         await browser.waitUntil(async () => await (await this._getGridFocusZoneMenuOption(arg)).isDisplayed());
         await (await this._getGridFocusZoneMenuOption(arg)).click();
         return;
-      case GridFocusZoneOption.Set2DNavigation:
+      case 'Set2DNavigation':
         switchElement = await this._twoDimSwitch;
         break;
-      case GridFocusZoneOption.SetCircularNavigation:
+      case 'SetCircularNavigation':
         switchElement = await this._circleNavSwitch;
         break;
-      case GridFocusZoneOption.UseDefaultTabbableElement:
+      case 'UseDefaultTabbableElement':
         switchElement = await this._defaultTabbableElementSwitch;
         break;
-      case GridFocusZoneOption.Disable:
+      case 'Disable':
         switchElement = await this._disabledSwitch;
         break;
       default:

--- a/apps/E2E/src/FocusZone/specs/FocusZone.spec.win.ts
+++ b/apps/E2E/src/FocusZone/specs/FocusZone.spec.win.ts
@@ -1,12 +1,12 @@
+import { Attribute, AttributeValue, BOOT_APP_TIMEOUT, Keys, PAGE_TIMEOUT } from '../../common/consts';
 import NavigateAppPage from '../../common/NavigateAppPage';
-import FocusZonePageObject, { GridButton, GridFocusZoneOption } from '../pages/FocusZonePageObject';
-import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT, Keys, Attribute, AttributeValue } from '../../common/consts';
+import FocusZonePageObject from '../pages/FocusZonePageObject';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('FocusZone Testing Initialization', function () {
   it('Wait for app load', async () => {
     await NavigateAppPage.waitForPageDisplayed(BOOT_APP_TIMEOUT);
-    await expect(await NavigateAppPage.isPageLoaded()).toBeTruthy(NavigateAppPage.ERRORMESSAGE_APPLOAD);
+    expect(await NavigateAppPage.isPageLoaded()).toBeTruthy(NavigateAppPage.ERRORMESSAGE_APPLOAD);
   });
 
   it('Click and navigate to FocusZone test page', async () => {
@@ -14,8 +14,8 @@ describe('FocusZone Testing Initialization', function () {
     await NavigateAppPage.clickAndGoToFocusZonePage();
     await FocusZonePageObject.waitForPageDisplayed(PAGE_TIMEOUT);
 
-    await expect(await FocusZonePageObject.isPageLoaded()).toBeTruthy(FocusZonePageObject.ERRORMESSAGE_PAGELOAD);
-    await expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    expect(await FocusZonePageObject.isPageLoaded()).toBeTruthy(FocusZonePageObject.ERRORMESSAGE_PAGELOAD);
+    expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
   });
 });
 
@@ -34,238 +34,226 @@ describe('FocusZone Functional Testing', () => {
 
   it('Navigate bidirectional focuszone by arrow keys - switches focus correctly', async () => {
     // move to 2 with right arrow
-    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton(GridButton.One), [Keys.ARROW_RIGHT]);
-    await expect(
-      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton(GridButton.Two), Attribute.IsFocused, AttributeValue.true),
+    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton('1'), [Keys.ARROW_RIGHT]);
+    expect(
+      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton('2'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
     // move to 3 with down arrow
-    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton(GridButton.Two), [Keys.ARROW_DOWN]);
-    await expect(
-      await FocusZonePageObject.compareAttribute(
-        FocusZonePageObject.gridButton(GridButton.Three),
-        Attribute.IsFocused,
-        AttributeValue.true,
-      ),
+    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton('2'), [Keys.ARROW_DOWN]);
+    expect(
+      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton('3'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    await expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
+    expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
   });
 
   it('Navigate horizontal focuszone by arrow keys - switches focus correctly', async () => {
-    await FocusZonePageObject.configureGridFocusZone(GridFocusZoneOption.SetDirection, 'horizontal');
+    await FocusZonePageObject.configureGridFocusZone('SetDirection', 'horizontal');
     // move to 2 with right arrow
-    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton(GridButton.One), [Keys.ARROW_RIGHT]);
-    await expect(
-      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton(GridButton.Two), Attribute.IsFocused, AttributeValue.true),
+    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton('1'), [Keys.ARROW_RIGHT]);
+    expect(
+      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton('2'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
     // down arrow shouldn't move focus
-    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton(GridButton.Two), [Keys.ARROW_DOWN]);
-    await expect(
-      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton(GridButton.Two), Attribute.IsFocused, AttributeValue.true),
+    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton('2'), [Keys.ARROW_DOWN]);
+    expect(
+      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton('2'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
     // left arrow goes back
-    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton(GridButton.Four), [Keys.ARROW_LEFT]);
-    await expect(
-      await FocusZonePageObject.compareAttribute(
-        FocusZonePageObject.gridButton(GridButton.Three),
-        Attribute.IsFocused,
-        AttributeValue.true,
-      ),
+    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton('4'), [Keys.ARROW_LEFT]);
+    expect(
+      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton('3'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    await expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
+    expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
   });
 
   it('Navigates vertical focuszone by arrow keys - switches focus correctly', async () => {
-    await FocusZonePageObject.configureGridFocusZone(GridFocusZoneOption.SetDirection, 'vertical');
+    await FocusZonePageObject.configureGridFocusZone('SetDirection', 'vertical');
 
     // move to 2 with down arrow
-    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton(GridButton.One), [Keys.ARROW_DOWN]);
-    await expect(
-      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton(GridButton.Two), Attribute.IsFocused, AttributeValue.true),
+    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton('1'), [Keys.ARROW_DOWN]);
+    expect(
+      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton('2'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
     // right arrow shouldn't move focus
-    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton(GridButton.Two), [Keys.ARROW_RIGHT]);
-    await expect(
-      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton(GridButton.Two), Attribute.IsFocused, AttributeValue.true),
+    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton('2'), [Keys.ARROW_RIGHT]);
+    expect(
+      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton('2'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
     // up arrow goes back
-    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton(GridButton.Four), [Keys.ARROW_UP]);
-    await expect(
-      await FocusZonePageObject.compareAttribute(
-        FocusZonePageObject.gridButton(GridButton.Three),
-        Attribute.IsFocused,
-        AttributeValue.true,
-      ),
+    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton('4'), [Keys.ARROW_UP]);
+    expect(
+      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton('3'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    await expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
+    expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
   });
 
   it("Navigates none-direction focuszone by arrow keys - doesn't switch focus", async () => {
-    await FocusZonePageObject.configureGridFocusZone(GridFocusZoneOption.SetDirection, 'none');
+    await FocusZonePageObject.configureGridFocusZone('SetDirection', 'none');
 
     // none of these key commands should move
-    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton(GridButton.Two), [Keys.ARROW_DOWN]);
-    await expect(
-      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton(GridButton.Two), Attribute.IsFocused, AttributeValue.true),
+    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton('2'), [Keys.ARROW_DOWN]);
+    expect(
+      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton('2'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton(GridButton.Two), [Keys.ARROW_UP]);
-    await expect(
-      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton(GridButton.Two), Attribute.IsFocused, AttributeValue.true),
+    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton('2'), [Keys.ARROW_UP]);
+    expect(
+      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton('2'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton(GridButton.Two), [Keys.ARROW_LEFT]);
-    await expect(
-      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton(GridButton.Two), Attribute.IsFocused, AttributeValue.true),
+    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton('2'), [Keys.ARROW_LEFT]);
+    expect(
+      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton('2'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton(GridButton.Two), [Keys.ARROW_RIGHT]);
-    await expect(
-      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton(GridButton.Two), Attribute.IsFocused, AttributeValue.true),
+    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton('2'), [Keys.ARROW_RIGHT]);
+    expect(
+      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton('2'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    await expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
+    expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
   });
 
   it('Navigates bi-directional focuszone with 2d navigation - switches focus correctly', async () => {
-    await FocusZonePageObject.configureGridFocusZone(GridFocusZoneOption.Set2DNavigation, true);
+    await FocusZonePageObject.configureGridFocusZone('Set2DNavigation', true);
 
-    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton(GridButton.One), [Keys.ARROW_DOWN]);
-    await expect(
-      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton(GridButton.Four), Attribute.IsFocused, AttributeValue.true),
+    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton('1'), [Keys.ARROW_DOWN]);
+    expect(
+      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton('4'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton(GridButton.Four), [Keys.ARROW_RIGHT]);
-    await expect(
-      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton(GridButton.Five), Attribute.IsFocused, AttributeValue.true),
+    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton('4'), [Keys.ARROW_RIGHT]);
+    expect(
+      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton('5'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    await expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
+    expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
   });
 
   it("Navigates focuszone with circular navigation off - doesn't switch focus", async () => {
-    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton(GridButton.One), [Keys.ARROW_LEFT]);
-    await expect(
-      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton(GridButton.One), Attribute.IsFocused, AttributeValue.true),
+    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton('1'), [Keys.ARROW_LEFT]);
+    expect(
+      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton('1'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton(GridButton.Nine), [Keys.ARROW_RIGHT]);
-    await expect(
-      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton(GridButton.Nine), Attribute.IsFocused, AttributeValue.true),
+    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton('9'), [Keys.ARROW_RIGHT]);
+    expect(
+      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton('9'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    await expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
+    expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
   });
 
   it('Navigates focuszone with circular navigation on - switches focus correctly', async () => {
-    await FocusZonePageObject.configureGridFocusZone(GridFocusZoneOption.SetCircularNavigation, true);
+    await FocusZonePageObject.configureGridFocusZone('SetCircularNavigation', true);
 
-    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton(GridButton.One), [Keys.ARROW_LEFT]);
-    await expect(
-      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton(GridButton.Nine), Attribute.IsFocused, AttributeValue.true),
+    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton('1'), [Keys.ARROW_LEFT]);
+    expect(
+      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton('9'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton(GridButton.Nine), [Keys.ARROW_RIGHT]);
-    await expect(
-      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton(GridButton.One), Attribute.IsFocused, AttributeValue.true),
+    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton('9'), [Keys.ARROW_RIGHT]);
+    expect(
+      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton('1'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    await expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
+    expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
   });
 
   it("Navigates disabled focuszone by arrow keys - doesn't switch focus", async () => {
-    await FocusZonePageObject.configureGridFocusZone(GridFocusZoneOption.Disable, true);
+    await FocusZonePageObject.configureGridFocusZone('Disable', true);
 
     // none of these key commands should move
-    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton(GridButton.Two), [Keys.ARROW_DOWN]);
-    await expect(
-      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton(GridButton.Two), Attribute.IsFocused, AttributeValue.true),
+    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton('2'), [Keys.ARROW_DOWN]);
+    expect(
+      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton('2'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton(GridButton.Two), [Keys.ARROW_UP]);
-    await expect(
-      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton(GridButton.Two), Attribute.IsFocused, AttributeValue.true),
+    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton('2'), [Keys.ARROW_UP]);
+    expect(
+      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton('2'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton(GridButton.Two), [Keys.ARROW_LEFT]);
-    await expect(
-      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton(GridButton.Two), Attribute.IsFocused, AttributeValue.true),
+    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton('2'), [Keys.ARROW_LEFT]);
+    expect(
+      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton('2'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton(GridButton.Two), [Keys.ARROW_RIGHT]);
-    await expect(
-      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton(GridButton.Two), Attribute.IsFocused, AttributeValue.true),
+    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton('2'), [Keys.ARROW_RIGHT]);
+    expect(
+      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton('2'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    await expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
+    expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
   });
 
   it('Tabs in and out of the FocusZone - switches focus correctly', async () => {
     await FocusZonePageObject.sendKeys(FocusZonePageObject._beforeButton, [Keys.TAB]);
-    await expect(
-      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton(GridButton.One), Attribute.IsFocused, AttributeValue.true),
+    expect(
+      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton('1'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton(GridButton.One), [Keys.TAB]);
-    await expect(
+    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton('1'), [Keys.TAB]);
+    expect(
       await FocusZonePageObject.compareAttribute(FocusZonePageObject._afterButton, Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
     await FocusZonePageObject.sendKeys(FocusZonePageObject._afterButton, [Keys.SHIFT, Keys.TAB]);
-    await expect(
-      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton(GridButton.Nine), Attribute.IsFocused, AttributeValue.true),
+    expect(
+      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton('9'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton(GridButton.Nine), [Keys.SHIFT, Keys.TAB]);
-    await expect(
+    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton('9'), [Keys.SHIFT, Keys.TAB]);
+    expect(
       await FocusZonePageObject.compareAttribute(FocusZonePageObject._beforeButton, Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    await expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
+    expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
   });
 
   it('Tabs in and out of the FocusZone with a defaultTabbableElement set - switches focus correctly', async () => {
     // This sets the defaultTabbableElement prop of the FocusZone to be grid button #4. Whenever a user tabs into the zone, button 4 should always be the first to be selected.
-    await FocusZonePageObject.configureGridFocusZone(GridFocusZoneOption.UseDefaultTabbableElement, true);
+    await FocusZonePageObject.configureGridFocusZone('UseDefaultTabbableElement', true);
 
     await FocusZonePageObject.sendKeys(FocusZonePageObject._beforeButton, [Keys.TAB]);
-    await expect(
-      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton(GridButton.Four), Attribute.IsFocused, AttributeValue.true),
+    expect(
+      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton('4'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton(GridButton.Four), [Keys.TAB]);
-    await expect(
+    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton('4'), [Keys.TAB]);
+    expect(
       await FocusZonePageObject.compareAttribute(FocusZonePageObject._afterButton, Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
     await FocusZonePageObject.sendKeys(FocusZonePageObject._afterButton, [Keys.SHIFT, Keys.TAB]);
-    await expect(
-      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton(GridButton.Four), Attribute.IsFocused, AttributeValue.true),
+    expect(
+      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton('4'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
     // Key to another button, tab out, and tab back in to make sure the default tabbable element is still the first to be tabbed to
-    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton(GridButton.Four), [Keys.ARROW_RIGHT]);
-    await expect(
-      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton(GridButton.Five), Attribute.IsFocused, AttributeValue.true),
+    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton('4'), [Keys.ARROW_RIGHT]);
+    expect(
+      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton('5'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton(GridButton.Five), [Keys.SHIFT, Keys.TAB]);
-    await expect(
+    await FocusZonePageObject.sendKeys(FocusZonePageObject.gridButton('5'), [Keys.SHIFT, Keys.TAB]);
+    expect(
       await FocusZonePageObject.compareAttribute(FocusZonePageObject._beforeButton, Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
     await FocusZonePageObject.sendKeys(FocusZonePageObject._beforeButton, [Keys.TAB]);
-    await expect(
-      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton(GridButton.Four), Attribute.IsFocused, AttributeValue.true),
+    expect(
+      await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton('4'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    await expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
+    expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
   });
 });

--- a/apps/E2E/src/Menu/pages/MenuPageObject.ts
+++ b/apps/E2E/src/Menu/pages/MenuPageObject.ts
@@ -1,24 +1,19 @@
-import {
-  MENU_TESTPAGE,
-  MENUTRIGGER_TEST_COMPONENT,
-  MENUITEM_NO_A11Y_LABEL_COMPONENT,
-  HOMEPAGE_MENU_BUTTON,
-  MENUITEM_TEST_COMPONENT,
-  MENUITEM_DISABLED_COMPONENT,
-  MENUITEM_FOURTH_COMPONENT,
-  MENU_CALLBACK_RESET_BUTTON,
-  MENUITEM_CALLBACK_LABEL,
-} from '../consts';
 import { BasePage, By } from '../../common/BasePage';
 import { Keys } from '../../common/consts';
+import {
+  HOMEPAGE_MENU_BUTTON,
+  MENUITEM_CALLBACK_LABEL,
+  MENUITEM_DISABLED_COMPONENT,
+  MENUITEM_FOURTH_COMPONENT,
+  MENUITEM_NO_A11Y_LABEL_COMPONENT,
+  MENUITEM_TEST_COMPONENT,
+  MENUTRIGGER_TEST_COMPONENT,
+  MENU_CALLBACK_RESET_BUTTON,
+  MENU_TESTPAGE,
+} from '../consts';
 
 /** Allows a caller to get specific menu items using .getMenuItem() */
-export const enum MenuItem {
-  First,
-  Second,
-  Third,
-  Fourth,
-}
+type MenuItem = 'First' | 'Second' | 'Third' | 'Fourth';
 
 class MenuPageObject extends BasePage {
   /******************************************************************/
@@ -39,7 +34,7 @@ class MenuPageObject extends BasePage {
 
   async closeMenu(): Promise<void> {
     if (await this.menuIsExpanded()) {
-      await this.sendKeys(this.getMenuItem(MenuItem.First), [Keys.ESCAPE]);
+      await this.sendKeys(this.getMenuItem('First'), [Keys.ESCAPE]);
       await this.waitForMenuToClose();
     }
   }
@@ -68,7 +63,7 @@ class MenuPageObject extends BasePage {
 
   /* If the first item is displayed, then it's safe to say that the rest of the menu is expanded. */
   async menuIsExpanded(): Promise<boolean> {
-    const menuItem = await this.getMenuItem(MenuItem.First);
+    const menuItem = await this.getMenuItem('First');
     if (menuItem.error) {
       // Not displayed because the item can't be found by appium
       return false;
@@ -95,13 +90,13 @@ class MenuPageObject extends BasePage {
 
   async getMenuItem(item: MenuItem): Promise<WebdriverIO.Element> {
     switch (item) {
-      case MenuItem.First:
+      case 'First':
         return await By(MENUITEM_TEST_COMPONENT);
-      case MenuItem.Second:
+      case 'Second':
         return await By(MENUITEM_DISABLED_COMPONENT);
-      case MenuItem.Third:
+      case 'Third':
         return await By(MENUITEM_NO_A11Y_LABEL_COMPONENT);
-      case MenuItem.Fourth:
+      case 'Fourth':
         return await By(MENUITEM_FOURTH_COMPONENT);
     }
   }

--- a/apps/E2E/src/Menu/specs/Menu.spec.win.ts
+++ b/apps/E2E/src/Menu/specs/Menu.spec.win.ts
@@ -1,13 +1,13 @@
+import { Attribute, AttributeValue, BOOT_APP_TIMEOUT, Keys, MENUITEM_A11Y_ROLE, PAGE_TIMEOUT } from '../../common/consts';
 import NavigateAppPage from '../../common/NavigateAppPage';
-import MenuPageObject, { MenuItem } from '../pages/MenuPageObject';
-import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT, Keys, MENUITEM_A11Y_ROLE, AttributeValue, Attribute } from '../../common/consts';
 import { MENUITEM_ACCESSIBILITY_LABEL, MENUITEM_TEST_LABEL } from '../consts';
+import MenuPageObject from '../pages/MenuPageObject';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Menu Testing Initialization', function () {
   it('Wait for app load', async () => {
     await NavigateAppPage.waitForPageDisplayed(BOOT_APP_TIMEOUT);
-    await expect(await NavigateAppPage.isPageLoaded()).toBeTruthy(NavigateAppPage.ERRORMESSAGE_APPLOAD);
+    expect(await NavigateAppPage.isPageLoaded()).toBeTruthy(NavigateAppPage.ERRORMESSAGE_APPLOAD);
   });
 
   it('Click and navigate to Menu test page', async () => {
@@ -15,9 +15,9 @@ describe('Menu Testing Initialization', function () {
     await NavigateAppPage.clickAndGoToMenuPage();
     await MenuPageObject.waitForPageDisplayed(PAGE_TIMEOUT);
 
-    await expect(await MenuPageObject.isPageLoaded()).toBeTruthy(MenuPageObject.ERRORMESSAGE_PAGELOAD);
+    expect(await MenuPageObject.isPageLoaded()).toBeTruthy(MenuPageObject.ERRORMESSAGE_PAGELOAD);
 
-    await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
   });
 });
 
@@ -29,45 +29,45 @@ describe('Menu Accessibility Testing', () => {
 
   it('Validate MenuItem "accessibilityRole" defaults to MenuItem "ControlType" element attribute.', async () => {
     // The popover is where we can find the a11y role of menu
-    await expect(
-      await MenuPageObject.compareAttribute(MenuPageObject.getMenuItem(MenuItem.First), Attribute.AccessibilityRole, MENUITEM_A11Y_ROLE),
+    expect(
+      await MenuPageObject.compareAttribute(MenuPageObject.getMenuItem('First'), Attribute.AccessibilityRole, MENUITEM_A11Y_ROLE),
     ).toBeTruthy();
 
-    await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
+    expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
   });
 
   it('Set MenuItem "accessibilityLabel" prop. Validate "accessibilityLabel" value propagates to "Name" element attribute.', async () => {
-    await expect(
+    expect(
       await MenuPageObject.compareAttribute(
-        MenuPageObject.getMenuItem(MenuItem.First),
+        MenuPageObject.getMenuItem('First'),
         Attribute.AccessibilityLabel,
         MENUITEM_ACCESSIBILITY_LABEL,
       ),
     ).toBeTruthy();
 
-    await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
+    expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
   });
 
   it('Do not set MenuItem "accessibilityLabel". Validate MenuItem "Name" element attribute defaults to current MenuItem label.', async () => {
-    await expect(
-      await MenuPageObject.compareAttribute(MenuPageObject.getMenuItem(MenuItem.Third), Attribute.AccessibilityLabel, MENUITEM_TEST_LABEL),
+    expect(
+      await MenuPageObject.compareAttribute(MenuPageObject.getMenuItem('Third'), Attribute.AccessibilityLabel, MENUITEM_TEST_LABEL),
     ).toBeTruthy();
 
-    await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
+    expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
   });
 
   it('Toggle Menu by click. Validate "ExpandCollapseState" element attribute correctly changes.', async () => {
-    await expect(
+    expect(
       await MenuPageObject.compareAttribute(MenuPageObject._menuTrigger, Attribute.ExpandCollapseState, AttributeValue.expanded),
     ).toBeTruthy();
 
     await MenuPageObject.closeMenu();
 
-    await expect(
+    expect(
       await MenuPageObject.compareAttribute(MenuPageObject._menuTrigger, Attribute.ExpandCollapseState, AttributeValue.collapsed),
     ).toBeTruthy();
 
-    await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
+    expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
   });
 });
 
@@ -81,106 +81,106 @@ describe('Menu Functional Testing', () => {
 
   it('Click MenuTrigger. Validate Menu is opened by checking if MenuItems are visible.', async () => {
     await MenuPageObject.click(MenuPageObject._menuTrigger);
-    await expect(await MenuPageObject.waitForMenuToOpen()).toBeTruthy();
+    expect(await MenuPageObject.waitForMenuToOpen()).toBeTruthy();
 
-    await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
+    expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
   });
 
   it('Press "Enter" on MenuTrigger. Validate Menu is opened by checking if MenuItems are visible.', async () => {
     await MenuPageObject.sendKeys(MenuPageObject._menuTrigger, [Keys.ENTER]);
-    await expect(await MenuPageObject.waitForMenuToOpen()).toBeTruthy();
+    expect(await MenuPageObject.waitForMenuToOpen()).toBeTruthy();
 
-    await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
+    expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
   });
 
   it('Press "Space" on MenuTrigger -> Validate Menu is opened by checking if MenuItems are visible.', async () => {
     await MenuPageObject.sendKeys(MenuPageObject._menuTrigger, [Keys.SPACE]);
-    await expect(await MenuPageObject.waitForMenuToOpen()).toBeTruthy();
+    expect(await MenuPageObject.waitForMenuToOpen()).toBeTruthy();
 
-    await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
+    expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
   });
 
   it('Press "Space", Press "Enter", and "Click" on MenuItem. Validate that onClick() callback fires correctly.', async () => {
     await MenuPageObject.openMenu();
 
-    await MenuPageObject.sendKeys(MenuPageObject.getMenuItem(MenuItem.First), [Keys.SPACE]);
+    await MenuPageObject.sendKeys(MenuPageObject.getMenuItem('First'), [Keys.SPACE]);
     await MenuPageObject.waitForItemCallbackToFire(1);
-    await expect(await MenuPageObject.itemOnClickHasFired(1)).toBeTruthy('Space input failed to fire MenuItem onClick callback');
+    expect(await MenuPageObject.itemOnClickHasFired(1)).toBeTruthy('Space input failed to fire MenuItem onClick callback');
 
-    await MenuPageObject.sendKeys(MenuPageObject.getMenuItem(MenuItem.First), [Keys.ENTER]);
+    await MenuPageObject.sendKeys(MenuPageObject.getMenuItem('First'), [Keys.ENTER]);
     await MenuPageObject.waitForItemCallbackToFire(2);
-    await expect(await MenuPageObject.itemOnClickHasFired(2)).toBeTruthy('Enter input failed to fire MenuItem onClick callback');
+    expect(await MenuPageObject.itemOnClickHasFired(2)).toBeTruthy('Enter input failed to fire MenuItem onClick callback');
 
-    await MenuPageObject.click(MenuPageObject.getMenuItem(MenuItem.First));
+    await MenuPageObject.click(MenuPageObject.getMenuItem('First'));
     await MenuPageObject.waitForItemCallbackToFire(3);
-    await expect(await MenuPageObject.itemOnClickHasFired(3)).toBeTruthy('Click input failed to fire MenuItem onClick callback');
+    expect(await MenuPageObject.itemOnClickHasFired(3)).toBeTruthy('Click input failed to fire MenuItem onClick callback');
 
-    await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
+    expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
   });
 
   it('Press "Space", Press "Enter", and "Click" on disabled MenuItem. Validate that onClick() callback does not fire.', async () => {
     await MenuPageObject.openMenu();
 
-    await MenuPageObject.sendKeys(MenuPageObject.getMenuItem(MenuItem.Second), [Keys.SPACE]);
+    await MenuPageObject.sendKeys(MenuPageObject.getMenuItem('Second'), [Keys.SPACE]);
     await MenuPageObject.waitForItemCallbackToFire(0);
-    await expect(await MenuPageObject.itemOnClickHasFired(0)).toBeTruthy('Space input fired disabled MenuItem onClick callback');
+    expect(await MenuPageObject.itemOnClickHasFired(0)).toBeTruthy('Space input fired disabled MenuItem onClick callback');
 
-    await MenuPageObject.sendKeys(MenuPageObject.getMenuItem(MenuItem.Second), [Keys.ENTER]);
+    await MenuPageObject.sendKeys(MenuPageObject.getMenuItem('Second'), [Keys.ENTER]);
     await MenuPageObject.waitForItemCallbackToFire(0);
-    await expect(await MenuPageObject.itemOnClickHasFired(0)).toBeTruthy('Enter input fired disabled MenuItem onClick callback');
+    expect(await MenuPageObject.itemOnClickHasFired(0)).toBeTruthy('Enter input fired disabled MenuItem onClick callback');
 
-    await MenuPageObject.click(MenuPageObject.getMenuItem(MenuItem.Second));
+    await MenuPageObject.click(MenuPageObject.getMenuItem('Second'));
     await MenuPageObject.waitForItemCallbackToFire(0);
-    await expect(await MenuPageObject.itemOnClickHasFired(0)).toBeTruthy('Click input fired disabled MenuItem onClick callback');
+    expect(await MenuPageObject.itemOnClickHasFired(0)).toBeTruthy('Click input fired disabled MenuItem onClick callback');
 
-    await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
+    expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
   });
 
   it('Press "Up" + "Down" to navigate between MenuItems. Validate that focus switches correctly between MenuItems.', async () => {
     await MenuPageObject.openMenu();
 
-    await MenuPageObject.sendKeys(MenuPageObject.getMenuItem(MenuItem.First), [Keys.DOWN]);
-    await expect(
-      await MenuPageObject.compareAttribute(MenuPageObject.getMenuItem(MenuItem.Second), Attribute.IsFocused, AttributeValue.true),
+    await MenuPageObject.sendKeys(MenuPageObject.getMenuItem('First'), [Keys.DOWN]);
+    expect(
+      await MenuPageObject.compareAttribute(MenuPageObject.getMenuItem('Second'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    await MenuPageObject.sendKeys(MenuPageObject.getMenuItem(MenuItem.Second), [Keys.UP]);
-    await expect(
-      await MenuPageObject.compareAttribute(MenuPageObject.getMenuItem(MenuItem.First), Attribute.IsFocused, AttributeValue.true),
+    await MenuPageObject.sendKeys(MenuPageObject.getMenuItem('Second'), [Keys.UP]);
+    expect(
+      await MenuPageObject.compareAttribute(MenuPageObject.getMenuItem('First'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    await MenuPageObject.sendKeys(MenuPageObject.getMenuItem(MenuItem.First), [Keys.UP]);
-    await expect(
-      await MenuPageObject.compareAttribute(MenuPageObject.getMenuItem(MenuItem.Fourth), Attribute.IsFocused, AttributeValue.true),
+    await MenuPageObject.sendKeys(MenuPageObject.getMenuItem('First'), [Keys.UP]);
+    expect(
+      await MenuPageObject.compareAttribute(MenuPageObject.getMenuItem('Fourth'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
+    expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
   });
 
   it('Press "Tab" to navigate between MenuItems. Validate that focus switches correctly between MenuItems.', async () => {
     await MenuPageObject.openMenu();
 
-    await MenuPageObject.sendKeys(MenuPageObject.getMenuItem(MenuItem.Third), [Keys.TAB]);
-    await expect(
-      await MenuPageObject.compareAttribute(MenuPageObject.getMenuItem(MenuItem.Fourth), Attribute.IsFocused, AttributeValue.true),
+    await MenuPageObject.sendKeys(MenuPageObject.getMenuItem('Third'), [Keys.TAB]);
+    expect(
+      await MenuPageObject.compareAttribute(MenuPageObject.getMenuItem('Fourth'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    await MenuPageObject.sendKeys(MenuPageObject.getMenuItem(MenuItem.Fourth), [Keys.TAB]);
-    await expect(
-      await MenuPageObject.compareAttribute(MenuPageObject.getMenuItem(MenuItem.First), Attribute.IsFocused, AttributeValue.true),
+    await MenuPageObject.sendKeys(MenuPageObject.getMenuItem('Fourth'), [Keys.TAB]);
+    expect(
+      await MenuPageObject.compareAttribute(MenuPageObject.getMenuItem('First'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
+    expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
   });
 
   it('Press "Escape" on MenuItem. Validate that Menu closes by checking if MenuItems are not visible.', async () => {
     await MenuPageObject.openMenu();
 
-    await MenuPageObject.sendKeys(MenuPageObject.getMenuItem(MenuItem.First), [Keys.ESCAPE]);
-    await expect(await MenuPageObject.menuIsExpanded()).toBeFalsy(
+    await MenuPageObject.sendKeys(MenuPageObject.getMenuItem('First'), [Keys.ESCAPE]);
+    expect(await MenuPageObject.menuIsExpanded()).toBeFalsy(
       'Expected the Menu to close, but its MenuItems are still displayed - the menu appears to still be open.',
     );
 
-    await expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
+    expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
   });
 });

--- a/apps/E2E/src/MenuButtonLegacy/pages/MenuButtonLegacyPageObject.win.ts
+++ b/apps/E2E/src/MenuButtonLegacy/pages/MenuButtonLegacyPageObject.win.ts
@@ -1,16 +1,11 @@
+import { BasePage, By } from '../../common/BasePage';
 import {
-  MENU_BUTTON_TESTPAGE,
-  MENU_BUTTON_TEST_COMPONENT,
   HOMEPAGE_MENUBUTTON_BUTTON,
   MENU_BUTTON_NO_A11Y_LABEL_COMPONENT,
+  MENU_BUTTON_TESTPAGE,
+  MENU_BUTTON_TEST_COMPONENT,
   MENU_ITEM_1_COMPONENT,
 } from '../consts';
-import { BasePage, By } from '../../common/BasePage';
-
-export const enum MenuButtonSelector {
-  MenuButton = 0, // this._primarySelector
-  MenuItem1, // this._menuItem
-}
 
 class MenuButtonLegacyPageObject extends BasePage {
   /******************************************************************/

--- a/apps/E2E/src/RadioGroupLegacy/pages/RadioGroupLegacyPageObject.ts
+++ b/apps/E2E/src/RadioGroupLegacy/pages/RadioGroupLegacyPageObject.ts
@@ -1,24 +1,23 @@
+import { BasePage, By } from '../../common/BasePage';
 import {
+  FIRST_RADIO_BUTTON,
+  FOURTH_RADIO_BUTTON,
+  HOMEPAGE_RADIOGROUP_BUTTON,
+  RADIOGROUP_NO_A11Y_LABEL_COMPONENT,
   RADIOGROUP_TESTPAGE,
   RADIOGROUP_TEST_COMPONENT,
-  RADIOGROUP_NO_A11Y_LABEL_COMPONENT,
-  HOMEPAGE_RADIOGROUP_BUTTON,
-  FIRST_RADIO_BUTTON,
   SECOND_RADIO_BUTTON,
   THIRD_RADIO_BUTTON,
-  FOURTH_RADIO_BUTTON,
 } from '../consts';
-import { BasePage, By } from '../../common/BasePage';
 
 /* This enum gives the spec file an EASY way to interact with SPECIFIC UI elements on the page.
  * The main RadioGroup we are testing has FOUR RadioButtons. The spec file will
  * import this enum to easily write tests using these 4 radio buttons. */
-export const enum RadioButton {
-  First = 1, // this._firstRadioButton
-  Second, // this._secondRadioButton
-  Third, // this._thirdRadioButton
-  Fourth, // this._fourthRadioButton
-}
+type RadioButton =
+  | 'First' // this._firstRadioButton
+  | 'Second' // this._secondRadioButton
+  | 'Third' // this._thirdRadioButton
+  | 'Fourth'; // this._fourthRadioButton
 
 class RadioGroupLegacyPage extends BasePage {
   /******************************************************************/
@@ -28,7 +27,7 @@ class RadioGroupLegacyPage extends BasePage {
   /* This resets the RadioGroup selection by clicking/selecting the 1st RadioButton in the RadioGroup.
    * Useful in beforeEach() hooks to reset the RadioGroup before additional tests */
   async resetRadioGroupSelection(): Promise<void> {
-    await (await this.getRadioButton(RadioButton.First)).click();
+    await (await this.getRadioButton('First')).click();
   }
 
   async isRadioButtonSelected(selector: RadioButton): Promise<boolean> {
@@ -43,13 +42,13 @@ class RadioGroupLegacyPage extends BasePage {
   /* Returns the correct WebDriverIO element from the RadioButton Selector */
   async getRadioButton(selector: RadioButton): Promise<WebdriverIO.Element> {
     switch (selector) {
-      case RadioButton.First:
+      case 'First':
         return await By(FIRST_RADIO_BUTTON);
-      case RadioButton.Second:
+      case 'Second':
         return await By(SECOND_RADIO_BUTTON);
-      case RadioButton.Third:
+      case 'Third':
         return await By(THIRD_RADIO_BUTTON);
-      case RadioButton.Fourth:
+      case 'Fourth':
         return await By(FOURTH_RADIO_BUTTON);
     }
   }

--- a/apps/E2E/src/RadioGroupLegacy/specs/RadioGroupLegacy.spec.win.ts
+++ b/apps/E2E/src/RadioGroupLegacy/specs/RadioGroupLegacy.spec.win.ts
@@ -1,18 +1,18 @@
+import { Attribute, BOOT_APP_TIMEOUT, Keys, PAGE_TIMEOUT, RADIOBUTTON_A11Y_ROLE, RADIOGROUP_A11Y_ROLE } from '../../common/consts';
 import NavigateAppPage from '../../common/NavigateAppPage';
-import RadioGroupPageObject, { RadioButton } from '../pages/RadioGroupLegacyPageObject';
-import { RADIOBUTTON_A11Y_ROLE, RADIOGROUP_A11Y_ROLE, PAGE_TIMEOUT, BOOT_APP_TIMEOUT, Keys, Attribute } from '../../common/consts';
 import {
+  FIRST_RADIO_BUTTON_ACCESSIBILITY_LABEL,
   RADIOGROUP_ACCESSIBILITY_LABEL,
   RADIOGROUP_TEST_COMPONENT_LABEL,
-  FIRST_RADIO_BUTTON_ACCESSIBILITY_LABEL,
   SECOND_RADIO_BUTTON_LABEL,
 } from '../consts';
+import RadioGroupPageObject from '../pages/RadioGroupLegacyPageObject';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('RadioGroup/RadioButton Legacy Testing Initialization', function () {
   it('Wait for app load', async () => {
     await NavigateAppPage.waitForPageDisplayed(BOOT_APP_TIMEOUT);
-    await expect(await NavigateAppPage.isPageLoaded()).toBeTruthy(NavigateAppPage.ERRORMESSAGE_APPLOAD);
+    expect(await NavigateAppPage.isPageLoaded()).toBeTruthy(NavigateAppPage.ERRORMESSAGE_APPLOAD);
   });
 
   it('Click and navigate to RadioGroup Legacy test page', async () => {
@@ -20,8 +20,8 @@ describe('RadioGroup/RadioButton Legacy Testing Initialization', function () {
     await NavigateAppPage.clickAndGoToRadioGroupLegacyPage();
     await RadioGroupPageObject.waitForPageDisplayed(PAGE_TIMEOUT);
 
-    await expect(await RadioGroupPageObject.isPageLoaded()).toBeTruthy(RadioGroupPageObject.ERRORMESSAGE_PAGELOAD);
-    await expect(await RadioGroupPageObject.didAssertPopup()).toBeFalsy(RadioGroupPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    expect(await RadioGroupPageObject.isPageLoaded()).toBeTruthy(RadioGroupPageObject.ERRORMESSAGE_PAGELOAD);
+    expect(await RadioGroupPageObject.didAssertPopup()).toBeFalsy(RadioGroupPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
   });
 });
 
@@ -32,27 +32,27 @@ describe('RadioGroup/RadioButton Legacy Accessibility Testing', () => {
   });
 
   it('Validate RadioGroup\'s "accessibilityRole" defaults to List "ControlType" element attribute.', async () => {
-    await expect(
+    expect(
       await RadioGroupPageObject.compareAttribute(RadioGroupPageObject._firstRadioGroup, Attribute.AccessibilityRole, RADIOGROUP_A11Y_ROLE),
     ).toBeTruthy();
 
-    await expect(await RadioGroupPageObject.didAssertPopup()).toBeFalsy(RadioGroupPageObject.ERRORMESSAGE_ASSERT);
+    expect(await RadioGroupPageObject.didAssertPopup()).toBeFalsy(RadioGroupPageObject.ERRORMESSAGE_ASSERT);
   });
 
   it('Validate RadioButton\'s "accessibilityRole" defaults to RadioButton "ControlType" element attribute.', async () => {
-    await expect(
+    expect(
       await RadioGroupPageObject.compareAttribute(
-        RadioGroupPageObject.getRadioButton(RadioButton.First),
+        RadioGroupPageObject.getRadioButton('First'),
         Attribute.AccessibilityRole,
         RADIOBUTTON_A11Y_ROLE,
       ),
     ).toBeTruthy();
 
-    await expect(await RadioGroupPageObject.didAssertPopup()).toBeFalsy(RadioGroupPageObject.ERRORMESSAGE_ASSERT);
+    expect(await RadioGroupPageObject.didAssertPopup()).toBeFalsy(RadioGroupPageObject.ERRORMESSAGE_ASSERT);
   });
 
   it('Set RadioGroup "accessibilityLabel" prop. Validate "accessibilityLabel" value propagates to "Name" element attribute.', async () => {
-    await expect(
+    expect(
       await RadioGroupPageObject.compareAttribute(
         RadioGroupPageObject._firstRadioGroup,
         Attribute.AccessibilityLabel,
@@ -60,11 +60,11 @@ describe('RadioGroup/RadioButton Legacy Accessibility Testing', () => {
       ),
     ).toBeTruthy();
 
-    await expect(await RadioGroupPageObject.didAssertPopup()).toBeFalsy(RadioGroupPageObject.ERRORMESSAGE_ASSERT);
+    expect(await RadioGroupPageObject.didAssertPopup()).toBeFalsy(RadioGroupPageObject.ERRORMESSAGE_ASSERT);
   });
 
   it('Do not set RadioGroup "accessibilityLabel" prop. Validate "Name" element attribute defaults to current RadioGroup label.', async () => {
-    await expect(
+    expect(
       await RadioGroupPageObject.compareAttribute(
         RadioGroupPageObject._secondRadioGroup,
         Attribute.AccessibilityLabel,
@@ -72,31 +72,31 @@ describe('RadioGroup/RadioButton Legacy Accessibility Testing', () => {
       ),
     ).toBeTruthy();
 
-    await expect(await RadioGroupPageObject.didAssertPopup()).toBeFalsy(RadioGroupPageObject.ERRORMESSAGE_ASSERT);
+    expect(await RadioGroupPageObject.didAssertPopup()).toBeFalsy(RadioGroupPageObject.ERRORMESSAGE_ASSERT);
   });
 
   it('Set RadioButton "accessibilityLabel" prop. Validate "accessibilityLabel" value propagates to "Name" element attribute.', async () => {
-    await expect(
+    expect(
       await RadioGroupPageObject.compareAttribute(
-        RadioGroupPageObject.getRadioButton(RadioButton.First),
+        RadioGroupPageObject.getRadioButton('First'),
         Attribute.AccessibilityLabel,
         FIRST_RADIO_BUTTON_ACCESSIBILITY_LABEL,
       ),
     ).toBeTruthy();
 
-    await expect(await RadioGroupPageObject.didAssertPopup()).toBeFalsy(RadioGroupPageObject.ERRORMESSAGE_ASSERT);
+    expect(await RadioGroupPageObject.didAssertPopup()).toBeFalsy(RadioGroupPageObject.ERRORMESSAGE_ASSERT);
   });
 
   it('Do not set RadioButton "accessibilityLabel" prop. Validate "Name" element attribute defaults to current RadioButton label.', async () => {
-    await expect(
+    expect(
       await RadioGroupPageObject.compareAttribute(
-        RadioGroupPageObject.getRadioButton(RadioButton.Second),
+        RadioGroupPageObject.getRadioButton('Second'),
         Attribute.AccessibilityLabel,
         SECOND_RADIO_BUTTON_LABEL,
       ),
     ).toBeTruthy();
 
-    await expect(await RadioGroupPageObject.didAssertPopup()).toBeFalsy(RadioGroupPageObject.ERRORMESSAGE_ASSERT);
+    expect(await RadioGroupPageObject.didAssertPopup()).toBeFalsy(RadioGroupPageObject.ERRORMESSAGE_ASSERT);
   });
 });
 
@@ -110,51 +110,48 @@ describe('RadioGroup Legacy Functional Testing', async () => {
 
   it('Click on a RadioButton. Validate that it changes state from unselected to selected.', async () => {
     /* Validate the RadioButton is not initially selected */
-    await expect(await RadioGroupPageObject.isRadioButtonSelected(RadioButton.Second)).toBeFalsy(
+    expect(await RadioGroupPageObject.isRadioButtonSelected('Second')).toBeFalsy(
       'Expected the first RadioButton to be initially selected, but the second RadioButton was initially selected.',
     );
 
     /* Click on the RadioButton to select it */
-    await RadioGroupPageObject.click(RadioGroupPageObject.getRadioButton(RadioButton.Second));
+    await RadioGroupPageObject.click(RadioGroupPageObject.getRadioButton('Second'));
 
     /* Validate the RadioButton is selected */
-    await expect(
-      await RadioGroupPageObject.waitForRadioButtonSelected(
-        RadioButton.Second,
-        'Clicked the second RadioButton, but it failed to be selected.',
-      ),
+    expect(
+      await RadioGroupPageObject.waitForRadioButtonSelected('Second', 'Clicked the second RadioButton, but it failed to be selected.'),
     ).toBeTruthy();
 
-    await expect(await RadioGroupPageObject.didAssertPopup()).toBeFalsy(RadioGroupPageObject.ERRORMESSAGE_ASSERT);
+    expect(await RadioGroupPageObject.didAssertPopup()).toBeFalsy(RadioGroupPageObject.ERRORMESSAGE_ASSERT);
   });
 
   it('Press forward "Arrow Key" on a RadioButton. Validate adjacent RadioButton is newly selected.', async () => {
     // Presses the ArrowDown key while the first (A) RadioButton is selected
-    await RadioGroupPageObject.sendKeys(RadioGroupPageObject.getRadioButton(RadioButton.First), [Keys.ARROW_DOWN]);
+    await RadioGroupPageObject.sendKeys(RadioGroupPageObject.getRadioButton('First'), [Keys.ARROW_DOWN]);
 
     /* Validate the RadioButton is selected */
-    await expect(
+    expect(
       await RadioGroupPageObject.waitForRadioButtonSelected(
-        RadioButton.Second,
+        'Second',
         'Pressed "Down Arrow" on the first RadioButton, but the second RadioButton failed to be selected.',
       ),
     ).toBeTruthy();
 
-    await expect(await RadioGroupPageObject.didAssertPopup()).toBeFalsy(RadioGroupPageObject.ERRORMESSAGE_ASSERT);
+    expect(await RadioGroupPageObject.didAssertPopup()).toBeFalsy(RadioGroupPageObject.ERRORMESSAGE_ASSERT);
   });
 
   it('Press forward "Arrow Key" on a RadioButton adjacent to a disabled RadioButton. Validate disabled RadioButton is skipped.', async () => {
     // Presses the ArrowDown key while the second (B) RadioButton is selected
-    await RadioGroupPageObject.sendKeys(RadioGroupPageObject.getRadioButton(RadioButton.Second), [Keys.ARROW_DOWN]);
+    await RadioGroupPageObject.sendKeys(RadioGroupPageObject.getRadioButton('Second'), [Keys.ARROW_DOWN]);
 
     /* Validate the RadioButton is selected */
-    await expect(
+    expect(
       await RadioGroupPageObject.waitForRadioButtonSelected(
-        RadioButton.Fourth,
+        'Fourth',
         'Pressed "Down Arrow" on the second RadioButton, but the fourth RadioButton failed to be selected. The third RadioButton is disabled so it should be skipped.',
       ),
     ).toBeTruthy(); // It should skip RadioButton 3 since it is disabled
 
-    await expect(await RadioGroupPageObject.didAssertPopup()).toBeFalsy(RadioGroupPageObject.ERRORMESSAGE_ASSERT);
+    expect(await RadioGroupPageObject.didAssertPopup()).toBeFalsy(RadioGroupPageObject.ERRORMESSAGE_ASSERT);
   });
 });

--- a/apps/E2E/src/RadioGroupV1/pages/RadioGroupV1PageObject.ts
+++ b/apps/E2E/src/RadioGroupV1/pages/RadioGroupV1PageObject.ts
@@ -1,27 +1,26 @@
-import {
-  RADIOGROUPV1_TESTPAGE,
-  RADIOGROUPV1_TEST_COMPONENT,
-  RADIOGROUPV1_NO_A11Y_LABEL_COMPONENT,
-  HOMEPAGE_RADIOGROUPV1_BUTTON,
-  FIRST_RADIO,
-  SECOND_RADIO,
-  THIRD_RADIO,
-  FOURTH_RADIO,
-  FIFTH_RADIO,
-} from '../consts';
 import { BasePage, By } from '../../common/BasePage';
 import { Attribute, AttributeValue } from '../../common/consts';
+import {
+  FIFTH_RADIO,
+  FIRST_RADIO,
+  FOURTH_RADIO,
+  HOMEPAGE_RADIOGROUPV1_BUTTON,
+  RADIOGROUPV1_NO_A11Y_LABEL_COMPONENT,
+  RADIOGROUPV1_TESTPAGE,
+  RADIOGROUPV1_TEST_COMPONENT,
+  SECOND_RADIO,
+  THIRD_RADIO,
+} from '../consts';
 
 /* This enum gives the spec file an EASY way to interact with SPECIFIC UI elements on the page.
  * The main RadioGroup we are testing has FOUR Radios. The spec file will
  * import this enum to easily write tests using these 4 radio buttons. */
-export const enum Radio {
-  First = 1, // this._firstRadio
-  Second, // this._secondRadio
-  Third, // this._thirdRadio
-  Fourth, // this._fourthRadio
-  Fifth, // this._fifthRadio
-}
+type Radio =
+  | 'First' // this._firstRadio
+  | 'Second' // this._secondRadio
+  | 'Third' // this._thirdRadio
+  | 'Fourth' // this._fourthRadio
+  | 'Fifth'; // this._fifthRadio
 
 class RadioGroupV1Page extends BasePage {
   /******************************************************************/
@@ -31,7 +30,7 @@ class RadioGroupV1Page extends BasePage {
   /* This resets the RadioGroup selection by clicking/selecting the 1st Radio in the RadioGroup.
    * Useful in beforeEach() hooks to reset the RadioGroup before additional tests */
   async resetRadioGroupSelection(): Promise<void> {
-    await (await this.getRadio(Radio.First)).click();
+    await (await this.getRadio('First')).click();
   }
 
   async isRadioSelected(radioSelector: Radio): Promise<boolean> {
@@ -55,15 +54,15 @@ class RadioGroupV1Page extends BasePage {
   /* Returns the correct WebDriverIO element from the Radio Selector */
   async getRadio(radioSelector: Radio): Promise<WebdriverIO.Element> {
     switch (radioSelector) {
-      case Radio.First:
+      case 'First':
         return By(FIRST_RADIO);
-      case Radio.Second:
+      case 'Second':
         return By(SECOND_RADIO);
-      case Radio.Third:
+      case 'Third':
         return By(THIRD_RADIO);
-      case Radio.Fourth:
+      case 'Fourth':
         return By(FOURTH_RADIO);
-      case Radio.Fifth:
+      case 'Fifth':
         return By(FIFTH_RADIO);
     }
   }

--- a/apps/E2E/src/RadioGroupV1/specs/RadioGroupV1.spec.android.ts
+++ b/apps/E2E/src/RadioGroupV1/specs/RadioGroupV1.spec.android.ts
@@ -1,13 +1,13 @@
+import { AndroidAttribute, ANDROID_RADIOBUTTON, BOOT_APP_TIMEOUT, PAGE_TIMEOUT } from '../../common/consts';
 import NavigateAppPage from '../../common/NavigateAppPage';
-import RadioGroupV1Page, { Radio } from '../pages/RadioGroupV1PageObject';
-import { PAGE_TIMEOUT, BOOT_APP_TIMEOUT, AndroidAttribute, ANDROID_RADIOBUTTON } from '../../common/consts';
 import { RADIOGROUPV1_TEST_COMPONENT } from '../consts';
+import RadioGroupV1Page from '../pages/RadioGroupV1PageObject';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('RadioGroupV1/RadioV1 Testing Initialization', function () {
   it('Wait for app load', async () => {
     await NavigateAppPage.waitForPageDisplayed(BOOT_APP_TIMEOUT);
-    await expect(await NavigateAppPage.isPageLoaded()).toBeTruthy(NavigateAppPage.ERRORMESSAGE_APPLOAD);
+    expect(await NavigateAppPage.isPageLoaded()).toBeTruthy(NavigateAppPage.ERRORMESSAGE_APPLOAD);
   });
 
   it('Click and navigate to RadioGroupV1 test page', async () => {
@@ -18,8 +18,8 @@ describe('RadioGroupV1/RadioV1 Testing Initialization', function () {
     await NavigateAppPage.clickAndGoToRadioGroupV1Page();
     await RadioGroupV1Page.waitForPageDisplayed(PAGE_TIMEOUT);
 
-    await expect(await RadioGroupV1Page.isPageLoaded()).toBeTruthy(RadioGroupV1Page.ERRORMESSAGE_PAGELOAD);
-    await expect(await RadioGroupV1Page.didAssertPopup()).toBeFalsy(RadioGroupV1Page.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    expect(await RadioGroupV1Page.isPageLoaded()).toBeTruthy(RadioGroupV1Page.ERRORMESSAGE_PAGELOAD);
+    expect(await RadioGroupV1Page.didAssertPopup()).toBeFalsy(RadioGroupV1Page.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
   });
 });
 
@@ -30,22 +30,22 @@ describe('RadioGroupV1/RadioV1 Accessibility Testing', () => {
   });
 
   it('RadioGroup - Verify accessibilityLabel', async () => {
-    await expect(
+    expect(
       await RadioGroupV1Page.compareAttribute(
         RadioGroupV1Page._primaryComponent,
         AndroidAttribute.AccessibilityLabel,
         RADIOGROUPV1_TEST_COMPONENT,
       ),
     ).toBeTruthy();
-    await expect(await RadioGroupV1Page.didAssertPopup()).toBeFalsy(RadioGroupV1Page.ERRORMESSAGE_ASSERT);
+    expect(await RadioGroupV1Page.didAssertPopup()).toBeFalsy(RadioGroupV1Page.ERRORMESSAGE_ASSERT);
   });
 
   it('Validate Radio Group Class on Android', async () => {
-    await expect(
-      await RadioGroupV1Page.compareAttribute(RadioGroupV1Page.getRadio(Radio.First), AndroidAttribute.Class, ANDROID_RADIOBUTTON),
+    expect(
+      await RadioGroupV1Page.compareAttribute(RadioGroupV1Page.getRadio('First'), AndroidAttribute.Class, ANDROID_RADIOBUTTON),
     ).toBeTruthy();
 
-    await expect(await RadioGroupV1Page.didAssertPopup()).toBeFalsy(RadioGroupV1Page.ERRORMESSAGE_ASSERT);
+    expect(await RadioGroupV1Page.didAssertPopup()).toBeFalsy(RadioGroupV1Page.ERRORMESSAGE_ASSERT);
   });
 });
 
@@ -59,13 +59,13 @@ describe('RadioGroupV1 Functional Testing', async () => {
 
   it('Click on a Radio and ensure it changes state from unselected -> selected', async () => {
     /* Validate the Radio is not initially selected */
-    await expect(await RadioGroupV1Page.isRadioSelected(Radio.Second)).toBeFalsy();
+    expect(await RadioGroupV1Page.isRadioSelected('Second')).toBeFalsy();
 
     /* Click on the Radio to select it */
-    await RadioGroupV1Page.click(RadioGroupV1Page.getRadio(Radio.Second));
+    await RadioGroupV1Page.click(RadioGroupV1Page.getRadio('Second'));
 
     /* Validate the Radio is selected */
-    await expect(await RadioGroupV1Page.waitForRadioSelected(Radio.Second, 'Expected radio #2 to be selected by click.')).toBeTruthy();
-    await expect(await RadioGroupV1Page.didAssertPopup()).toBeFalsy(RadioGroupV1Page.ERRORMESSAGE_ASSERT);
+    expect(await RadioGroupV1Page.waitForRadioSelected('Second', 'Expected radio #2 to be selected by click.')).toBeTruthy();
+    expect(await RadioGroupV1Page.didAssertPopup()).toBeFalsy(RadioGroupV1Page.ERRORMESSAGE_ASSERT);
   });
 });

--- a/apps/E2E/src/RadioGroupV1/specs/RadioGroupV1.spec.win.ts
+++ b/apps/E2E/src/RadioGroupV1/specs/RadioGroupV1.spec.win.ts
@@ -1,18 +1,18 @@
+import { Attribute, BOOT_APP_TIMEOUT, Keys, PAGE_TIMEOUT, RADIOBUTTON_A11Y_ROLE, RADIOGROUP_A11Y_ROLE } from '../../common/consts';
 import NavigateAppPage from '../../common/NavigateAppPage';
-import RadioGroupV1Page, { Radio } from '../pages/RadioGroupV1PageObject';
-import { RADIOBUTTON_A11Y_ROLE, RADIOGROUP_A11Y_ROLE, PAGE_TIMEOUT, BOOT_APP_TIMEOUT, Keys, Attribute } from '../../common/consts';
 import {
+  FIRST_RADIO_ACCESSIBILITY_LABEL,
   RADIOGROUPV1_ACCESSIBILITY_LABEL,
   RADIOGROUPV1_TEST_COMPONENT_LABEL,
-  FIRST_RADIO_ACCESSIBILITY_LABEL,
   SECOND_RADIO_LABEL,
 } from '../consts';
+import RadioGroupV1Page from '../pages/RadioGroupV1PageObject';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('RadioGroupV1/RadioV1 Testing Initialization', function () {
   it('Wait for app load', async () => {
     await NavigateAppPage.waitForPageDisplayed(BOOT_APP_TIMEOUT);
-    await expect(await NavigateAppPage.isPageLoaded()).toBeTruthy(NavigateAppPage.ERRORMESSAGE_APPLOAD);
+    expect(await NavigateAppPage.isPageLoaded()).toBeTruthy(NavigateAppPage.ERRORMESSAGE_APPLOAD);
   });
 
   it('Click and navigate to RadioGroupV1 test page', async () => {
@@ -20,8 +20,8 @@ describe('RadioGroupV1/RadioV1 Testing Initialization', function () {
     await NavigateAppPage.clickAndGoToRadioGroupV1Page();
     await RadioGroupV1Page.waitForPageDisplayed(PAGE_TIMEOUT);
 
-    await expect(await RadioGroupV1Page.isPageLoaded()).toBeTruthy(RadioGroupV1Page.ERRORMESSAGE_PAGELOAD);
-    await expect(await RadioGroupV1Page.didAssertPopup()).toBeFalsy(RadioGroupV1Page.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    expect(await RadioGroupV1Page.isPageLoaded()).toBeTruthy(RadioGroupV1Page.ERRORMESSAGE_PAGELOAD);
+    expect(await RadioGroupV1Page.didAssertPopup()).toBeFalsy(RadioGroupV1Page.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
   });
 });
 
@@ -32,23 +32,23 @@ describe('RadioGroupV1/RadioV1 Accessibility Testing', () => {
   });
 
   it('Validate RadioGroup\'s "accessibilityRole" defaults to "List.ControlType".', async () => {
-    await expect(
+    expect(
       await RadioGroupV1Page.compareAttribute(RadioGroupV1Page._primaryComponent, Attribute.AccessibilityRole, RADIOGROUP_A11Y_ROLE),
     ).toBeTruthy();
 
-    await expect(await RadioGroupV1Page.didAssertPopup()).toBeFalsy(RadioGroupV1Page.ERRORMESSAGE_ASSERT);
+    expect(await RadioGroupV1Page.didAssertPopup()).toBeFalsy(RadioGroupV1Page.ERRORMESSAGE_ASSERT);
   });
 
   it('Validate Radio\'s "accessibilityRole" defaults to "RadioButton.ControlType".', async () => {
-    await expect(
-      await RadioGroupV1Page.compareAttribute(RadioGroupV1Page.getRadio(Radio.First), Attribute.AccessibilityRole, RADIOBUTTON_A11Y_ROLE),
+    expect(
+      await RadioGroupV1Page.compareAttribute(RadioGroupV1Page.getRadio('First'), Attribute.AccessibilityRole, RADIOBUTTON_A11Y_ROLE),
     ).toBeTruthy();
 
-    await expect(await RadioGroupV1Page.didAssertPopup()).toBeFalsy(RadioGroupV1Page.ERRORMESSAGE_ASSERT);
+    expect(await RadioGroupV1Page.didAssertPopup()).toBeFalsy(RadioGroupV1Page.ERRORMESSAGE_ASSERT);
   });
 
   it('Set RadioGroup "accessibilityLabel" prop. Validate "accessibilityLabel" value propagates to "Name" element attribute.', async () => {
-    await expect(
+    expect(
       await RadioGroupV1Page.compareAttribute(
         RadioGroupV1Page._primaryComponent,
         Attribute.AccessibilityLabel,
@@ -56,11 +56,11 @@ describe('RadioGroupV1/RadioV1 Accessibility Testing', () => {
       ),
     ).toBeTruthy();
 
-    await expect(await RadioGroupV1Page.didAssertPopup()).toBeFalsy(RadioGroupV1Page.ERRORMESSAGE_ASSERT);
+    expect(await RadioGroupV1Page.didAssertPopup()).toBeFalsy(RadioGroupV1Page.ERRORMESSAGE_ASSERT);
   });
 
   it('Do not set RadioGroup "accessibilityLabel" prop. Validate "Name" element attribute defaults to current RadioGroup label.', async () => {
-    await expect(
+    expect(
       await RadioGroupV1Page.compareAttribute(
         RadioGroupV1Page._secondaryComponent,
         Attribute.AccessibilityLabel,
@@ -68,27 +68,27 @@ describe('RadioGroupV1/RadioV1 Accessibility Testing', () => {
       ),
     ).toBeTruthy();
 
-    await expect(await RadioGroupV1Page.didAssertPopup()).toBeFalsy(RadioGroupV1Page.ERRORMESSAGE_ASSERT);
+    expect(await RadioGroupV1Page.didAssertPopup()).toBeFalsy(RadioGroupV1Page.ERRORMESSAGE_ASSERT);
   });
 
   it('Set Radio "accessibilityLabel" prop. Validate "accessibilityLabel" value propagates to "Name" element attribute.', async () => {
-    await expect(
+    expect(
       await RadioGroupV1Page.compareAttribute(
-        RadioGroupV1Page.getRadio(Radio.First),
+        RadioGroupV1Page.getRadio('First'),
         Attribute.AccessibilityLabel,
         FIRST_RADIO_ACCESSIBILITY_LABEL,
       ),
     ).toBeTruthy();
 
-    await expect(await RadioGroupV1Page.didAssertPopup()).toBeFalsy(RadioGroupV1Page.ERRORMESSAGE_ASSERT);
+    expect(await RadioGroupV1Page.didAssertPopup()).toBeFalsy(RadioGroupV1Page.ERRORMESSAGE_ASSERT);
   });
 
   it('Do not set Radio "accessibilityLabel" prop. Validate "Name" element attribute defaults to current Radio label.', async () => {
-    await expect(
-      await RadioGroupV1Page.compareAttribute(RadioGroupV1Page.getRadio(Radio.Second), Attribute.AccessibilityLabel, SECOND_RADIO_LABEL),
+    expect(
+      await RadioGroupV1Page.compareAttribute(RadioGroupV1Page.getRadio('Second'), Attribute.AccessibilityLabel, SECOND_RADIO_LABEL),
     ).toBeTruthy();
 
-    await expect(await RadioGroupV1Page.didAssertPopup()).toBeFalsy(RadioGroupV1Page.ERRORMESSAGE_ASSERT);
+    expect(await RadioGroupV1Page.didAssertPopup()).toBeFalsy(RadioGroupV1Page.ERRORMESSAGE_ASSERT);
   });
 });
 
@@ -102,72 +102,69 @@ describe('RadioGroupV1 Functional Testing', async () => {
 
   it('Click on a Radio. Validate that it changes state from unselected to selected.', async () => {
     /* Validate the Radio is not initially selected */
-    await expect(await RadioGroupV1Page.isRadioSelected(Radio.Second)).toBeFalsy(
+    expect(await RadioGroupV1Page.isRadioSelected('Second')).toBeFalsy(
       'Expected radio #2 to be unselected at test start, but #2 was initially selected.',
     );
 
     /* Click on the Radio to select it */
-    await RadioGroupV1Page.click(RadioGroupV1Page.getRadio(Radio.Second));
+    await RadioGroupV1Page.click(RadioGroupV1Page.getRadio('Second'));
 
     /* Validate the Radio is selected */
-    await expect(
-      await RadioGroupV1Page.waitForRadioSelected(Radio.Second, 'Expected radio #2 to be selected by click, but #2 remained unselected.'),
+    expect(
+      await RadioGroupV1Page.waitForRadioSelected('Second', 'Expected radio #2 to be selected by click, but #2 remained unselected.'),
     ).toBeTruthy();
 
-    await expect(await RadioGroupV1Page.didAssertPopup()).toBeFalsy(RadioGroupV1Page.ERRORMESSAGE_ASSERT);
+    expect(await RadioGroupV1Page.didAssertPopup()).toBeFalsy(RadioGroupV1Page.ERRORMESSAGE_ASSERT);
   });
 
   it('Navigate to unselected radio using "DOWN ARROW" key. Validate state changes from unselected to selected.', async () => {
     // Presses the ArrowDown key while the first (A) Radio is selected
-    await RadioGroupV1Page.sendKeys(RadioGroupV1Page.getRadio(Radio.First), [Keys.ARROW_DOWN]);
+    await RadioGroupV1Page.sendKeys(RadioGroupV1Page.getRadio('First'), [Keys.ARROW_DOWN]);
 
     /* Validate the Radio is selected */
-    await expect(
-      await RadioGroupV1Page.waitForRadioSelected(Radio.Second, 'Expected radio #2 to be selected by a "DOWN ARROW" input from radio #1.'),
+    expect(
+      await RadioGroupV1Page.waitForRadioSelected('Second', 'Expected radio #2 to be selected by a "DOWN ARROW" input from radio #1.'),
     ).toBeTruthy();
 
-    await expect(await RadioGroupV1Page.didAssertPopup()).toBeFalsy(RadioGroupV1Page.ERRORMESSAGE_ASSERT);
+    expect(await RadioGroupV1Page.didAssertPopup()).toBeFalsy(RadioGroupV1Page.ERRORMESSAGE_ASSERT);
   });
 
   it('Navigate to unselected radio using "DOWN ARROW" key. Validate disabled Radio is skipped.', async () => {
     // Presses the ArrowDown key while the second (B) Radio is selected
-    await RadioGroupV1Page.sendKeys(RadioGroupV1Page.getRadio(Radio.Second), [Keys.ARROW_DOWN]);
+    await RadioGroupV1Page.sendKeys(RadioGroupV1Page.getRadio('Second'), [Keys.ARROW_DOWN]);
 
     /* Validate the Radio is selected */
-    await expect(
+    expect(
       await RadioGroupV1Page.waitForRadioSelected(
-        Radio.Fourth,
+        'Fourth',
         'Expected radio #4 to be selected by a "DOWN ARROW" input from radio #2 and radio #3 (disabled) to be skipped.',
       ),
     ).toBeTruthy();
 
-    await expect(await RadioGroupV1Page.didAssertPopup()).toBeFalsy(RadioGroupV1Page.ERRORMESSAGE_ASSERT);
+    expect(await RadioGroupV1Page.didAssertPopup()).toBeFalsy(RadioGroupV1Page.ERRORMESSAGE_ASSERT);
   });
 
   it('Press "DOWN ARROW" on the last Radio of a RadioGroup. Validate circular navigation functions correctly.', async () => {
     // Presses the ArrowDown key while the fourth (D) Radio is selected
-    await RadioGroupV1Page.sendKeys(RadioGroupV1Page.getRadio(Radio.Fourth), [Keys.ARROW_DOWN]);
+    await RadioGroupV1Page.sendKeys(RadioGroupV1Page.getRadio('Fourth'), [Keys.ARROW_DOWN]);
 
     /* Validate the Radio is selected */
-    await expect(
-      await RadioGroupV1Page.waitForRadioSelected(Radio.First, 'Expected radio #1 to be selected by a "DOWN ARROW" input from radio #4.'),
+    expect(
+      await RadioGroupV1Page.waitForRadioSelected('First', 'Expected radio #1 to be selected by a "DOWN ARROW" input from radio #4.'),
     ).toBeTruthy();
 
-    await expect(await RadioGroupV1Page.didAssertPopup()).toBeFalsy(RadioGroupV1Page.ERRORMESSAGE_ASSERT);
+    expect(await RadioGroupV1Page.didAssertPopup()).toBeFalsy(RadioGroupV1Page.ERRORMESSAGE_ASSERT);
   });
 
   it('Press "TAB" on a Radio. Validate Radio in the next RadioGroup is focused.', async () => {
     // Presses the Tab key while the second (B) Radio is selected in first RadioGroup
-    await RadioGroupV1Page.sendKeys(RadioGroupV1Page.getRadio(Radio.Second), [Keys.TAB]);
+    await RadioGroupV1Page.sendKeys(RadioGroupV1Page.getRadio('Second'), [Keys.TAB]);
 
     /* Validate the Radio is not focused */
-    await expect(
-      await RadioGroupV1Page.waitForRadioFocused(
-        Radio.Fifth,
-        'Expected radio #5 to be focused by a "TAB" input from previous radio group.',
-      ),
+    expect(
+      await RadioGroupV1Page.waitForRadioFocused('Fifth', 'Expected radio #5 to be focused by a "TAB" input from previous radio group.'),
     ).toBeTruthy();
 
-    await expect(await RadioGroupV1Page.didAssertPopup()).toBeFalsy(RadioGroupV1Page.ERRORMESSAGE_ASSERT);
+    expect(await RadioGroupV1Page.didAssertPopup()).toBeFalsy(RadioGroupV1Page.ERRORMESSAGE_ASSERT);
   });
 });

--- a/apps/E2E/src/Switch/pages/SwitchPageObject.ts
+++ b/apps/E2E/src/Switch/pages/SwitchPageObject.ts
@@ -1,12 +1,5 @@
-import { SWITCH_TESTPAGE, SWITCH_TEST_COMPONENT, SWITCH_NO_A11Y_LABEL_COMPONENT, HOMEPAGE_SWITCH_BUTTON, SWITCH_ON_PRESS } from '../consts';
 import { BasePage, By } from '../../common/BasePage';
-
-/* This enum gives the spec file an EASY way to interact with SPECIFIC UI elements on the page.
- * The spec file should import this enum and use it when wanting to interact with different elements on the page. */
-export const enum SwitchComponentSelector {
-  PrimaryComponent, //this._primaryComponent
-  SecondaryComponent, // this._secondaryComponent
-}
+import { HOMEPAGE_SWITCH_BUTTON, SWITCH_NO_A11Y_LABEL_COMPONENT, SWITCH_ON_PRESS, SWITCH_TESTPAGE, SWITCH_TEST_COMPONENT } from '../consts';
 
 class SwitchPageObject extends BasePage {
   /******************************************************************/

--- a/apps/E2E/src/TabsLegacy/pages/TabsLegacyPageObject.ts
+++ b/apps/E2E/src/TabsLegacy/pages/TabsLegacyPageObject.ts
@@ -15,11 +15,10 @@ import { BasePage, By } from '../../common/BasePage';
  * The spec file should import this enum and use it when wanting to interact with different elements on the page.
  * The main Tab group we are testing has THREE tab items. The spec file will
  * import this enum to easily write tests using these 3 tab items */
-export const enum TabItemSelector {
-  First = 0, // this._firstTabItem
-  Second, // this._secondTabItem
-  Third, // this._thirdTabItem
-}
+type TabItemSelector =
+  | 'First' // this._firstTabItem
+  | 'Second' // this._secondTabItem
+  | 'Third'; // this._thirdTabItem
 
 class TabsLegacyPageObject extends BasePage {
   /******************************************************************/
@@ -47,9 +46,9 @@ class TabsLegacyPageObject extends BasePage {
 
   /* Returns the correct WebDriverIO element from the TabItem Selector */
   async getTabItem(tabItemSelector: TabItemSelector): Promise<WebdriverIO.Element> {
-    if (tabItemSelector == TabItemSelector.First) {
+    if (tabItemSelector === 'First') {
       return await this._firstTabItem;
-    } else if (tabItemSelector == TabItemSelector.Second) {
+    } else if (tabItemSelector === 'Second') {
       return await this._secondTabItem;
     } else {
       return await this._thirdTabItem;
@@ -58,9 +57,9 @@ class TabsLegacyPageObject extends BasePage {
 
   /* Returns the correct WebDriverIO element from the TabItem Selector */
   async getTabItemContent(tabItemSelector: TabItemSelector): Promise<WebdriverIO.Element> {
-    if (tabItemSelector == TabItemSelector.First) {
+    if (tabItemSelector === 'First') {
       return await this._firstTabItemContent;
-    } else if (tabItemSelector == TabItemSelector.Second) {
+    } else if (tabItemSelector === 'Second') {
       return await this._secondTabItemContent;
     } else {
       return await this._thirdTabItemContent;

--- a/apps/E2E/src/TabsLegacy/specs/TabsLegacy.spec.win.ts
+++ b/apps/E2E/src/TabsLegacy/specs/TabsLegacy.spec.win.ts
@@ -1,6 +1,6 @@
+import { BOOT_APP_TIMEOUT, Keys, PAGE_TIMEOUT, TABITEM_A11Y_ROLE, TAB_A11Y_ROLE } from '../../common/consts';
 import NavigateAppPage from '../../common/NavigateAppPage';
-import TabsLegacyPageObject, { TabItemSelector } from '../pages/TabsLegacyPageObject';
-import { TAB_A11Y_ROLE, BOOT_APP_TIMEOUT, PAGE_TIMEOUT, TABITEM_A11Y_ROLE, Keys } from '../../common/consts';
+import TabsLegacyPageObject from '../pages/TabsLegacyPageObject';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Tabs Legacy Testing Initialization', function () {
@@ -31,7 +31,7 @@ describe('Tabs Legacy Accessibility Testing', () => {
   });
 
   it("Validate TabItem's accessibilityRole is correct", async () => {
-    await expect(await TabsLegacyPageObject.getTabItemAccesibilityRole(TabItemSelector.First)).toEqual(TABITEM_A11Y_ROLE);
+    await expect(await TabsLegacyPageObject.getTabItemAccesibilityRole('First')).toEqual(TABITEM_A11Y_ROLE);
     await expect(await TabsLegacyPageObject.didAssertPopup()).toBeFalsy(TabsLegacyPageObject.ERRORMESSAGE_ASSERT);
   });
 });
@@ -42,41 +42,41 @@ describe('Tabs Legacy Functional Tests', () => {
     await TabsLegacyPageObject.scrollToTestElement();
 
     // Reset the TabGroup by putting focus on First tab item
-    await TabsLegacyPageObject.clickOnTabItem(TabItemSelector.First);
+    await TabsLegacyPageObject.clickOnTabItem('First');
   });
 
   it('Click on the second tab header and validate the correct TabItem content is shown', async () => {
-    await TabsLegacyPageObject.clickOnTabItem(TabItemSelector.Second);
-    await TabsLegacyPageObject.waitForTabsItemsToOpen(TabItemSelector.Second, PAGE_TIMEOUT);
+    await TabsLegacyPageObject.clickOnTabItem('Second');
+    await TabsLegacyPageObject.waitForTabsItemsToOpen('Second', PAGE_TIMEOUT);
 
-    await expect(await TabsLegacyPageObject.didTabItemContentLoad(TabItemSelector.Second)).toBeTruthy();
+    await expect(await TabsLegacyPageObject.didTabItemContentLoad('Second')).toBeTruthy();
     await expect(await TabsLegacyPageObject.didAssertPopup()).toBeFalsy(TabsLegacyPageObject.ERRORMESSAGE_ASSERT);
   });
 
   it('Keyboarding: Arrow Navigation: Right -> Down -> Left -> Up -> Validate the correct TabItem content is shown', async () => {
     /* At First tab element, press Right Arrow to navigate to the Second tab element */
-    await TabsLegacyPageObject.sendKey(Keys.ARROW_RIGHT, TabItemSelector.First);
-    await TabsLegacyPageObject.waitForTabsItemsToOpen(TabItemSelector.Second, PAGE_TIMEOUT);
+    await TabsLegacyPageObject.sendKey(Keys.ARROW_RIGHT, 'First');
+    await TabsLegacyPageObject.waitForTabsItemsToOpen('Second', PAGE_TIMEOUT);
 
-    await expect(await TabsLegacyPageObject.didTabItemContentLoad(TabItemSelector.Second)).toBeTruthy();
+    await expect(await TabsLegacyPageObject.didTabItemContentLoad('Second')).toBeTruthy();
 
     /* At Second tab element, press Down Arrow to navigate to the Third tab element */
-    await TabsLegacyPageObject.sendKey(Keys.ARROW_DOWN, TabItemSelector.Second);
-    await TabsLegacyPageObject.waitForTabsItemsToOpen(TabItemSelector.Third, PAGE_TIMEOUT);
+    await TabsLegacyPageObject.sendKey(Keys.ARROW_DOWN, 'Second');
+    await TabsLegacyPageObject.waitForTabsItemsToOpen('Third', PAGE_TIMEOUT);
 
-    await expect(await TabsLegacyPageObject.didTabItemContentLoad(TabItemSelector.Third)).toBeTruthy();
+    await expect(await TabsLegacyPageObject.didTabItemContentLoad('Third')).toBeTruthy();
 
     /* At Third tab element, press Left Arrow to navigate to the Second tab element */
-    await TabsLegacyPageObject.sendKey(Keys.ARROW_LEFT, TabItemSelector.Third);
-    await TabsLegacyPageObject.waitForTabsItemsToOpen(TabItemSelector.Second, PAGE_TIMEOUT);
+    await TabsLegacyPageObject.sendKey(Keys.ARROW_LEFT, 'Third');
+    await TabsLegacyPageObject.waitForTabsItemsToOpen('Second', PAGE_TIMEOUT);
 
-    await expect(await TabsLegacyPageObject.didTabItemContentLoad(TabItemSelector.Second)).toBeTruthy();
+    await expect(await TabsLegacyPageObject.didTabItemContentLoad('Second')).toBeTruthy();
 
     /* At Second tab element, press Up Arrow to navigate to the First tab element */
-    await TabsLegacyPageObject.sendKey(Keys.ARROW_UP, TabItemSelector.Second);
-    await TabsLegacyPageObject.waitForTabsItemsToOpen(TabItemSelector.First, PAGE_TIMEOUT);
+    await TabsLegacyPageObject.sendKey(Keys.ARROW_UP, 'Second');
+    await TabsLegacyPageObject.waitForTabsItemsToOpen('First', PAGE_TIMEOUT);
 
-    await expect(await TabsLegacyPageObject.didTabItemContentLoad(TabItemSelector.First)).toBeTruthy();
+    await expect(await TabsLegacyPageObject.didTabItemContentLoad('First')).toBeTruthy();
     await expect(await TabsLegacyPageObject.didAssertPopup()).toBeFalsy(TabsLegacyPageObject.ERRORMESSAGE_ASSERT);
   });
 });

--- a/apps/E2E/src/TabsLegacy/specs/TabsLegacy.spec.windows.ts
+++ b/apps/E2E/src/TabsLegacy/specs/TabsLegacy.spec.windows.ts
@@ -1,12 +1,12 @@
+import { BOOT_APP_TIMEOUT, PAGE_TIMEOUT, TABITEM_A11Y_ROLE, TAB_A11Y_ROLE } from '../../common/consts';
 import NavigateAppPage from '../../common/NavigateAppPage';
-import TabsLegacyPageObject, { TabItemSelector } from '../pages/TabsLegacyPageObject';
-import { TAB_A11Y_ROLE, BOOT_APP_TIMEOUT, PAGE_TIMEOUT, TABITEM_A11Y_ROLE } from '../../common/consts';
+import TabsLegacyPageObject from '../pages/TabsLegacyPageObject';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Tabs Legacy Testing Initialization', function () {
   it('Wait for app load', async () => {
     await NavigateAppPage.waitForPageDisplayed(BOOT_APP_TIMEOUT);
-    await expect(await NavigateAppPage.isPageLoaded()).toBeTruthy();
+    expect(await NavigateAppPage.isPageLoaded()).toBeTruthy();
   });
 
   it('Click and navigate to Tabs Legacy test page', async () => {
@@ -14,7 +14,7 @@ describe('Tabs Legacy Testing Initialization', function () {
     await NavigateAppPage.clickAndGoToTabsLegacyPage();
     await TabsLegacyPageObject.waitForPageDisplayed(PAGE_TIMEOUT);
 
-    await expect(await TabsLegacyPageObject.isPageLoaded()).toBeTruthy();
+    expect(await TabsLegacyPageObject.isPageLoaded()).toBeTruthy();
   });
 });
 
@@ -25,11 +25,11 @@ describe('Tabs Legacy Accessibility Testing', () => {
   });
 
   it("Validate Tab's accessibilityRole is correct", async () => {
-    await expect(await TabsLegacyPageObject.getAccessibilityRole()).toEqual(TAB_A11Y_ROLE);
+    expect(await TabsLegacyPageObject.getAccessibilityRole()).toEqual(TAB_A11Y_ROLE);
   });
 
   it("Validate TabItem's accessibilityRole is correct", async () => {
-    await expect(await TabsLegacyPageObject.getTabItemAccesibilityRole(TabItemSelector.First)).toEqual(TABITEM_A11Y_ROLE);
+    expect(await TabsLegacyPageObject.getTabItemAccesibilityRole('First')).toEqual(TABITEM_A11Y_ROLE);
   });
 });
 
@@ -39,40 +39,40 @@ describe('Tabs Legacy Functional Tests', () => {
     await TabsLegacyPageObject.scrollToTestElement();
 
     // Reset the TabGroup by putting focus on First tab item
-    await TabsLegacyPageObject.clickOnTabItem(TabItemSelector.First);
+    await TabsLegacyPageObject.clickOnTabItem('First');
   });
 
   it('Click on the second tab header and validate the correct TabItem content is shown', async () => {
-    await TabsLegacyPageObject.clickOnTabItem(TabItemSelector.Second);
-    await TabsLegacyPageObject.waitForTabsItemsToOpen(TabItemSelector.Second, PAGE_TIMEOUT);
+    await TabsLegacyPageObject.clickOnTabItem('Second');
+    await TabsLegacyPageObject.waitForTabsItemsToOpen('Second', PAGE_TIMEOUT);
 
-    await expect(await TabsLegacyPageObject.didTabItemContentLoad(TabItemSelector.Second)).toBeTruthy();
+    expect(await TabsLegacyPageObject.didTabItemContentLoad('Second')).toBeTruthy();
   });
 
   // Keyboarding is currently not integrated for UWP tabs - Task #5758598
   // it('Keyboarding: Arrow Navigation: Right -> Down -> Left -> Up -> Validate the correct TabItem content is shown', () => {
   //   /* At First tab element, press Right Arrow to navigate to the Second tab element */
-  //   TabsPageObject.sendKey(Keys.Right_Arrow, TabItemSelector.First);
-  //   TabsPageObject.waitForTabsItemsToOpen(TabItemSelector.Second, PAGE_TIMEOUT);
+  //   TabsPageObject.sendKey(Keys.Right_Arrow, 'First');
+  //   TabsPageObject.waitForTabsItemsToOpen('Second', PAGE_TIMEOUT);
 
-  //   expect(TabsPageObject.didTabItemContentLoad(TabItemSelector.Second)).toBeTruthy();
+  //   expect(TabsPageObject.didTabItemContentLoad('Second')).toBeTruthy();
 
   //   /* At Second tab element, press Down Arrow to navigate to the Third tab element */
-  //   TabsPageObject.sendKey(Keys.Down_Arrow, TabItemSelector.Second);
-  //   TabsPageObject.waitForTabsItemsToOpen(TabItemSelector.Third, PAGE_TIMEOUT);
+  //   TabsPageObject.sendKey(Keys.Down_Arrow, 'Second');
+  //   TabsPageObject.waitForTabsItemsToOpen('Third', PAGE_TIMEOUT);
 
-  //   expect(TabsPageObject.didTabItemContentLoad(TabItemSelector.Third)).toBeTruthy();
+  //   expect(TabsPageObject.didTabItemContentLoad('Third')).toBeTruthy();
 
   //   /* At Third tab element, press Left Arrow to navigate to the Second tab element */
-  //   TabsPageObject.sendKey(Keys.Left_Arrow, TabItemSelector.Third);
-  //   TabsPageObject.waitForTabsItemsToOpen(TabItemSelector.Second, PAGE_TIMEOUT);
+  //   TabsPageObject.sendKey(Keys.Left_Arrow, 'Third');
+  //   TabsPageObject.waitForTabsItemsToOpen('Second', PAGE_TIMEOUT);
 
-  //   expect(TabsPageObject.didTabItemContentLoad(TabItemSelector.Second)).toBeTruthy();
+  //   expect(TabsPageObject.didTabItemContentLoad('Second')).toBeTruthy();
 
   //   /* At Second tab element, press Up Arrow to navigate to the First tab element */
-  //   TabsPageObject.sendKey(Keys.Up_Arrow, TabItemSelector.Second);
-  //   TabsPageObject.waitForTabsItemsToOpen(TabItemSelector.First, PAGE_TIMEOUT);
+  //   TabsPageObject.sendKey(Keys.Up_Arrow, 'Second');
+  //   TabsPageObject.waitForTabsItemsToOpen('First', PAGE_TIMEOUT);
 
-  //   expect(TabsPageObject.didTabItemContentLoad(TabItemSelector.First)).toBeTruthy();
+  //   expect(TabsPageObject.didTabItemContentLoad('First')).toBeTruthy();
   // });
 });

--- a/apps/E2E/src/TextLegacy/pages/TextLegacyPageObject.ts
+++ b/apps/E2E/src/TextLegacy/pages/TextLegacyPageObject.ts
@@ -2,19 +2,18 @@ import { Attribute } from '../../common/consts';
 import { TEXT_TESTPAGE, HOMEPAGE_TEXT_BUTTON, DEPRECATED_TEXT_FIRST_COMPONENT, DEPRECATED_TEXT_SECOND_COMPONENT } from '../consts';
 import { BasePage, By } from '../../common/BasePage';
 
-export const enum TextComponentSelector {
-  Deprecated_First, // this._deprecatedFirstComponent
-  Deprecated_Second, // this._deprecatedSecondComponent
-}
+type TextComponentSelector =
+  | 'Deprecated_First' // this._deprecatedFirstComponent
+  | 'Deprecated_Second'; // this._deprecatedSecondComponent
 
 class TextLegacyPageObject extends BasePage {
   /* Gets the UI element given the selector */
   async getTextComponent(componentSelector: TextComponentSelector): Promise<WebdriverIO.Element> {
     switch (componentSelector) {
-      case TextComponentSelector.Deprecated_First:
+      case 'Deprecated_First':
         return await this._deprecatedFirstComponent;
 
-      case TextComponentSelector.Deprecated_Second:
+      case 'Deprecated_Second':
         return await this._deprecatedSecondComponent;
     }
   }

--- a/apps/E2E/src/TextLegacy/specs/TextLegacy.spec.win.ts
+++ b/apps/E2E/src/TextLegacy/specs/TextLegacy.spec.win.ts
@@ -1,13 +1,13 @@
+import { BOOT_APP_TIMEOUT, PAGE_TIMEOUT, TEXT_A11Y_ROLE } from '../../common/consts';
 import NavigateAppPage from '../../common/NavigateAppPage';
-import TextLegacyPageObject, { TextComponentSelector } from '../pages/TextLegacyPageObject';
-import { TEXT_A11Y_ROLE, PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
 import { DEPRECATED_TEXT_FIRST_ACCESSIBILITY_LABEL, DEPRECATED_TEXT_SECOND_COMPONENT_CONTENT } from '../consts';
+import TextLegacyPageObject from '../pages/TextLegacyPageObject';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Text Legacy Testing Initialization', function () {
   it('Wait for app load', async () => {
     await NavigateAppPage.waitForPageDisplayed(BOOT_APP_TIMEOUT);
-    await expect(await NavigateAppPage.isPageLoaded()).toBeTruthy(NavigateAppPage.ERRORMESSAGE_APPLOAD);
+    expect(await NavigateAppPage.isPageLoaded()).toBeTruthy(NavigateAppPage.ERRORMESSAGE_APPLOAD);
   });
 
   it('Click and navigate to Text Legacy test page', async () => {
@@ -15,8 +15,8 @@ describe('Text Legacy Testing Initialization', function () {
     await NavigateAppPage.clickAndGoToTextLegacyPage();
     await TextLegacyPageObject.waitForPageDisplayed(PAGE_TIMEOUT);
 
-    await expect(await TextLegacyPageObject.isPageLoaded()).toBeTruthy(TextLegacyPageObject.ERRORMESSAGE_PAGELOAD);
-    await expect(await TextLegacyPageObject.didAssertPopup()).toBeFalsy(TextLegacyPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    expect(await TextLegacyPageObject.isPageLoaded()).toBeTruthy(TextLegacyPageObject.ERRORMESSAGE_PAGELOAD);
+    expect(await TextLegacyPageObject.didAssertPopup()).toBeFalsy(TextLegacyPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
   });
 });
 
@@ -26,21 +26,17 @@ describe('Text Legacy Accessibility Testing', () => {
   });
 
   it('Text Legacy - Validate accessibilityRole is correct', async () => {
-    await expect(await TextLegacyPageObject.getTextAccessibilityRole(TextComponentSelector.Deprecated_First)).toEqual(TEXT_A11Y_ROLE);
-    await expect(await TextLegacyPageObject.didAssertPopup()).toBeFalsy(TextLegacyPageObject.ERRORMESSAGE_ASSERT);
+    expect(await TextLegacyPageObject.getTextAccessibilityRole('Deprecated_First')).toEqual(TEXT_A11Y_ROLE);
+    expect(await TextLegacyPageObject.didAssertPopup()).toBeFalsy(TextLegacyPageObject.ERRORMESSAGE_ASSERT);
   });
 
   it('Text Legacy - Set accessibilityLabel', async () => {
-    await expect(await TextLegacyPageObject.getTextAccessibilityLabel(TextComponentSelector.Deprecated_First)).toEqual(
-      DEPRECATED_TEXT_FIRST_ACCESSIBILITY_LABEL,
-    );
-    await expect(await TextLegacyPageObject.didAssertPopup()).toBeFalsy(TextLegacyPageObject.ERRORMESSAGE_ASSERT);
+    expect(await TextLegacyPageObject.getTextAccessibilityLabel('Deprecated_First')).toEqual(DEPRECATED_TEXT_FIRST_ACCESSIBILITY_LABEL);
+    expect(await TextLegacyPageObject.didAssertPopup()).toBeFalsy(TextLegacyPageObject.ERRORMESSAGE_ASSERT);
   });
 
   it('Text Legacy - Do not set accessibilityLabel -> Default to content', async () => {
-    await expect(await TextLegacyPageObject.getTextAccessibilityLabel(TextComponentSelector.Deprecated_Second)).toEqual(
-      DEPRECATED_TEXT_SECOND_COMPONENT_CONTENT,
-    );
-    await expect(await TextLegacyPageObject.didAssertPopup()).toBeFalsy(TextLegacyPageObject.ERRORMESSAGE_ASSERT);
+    expect(await TextLegacyPageObject.getTextAccessibilityLabel('Deprecated_Second')).toEqual(DEPRECATED_TEXT_SECOND_COMPONENT_CONTENT);
+    expect(await TextLegacyPageObject.didAssertPopup()).toBeFalsy(TextLegacyPageObject.ERRORMESSAGE_ASSERT);
   });
 });

--- a/apps/E2E/src/TextV1/specs/TextV1.spec.win.ts
+++ b/apps/E2E/src/TextV1/specs/TextV1.spec.win.ts
@@ -1,14 +1,13 @@
+import { BOOT_APP_TIMEOUT, PAGE_TIMEOUT, TEXT_A11Y_ROLE } from '../../common/consts';
 import NavigateAppPage from '../../common/NavigateAppPage';
-import TextV1PageObject from '../pages/TextV1PageObject.win';
-import { TEXT_A11Y_ROLE, PAGE_TIMEOUT, BOOT_APP_TIMEOUT } from '../../common/consts';
-import { ComponentSelector } from '../../common/BasePage';
 import { TEXTV1_ACCESSIBILITY_LABEL, TEXTV1_CONTENT } from '../consts';
+import TextV1PageObject from '../pages/TextV1PageObject.win';
 
 // Before testing begins, allow up to 60 seconds for app to open
 describe('TextV1 Testing Initialization', function () {
   it('Wait for app load', async () => {
     await NavigateAppPage.waitForPageDisplayed(BOOT_APP_TIMEOUT);
-    await expect(await NavigateAppPage.isPageLoaded()).toBeTruthy(NavigateAppPage.ERRORMESSAGE_APPLOAD);
+    expect(await NavigateAppPage.isPageLoaded()).toBeTruthy(NavigateAppPage.ERRORMESSAGE_APPLOAD);
   });
 
   it('Click and navigate to TextV1 test page', async () => {
@@ -16,8 +15,8 @@ describe('TextV1 Testing Initialization', function () {
     await NavigateAppPage.clickAndGoToTextV1Page();
     await TextV1PageObject.waitForPageDisplayed(PAGE_TIMEOUT);
 
-    await expect(await TextV1PageObject.isPageLoaded()).toBeTruthy(TextV1PageObject.ERRORMESSAGE_PAGELOAD);
-    await expect(await TextV1PageObject.didAssertPopup()).toBeFalsy(TextV1PageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    expect(await TextV1PageObject.isPageLoaded()).toBeTruthy(TextV1PageObject.ERRORMESSAGE_PAGELOAD);
+    expect(await TextV1PageObject.didAssertPopup()).toBeFalsy(TextV1PageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
   });
 });
 
@@ -27,17 +26,17 @@ describe('TextV1 Accessibility Testing', () => {
   });
 
   it('Text - Validate accessibilityRole is correct', async () => {
-    await expect(await TextV1PageObject.getAccessibilityRole()).toEqual(TEXT_A11Y_ROLE);
-    await expect(await TextV1PageObject.didAssertPopup()).toBeFalsy(TextV1PageObject.ERRORMESSAGE_ASSERT);
+    expect(await TextV1PageObject.getAccessibilityRole()).toEqual(TEXT_A11Y_ROLE);
+    expect(await TextV1PageObject.didAssertPopup()).toBeFalsy(TextV1PageObject.ERRORMESSAGE_ASSERT);
   });
 
   it('Text - Set accessibilityLabel', async () => {
-    await expect(await TextV1PageObject.getAccessibilityLabel(ComponentSelector.Primary)).toEqual(TEXTV1_ACCESSIBILITY_LABEL);
-    await expect(await TextV1PageObject.didAssertPopup()).toBeFalsy(TextV1PageObject.ERRORMESSAGE_ASSERT);
+    expect(await TextV1PageObject.getAccessibilityLabel('Primary')).toEqual(TEXTV1_ACCESSIBILITY_LABEL);
+    expect(await TextV1PageObject.didAssertPopup()).toBeFalsy(TextV1PageObject.ERRORMESSAGE_ASSERT);
   });
 
   it('Text - Do not set accessibilityLabel -> Default to content', async () => {
-    await expect(await TextV1PageObject.getAccessibilityLabel(ComponentSelector.Secondary)).toEqual(TEXTV1_CONTENT);
-    await expect(await TextV1PageObject.didAssertPopup()).toBeFalsy(TextV1PageObject.ERRORMESSAGE_ASSERT);
+    expect(await TextV1PageObject.getAccessibilityLabel('Secondary')).toEqual(TEXTV1_CONTENT);
+    expect(await TextV1PageObject.didAssertPopup()).toBeFalsy(TextV1PageObject.ERRORMESSAGE_ASSERT);
   });
 });

--- a/apps/E2E/src/common/BasePage.ts
+++ b/apps/E2E/src/common/BasePage.ts
@@ -1,4 +1,5 @@
-import { AndroidAttribute, Keys, ROOT_VIEW, TESTPAGE_CONTENT_SCROLLVIEWER } from './consts';
+import type { AndroidAttribute } from './consts';
+import { Keys, ROOT_VIEW, TESTPAGE_CONTENT_SCROLLVIEWER } from './consts';
 import { Attribute, attributeToEnumName, TESTPAGE_BUTTONS_SCROLLVIEWER } from './consts';
 
 const DUMMY_CHAR = '';
@@ -10,7 +11,7 @@ let rootView: WebdriverIO.Element | null = null;
 
 /* Win32/UWP-Specific Selector. We use this to get elements on the test page */
 export async function By(identifier: string) {
-  if (PLATFORM === DesktopPlatform.Windows) {
+  if (PLATFORM === 'windows') {
     // For some reason, the rootView node is never put into the element tree on the UWP tester. Remove this when fixed.
     return await $('~' + identifier);
   }
@@ -35,23 +36,15 @@ async function QueryWithChaining(identifier) {
 /* The values in this enum map to the UI components we want to test in our app. We use this to
 make the communication from our spec document to our page object easier. Please read below to
 see why we have Primary/Secondary components. */
-export const enum ComponentSelector {
-  Primary = 0, // this._primaryComponent
-  Secondary, // this._secondaryComponent
-}
+type ComponentSelector =
+  | 'Primary' // this._primaryComponent
+  | 'Secondary'; // this._secondaryComponent
 
-export const enum MobilePlatform {
-  iOS = 'ios',
-  Android = 'android',
-}
+type MobilePlatform = 'android' | 'ios';
 
-export const enum DesktopPlatform {
-  Win32 = 'win32',
-  Windows = 'windows',
-  macOS = 'macos',
-}
+type DesktopPlatform = 'win32' | 'windows' | 'macos';
 
-export type Platform = MobilePlatform | DesktopPlatform;
+type Platform = MobilePlatform | DesktopPlatform;
 
 /****************************** IMPORTANT! PLEASE READ! **************************************************
  * Every component's page object extends this. We can assume each test page will interact with at least
@@ -102,10 +95,10 @@ export abstract class BasePage {
   /* Gets the accessibility label of an UI element given the selector */
   async getAccessibilityLabel(componentSelector: ComponentSelector): Promise<string> {
     switch (componentSelector) {
-      case ComponentSelector.Primary:
+      case 'Primary':
         return await this.getElementAttribute(await this._primaryComponent, Attribute.AccessibilityLabel);
 
-      case ComponentSelector.Secondary:
+      case 'Secondary':
         return await this.getElementAttribute(await this._secondaryComponent, Attribute.AccessibilityLabel);
     }
   }
@@ -151,7 +144,7 @@ export abstract class BasePage {
       'Could not scroll to the ' + this._pageName + "'s Button. Please see Pipeline artifacts for more debugging information.";
 
     switch (this.platform) {
-      case MobilePlatform.iOS: {
+      case 'ios': {
         await browser.waitUntil(
           async () => {
             await driver.execute('mobile: scroll', { direction: 'down' });
@@ -165,7 +158,7 @@ export abstract class BasePage {
         break;
       }
       default:
-      case MobilePlatform.Android:
+      case 'android':
         /* 'mobile: scroll' which is used for iOS, does not support direction option on Android.
          * Instead, we use the UiScrollable class to scroll down to the desired view based on its 'description' (accessibilityLabel).
          * The first selector tells which container to scroll in, and the other selector tells which component to scroll to. */
@@ -252,7 +245,7 @@ export abstract class BasePage {
     const errorMsg = 'Could not scroll to the ' + componentToScrollTo + '. Please see Pipeline artifacts for more debugging information.';
 
     switch (this.platform) {
-      case MobilePlatform.iOS: {
+      case 'ios': {
         await browser.waitUntil(
           async () => {
             await driver.execute('mobile: scroll', { direction: 'down' });
@@ -265,7 +258,7 @@ export abstract class BasePage {
         );
         break;
       }
-      case MobilePlatform.Android:
+      case 'android':
         /* 'mobile: scroll' which is used for iOS, does not support direction option on Android.
          * Instead, we use the UiScrollable class to scroll down to the desired view based on its 'description' (accessibilityLabel).
          * The first selector tells which container to scroll in, and the other selector tells which component to scroll to. */
@@ -309,7 +302,7 @@ export abstract class BasePage {
   async didAssertPopup(): Promise<boolean> {
     /* On Android, we can't get the window handles. Instead, we check if the page is still visible.
      * In case of any error, a full page crash message is displayed and the test page is no longer accessible. */
-    if (PLATFORM === MobilePlatform.Android) {
+    if (PLATFORM === 'android') {
       return !(await this.isPageLoaded());
     }
     // If more than 1 instance of the app is open, we know an assert dialogue popped up.

--- a/apps/E2E/src/common/consts.ts
+++ b/apps/E2E/src/common/consts.ts
@@ -26,6 +26,7 @@ export const ANDROID_RADIOBUTTON = 'android.widget.RadioButton';
 export const BOOT_APP_TIMEOUT = 60000;
 export const PAGE_TIMEOUT = 15000;
 
+// eslint-disable-next-line @rnx-kit/no-const-enum
 export const enum Attribute {
   AccessibilityHint = 'HelpText',
   AccessibilityLabel = 'Name',
@@ -40,6 +41,7 @@ export const enum Attribute {
 }
 
 /* Android Element Attributes - https://github.com/appium/appium-uiautomator2-driver#element-attributes */
+// eslint-disable-next-line @rnx-kit/no-const-enum
 export const enum AndroidAttribute {
   AccessibilityLabel = 'content-desc',
   Class = 'class',
@@ -60,6 +62,7 @@ export const attributeToEnumName = {
   [Attribute.ToggleState]: 'ToggleState',
 };
 
+// eslint-disable-next-line @rnx-kit/no-const-enum
 export const enum AttributeValue {
   on = '1',
   off = '0',
@@ -70,6 +73,7 @@ export const enum AttributeValue {
 }
 
 /* Keyboard Key Constants */
+// eslint-disable-next-line @rnx-kit/no-const-enum
 export const enum Keys {
   NULL = '\uE000',
   CANCEL = '\uE001', // ^break

--- a/packages/framework/eslint-config-rules/eslintrc.js
+++ b/packages/framework/eslint-config-rules/eslintrc.js
@@ -1,6 +1,7 @@
 module.exports = {
   extends: ['plugin:@rnx-kit/recommended'],
   rules: {
+    '@rnx-kit/no-const-enum': 'error',
     '@rnx-kit/no-export-all': ['error', { expand: 'external-only' }],
     '@typescript-eslint/consistent-type-assertions': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
@@ -13,12 +14,6 @@ module.exports = {
     'no-prototype-builtins': 'off',
     'no-undef': 'off',
     'react/display-name': 'off',
-    '@typescript-eslint/consistent-type-imports': [
-      'error',
-      {
-        disallowTypeAnnotations: false,
-      },
-    ],
   },
   overrides: [
     {

--- a/packages/framework/eslint-config-rules/package.json
+++ b/packages/framework/eslint-config-rules/package.json
@@ -11,7 +11,7 @@
   "main": "./eslintrc.js",
   "license": "MIT",
   "devDependencies": {
-    "@rnx-kit/eslint-plugin": "^0.3.0",
+    "@rnx-kit/eslint-plugin": "^0.4.0",
     "eslint": "^8.0.0",
     "eslint-plugin-jest": "^25.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2729,10 +2729,10 @@
   dependencies:
     chalk "^4.1.0"
 
-"@rnx-kit/eslint-plugin@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@rnx-kit/eslint-plugin/-/eslint-plugin-0.3.0.tgz#3976bd59c95d55d90c330488ab47acc17331caa5"
-  integrity sha512-LdbQGk5hAZ7jR3m6AYyY6W6+dhP+ybciwZcAN5PbOK2d9qAWQJbl3aOPHygHTJdO1kDZlAvM5sFpSjxHfwZfVw==
+"@rnx-kit/eslint-plugin@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@rnx-kit/eslint-plugin/-/eslint-plugin-0.4.0.tgz#4d5ff71cded1780d3a126d86015a5c2cfa996454"
+  integrity sha512-jYuzCywyNzJcFoDMUOWlghdx2ua9v9/QZe8xwSRlbGbBfHBRKJhEJxF+ZA4sw04emZW84y80dTtpRq9d8gI1dA==
   dependencies:
     "@typescript-eslint/eslint-plugin" "^5.0.0"
     "@typescript-eslint/parser" "^5.0.0"


### PR DESCRIPTION
### Platforms Impacted

- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Disallow use of `const enum`. More on why here: https://hackmd.io/bBcd6R-1TB6Zq95PSquooQ

Luckily, they are only used in E2E. I've tried replacing the ones found there, but there are a few I couldn't find a satisfactory replacement for. For now, I've added suppressors since this package doesn't get published anyway.

Also noticed that we use `await expect(…)` in lots of places throughout the repository. `expect` is not an async function. I'll clean those up in a separate PR.

### Verification

Existing tests should pass.

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts