### PR TITLE
iOS Get initial trait collection correctly on boot

### DIFF
--- a/change/@fluentui-react-native-experimental-appearance-additions-90512076-d861-47b4-9ba3-7442d36c34c7.json
+++ b/change/@fluentui-react-native-experimental-appearance-additions-90512076-d861-47b4-9ba3-7442d36c34c7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Create method to initialize trait collection from root view",
+  "packageName": "@fluentui-react-native/experimental-appearance-additions",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/AppearanceAdditions/ios/FRNAppearanceAdditions.m
+++ b/packages/experimental/AppearanceAdditions/ios/FRNAppearanceAdditions.m
@@ -124,15 +124,6 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(accessibilityContrastOption)
 
 #pragma mark - Event processing
 
-RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getInitialTraitCollection)
-{
-    return @{
-        @"horizontalSizeClass": _horizontalSizeClass,
-        @"userInterfaceLevel": _userInterfaceLevel,
-        @"accessibilityContrastOption": _accessibilityContrastOption,
-    };
-}
-
 - (void)appearanceChanged:(NSNotification *)notification {
     if (_hasListeners) {
         UITraitCollection *traitCollection = [[notification userInfo] valueForKey:RCTUserInterfaceStyleDidChangeNotificationTraitCollectionKey];

--- a/packages/experimental/AppearanceAdditions/ios/FRNAppearanceAdditions.m
+++ b/packages/experimental/AppearanceAdditions/ios/FRNAppearanceAdditions.m
@@ -105,14 +105,22 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(accessibilityContrastOption)
 - (void)startObserving {
     _hasListeners = YES;
     
-    // [UITraitCollection currentTraitCollection] never returns the correct trait collection, presumably because FRNAppearanceAdditions isn't a view
-    // so it never gets updated with the right traitCollection (which happens when a view gets added to the view hierachy). In order
-    // to get the right trait collection we need to access the root view.
-    UITraitCollection *rootViewTraitCollection = [[[[[UIApplication sharedApplication] delegate] window] rootViewController] traitCollection];
+    // Note that [UITraitCollection currentTraitCollection] always returns the same default trait collection,
+    // presumably because FRNAppearanceAdditions isn't a view, so it never gets updated with the right traitCollection
+    // (which happens when a view gets added to the view hierachy). In order to get the right trait collection,
+    // we need to access a view that's been added to the view hierarchy
+    UIViewController *viewControllerWithInitialTraitCollection = RCTPresentedViewController();
+    UITraitCollection *initialTraitCollection;
     
-    _horizontalSizeClass = RCTHorizontalSizeClassPreference(rootViewTraitCollection);
-    _userInterfaceLevel = RCTUserInterfaceLevelPreference(rootViewTraitCollection);
-    _accessibilityContrastOption = RCTAccessibilityContrastPreference(rootViewTraitCollection);
+    if (viewControllerWithInitialTraitCollection != nil) {
+        initialTraitCollection = [viewControllerWithInitialTraitCollection traitCollection];
+    } else {
+        initialTraitCollection = [UITraitCollection currentTraitCollection];
+    }
+    
+    _horizontalSizeClass = RCTHorizontalSizeClassPreference(initialTraitCollection);
+    _userInterfaceLevel = RCTUserInterfaceLevelPreference(initialTraitCollection);
+    _accessibilityContrastOption = RCTAccessibilityContrastPreference(initialTraitCollection);
     
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(appearanceChanged:)

--- a/packages/experimental/AppearanceAdditions/ios/FRNAppearanceAdditions.m
+++ b/packages/experimental/AppearanceAdditions/ios/FRNAppearanceAdditions.m
@@ -104,6 +104,13 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(accessibilityContrastOption)
 
 - (void)startObserving {
     _hasListeners = YES;
+    
+    UITraitCollection *rootViewTraitCollection = [[[[[UIApplication sharedApplication] delegate] window] rootViewController] traitCollection];
+    
+    _horizontalSizeClass = RCTHorizontalSizeClassPreference(rootViewTraitCollection);
+    _userInterfaceLevel = RCTUserInterfaceLevelPreference(rootViewTraitCollection);
+    _accessibilityContrastOption = RCTAccessibilityContrastPreference(rootViewTraitCollection);
+    
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(appearanceChanged:)
                                                  name:RCTUserInterfaceStyleDidChangeNotification
@@ -119,16 +126,10 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(accessibilityContrastOption)
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getInitialTraitCollection)
 {
-    UITraitCollection *rootViewTraitCollection = [[[[[UIApplication sharedApplication] delegate] window] rootViewController] traitCollection];
-    
-    _horizontalSizeClass = RCTHorizontalSizeClassPreference(rootViewTraitCollection);
-    _userInterfaceLevel = RCTUserInterfaceLevelPreference(rootViewTraitCollection);
-    _accessibilityContrastOption = RCTAccessibilityContrastPreference(rootViewTraitCollection);
-    
     return @{
         @"horizontalSizeClass": _horizontalSizeClass,
-        @"userInterfaceLevel": RCTUserInterfaceLevelPreference(nil),
-        @"accessibilityContrastOption": RCTAccessibilityContrastPreference(nil),
+        @"userInterfaceLevel": _userInterfaceLevel,
+        @"accessibilityContrastOption": _accessibilityContrastOption,
     };
 }
 

--- a/packages/experimental/AppearanceAdditions/ios/FRNAppearanceAdditions.m
+++ b/packages/experimental/AppearanceAdditions/ios/FRNAppearanceAdditions.m
@@ -22,8 +22,6 @@ NSString *RCTHorizontalSizeClassPreference(UITraitCollection *traitCollection) {
       };
     });
 
-    traitCollection = traitCollection ?: [UITraitCollection currentTraitCollection];
-
     NSString *sizeClass = sizeClasses[@(traitCollection.horizontalSizeClass)];
     if (sizeClass == nil) {
         sizeClass = [traitCollection userInterfaceIdiom] == UIUserInterfaceIdiomPhone ? FRNAppearanceSizeClassCompact : FRNAppearanceSizeClassRegular;
@@ -42,8 +40,6 @@ NSString *RCTUserInterfaceLevelPreference(UITraitCollection *traitCollection) {
       };
     });
 
