### PR TITLE
Revert default theme change from object to function

### DIFF
--- a/change/@fluentui-react-native-default-theme-9f4bea32-7537-451d-9512-a9ad6c72a56c.json
+++ b/change/@fluentui-react-native-default-theme-9f4bea32-7537-451d-9512-a9ad6c72a56c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Revert \"Change default theme from a const object to a function that returns the object #2483\"",
+  "packageName": "@fluentui-react-native/default-theme",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-framework-61cb1522-6e50-4f85-884b-8cce330b7b77.json
+++ b/change/@fluentui-react-native-framework-61cb1522-6e50-4f85-884b-8cce330b7b77.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Revert \"Change default theme from a const object to a function that returns the object #2483\"",
+  "packageName": "@fluentui-react-native/framework",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-theme-376681aa-6a16-405e-8601-d1b4173d5777.json
+++ b/change/@fluentui-react-native-theme-376681aa-6a16-405e-8601-d1b4173d5777.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Revert \"Change default theme from a const object to a function that returns the object #2483\"",
+  "packageName": "@fluentui-react-native/theme",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-win32-theme-ab9aa1ec-898c-489a-830c-a59fdb6dcce0.json
+++ b/change/@fluentui-react-native-win32-theme-ab9aa1ec-898c-489a-830c-a59fdb6dcce0.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Revert \"Change default theme from a const object to a function that returns the object #2483\"",
+  "packageName": "@fluentui-react-native/win32-theme",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabricshared-foundation-compose-2a42cf90-c343-4b56-8243-88d22b3e296e.json
+++ b/change/@uifabricshared-foundation-compose-2a42cf90-c343-4b56-8243-88d22b3e296e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Revert \"Change default theme from a const object to a function that returns the object #2483\"",
+  "packageName": "@uifabricshared/foundation-compose",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabricshared-theming-react-native-db0b6f05-f799-444e-9242-9f53c2bb69b7.json
+++ b/change/@uifabricshared-theming-react-native-db0b6f05-f799-444e-9242-9f53c2bb69b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Revert \"Change default theme from a const object to a function that returns the object #2483\"",
+  "packageName": "@uifabricshared/theming-react-native",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/deprecated/foundation-compose/src/useStyling.ts
+++ b/packages/deprecated/foundation-compose/src/useStyling.ts
@@ -42,7 +42,7 @@ function useStylingCore<TProps, TSlotProps extends ISlotProps, TTokens extends o
   lookupOverride?: IOverrideLookup,
 ): IWithTokens<TSlotProps, TTokens> {
   // get the theme value from the context (or the default theme if it is not set)
-  const theme = useTheme() || defaultFluentTheme();
+  const theme = useTheme() || defaultFluentTheme;
 
   // resolve the array of settings for these options
   lookupOverride = lookupOverride || props;

--- a/packages/deprecated/theming-react-native/src/BaselinePlatformDefaults.ts
+++ b/packages/deprecated/theming-react-native/src/BaselinePlatformDefaults.ts
@@ -5,5 +5,5 @@ import { defaultFluentTheme } from '@fluentui-react-native/default-theme';
  * @deprecated
  */
 export function getBaselinePlatformTheme(): ITheme {
-  return defaultFluentTheme();
+  return defaultFluentTheme;
 }

--- a/packages/framework/framework/src/useFluentTheme.ts
+++ b/packages/framework/framework/src/useFluentTheme.ts
@@ -8,5 +8,5 @@ import { useTheme } from '@fluentui-react-native/theme-types';
  * @returns - a valid Theme object
  */
 export function useFluentTheme(): Theme {
-  return useTheme() || defaultFluentTheme();
+  return useTheme() || defaultFluentTheme;
 }

--- a/packages/framework/theme/README.md
+++ b/packages/framework/theme/README.md
@@ -32,7 +32,7 @@ export const createMyCustomTheme = () => {
   // create the reference
   const themeRef = new ThemeReference(
     // base it on the default fluent theme
-    defaultFluentTheme(),
+    defaultFluentTheme,
     // mix in some constant values to override
     {
       colors: {

--- a/packages/theming/default-theme/src/__tests__/default-theme.test.ts
+++ b/packages/theming/default-theme/src/__tests__/default-theme.test.ts
@@ -21,11 +21,11 @@ beforeAll(() => {
 });
 
 it('defaultFluentTheme test', () => {
-  expect(defaultFluentTheme()).toMatchSnapshot();
+  expect(defaultFluentTheme).toMatchSnapshot();
 });
 
 it('defaultFluentDarkTheme test', () => {
-  expect(defaultFluentDarkTheme()).toMatchSnapshot();
+  expect(defaultFluentDarkTheme).toMatchSnapshot();
 });
 
 describe('createDefaultTheme test', () => {

--- a/packages/theming/default-theme/src/createDefaultTheme.ts
+++ b/packages/theming/default-theme/src/createDefaultTheme.ts
@@ -10,13 +10,13 @@ export function createDefaultTheme(options: ThemeOptions = {}): ThemeReference {
     const current = getCurrentAppearance(options.appearance, options.defaultAppearance || 'light');
     switch (current) {
       case 'light':
-        return defaultFluentTheme();
+        return defaultFluentTheme;
       case 'dark':
-        return defaultFluentDarkTheme();
+        return defaultFluentDarkTheme;
       case 'darkElevated':
-        return defaultFluentDarkTheme();
+        return defaultFluentDarkTheme;
       case 'highContrast':
-        return defaultFluentHighConstrastTheme();
+        return defaultFluentHighConstrastTheme;
       default:
         assertNever(current);
     }

--- a/packages/theming/default-theme/src/defaultTheme.ts
+++ b/packages/theming/default-theme/src/defaultTheme.ts
@@ -3,7 +3,6 @@ import { Platform } from 'react-native';
 import { getStockWebPalette, getStockWebDarkPalette, getStockWebHCPalette } from './defaultColors';
 import { globalTokens } from '@fluentui-react-native/theme-tokens';
 import { createShadowAliasTokens } from './createAliasTokens';
-import { memoize } from '@fluentui-react-native/memo-cache';
 
 function _defaultTypography(): Typography {
   const defaultsDict = {
@@ -78,43 +77,29 @@ export function defaultSpacing(): Spacing {
   return { s2: '4px', s1: '8px', m: '16px', l1: '20px', l2: '32px' };
 }
 
-function defaultFluentThemeWorker(): Theme {
-  return {
-    colors: getStockWebPalette(),
-    typography: _defaultTypography(),
-    spacing: defaultSpacing(),
-    shadows: createShadowAliasTokens('light'),
-    components: {},
-    host: { appearance: 'light' },
-  };
-}
+export const defaultFluentTheme: Theme = {
+  colors: getStockWebPalette(),
+  typography: _defaultTypography(),
+  spacing: defaultSpacing(),
+  shadows: createShadowAliasTokens('light'),
+  components: {},
+  host: { appearance: 'light' },
+};
 
-export const defaultFluentTheme = memoize(defaultFluentThemeWorker);
+export const defaultFluentDarkTheme: Theme = {
+  colors: getStockWebDarkPalette(),
+  typography: defaultFluentTheme.typography,
+  shadows: createShadowAliasTokens('dark'),
+  spacing: defaultFluentTheme.spacing,
+  components: {},
+  host: { appearance: 'dark' },
+};
 
-function defaultFluentDarkThemeWorker(): Theme {
-  const defaultTheme = defaultFluentTheme();
-  return {
-    colors: getStockWebDarkPalette(),
-    typography: defaultTheme.typography,
-    shadows: createShadowAliasTokens('dark'),
-    spacing: defaultTheme.spacing,
-    components: {},
-    host: { appearance: 'dark' },
-  };
-}
-
-export const defaultFluentDarkTheme = memoize(defaultFluentDarkThemeWorker);
-
-function defaultFluentHighConstrastThemeWorker(): Theme {
-  const defaultTheme = defaultFluentTheme();
-  return {
-    colors: getStockWebHCPalette(),
-    typography: defaultTheme.typography,
-    shadows: createShadowAliasTokens('highContrast'),
-    spacing: defaultTheme.spacing,
-    components: {},
-    host: { appearance: 'highContrast' },
-  };
-}
-
-export const defaultFluentHighConstrastTheme = memoize(defaultFluentHighConstrastThemeWorker);
+export const defaultFluentHighConstrastTheme: Theme = {
+  colors: getStockWebHCPalette(),
+  typography: defaultFluentTheme.typography,
+  shadows: createShadowAliasTokens('highContrast'),
+  spacing: defaultFluentTheme.spacing,
+  components: {},
+  host: { appearance: 'highContrast' },
+};

--- a/packages/theming/win32-theme/src/getThemeTypography.ts
+++ b/packages/theming/win32-theme/src/getThemeTypography.ts
@@ -4,8 +4,8 @@ import { createFontAliasTokens } from './createFontAliasTokens';
 
 export function win32Typography(): Typography {
   const win32Dict = {
-    sizes: defaultFluentTheme().typography.sizes,
-    weights: defaultFluentTheme().typography.weights,
+    sizes: defaultFluentTheme.typography.sizes,
+    weights: defaultFluentTheme.typography.weights,
     // hard coded until we support new fontFamily format
     families: {
       primary: 'Segoe UI',


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

Revert of https://github.com/microsoft/fluentui-react-native/pull/2483 - this was actually a breaking change and caused issues for some clients. 

The change was originally introduced to unblock some iOS color token work, but there have been some updates with the iOS token work where this change can now be removed without breaking iOS tokens.

### Verification

CI should pass, no visual changes

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
