### PR TITLE
[Switch] Fix RTL switch issue

### DIFF
--- a/change/@fluentui-react-native-switch-0accd738-718e-46e3-92e1-865241bf5ee2.json
+++ b/change/@fluentui-react-native-switch-0accd738-718e-46e3-92e1-865241bf5ee2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix rtl switch issue",
+  "packageName": "@fluentui-react-native/switch",
+  "email": "rohanpd.work@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Switch/src/useSwitch.ts
+++ b/packages/experimental/Switch/src/useSwitch.ts
@@ -34,15 +34,12 @@ export const useSwitch = (props: SwitchProps, animationConfig?: AnimationConfig)
   } = props;
 
   const [checkedState, toggleCallback] = useAsToggleWithEvent(defaultChecked, checked, onChange);
+  const thumbTranslateValue = animationConfig.trackWidth - (animationConfig.thumbWidth + animationConfig.thumbMargin * 2);
   //Setting the initial position of the knob on track when page loads.
   React.useEffect(() => {
     if (isMobile) {
       Animated.timing(animation, {
-        toValue: checkedState
-          ? isRTL
-            ? -(animationConfig.trackWidth - (animationConfig.thumbWidth + animationConfig.thumbMargin * 2))
-            : animationConfig.trackWidth - (animationConfig.thumbWidth + animationConfig.thumbMargin * 2)
-          : 0,
+        toValue: checkedState ? (isRTL ? -thumbTranslateValue : thumbTranslateValue) : 0,
         duration: isInit ? 0 : 300,
         useNativeDriver: false,
       }).start();

--- a/packages/experimental/Switch/src/useSwitch.ts
+++ b/packages/experimental/Switch/src/useSwitch.ts
@@ -2,13 +2,14 @@ import * as React from 'react';
 import { usePressableState, useKeyProps, useOnPressWithFocus, useViewCommandFocus } from '@fluentui-react-native/interactive-hooks';
 import type { SwitchProps, SwitchInfo, AnimationConfig } from './Switch.types';
 import type { AccessibilityState, AccessibilityActionEvent } from 'react-native';
-import { Animated, Platform } from 'react-native';
+import { Animated, Platform, I18nManager } from 'react-native';
 import { memoize } from '@fluentui-react-native/framework';
 import { useAsToggleWithEvent } from '@fluentui-react-native/interactive-hooks';
 
 const defaultAccessibilityActions = [{ name: 'Toggle' }];
 
 const isMobile = Platform.OS === 'android' || Platform.OS == 'ios';
+const isRTL = I18nManager.isRTL;
 
 export const useSwitch = (props: SwitchProps, animationConfig?: AnimationConfig): SwitchInfo => {
   const defaultComponentRef = React.useRef(null);
@@ -33,12 +34,15 @@ export const useSwitch = (props: SwitchProps, animationConfig?: AnimationConfig)
   } = props;
 
   const [checkedState, toggleCallback] = useAsToggleWithEvent(defaultChecked, checked, onChange);
-
   //Setting the initial position of the knob on track when page loads.
   React.useEffect(() => {
     if (isMobile) {
       Animated.timing(animation, {
-        toValue: checkedState ? animationConfig.trackWidth - (animationConfig.thumbWidth + animationConfig.thumbMargin * 2) : 0,
+        toValue: checkedState
+          ? isRTL
+            ? -(animationConfig.trackWidth - (animationConfig.thumbWidth + animationConfig.thumbMargin * 2))
+            : animationConfig.trackWidth - (animationConfig.thumbWidth + animationConfig.thumbMargin * 2)
+          : 0,
         duration: isInit ? 0 : 300,
         useNativeDriver: false,
       }).start();


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [x] android

### Description of changes
On RTL the transform property was not set properly and the the thumb was going out. 

### Verification
Visually tested doing RTL. 

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="385" alt="image" src="https://user-images.githubusercontent.com/30728574/217554822-047cd5b4-1078-4dd8-82a8-27d03fe2fa0a.png"> | <img width="333" alt="image" src="https://user-images.githubusercontent.com/30728574/217554718-81b48833-6db6-405a-aa0b-bf8f69cbd6bd.png"> |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
