### PR TITLE
macOS: Update submenu indicator color

### DIFF
--- a/change/@fluentui-react-native-menu-a74cbe95-cb27-4f20-ba46-ff79c99a5a6e.json
+++ b/change/@fluentui-react-native-menu-a74cbe95-cb27-4f20-ba46-ff79c99a5a6e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "macOS: Update submenu indicator color",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "amchiu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/MenuItem/MenuItemTokens.macos.ts
+++ b/packages/components/Menu/src/MenuItem/MenuItemTokens.macos.ts
@@ -14,6 +14,7 @@ export const defaultMenuItemTokens: TokenSettings<MenuItemTokens, Theme> = (t: T
   gap: globalTokens.size40,
   paddingHorizontal: 5, // hardcoded for now to match ContextualMenu
   paddingVertical: 3, // hardcoded for now to match ContextualMenu
+  submenuIndicatorColor: t.colors.neutralForeground2,
   submenuIndicatorPadding: globalTokens.sizeNone,
   submenuIndicatorSize: 16,
   focused: {

--- a/packages/components/Menu/src/MenuItem/MenuItemTokens.macos.ts
+++ b/packages/components/Menu/src/MenuItem/MenuItemTokens.macos.ts
@@ -5,15 +5,15 @@ import type { MenuItemTokens } from './MenuItem.types';
 
 export const defaultMenuItemTokens: TokenSettings<MenuItemTokens, Theme> = (t: Theme): MenuItemTokens => ({
   backgroundColor: t.colors.transparentBackground,
-  borderRadius: 5, // hardcoded for now to match ContextualMenu
+  borderRadius: 5, // hardcoded for now to match NSMenu
   checkmarkSize: 16,
-  color: t.colors.menuItemText, // matches ContextualMenu
+  color: t.colors.menuItemText, // hardcoded for now to match NSMenu
   fontFamily: t.typography.families.primary,
   fontSize: 13, // aligning with NSMenu font size
   fontWeight: globalTokens.font.weight.regular as FontWeightValue,
   gap: globalTokens.size40,
-  paddingHorizontal: 5, // hardcoded for now to match ContextualMenu
-  paddingVertical: 3, // hardcoded for now to match ContextualMenu
+  paddingHorizontal: 5, // hardcoded for now to match NSMenu
+  paddingVertical: 3, // hardcoded for now to match NSMenu
   submenuIndicatorColor: t.colors.neutralForeground2,
   submenuIndicatorPadding: globalTokens.sizeNone,
   submenuIndicatorSize: 16,

--- a/packages/components/Menu/src/MenuList/MenuListTokens.macos.ts
+++ b/packages/components/Menu/src/MenuList/MenuListTokens.macos.ts
@@ -4,7 +4,7 @@ import type { TokenSettings } from '@fluentui-react-native/use-styling';
 import type { MenuListTokens } from './MenuList.types';
 
 export const defaultMenuListTokens: TokenSettings<MenuListTokens, Theme> = (t: Theme): MenuListTokens => ({
-  padding: 5, // hardcoded for now to match ContextualMenu
+  padding: 5, // hardcoded for now to match NSMenu
   backgroundColor: t.colors.transparentBackground,
   gap: globalTokens.size20,
 });


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

We are showing the submenu indicator color as blue which is wrong, let's set it with the same alias token as the default one.
### Verification


| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|![before](https://user-images.githubusercontent.com/67026167/216722777-4a6e9daf-c487-41bf-8969-67cf9dd0794f.png) |![after](https://user-images.githubusercontent.com/67026167/216722807-7a5fe773-70ce-45f4-aa7f-a0e52b908d28.png) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