-    traitCollection = traitCollection ?: [UITraitCollection currentTraitCollection];
-
     NSString *userInterfaceLevel = userInterfaceLevels[@(traitCollection.userInterfaceLevel)];
     if (userInterfaceLevel == nil) {
         userInterfaceLevel = FRNUserInterfaceLevelBase;
@@ -61,8 +57,6 @@ NSString *RCTAccessibilityContrastPreference(UITraitCollection *traitCollection)
         @(UIAccessibilityContrastHigh) : FRNAccessibilityContrastHigh,
       };
     });
-
-    traitCollection = traitCollection ?: [UITraitCollection currentTraitCollection];
 
     NSString *accessibilityContrastOption = accessibilityContrastOptions[@(traitCollection.accessibilityContrast)];
     if (accessibilityContrastOption == nil) {
@@ -103,11 +97,13 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(accessibilityContrastOption)
     return @[ @"appearanceChanged" ];
 }
 
+- (dispatch_queue_t)methodQueue
+{
+    return dispatch_get_main_queue();
+}
+
 - (void)startObserving {
     _hasListeners = YES;
-    _horizontalSizeClass = RCTHorizontalSizeClassPreference(nil);
-    _userInterfaceLevel = RCTUserInterfaceLevelPreference(nil);
-    _accessibilityContrastOption = RCTAccessibilityContrastPreference(nil);
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(appearanceChanged:)
                                                  name:RCTUserInterfaceStyleDidChangeNotification
@@ -120,6 +116,21 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(accessibilityContrastOption)
 }
 
 #pragma mark - Event processing
