### PR TITLE
Remove "Enter" and "Space Key" key triggers from disabled MenuItems

### DIFF
--- a/change/@fluentui-react-native-menu-4c78b389-aaee-44e8-a91e-16f2e283ad9d.json
+++ b/change/@fluentui-react-native-menu-4c78b389-aaee-44e8-a91e-16f2e283ad9d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove enter and space key triggers from disabled menu items",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/MenuItem/useMenuItem.ts
+++ b/packages/components/Menu/src/MenuItem/useMenuItem.ts
@@ -9,9 +9,8 @@ import { useMenuContext } from '../context/menuContext';
 import { useMenuListContext } from '../context/menuListContext';
 import { useMenuTriggerContext } from '../context/menuTriggerContext';
 
-export const disabledTriggerKeys = ['ArrowLeft', 'ArrowRight'];
 export const triggerKeys = [' ', 'Enter'];
-export const submenuTriggerKeys = [...triggerKeys, ...disabledTriggerKeys];
+export const submenuTriggerKeys = ['ArrowLeft', 'ArrowRight', ...triggerKeys];
 
 export const useMenuItem = (props: MenuItemProps): MenuItemInfo => {
   // attach the pressable state handlers
@@ -54,7 +53,7 @@ export const useMenuItem = (props: MenuItemProps): MenuItemInfo => {
 
   const pressable = usePressableState({ ...rest, onPress: onInvoke });
   const itemRef = useViewCommandFocus(componentRef);
-  const keys = disabled ? disabledTriggerKeys : isSubmenu ? submenuTriggerKeys : triggerKeys;
+  const keys = disabled ? [] : isSubmenu ? submenuTriggerKeys : triggerKeys;
 
   // Explicitly override onKeyDown to override the native behavior of moving focus with arrow keys.
   const onKeyDownProps = useKeyDownProps(onInvoke, ...keys);

--- a/packages/components/Menu/src/MenuItem/useMenuItem.ts
+++ b/packages/components/Menu/src/MenuItem/useMenuItem.ts
@@ -9,8 +9,9 @@ import { useMenuContext } from '../context/menuContext';
 import { useMenuListContext } from '../context/menuListContext';
 import { useMenuTriggerContext } from '../context/menuTriggerContext';
 
+export const disabledTriggerKeys = ['ArrowLeft', 'ArrowRight'];
 export const triggerKeys = [' ', 'Enter'];
-export const submenuTriggerKeys = [...triggerKeys, 'ArrowLeft', 'ArrowRight'];
+export const submenuTriggerKeys = [...triggerKeys, ...disabledTriggerKeys];
 
 export const useMenuItem = (props: MenuItemProps): MenuItemInfo => {
   // attach the pressable state handlers
@@ -53,7 +54,7 @@ export const useMenuItem = (props: MenuItemProps): MenuItemInfo => {
 
   const pressable = usePressableState({ ...rest, onPress: onInvoke });
   const itemRef = useViewCommandFocus(componentRef);
-  const keys = isSubmenu ? submenuTriggerKeys : triggerKeys;
+  const keys = disabled ? disabledTriggerKeys : isSubmenu ? submenuTriggerKeys : triggerKeys;
 
   // Explicitly override onKeyDown to override the native behavior of moving focus with arrow keys.
   const onKeyDownProps = useKeyDownProps(onInvoke, ...keys);

--- a/packages/components/Menu/src/MenuItemCheckbox/useMenuItemCheckbox.ts
+++ b/packages/components/Menu/src/MenuItemCheckbox/useMenuItemCheckbox.ts
@@ -6,7 +6,7 @@ import { memoize } from '@fluentui-react-native/framework';
 import type { InteractionEvent, KeyPressEvent } from '@fluentui-react-native/interactive-hooks';
 import { usePressableState, useKeyDownProps, useOnPressWithFocus, useViewCommandFocus } from '@fluentui-react-native/interactive-hooks';
 import { useMenuListContext } from '../context/menuListContext';
-import { submenuTriggerKeys, triggerKeys, useHoverFocusEffect } from '../MenuItem/useMenuItem';
+import { disabledTriggerKeys, submenuTriggerKeys, triggerKeys, useHoverFocusEffect } from '../MenuItem/useMenuItem';
 import { useMenuContext } from '../context/menuContext';
 
 const defaultAccessibilityActions = [{ name: 'Toggle' }];
@@ -90,7 +90,7 @@ export const useMenuCheckboxInteraction = (
     [disabled, isSubmenu, onArrowClose, toggleCallback],
   );
 
-  const keys = isSubmenu ? submenuTriggerKeys : triggerKeys;
+  const keys = disabled ? disabledTriggerKeys : isSubmenu ? submenuTriggerKeys : triggerKeys;
   const onKeyProps = useKeyDownProps(onKeysPressed, ...keys);
 
   const accessibilityActionsProp = accessibilityActions

--- a/packages/components/Menu/src/MenuItemCheckbox/useMenuItemCheckbox.ts
+++ b/packages/components/Menu/src/MenuItemCheckbox/useMenuItemCheckbox.ts
@@ -6,7 +6,7 @@ import { memoize } from '@fluentui-react-native/framework';
 import type { InteractionEvent, KeyPressEvent } from '@fluentui-react-native/interactive-hooks';
 import { usePressableState, useKeyDownProps, useOnPressWithFocus, useViewCommandFocus } from '@fluentui-react-native/interactive-hooks';
 import { useMenuListContext } from '../context/menuListContext';
-import { disabledTriggerKeys, submenuTriggerKeys, triggerKeys, useHoverFocusEffect } from '../MenuItem/useMenuItem';
+import { submenuTriggerKeys, triggerKeys, useHoverFocusEffect } from '../MenuItem/useMenuItem';
 import { useMenuContext } from '../context/menuContext';
 
 const defaultAccessibilityActions = [{ name: 'Toggle' }];
@@ -90,7 +90,7 @@ export const useMenuCheckboxInteraction = (
     [disabled, isSubmenu, onArrowClose, toggleCallback],
   );
 
-  const keys = disabled ? disabledTriggerKeys : isSubmenu ? submenuTriggerKeys : triggerKeys;
+  const keys = disabled ? [] : isSubmenu ? submenuTriggerKeys : triggerKeys;
   const onKeyProps = useKeyDownProps(onKeysPressed, ...keys);
 
   const accessibilityActionsProp = accessibilityActions

--- a/packages/components/Menu/src/__tests__/__snapshots__/Menu.test.tsx.snap
+++ b/packages/components/Menu/src/__tests__/__snapshots__/Menu.test.tsx.snap
@@ -296,16 +296,7 @@ Array [
           accessible={true}
           enableFocusRing={true}
           focusable={true}
-          keyDownEvents={
-            Array [
-              Object {
-                "key": "ArrowLeft",
-              },
-              Object {
-                "key": "ArrowRight",
-              },
-            ]
-          }
+          keyDownEvents={Array []}
           onAccessibilityTap={[Function]}
           onBlur={[Function]}
           onClick={[Function]}
@@ -860,16 +851,7 @@ Array [
           accessible={true}
           enableFocusRing={true}
           focusable={true}
-          keyDownEvents={
-            Array [
-              Object {
-                "key": "ArrowLeft",
-              },
-              Object {
-                "key": "ArrowRight",
-              },
-            ]
-          }
+          keyDownEvents={Array []}
           onAccessibilityAction={[Function]}
           onBlur={[Function]}
           onClick={[Function]}
@@ -2414,16 +2396,16 @@ Array [
           keyDownEvents={
             Array [
               Object {
-                "key": " ",
-              },
-              Object {
-                "key": "Enter",
-              },
-              Object {
                 "key": "ArrowLeft",
               },
               Object {
                 "key": "ArrowRight",
+              },
+              Object {
+                "key": " ",
+              },
+              Object {
+                "key": "Enter",
               },
             ]
           }

--- a/packages/components/Menu/src/__tests__/__snapshots__/Menu.test.tsx.snap
+++ b/packages/components/Menu/src/__tests__/__snapshots__/Menu.test.tsx.snap
@@ -299,10 +299,10 @@ Array [
           keyDownEvents={
             Array [
               Object {
-                "key": " ",
+                "key": "ArrowLeft",
               },
               Object {
-                "key": "Enter",
+                "key": "ArrowRight",
               },
             ]
           }
@@ -863,10 +863,10 @@ Array [
           keyDownEvents={
             Array [
               Object {
-                "key": " ",
+                "key": "ArrowLeft",
               },
               Object {
-                "key": "Enter",
+                "key": "ArrowRight",
               },
             ]
           }


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [] macOS
- [X] win32 (Office)
- [X] windows
- [ ] android

### Description of changes
Added a check for disabled before adding triggers for Enter and Space keys. For win32, menuItems are keyboard focusable by default. No additional key triggers will be passed into disabled menu items.

### Verification
Tested on FURN tester

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [X] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
