### PR TITLE
Notification clean up - make NotificationTokens properties optional, remove tokens that weren't being used

### DIFF
--- a/change/@fluentui-react-native-notification-a6459db1-cdfc-40ce-a333-340b67b1ba18.json
+++ b/change/@fluentui-react-native-notification-a6459db1-cdfc-40ce-a333-340b67b1ba18.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove tokens that no longer affect the component",
+  "packageName": "@fluentui-react-native/notification",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Notification/src/Notification.helper.tsx
+++ b/packages/components/Notification/src/Notification.helper.tsx
@@ -9,7 +9,7 @@ import { createIconProps } from '@fluentui-react-native/icon';
 import { globalTokens } from '@fluentui-react-native/theme-tokens';
 import type { NotificationProps } from './Notification.types';
 
-export type NotificationButtonColorStates = { disabledColor; pressedColor };
+export type NotificationButtonColorStates = { disabledColor?; pressedColor? };
 
 type NotificationButtonProps = ButtonProps & ButtonTokens & NotificationButtonColorStates;
 

--- a/packages/components/Notification/src/Notification.types.ts
+++ b/packages/components/Notification/src/Notification.types.ts
@@ -13,14 +13,14 @@ export const NotificationVariants = ['primary', 'neutral', 'primaryBar', 'primar
 export type NotificationVariant = (typeof NotificationVariants)[number];
 
 export interface NotificationTokens extends LayoutTokens, IBorderTokens, IColorTokens, FontTokens, NotificationButtonColorStates {
-  primary: NotificationTokens;
-  neutral: NotificationTokens;
-  primaryBar: NotificationTokens;
-  primaryOutlineBar: NotificationTokens;
-  neutralBar: NotificationTokens;
-  danger: NotificationTokens;
-  warning: NotificationTokens;
-  isBar: NotificationTokens;
+  primary?: NotificationTokens;
+  neutral?: NotificationTokens;
+  primaryBar?: NotificationTokens;
+  primaryOutlineBar?: NotificationTokens;
+  neutralBar?: NotificationTokens;
+  danger?: NotificationTokens;
+  warning?: NotificationTokens;
+  isBar?: NotificationTokens;
   shadowToken?: ShadowToken;
 }
 

--- a/packages/components/Notification/src/NotificationTokens.ios.ts
+++ b/packages/components/Notification/src/NotificationTokens.ios.ts
@@ -32,23 +32,15 @@ const notificationColors = {
 
 export const defaultNotificationTokens: TokenSettings<NotificationTokens, Theme> = (t: Theme) =>
   ({
-    backgroundColor: t.colors.background,
     borderColor: 'transparent',
     borderRadius: globalTokens.corner.radius120,
     borderWidth: globalTokens.stroke.width10,
-    color: t.colors.brandForeground1,
-    fontFamily: 'primary',
-    fontLetterSpacing: -0.24,
-    fontLineHeight: 20,
-    fontSize: 15,
-    fontWeight: '400',
     minHeight: 52,
     padding: globalTokens.size160,
     paddingVertical: globalTokens.size120,
     shadowToken: t.shadows.shadow16,
     isBar: {
       borderRadius: globalTokens.corner.radiusNone,
-      fontWeight: '400',
       shadowToken: undefined,
     },
     primary: {

--- a/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
+++ b/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
@@ -107,8 +107,6 @@ exports[`Notification component tests Notification default 1`] = `
             "fontFamily": "System",
             "fontSize": 15,
             "fontWeight": "400",
-            "letterSpacing": -0.24,
-            "lineHeight": 20,
             "margin": 0,
           }
         }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Some clean up around the Notification component that I noticed while updating the colors to use alias color tokens:
- The defaultNotificationTokens objects in NotificationTokens.ios.ts and NotificationTokens.ts files were causing linting issues, fixed by making the properties in the NotificationTokens interface optional (which is also what other Tokens interfaces do)
- Noticed that some properties in defaultNotificationTokens weren't being shown anywhere and removing them doesn't affect the component. Background color is already being set for all the variants, and the properties related to font were already being set in the Notification component (done in this [PR](https://github.com/microsoft/fluentui-react-native/pull/2383)) 
- The snapshot was updated because jest tests take styles from [the default theme package](https://github.com/microsoft/fluentui-react-native/blob/c225025e9ccfbf3e3b910796f1628062f8d3c30b/packages/theming/default-theme/src/defaultTheme.ts#L49), which doesn't define letter spacing or line height. This [PR](https://github.com/microsoft/fluentui-react-native/pull/2472) made a similar change and describes why this happened

### Verification

There should be no visual changes

Before

https://user-images.githubusercontent.com/78454019/216706435-f926fd88-7fa0-4fcc-8fdb-90711a3137bb.mp4



After


https://user-images.githubusercontent.com/78454019/216706449-216c3514-fee5-4f9f-b59d-3eb3db10ebd0.mp4



### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
