### PR TITLE
macOS: Only show scroll indicators if maxHeight/maxWidth is specified

### DIFF
--- a/change/@fluentui-react-native-menu-330c418d-fa46-4b55-8b81-c50292fc1b0d.json
+++ b/change/@fluentui-react-native-menu-330c418d-fa46-4b55-8b81-c50292fc1b0d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "macOS: Only show scroll indicators if maxHeight/maxWidth is specified",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/Menu/Menu.types.ts
+++ b/packages/components/Menu/src/Menu/Menu.types.ts
@@ -44,4 +44,5 @@ export interface MenuState extends MenuProps {
   shouldFocusOnContainer: boolean;
   triggerRef: React.RefObject<React.Component>;
   hasMaxHeight?: boolean;
+  hasMaxWidth?: boolean;
 }

--- a/packages/components/Menu/src/MenuList/MenuList.tsx
+++ b/packages/components/Menu/src/MenuList/MenuList.tsx
@@ -59,7 +59,10 @@ export const MenuList = compose<MenuListType>({
       const content =
         Platform.OS === 'macos' ? (
           <Slots.root>
-            <Slots.scrollView>
+            <Slots.scrollView
+              showsVerticalScrollIndicator={menuContext.hasMaxHeight}
+              showsHorizontalScrollIndicator={menuContext.hasMaxWidth}
+            >
               <Slots.focusZone
                 componentRef={focusZoneRef}
                 focusZoneDirection={'vertical'}

--- a/packages/components/Menu/src/MenuList/MenuList.types.ts
+++ b/packages/components/Menu/src/MenuList/MenuList.types.ts
@@ -49,6 +49,7 @@ export interface MenuListState extends Omit<MenuListProps, 'checked' | 'onChecke
   addRadioItem: (name: string) => void;
   removeRadioItem: (name: string) => void;
   hasMaxHeight?: boolean;
+  hasMaxWidth?: boolean;
 }
 
 export interface MenuListSlotProps {

--- a/packages/components/Menu/src/MenuList/useMenuList.ts
+++ b/packages/components/Menu/src/MenuList/useMenuList.ts
@@ -121,5 +121,6 @@ export const useMenuList = (_props: MenuListProps): MenuListState => {
     addRadioItem,
     removeRadioItem,
     hasMaxHeight: context.hasMaxHeight,
+    hasMaxWidth: context.hasMaxWidth,
   };
 };

--- a/packages/components/Menu/src/context/menuContext.ts
+++ b/packages/components/Menu/src/context/menuContext.ts
@@ -23,6 +23,7 @@ export const MenuContext = React.createContext<MenuContextValue>({
   shouldFocusOnContainer: false,
   triggerRef: null,
   hasMaxHeight: false,
+  hasMaxWidth: false,
 });
 
 export const MenuProvider = MenuContext.Provider;


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Similar to #1611, we want to show scroll indicator only if content overflows/scrollbar is present. This change adopts the same logic where vertical/horizontal scroll indicator props are enabled if maxHeight/maxWidth is set respectively. 

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|  ![before](https://user-images.githubusercontent.com/67026167/217596172-03dc6f7c-5075-4442-9364-d9e6e4757360.png)|<img width="267" alt="after" src="https://user-images.githubusercontent.com/67026167/217596348-68e89a93-5158-4a0d-9d58-5a2387046a8b.png">  |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
