### PR TITLE
Divider `appearance` prop now correctly applies color

### DIFF
--- a/change/@fluentui-react-native-divider-fadf8fd8-fd40-4439-8757-4a3684f9d4b7.json
+++ b/change/@fluentui-react-native-divider-fadf8fd8-fd40-4439-8757-4a3684f9d4b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Appearance prop correctly affects color",
+  "packageName": "@fluentui-react-native/divider",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Divider/src/DividerTokens.ts
+++ b/packages/experimental/Divider/src/DividerTokens.ts
@@ -1,16 +1,13 @@
 import { buildUseTokens } from '@fluentui-react-native/framework';
-import type { Theme } from '@fluentui-react-native/framework';
 import type { DividerTokens } from './Divider.types';
 import { globalTokens } from '@fluentui-react-native/theme-tokens';
 
-export const useDividerTokens = buildUseTokens<DividerTokens>((theme: Theme) => ({
+export const useDividerTokens = buildUseTokens<DividerTokens>(() => ({
   // base tokens
   contentPadding: globalTokens.size120,
   flexAfter: 1,
   flexBefore: 1,
   insetSize: 0,
-  lineColor: theme.colors.neutralStroke2,
-  contentColor: theme.colors.neutralForeground2,
   minLineSize: globalTokens.size80,
   minWidth: 0,
   minHeight: 0,


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Previous pushed changes to the divider left logic that set default tokens for `lineColor` and `contentColor`, which prevented the `appearance` prop from coloring the divider if the user did not pass in color tokens. 

This commit removes those default tokens values, allowing the `appearance` prop to apply color if the user doesn't pass values for `lineColor` and `contentColor`.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
