### PR TITLE
iOS Support accessibilityContrast from traitCollection

### DIFF
--- a/change/@fluentui-react-native-experimental-appearance-additions-e6e1dfe7-cdd3-4095-bca9-e47c1611c381.json
+++ b/change/@fluentui-react-native-experimental-appearance-additions-e6e1dfe7-cdd3-4095-bca9-e47c1611c381.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add ability to get accessibilityContrast from traitcollection",
+  "packageName": "@fluentui-react-native/experimental-appearance-additions",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/AppearanceAdditions/src/NativeAppearanceAdditions.ios.ts
+++ b/packages/experimental/AppearanceAdditions/src/NativeAppearanceAdditions.ios.ts
@@ -5,5 +5,4 @@ export const NativeAppearanceAdditions = NativeModules.FRNAppearanceAdditions;
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface NativeAppearanceAdditionsInterface {}
 
-// export default NativeFontMetrics as NativeFontMetricsInterface;
 export default NativeAppearanceAdditions as NativeAppearanceAdditionsInterface;

--- a/packages/experimental/AppearanceAdditions/src/NativeAppearanceAdditions.ts
+++ b/packages/experimental/AppearanceAdditions/src/NativeAppearanceAdditions.ts
@@ -1,4 +1,4 @@
-import type { SizeClass, UserInterfaceLevel } from './NativeAppearanceAdditions.types';
+import type { AccessibilityContrastOption, SizeClass, UserInterfaceLevel } from './NativeAppearanceAdditions.types';
 
 export const NativeAppearanceAdditions = {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -13,7 +13,10 @@ export const NativeAppearanceAdditions = {
     console.warn('NativeAppearanceAdditions is only available on iOS');
     return 'base' as UserInterfaceLevel;
   },
+  accessibilityContrastOption: () => {
+    console.warn('NativeAppearanceAdditions is only available on iOS');
+    return 'normal' as AccessibilityContrastOption;
+  },
 };
 
-// export default NativeFontMetrics;
 export default NativeAppearanceAdditions;

--- a/packages/experimental/AppearanceAdditions/src/NativeAppearanceAdditions.types.ts
+++ b/packages/experimental/AppearanceAdditions/src/NativeAppearanceAdditions.types.ts
@@ -1,6 +1,7 @@
 export interface AppearanceAdditions {
   readonly horizontalSizeClass: SizeClass;
   readonly userInterfaceLevel: UserInterfaceLevel;
+  readonly accessibilityContrastOption: AccessibilityContrastOption;
 }
 
 export const HorizontalSizeClassKey = 'horizontalSizeClass';
@@ -8,3 +9,6 @@ export type SizeClass = 'compact' | 'regular';
 
 export const UserInterfaceLevelKey = 'userInterfaceLevel';
 export type UserInterfaceLevel = 'base' | 'elevated';
+
+export const AccessibilityContrastOptionKey = 'accessibilityContrastOption';
+export type AccessibilityContrastOption = 'normal' | 'high';

--- a/packages/experimental/AppearanceAdditions/src/appearanceAdditions.ios.ts
+++ b/packages/experimental/AppearanceAdditions/src/appearanceAdditions.ios.ts
@@ -1,12 +1,13 @@
 import { NativeEventEmitter } from 'react-native';
 import NativeAppearanceAdditions from './NativeAppearanceAdditions.ios';
-import type { AppearanceAdditions, SizeClass, UserInterfaceLevel } from './NativeAppearanceAdditions.types';
-import { HorizontalSizeClassKey, UserInterfaceLevelKey } from './NativeAppearanceAdditions.types';
+import type { AppearanceAdditions, SizeClass, UserInterfaceLevel, AccessibilityContrastOption } from './NativeAppearanceAdditions.types';
+import { HorizontalSizeClassKey, UserInterfaceLevelKey, AccessibilityContrastOptionKey } from './NativeAppearanceAdditions.types';
 import { memoize } from '@fluentui-react-native/framework';
 
 class AppearanceAdditionsImpl implements AppearanceAdditions {
   _horizontalSizeClass: SizeClass;
   _userInterfaceLevel: UserInterfaceLevel;
+  _accessibilityContrastOption: AccessibilityContrastOption;
 
   get horizontalSizeClass(): SizeClass {
     return this._horizontalSizeClass;
@@ -16,11 +17,16 @@ class AppearanceAdditionsImpl implements AppearanceAdditions {
     return this._userInterfaceLevel;
   }
 
+  get accessibilityContrastOption(): AccessibilityContrastOption {
+    return this._accessibilityContrastOption;
+  }
+
   constructor() {
     const eventEmitter = new NativeEventEmitter(NativeAppearanceAdditions as any);
     eventEmitter.addListener('appearanceChanged', (newValue) => {
       this._horizontalSizeClass = newValue[HorizontalSizeClassKey];
       this._userInterfaceLevel = newValue[UserInterfaceLevelKey];
+      this._accessibilityContrastOption = newValue[AccessibilityContrastOptionKey];
     });
   }
 }

--- a/packages/experimental/AppearanceAdditions/src/appearanceAdditions.ts
+++ b/packages/experimental/AppearanceAdditions/src/appearanceAdditions.ts
@@ -6,6 +6,7 @@ function getAppearanceAdditionsWorker() {
   return {
     horizontalSizeClass: 'regular',
     userInterfaceLevel: 'base',
+    accessibilityContrastOption: 'normal',
   } as AppearanceAdditions;
 }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

On iOS we currently don't have a way to detect whether what the user's accessibility contrast setting is.

This setting is found here:
Settings -> Accessibility -> Display & Text Size -> Increase Contrast

<img width="337" alt="Screenshot 2023-02-07 at 12 17 29 PM" src="https://user-images.githubusercontent.com/78454019/217355539-bd575ae1-6760-4320-a0ba-e6601bea7d84.png">


With the recent work is add a native module for detecting dark elevated mode and size classes, we can now also use the same module to add the ability to get the accessibility contrast setting from the trait collection.

### Verification

Locally added a console.log statement in createAppleTheme.ts to print out the accessibility contrast. Verified that when toggling on/off the high contrast setting, the printed statements reflect the setting.

<img width="676" alt="Screenshot 2023-02-07 at 12 12 50 PM" src="https://user-images.githubusercontent.com/78454019/217354655-e3efb960-2a16-46b1-a8b4-dd8c70396be3.png">


https://user-images.githubusercontent.com/78454019/217356837-b0d73230-a574-4880-99d6-57ab4992a336.mov



### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
