### PR TITLE
Add Divider E2E Tests on Mobile Platforms

### DIFF
--- a/apps/E2E/src/Divider/specs/Divider.spec.android.ts
+++ b/apps/E2E/src/Divider/specs/Divider.spec.android.ts
@@ -1,0 +1,17 @@
+import DividerPageObject from '../pages/DividerPageObject';
+
+// Before testing begins, allow up to 60 seconds for app to open
+describe('Divider Testing Initialization', () => {
+  it('Wait for app load', async () => {
+    await DividerPageObject.waitForInitialPageToDisplay();
+    expect(await DividerPageObject.isInitialPageDisplayed()).toBeTruthy(DividerPageObject.ERRORMESSAGE_APPLOAD);
+  });
+
+  it('Click and navigate to Divider test page', async () => {
+    /* Click on component button to navigate to test page */
+    await DividerPageObject.navigateToPageAndLoadTests();
+    expect(await DividerPageObject.isPageLoaded()).toBeTruthy(DividerPageObject.ERRORMESSAGE_PAGELOAD);
+
+    expect(await DividerPageObject.didAssertPopup()).toBeFalsy(DividerPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+  });
+});

--- a/apps/E2E/src/Divider/specs/Divider.spec.ios.ts
+++ b/apps/E2E/src/Divider/specs/Divider.spec.ios.ts
@@ -1,0 +1,15 @@
+import DividerPageObject from '../pages/DividerPageObject';
+
+// Before testing begins, allow up to 60 seconds for app to open
+describe('Divider Testing Initialization', () => {
+  it('Wait for app load', async () => {
+    await DividerPageObject.waitForInitialPageToDisplay();
+    expect(await DividerPageObject.isInitialPageDisplayed()).toBeTruthy(DividerPageObject.ERRORMESSAGE_APPLOAD);
+  });
+
+  it('Click and navigate to Divider test page', async () => {
+    /* Click on component button to navigate to test page */
+    await DividerPageObject.navigateToPageAndLoadTests();
+    expect(await DividerPageObject.isPageLoaded()).toBeTruthy(DividerPageObject.ERRORMESSAGE_PAGELOAD);
+  });
+});

--- a/change/@fluentui-react-native-e2e-testing-a94d5c1d-a920-49e1-9e92-965901c17430.json
+++ b/change/@fluentui-react-native-e2e-testing-a94d5c1d-a920-49e1-9e92-965901c17430.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add mobile e2e tests for Divider",
+  "packageName": "@fluentui-react-native/e2e-testing",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [x] android

### Description of changes

This PR adds two new test specs for the Divider component that run on android and iOS. These specs run baseline E2E tests that open the Divider page on the test app and check whether the page loads without crashing. 

### Verification

Tests pass in CI. 

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
