### PR TITLE
[Menu] Get minWidth to work on macOS

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Menu/MenuTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Menu/MenuTest.tsx
@@ -125,7 +125,7 @@ const Submenu: React.FunctionComponent = () => {
       <MenuTrigger>
         <MenuItem>A second MenuItem</MenuItem>
       </MenuTrigger>
-      <MenuPopover>
+      <MenuPopover minWidth={230}>
         <MenuList>
           <MenuItemCheckbox name={'a'}>A nested MenuItemCheckbox</MenuItemCheckbox>
           <MenuItem>A nested MenuItem</MenuItem>

--- a/change/@fluentui-react-native-menu-93ec5b1b-8cb9-422b-9e47-fcdcf8efc676.json
+++ b/change/@fluentui-react-native-menu-93ec5b1b-8cb9-422b-9e47-fcdcf8efc676.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Passing in the minWidth token to the patch function",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-83711a93-2226-4559-8616-4e1dd8fa246c.json
+++ b/change/@fluentui-react-native-tester-83711a93-2226-4559-8616-4e1dd8fa246c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Passing in the minWidth token to the patch function",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/MenuPopover/MenuPopover.tsx
+++ b/packages/components/Menu/src/MenuPopover/MenuPopover.tsx
@@ -25,6 +25,7 @@ export const MenuPopover = compressible<MenuPopoverProps, MenuPopoverTokens>(
       gapSpace,
       maxHeight,
       maxWidth,
+      minWidth,
       minPadding,
       borderWidth,
       borderColor,


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

In #2611, the minWidth token was added to Callout so that the menu content doesn't get wrapped/truncated unexpectedly. This change adds that token to the patch function so that the initial token value gets populated.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="333" alt="before" src="https://user-images.githubusercontent.com/67026167/218596810-d2fe0a8f-60e3-491f-a434-2259d10bc148.png">|<img width="429" alt="before" src="https://user-images.githubusercontent.com/67026167/218596551-0236f9bc-e44d-409c-9cf0-ba3fbb091998.png">  |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