+
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getInitialTraitCollection)
+{
+    UITraitCollection *rootViewTraitCollection = [[[[[UIApplication sharedApplication] delegate] window] rootViewController] traitCollection];
+    
+    _horizontalSizeClass = RCTHorizontalSizeClassPreference(rootViewTraitCollection);
+    _userInterfaceLevel = RCTUserInterfaceLevelPreference(rootViewTraitCollection);
+    _accessibilityContrastOption = RCTAccessibilityContrastPreference(rootViewTraitCollection);
+    
+    return @{
+        @"horizontalSizeClass": _horizontalSizeClass,
+        @"userInterfaceLevel": RCTUserInterfaceLevelPreference(nil),
+        @"accessibilityContrastOption": RCTAccessibilityContrastPreference(nil),
+    };
+}
 
 - (void)appearanceChanged:(NSNotification *)notification {
     if (_hasListeners) {

--- a/packages/experimental/AppearanceAdditions/ios/FRNAppearanceAdditions.m
+++ b/packages/experimental/AppearanceAdditions/ios/FRNAppearanceAdditions.m
@@ -105,6 +105,9 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(accessibilityContrastOption)
 - (void)startObserving {
     _hasListeners = YES;
     
+    // [UITraitCollection currentTraitCollection] never returns the correct trait collection, presumably because FRNAppearanceAdditions isn't a view
+    // so it never gets updated with the right traitCollection (which happens when a view gets added to the view hierachy). In order
+    // to get the right trait collection we need to access the root view.
     UITraitCollection *rootViewTraitCollection = [[[[[UIApplication sharedApplication] delegate] window] rootViewController] traitCollection];
     
     _horizontalSizeClass = RCTHorizontalSizeClassPreference(rootViewTraitCollection);

--- a/packages/experimental/AppearanceAdditions/src/appearanceAdditions.ios.ts
+++ b/packages/experimental/AppearanceAdditions/src/appearanceAdditions.ios.ts
@@ -3,6 +3,7 @@ import NativeAppearanceAdditions from './NativeAppearanceAdditions.ios';
 import type { AppearanceAdditions, SizeClass, UserInterfaceLevel, AccessibilityContrastOption } from './NativeAppearanceAdditions.types';
 import { HorizontalSizeClassKey, UserInterfaceLevelKey, AccessibilityContrastOptionKey } from './NativeAppearanceAdditions.types';
 import { memoize } from '@fluentui-react-native/framework';
+import { NativeModules } from 'react-native';
 
 class AppearanceAdditionsImpl implements AppearanceAdditions {
   _horizontalSizeClass: SizeClass;
@@ -22,6 +23,12 @@ class AppearanceAdditionsImpl implements AppearanceAdditions {
   }
 
   constructor() {
+    const { FRNAppearanceAdditions } = NativeModules;
+    const getInitialTraitCollection = FRNAppearanceAdditions.getInitialTraitCollection();
+    this._horizontalSizeClass = getInitialTraitCollection.horizontalSizeClass;
+    this._userInterfaceLevel = getInitialTraitCollection.userInterfaceLevel;
+    this._accessibilityContrastOption = getInitialTraitCollection.accessibilityContrastOption;
+
     const eventEmitter = new NativeEventEmitter(NativeAppearanceAdditions as any);
     eventEmitter.addListener('appearanceChanged', (newValue) => {
       this._horizontalSizeClass = newValue[HorizontalSizeClassKey];

--- a/packages/experimental/AppearanceAdditions/src/appearanceAdditions.ios.ts
+++ b/packages/experimental/AppearanceAdditions/src/appearanceAdditions.ios.ts
@@ -1,9 +1,8 @@
 import { NativeEventEmitter } from 'react-native';
-import NativeAppearanceAdditions from './NativeAppearanceAdditions.ios';
+import NativeAppearanceAdditions from './NativeAppearanceAdditions';
 import type { AppearanceAdditions, SizeClass, UserInterfaceLevel, AccessibilityContrastOption } from './NativeAppearanceAdditions.types';
 import { HorizontalSizeClassKey, UserInterfaceLevelKey, AccessibilityContrastOptionKey } from './NativeAppearanceAdditions.types';
 import { memoize } from '@fluentui-react-native/framework';
-import { NativeModules } from 'react-native';
 
 class AppearanceAdditionsImpl implements AppearanceAdditions {
   _horizontalSizeClass: SizeClass;
@@ -23,11 +22,9 @@ class AppearanceAdditionsImpl implements AppearanceAdditions {
   }
 
   constructor() {
-    const { FRNAppearanceAdditions } = NativeModules;
-    const getInitialTraitCollection = FRNAppearanceAdditions.getInitialTraitCollection();
-    this._horizontalSizeClass = getInitialTraitCollection.horizontalSizeClass;
-    this._userInterfaceLevel = getInitialTraitCollection.userInterfaceLevel;
-    this._accessibilityContrastOption = getInitialTraitCollection.accessibilityContrastOption;
+    this._horizontalSizeClass = NativeAppearanceAdditions.horizontalSizeClass();
+    this._userInterfaceLevel = NativeAppearanceAdditions.userInterfaceLevel();
+    this._accessibilityContrastOption = NativeAppearanceAdditions.accessibilityContrastOption();
 
     const eventEmitter = new NativeEventEmitter(NativeAppearanceAdditions as any);
     eventEmitter.addListener('appearanceChanged', (newValue) => {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

With the recent work to expose iOS trait collection through a new Native Module, one of the remaining issues was that we weren't getting some of the right initial trait collection values at boot. When we tried to access traits specific to a view - horizontal size class (compact vs regular) and user interface level (base vs elevated) - we would always just get undefined or the default value. Note that the other trait we're exposing, accessibility contrast, is a system wide trait so we were always getting the correct value for that.

After further investigation, the issue was that we were relying on getting the RCTUserInterfaceStyleDidChangeNotification to get fired from the RCTRootView traitCollectionDidChange method, which would contain the right values on boot. It turns out that this notification _was_ getting posted as expected, and contained the right values, but it gets posted before the AppearanceAdditions native module has even set up the ability to listen to any notifications (i.e. before startObserving gets called), so it didn't receive the initial notification. 

This fix 1) initializes the native module with the right values for trait collection, which needed to be retrieved from the rootView (added a comment inline for why), and 2) adds a call from JS to access these values when the JS constructor is called. 

Notes
- We're initializing the native module's trait collection values in startObserving, but maybe this should be done in an init method?
- Making all the methods get called on the main thread needed to be added since [UIApplication sharedApplication] can only be accessed on the main thread

### Verification

Tested by visually verifying the size class. On iPad compact mode, if we've determined the right size class (compact) at boot, we'll render the single pane view (like what you would see on mobile). If we haven't determined the right size class, we render the double pane view (like what you would see on desktop)

In the before screen recording you can see that at boot we render with the double pane view which isn't correct - only when we switch back to it do we get the single pane view. In the after screen recording the app boots with the single pane view at the start.

https://user-images.githubusercontent.com/78454019/218217167-5f7d4acc-4f34-4339-a607-1f0b9ebcb025.mov


https://user-images.githubusercontent.com/78454019/218217195-c68a748e-df80-4162-9e46-573ab524ffa2.mov



### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
