### PR TITLE
chore: bump @rnx-kit/metro-plugin-typescript to 0.3.2

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2776,9 +2776,9 @@
     "@rnx-kit/tools-node" "^1.2.7"
 
 "@rnx-kit/metro-plugin-typescript@^0.3.0":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@rnx-kit/metro-plugin-typescript/-/metro-plugin-typescript-0.3.1.tgz#1e30850455bc28dd5ac73670135739ff1e252a23"
-  integrity sha512-KIFyEfU047mztQV+P3d8kthBYV4Pz8E5h7F5bzvbb2aVSyaiXDD8HN5GIt6dX2wvYiNEqCqkKg+zuEE6VTGjCA==
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@rnx-kit/metro-plugin-typescript/-/metro-plugin-typescript-0.3.2.tgz#f3b2b42c7b77348959c4cd8173698a0e48449ac4"
+  integrity sha512-VHQpKRdSgbYPOeHsRmkLwMHTvCzVui6RrxHiTaz9RZjn0tX/2GKnQFa7sMu9VwI6AWKXZlPovIjey3Myjz0b3w==
   dependencies:
     "@rnx-kit/config" "^0.6.1"
     "@rnx-kit/tools-node" "^1.3.1"


### PR DESCRIPTION
### Platforms Impacted

- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Latest version of `@rnx-kit/metro-plugin-typescript` contains a fix for typechecking on Windows.