### PR TITLE
[Proposal] Nest files with platform overrides in VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,13 @@
   "eslint.enable": true,
   "eslint.workingDirectories": [{ "mode": "auto" }], // infer working directory based on .eslintrc/package.json location
 
+  "explorer.fileNesting.enabled": true,
+  "explorer.fileNesting.patterns": {
+    "*.js": "${capture}.js.map, ${capture}.d.ts, ${capture}.d.ts.map",
+    "*.ts": "${capture}.android.tsx, ${capture}.ios.tsx, ${capture}.macos.tsx, ${capture}.windows.tsx, ${capture}.win32.tsx, ${capture}.android.ts, ${capture}.ios.ts, ${capture}.macos.ts, ${capture}.windows.ts, ${capture}.win32.ts",
+    "*.tsx": "${capture}.android.tsx, ${capture}.ios.tsx, ${capture}.macos.tsx, ${capture}.windows.tsx, ${capture}.win32.tsx, ${capture}.android.ts, ${capture}.ios.ts, ${capture}.macos.ts, ${capture}.windows.ts, ${capture}.win32.ts"
+  },
+
   "files.trimTrailingWhitespace": true,
   "files.associations": {
     "**/package.json.hbs": "json",


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Inspired by https://twitter.com/Baconbrix/status/1625564914034085922?t=WaD1ZAg7BvMlA10EnLlz-Q&s=19

If we like this, we can perhaps add it to the official React Native VS Code extension :D 

VS Code lets you nest files together. Let's add the settings to do that in this project 😄. I modified the example in the tweet above to exclude `.test / .native / .node` and include `.macos / .windows / .win32`. I specifically didn't include stuff like `.mobile / .desktop` to hopefully make it more clear that metro won't automatically recognize those as platform overrides.

### Verification
<img width="373" alt="Screenshot 2023-02-15 at 11 05 12 AM" src="https://user-images.githubusercontent.com/6722175/219103361-a2d623c8-1442-471b-a898-28ab3abb1a61.png">

https://user-images.githubusercontent.com/6722175/219103402-4cfb85f8-eaa4-48b4-9c30-08e9fef51924.mov

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
