### PR TITLE
Update native modules to FUA 0.13

### DIFF
--- a/apps/fluent-tester/ios/Podfile.lock
+++ b/apps/fluent-tester/ios/Podfile.lock
@@ -1,98 +1,98 @@
 PODS:
   - boost (1.76.0)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.68.5)
-  - FBReactNativeSpec (0.68.5):
+  - FBLazyVector (0.68.6)
+  - FBReactNativeSpec (0.68.6):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.5)
-    - RCTTypeSafety (= 0.68.5)
-    - React-Core (= 0.68.5)
-    - React-jsi (= 0.68.5)
-    - ReactCommon/turbomodule/core (= 0.68.5)
+    - RCTRequired (= 0.68.6)
+    - RCTTypeSafety (= 0.68.6)
+    - React-Core (= 0.68.6)
+    - React-jsi (= 0.68.6)
+    - ReactCommon/turbomodule/core (= 0.68.6)
   - fmt (6.2.1)
-  - FRNAppearanceAdditions (0.1.0):
+  - FRNAppearanceAdditions (0.3.1):
     - React
-  - FRNAvatar (0.17.10):
-    - MicrosoftFluentUI (= 0.10.0)
+  - FRNAvatar (0.17.15):
+    - MicrosoftFluentUI (= 0.13.1)
     - React
-  - FRNDatePicker (0.7.4):
-    - MicrosoftFluentUI (= 0.10.0)
+  - FRNDatePicker (0.7.5):
+    - MicrosoftFluentUI (= 0.13.1)
     - React
-  - FRNFontMetrics (0.3.0):
+  - FRNFontMetrics (0.3.1):
     - React
   - glog (0.3.5)
-  - MicrosoftFluentUI (0.10.0):
-    - MicrosoftFluentUI/ActivityIndicator_ios (= 0.10.0)
-    - MicrosoftFluentUI/Appearance_mac (= 0.10.0)
-    - MicrosoftFluentUI/Avatar_ios (= 0.10.0)
-    - MicrosoftFluentUI/AvatarGroup_ios (= 0.10.0)
-    - MicrosoftFluentUI/AvatarView_mac (= 0.10.0)
-    - MicrosoftFluentUI/BadgeField_ios (= 0.10.0)
-    - MicrosoftFluentUI/BadgeView_mac (= 0.10.0)
-    - MicrosoftFluentUI/BarButtonItems_ios (= 0.10.0)
-    - MicrosoftFluentUI/BottomCommanding_ios (= 0.10.0)
-    - MicrosoftFluentUI/BottomSheet_ios (= 0.10.0)
-    - MicrosoftFluentUI/Button_ios (= 0.10.0)
-    - MicrosoftFluentUI/Button_mac (= 0.10.0)
-    - MicrosoftFluentUI/Calendar_ios (= 0.10.0)
-    - MicrosoftFluentUI/Card_ios (= 0.10.0)
-    - MicrosoftFluentUI/CardNudge_ios (= 0.10.0)
-    - MicrosoftFluentUI/CommandBar_ios (= 0.10.0)
-    - MicrosoftFluentUI/Core_ios (= 0.10.0)
-    - MicrosoftFluentUI/Core_mac (= 0.10.0)
-    - MicrosoftFluentUI/DatePicker_mac (= 0.10.0)
-    - MicrosoftFluentUI/Divider_ios (= 0.10.0)
-    - MicrosoftFluentUI/DotView_ios (= 0.10.0)
-    - MicrosoftFluentUI/Drawer_ios (= 0.10.0)
-    - MicrosoftFluentUI/DynamicColor_mac (= 0.10.0)
-    - MicrosoftFluentUI/EasyTapButton_ios (= 0.10.0)
-    - MicrosoftFluentUI/HUD_ios (= 0.10.0)
-    - MicrosoftFluentUI/IndeterminateProgressBar_ios (= 0.10.0)
-    - MicrosoftFluentUI/Label_ios (= 0.10.0)
-    - MicrosoftFluentUI/Link_mac (= 0.10.0)
-    - MicrosoftFluentUI/Navigation_ios (= 0.10.0)
-    - MicrosoftFluentUI/Notification_ios (= 0.10.0)
-    - MicrosoftFluentUI/Obscurable_ios (= 0.10.0)
-    - MicrosoftFluentUI/OtherCells_ios (= 0.10.0)
-    - MicrosoftFluentUI/PeoplePicker_ios (= 0.10.0)
-    - MicrosoftFluentUI/PersonaButton_ios (= 0.10.0)
-    - MicrosoftFluentUI/PersonaButtonCarousel_ios (= 0.10.0)
-    - MicrosoftFluentUI/PillButtonBar_ios (= 0.10.0)
-    - MicrosoftFluentUI/PopupMenu_ios (= 0.10.0)
-    - MicrosoftFluentUI/Presenters_ios (= 0.10.0)
-    - MicrosoftFluentUI/ResizingHandleView_ios (= 0.10.0)
-    - MicrosoftFluentUI/SegmentedControl_ios (= 0.10.0)
-    - MicrosoftFluentUI/Separator_ios (= 0.10.0)
-    - MicrosoftFluentUI/Separator_mac (= 0.10.0)
-    - MicrosoftFluentUI/Shimmer_ios (= 0.10.0)
-    - MicrosoftFluentUI/TabBar_ios (= 0.10.0)
-    - MicrosoftFluentUI/TableView_ios (= 0.10.0)
-    - MicrosoftFluentUI/Tooltip_ios (= 0.10.0)
-    - MicrosoftFluentUI/TouchForwardingView_ios (= 0.10.0)
-    - MicrosoftFluentUI/TwoLineTitleView_ios (= 0.10.0)
-    - MicrosoftFluentUI/Utilities_ios (= 0.10.0)
-  - MicrosoftFluentUI/ActivityIndicator_ios (0.10.0):
+  - MicrosoftFluentUI (0.13.1):
+    - MicrosoftFluentUI/ActivityIndicator_ios (= 0.13.1)
+    - MicrosoftFluentUI/Appearance_mac (= 0.13.1)
+    - MicrosoftFluentUI/Avatar_ios (= 0.13.1)
+    - MicrosoftFluentUI/AvatarGroup_ios (= 0.13.1)
+    - MicrosoftFluentUI/AvatarView_mac (= 0.13.1)
+    - MicrosoftFluentUI/BadgeField_ios (= 0.13.1)
+    - MicrosoftFluentUI/BadgeView_mac (= 0.13.1)
+    - MicrosoftFluentUI/BarButtonItems_ios (= 0.13.1)
+    - MicrosoftFluentUI/BottomCommanding_ios (= 0.13.1)
+    - MicrosoftFluentUI/BottomSheet_ios (= 0.13.1)
+    - MicrosoftFluentUI/Button_ios (= 0.13.1)
+    - MicrosoftFluentUI/Button_mac (= 0.13.1)
+    - MicrosoftFluentUI/Calendar_ios (= 0.13.1)
+    - MicrosoftFluentUI/Card_ios (= 0.13.1)
+    - MicrosoftFluentUI/CardNudge_ios (= 0.13.1)
+    - MicrosoftFluentUI/CommandBar_ios (= 0.13.1)
+    - MicrosoftFluentUI/Core_ios (= 0.13.1)
+    - MicrosoftFluentUI/Core_mac (= 0.13.1)
+    - MicrosoftFluentUI/DatePicker_mac (= 0.13.1)
+    - MicrosoftFluentUI/Divider_ios (= 0.13.1)
+    - MicrosoftFluentUI/DotView_ios (= 0.13.1)
+    - MicrosoftFluentUI/Drawer_ios (= 0.13.1)
+    - MicrosoftFluentUI/DynamicColor_mac (= 0.13.1)
+    - MicrosoftFluentUI/EasyTapButton_ios (= 0.13.1)
+    - MicrosoftFluentUI/HUD_ios (= 0.13.1)
+    - MicrosoftFluentUI/IndeterminateProgressBar_ios (= 0.13.1)
+    - MicrosoftFluentUI/Label_ios (= 0.13.1)
+    - MicrosoftFluentUI/Link_mac (= 0.13.1)
+    - MicrosoftFluentUI/Navigation_ios (= 0.13.1)
+    - MicrosoftFluentUI/Notification_ios (= 0.13.1)
+    - MicrosoftFluentUI/Obscurable_ios (= 0.13.1)
+    - MicrosoftFluentUI/OtherCells_ios (= 0.13.1)
+    - MicrosoftFluentUI/PeoplePicker_ios (= 0.13.1)
+    - MicrosoftFluentUI/PersonaButton_ios (= 0.13.1)
+    - MicrosoftFluentUI/PersonaButtonCarousel_ios (= 0.13.1)
+    - MicrosoftFluentUI/PillButtonBar_ios (= 0.13.1)
+    - MicrosoftFluentUI/PopupMenu_ios (= 0.13.1)
+    - MicrosoftFluentUI/Presenters_ios (= 0.13.1)
+    - MicrosoftFluentUI/ResizingHandleView_ios (= 0.13.1)
+    - MicrosoftFluentUI/SegmentedControl_ios (= 0.13.1)
+    - MicrosoftFluentUI/Separator_ios (= 0.13.1)
+    - MicrosoftFluentUI/Separator_mac (= 0.13.1)
+    - MicrosoftFluentUI/Shimmer_ios (= 0.13.1)
+    - MicrosoftFluentUI/TabBar_ios (= 0.13.1)
+    - MicrosoftFluentUI/TableView_ios (= 0.13.1)
+    - MicrosoftFluentUI/Tooltip_ios (= 0.13.1)
+    - MicrosoftFluentUI/TouchForwardingView_ios (= 0.13.1)
+    - MicrosoftFluentUI/TwoLineTitleView_ios (= 0.13.1)
+    - MicrosoftFluentUI/Utilities_ios (= 0.13.1)
+  - MicrosoftFluentUI/ActivityIndicator_ios (0.13.1):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/Avatar_ios (0.10.0):
+  - MicrosoftFluentUI/Avatar_ios (0.13.1):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/AvatarGroup_ios (0.10.0):
+  - MicrosoftFluentUI/AvatarGroup_ios (0.13.1):
     - MicrosoftFluentUI/Avatar_ios
-  - MicrosoftFluentUI/BadgeField_ios (0.10.0):
+  - MicrosoftFluentUI/BadgeField_ios (0.13.1):
     - MicrosoftFluentUI/Label_ios
-  - MicrosoftFluentUI/BarButtonItems_ios (0.10.0):
+  - MicrosoftFluentUI/BarButtonItems_ios (0.13.1):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/BottomCommanding_ios (0.10.0):
+  - MicrosoftFluentUI/BottomCommanding_ios (0.13.1):
     - MicrosoftFluentUI/BottomSheet_ios
     - MicrosoftFluentUI/OtherCells_ios
     - MicrosoftFluentUI/Separator_ios
     - MicrosoftFluentUI/TabBar_ios
     - MicrosoftFluentUI/TableView_ios
-  - MicrosoftFluentUI/BottomSheet_ios (0.10.0):
+  - MicrosoftFluentUI/BottomSheet_ios (0.13.1):
     - MicrosoftFluentUI/Obscurable_ios
     - MicrosoftFluentUI/ResizingHandleView_ios
-  - MicrosoftFluentUI/Button_ios (0.10.0):
+  - MicrosoftFluentUI/Button_ios (0.13.1):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/Calendar_ios (0.10.0):
+  - MicrosoftFluentUI/Calendar_ios (0.13.1):
     - MicrosoftFluentUI/BarButtonItems_ios
     - MicrosoftFluentUI/DotView_ios
     - MicrosoftFluentUI/Label_ios
@@ -100,88 +100,88 @@ PODS:
     - MicrosoftFluentUI/SegmentedControl_ios
     - MicrosoftFluentUI/Separator_ios
     - MicrosoftFluentUI/TwoLineTitleView_ios
-  - MicrosoftFluentUI/Card_ios (0.10.0):
+  - MicrosoftFluentUI/Card_ios (0.13.1):
     - MicrosoftFluentUI/Label_ios
-  - MicrosoftFluentUI/CardNudge_ios (0.10.0):
+  - MicrosoftFluentUI/CardNudge_ios (0.13.1):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/CommandBar_ios (0.10.0):
+  - MicrosoftFluentUI/CommandBar_ios (0.13.1):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/Core_ios (0.10.0)
-  - MicrosoftFluentUI/Divider_ios (0.10.0):
+  - MicrosoftFluentUI/Core_ios (0.13.1)
+  - MicrosoftFluentUI/Divider_ios (0.13.1):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/DotView_ios (0.10.0):
+  - MicrosoftFluentUI/DotView_ios (0.13.1):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/Drawer_ios (0.10.0):
+  - MicrosoftFluentUI/Drawer_ios (0.13.1):
     - MicrosoftFluentUI/Obscurable_ios
     - MicrosoftFluentUI/ResizingHandleView_ios
     - MicrosoftFluentUI/Separator_ios
     - MicrosoftFluentUI/TouchForwardingView_ios
-  - MicrosoftFluentUI/EasyTapButton_ios (0.10.0):
+  - MicrosoftFluentUI/EasyTapButton_ios (0.13.1):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/HUD_ios (0.10.0):
+  - MicrosoftFluentUI/HUD_ios (0.13.1):
     - MicrosoftFluentUI/ActivityIndicator_ios
     - MicrosoftFluentUI/Label_ios
     - MicrosoftFluentUI/TouchForwardingView_ios
-  - MicrosoftFluentUI/IndeterminateProgressBar_ios (0.10.0):
+  - MicrosoftFluentUI/IndeterminateProgressBar_ios (0.13.1):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/Label_ios (0.10.0):
+  - MicrosoftFluentUI/Label_ios (0.13.1):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/Navigation_ios (0.10.0):
+  - MicrosoftFluentUI/Navigation_ios (0.13.1):
     - MicrosoftFluentUI/ActivityIndicator_ios
     - MicrosoftFluentUI/Avatar_ios
     - MicrosoftFluentUI/Separator_ios
     - MicrosoftFluentUI/TwoLineTitleView_ios
-  - MicrosoftFluentUI/Notification_ios (0.10.0):
+  - MicrosoftFluentUI/Notification_ios (0.13.1):
     - MicrosoftFluentUI/Label_ios
     - MicrosoftFluentUI/Obscurable_ios
-  - MicrosoftFluentUI/Obscurable_ios (0.10.0):
+  - MicrosoftFluentUI/Obscurable_ios (0.13.1):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/OtherCells_ios (0.10.0):
+  - MicrosoftFluentUI/OtherCells_ios (0.13.1):
     - MicrosoftFluentUI/ActivityIndicator_ios
     - MicrosoftFluentUI/TableView_ios
-  - MicrosoftFluentUI/PeoplePicker_ios (0.10.0):
+  - MicrosoftFluentUI/PeoplePicker_ios (0.13.1):
     - MicrosoftFluentUI/Avatar_ios
     - MicrosoftFluentUI/BadgeField_ios
     - MicrosoftFluentUI/OtherCells_ios
     - MicrosoftFluentUI/Separator_ios
-  - MicrosoftFluentUI/PersonaButton_ios (0.10.0):
+  - MicrosoftFluentUI/PersonaButton_ios (0.13.1):
     - MicrosoftFluentUI/Avatar_ios
-  - MicrosoftFluentUI/PersonaButtonCarousel_ios (0.10.0):
+  - MicrosoftFluentUI/PersonaButtonCarousel_ios (0.13.1):
     - MicrosoftFluentUI/PersonaButton_ios
-  - MicrosoftFluentUI/PillButtonBar_ios (0.10.0):
+  - MicrosoftFluentUI/PillButtonBar_ios (0.13.1):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/PopupMenu_ios (0.10.0):
+  - MicrosoftFluentUI/PopupMenu_ios (0.13.1):
     - MicrosoftFluentUI/Drawer_ios
     - MicrosoftFluentUI/Label_ios
     - MicrosoftFluentUI/Separator_ios
     - MicrosoftFluentUI/TableView_ios
-  - MicrosoftFluentUI/Presenters_ios (0.10.0):
+  - MicrosoftFluentUI/Presenters_ios (0.13.1):
     - MicrosoftFluentUI/Obscurable_ios
-  - MicrosoftFluentUI/ResizingHandleView_ios (0.10.0):
+  - MicrosoftFluentUI/ResizingHandleView_ios (0.13.1):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/SegmentedControl_ios (0.10.0):
+  - MicrosoftFluentUI/SegmentedControl_ios (0.13.1):
     - MicrosoftFluentUI/Separator_ios
-  - MicrosoftFluentUI/Separator_ios (0.10.0):
+  - MicrosoftFluentUI/Separator_ios (0.13.1):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/Shimmer_ios (0.10.0):
+  - MicrosoftFluentUI/Shimmer_ios (0.13.1):
     - MicrosoftFluentUI/Core_ios
     - MicrosoftFluentUI/Utilities_ios
-  - MicrosoftFluentUI/TabBar_ios (0.10.0):
+  - MicrosoftFluentUI/TabBar_ios (0.13.1):
     - MicrosoftFluentUI/Avatar_ios
     - MicrosoftFluentUI/Label_ios
     - MicrosoftFluentUI/Separator_ios
-  - MicrosoftFluentUI/TableView_ios (0.10.0):
+  - MicrosoftFluentUI/TableView_ios (0.13.1):
     - MicrosoftFluentUI/Label_ios
     - MicrosoftFluentUI/Separator_ios
-  - MicrosoftFluentUI/Tooltip_ios (0.10.0):
+  - MicrosoftFluentUI/Tooltip_ios (0.13.1):
     - MicrosoftFluentUI/Label_ios
     - MicrosoftFluentUI/TouchForwardingView_ios
-  - MicrosoftFluentUI/TouchForwardingView_ios (0.10.0):
+  - MicrosoftFluentUI/TouchForwardingView_ios (0.13.1):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/TwoLineTitleView_ios (0.10.0):
+  - MicrosoftFluentUI/TwoLineTitleView_ios (0.13.1):
     - MicrosoftFluentUI/EasyTapButton_ios
     - MicrosoftFluentUI/Label_ios
-  - MicrosoftFluentUI/Utilities_ios (0.10.0)
+  - MicrosoftFluentUI/Utilities_ios (0.13.1)
   - RCT-Folly (2021.06.28.00-v2):
     - boost
     - DoubleConversion
@@ -193,278 +193,278 @@ PODS:
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
-  - RCTRequired (0.68.5)
-  - RCTTypeSafety (0.68.5):
-    - FBLazyVector (= 0.68.5)
+  - RCTRequired (0.68.6)
+  - RCTTypeSafety (0.68.6):
+    - FBLazyVector (= 0.68.6)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.5)
-    - React-Core (= 0.68.5)
-  - React (0.68.5):
-    - React-Core (= 0.68.5)
-    - React-Core/DevSupport (= 0.68.5)
-    - React-Core/RCTWebSocket (= 0.68.5)
-    - React-RCTActionSheet (= 0.68.5)
-    - React-RCTAnimation (= 0.68.5)
-    - React-RCTBlob (= 0.68.5)
-    - React-RCTImage (= 0.68.5)
-    - React-RCTLinking (= 0.68.5)
-    - React-RCTNetwork (= 0.68.5)
-    - React-RCTSettings (= 0.68.5)
-    - React-RCTText (= 0.68.5)
-    - React-RCTVibration (= 0.68.5)
-  - React-callinvoker (0.68.5)
-  - React-Codegen (0.68.5):
-    - FBReactNativeSpec (= 0.68.5)
+    - RCTRequired (= 0.68.6)
+    - React-Core (= 0.68.6)
+  - React (0.68.6):
+    - React-Core (= 0.68.6)
+    - React-Core/DevSupport (= 0.68.6)
+    - React-Core/RCTWebSocket (= 0.68.6)
+    - React-RCTActionSheet (= 0.68.6)
+    - React-RCTAnimation (= 0.68.6)
+    - React-RCTBlob (= 0.68.6)
+    - React-RCTImage (= 0.68.6)
+    - React-RCTLinking (= 0.68.6)
+    - React-RCTNetwork (= 0.68.6)
+    - React-RCTSettings (= 0.68.6)
+    - React-RCTText (= 0.68.6)
+    - React-RCTVibration (= 0.68.6)
+  - React-callinvoker (0.68.6)
+  - React-Codegen (0.68.6):
+    - FBReactNativeSpec (= 0.68.6)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.5)
-    - RCTTypeSafety (= 0.68.5)
-    - React-Core (= 0.68.5)
-    - React-jsi (= 0.68.5)
-    - React-jsiexecutor (= 0.68.5)
-    - ReactCommon/turbomodule/core (= 0.68.5)
-  - React-Core (0.68.5):
+    - RCTRequired (= 0.68.6)
+    - RCTTypeSafety (= 0.68.6)
+    - React-Core (= 0.68.6)
+    - React-jsi (= 0.68.6)
+    - React-jsiexecutor (= 0.68.6)
+    - ReactCommon/turbomodule/core (= 0.68.6)
+  - React-Core (0.68.6):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.5)
-    - React-cxxreact (= 0.68.5)
-    - React-jsi (= 0.68.5)
-    - React-jsiexecutor (= 0.68.5)
-    - React-perflogger (= 0.68.5)
+    - React-Core/Default (= 0.68.6)
+    - React-cxxreact (= 0.68.6)
+    - React-jsi (= 0.68.6)
+    - React-jsiexecutor (= 0.68.6)
+    - React-perflogger (= 0.68.6)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.68.5):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default
-    - React-cxxreact (= 0.68.5)
-    - React-jsi (= 0.68.5)
-    - React-jsiexecutor (= 0.68.5)
-    - React-perflogger (= 0.68.5)
-    - Yoga
-  - React-Core/Default (0.68.5):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.68.5)
-    - React-jsi (= 0.68.5)
-    - React-jsiexecutor (= 0.68.5)
-    - React-perflogger (= 0.68.5)
-    - Yoga
-  - React-Core/DevSupport (0.68.5):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.5)
-    - React-Core/RCTWebSocket (= 0.68.5)
-    - React-cxxreact (= 0.68.5)
-    - React-jsi (= 0.68.5)
-    - React-jsiexecutor (= 0.68.5)
-    - React-jsinspector (= 0.68.5)
-    - React-perflogger (= 0.68.5)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.68.5):
+  - React-Core/CoreModulesHeaders (0.68.6):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.5)
-    - React-jsi (= 0.68.5)
-    - React-jsiexecutor (= 0.68.5)
-    - React-perflogger (= 0.68.5)
+    - React-cxxreact (= 0.68.6)
+    - React-jsi (= 0.68.6)
+    - React-jsiexecutor (= 0.68.6)
+    - React-perflogger (= 0.68.6)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.68.5):
+  - React-Core/Default (0.68.6):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-cxxreact (= 0.68.6)
+    - React-jsi (= 0.68.6)
+    - React-jsiexecutor (= 0.68.6)
+    - React-perflogger (= 0.68.6)
+    - Yoga
+  - React-Core/DevSupport (0.68.6):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-Core/Default (= 0.68.6)
+    - React-Core/RCTWebSocket (= 0.68.6)
+    - React-cxxreact (= 0.68.6)
+    - React-jsi (= 0.68.6)
+    - React-jsiexecutor (= 0.68.6)
+    - React-jsinspector (= 0.68.6)
+    - React-perflogger (= 0.68.6)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.68.6):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.5)
-    - React-jsi (= 0.68.5)
-    - React-jsiexecutor (= 0.68.5)
-    - React-perflogger (= 0.68.5)
+    - React-cxxreact (= 0.68.6)
+    - React-jsi (= 0.68.6)
+    - React-jsiexecutor (= 0.68.6)
+    - React-perflogger (= 0.68.6)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.68.5):
+  - React-Core/RCTAnimationHeaders (0.68.6):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.5)
-    - React-jsi (= 0.68.5)
-    - React-jsiexecutor (= 0.68.5)
-    - React-perflogger (= 0.68.5)
+    - React-cxxreact (= 0.68.6)
+    - React-jsi (= 0.68.6)
+    - React-jsiexecutor (= 0.68.6)
+    - React-perflogger (= 0.68.6)
     - Yoga
-  - React-Core/RCTImageHeaders (0.68.5):
+  - React-Core/RCTBlobHeaders (0.68.6):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.5)
-    - React-jsi (= 0.68.5)
-    - React-jsiexecutor (= 0.68.5)
-    - React-perflogger (= 0.68.5)
+    - React-cxxreact (= 0.68.6)
+    - React-jsi (= 0.68.6)
+    - React-jsiexecutor (= 0.68.6)
+    - React-perflogger (= 0.68.6)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.68.5):
+  - React-Core/RCTImageHeaders (0.68.6):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.5)
-    - React-jsi (= 0.68.5)
-    - React-jsiexecutor (= 0.68.5)
-    - React-perflogger (= 0.68.5)
+    - React-cxxreact (= 0.68.6)
+    - React-jsi (= 0.68.6)
+    - React-jsiexecutor (= 0.68.6)
+    - React-perflogger (= 0.68.6)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.68.5):
+  - React-Core/RCTLinkingHeaders (0.68.6):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.5)
-    - React-jsi (= 0.68.5)
-    - React-jsiexecutor (= 0.68.5)
-    - React-perflogger (= 0.68.5)
+    - React-cxxreact (= 0.68.6)
+    - React-jsi (= 0.68.6)
+    - React-jsiexecutor (= 0.68.6)
+    - React-perflogger (= 0.68.6)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.68.5):
+  - React-Core/RCTNetworkHeaders (0.68.6):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.5)
-    - React-jsi (= 0.68.5)
-    - React-jsiexecutor (= 0.68.5)
-    - React-perflogger (= 0.68.5)
+    - React-cxxreact (= 0.68.6)
+    - React-jsi (= 0.68.6)
+    - React-jsiexecutor (= 0.68.6)
+    - React-perflogger (= 0.68.6)
     - Yoga
-  - React-Core/RCTTextHeaders (0.68.5):
+  - React-Core/RCTSettingsHeaders (0.68.6):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.5)
-    - React-jsi (= 0.68.5)
-    - React-jsiexecutor (= 0.68.5)
-    - React-perflogger (= 0.68.5)
+    - React-cxxreact (= 0.68.6)
+    - React-jsi (= 0.68.6)
+    - React-jsiexecutor (= 0.68.6)
+    - React-perflogger (= 0.68.6)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.68.5):
+  - React-Core/RCTTextHeaders (0.68.6):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.5)
-    - React-jsi (= 0.68.5)
-    - React-jsiexecutor (= 0.68.5)
-    - React-perflogger (= 0.68.5)
+    - React-cxxreact (= 0.68.6)
+    - React-jsi (= 0.68.6)
+    - React-jsiexecutor (= 0.68.6)
+    - React-perflogger (= 0.68.6)
     - Yoga
-  - React-Core/RCTWebSocket (0.68.5):
+  - React-Core/RCTVibrationHeaders (0.68.6):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.5)
-    - React-cxxreact (= 0.68.5)
-    - React-jsi (= 0.68.5)
-    - React-jsiexecutor (= 0.68.5)
-    - React-perflogger (= 0.68.5)
+    - React-Core/Default
+    - React-cxxreact (= 0.68.6)
+    - React-jsi (= 0.68.6)
+    - React-jsiexecutor (= 0.68.6)
+    - React-perflogger (= 0.68.6)
     - Yoga
-  - React-CoreModules (0.68.5):
+  - React-Core/RCTWebSocket (0.68.6):
+    - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.5)
-    - React-Codegen (= 0.68.5)
-    - React-Core/CoreModulesHeaders (= 0.68.5)
-    - React-jsi (= 0.68.5)
-    - React-RCTImage (= 0.68.5)
-    - ReactCommon/turbomodule/core (= 0.68.5)
-  - React-cxxreact (0.68.5):
+    - React-Core/Default (= 0.68.6)
+    - React-cxxreact (= 0.68.6)
+    - React-jsi (= 0.68.6)
+    - React-jsiexecutor (= 0.68.6)
+    - React-perflogger (= 0.68.6)
+    - Yoga
+  - React-CoreModules (0.68.6):
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - RCTTypeSafety (= 0.68.6)
+    - React-Codegen (= 0.68.6)
+    - React-Core/CoreModulesHeaders (= 0.68.6)
+    - React-jsi (= 0.68.6)
+    - React-RCTImage (= 0.68.6)
+    - ReactCommon/turbomodule/core (= 0.68.6)
+  - React-cxxreact (0.68.6):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.68.5)
-    - React-jsi (= 0.68.5)
-    - React-jsinspector (= 0.68.5)
-    - React-logger (= 0.68.5)
-    - React-perflogger (= 0.68.5)
-    - React-runtimeexecutor (= 0.68.5)
-  - React-jsi (0.68.5):
+    - React-callinvoker (= 0.68.6)
+    - React-jsi (= 0.68.6)
+    - React-jsinspector (= 0.68.6)
+    - React-logger (= 0.68.6)
+    - React-perflogger (= 0.68.6)
+    - React-runtimeexecutor (= 0.68.6)
+  - React-jsi (0.68.6):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-jsi/Default (= 0.68.5)
-  - React-jsi/Default (0.68.5):
+    - React-jsi/Default (= 0.68.6)
+  - React-jsi/Default (0.68.6):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-  - React-jsiexecutor (0.68.5):
+  - React-jsiexecutor (0.68.6):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.68.5)
-    - React-jsi (= 0.68.5)
-    - React-perflogger (= 0.68.5)
-  - React-jsinspector (0.68.5)
-  - React-logger (0.68.5):
+    - React-cxxreact (= 0.68.6)
+    - React-jsi (= 0.68.6)
+    - React-perflogger (= 0.68.6)
+  - React-jsinspector (0.68.6)
+  - React-logger (0.68.6):
     - glog
   - react-native-menu (0.1.2):
     - React
-  - react-native-slider (4.4.0):
+  - react-native-slider (4.4.2):
     - React-Core
-  - React-perflogger (0.68.5)
-  - React-RCTActionSheet (0.68.5):
-    - React-Core/RCTActionSheetHeaders (= 0.68.5)
-  - React-RCTAnimation (0.68.5):
+  - React-perflogger (0.68.6)
+  - React-RCTActionSheet (0.68.6):
+    - React-Core/RCTActionSheetHeaders (= 0.68.6)
+  - React-RCTAnimation (0.68.6):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.5)
-    - React-Codegen (= 0.68.5)
-    - React-Core/RCTAnimationHeaders (= 0.68.5)
-    - React-jsi (= 0.68.5)
-    - ReactCommon/turbomodule/core (= 0.68.5)
-  - React-RCTBlob (0.68.5):
+    - RCTTypeSafety (= 0.68.6)
+    - React-Codegen (= 0.68.6)
+    - React-Core/RCTAnimationHeaders (= 0.68.6)
+    - React-jsi (= 0.68.6)
+    - ReactCommon/turbomodule/core (= 0.68.6)
+  - React-RCTBlob (0.68.6):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Codegen (= 0.68.5)
-    - React-Core/RCTBlobHeaders (= 0.68.5)
-    - React-Core/RCTWebSocket (= 0.68.5)
-    - React-jsi (= 0.68.5)
-    - React-RCTNetwork (= 0.68.5)
-    - ReactCommon/turbomodule/core (= 0.68.5)
-  - React-RCTImage (0.68.5):
+    - React-Codegen (= 0.68.6)
+    - React-Core/RCTBlobHeaders (= 0.68.6)
+    - React-Core/RCTWebSocket (= 0.68.6)
+    - React-jsi (= 0.68.6)
+    - React-RCTNetwork (= 0.68.6)
+    - ReactCommon/turbomodule/core (= 0.68.6)
+  - React-RCTImage (0.68.6):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.5)
-    - React-Codegen (= 0.68.5)
-    - React-Core/RCTImageHeaders (= 0.68.5)
-    - React-jsi (= 0.68.5)
-    - React-RCTNetwork (= 0.68.5)
-    - ReactCommon/turbomodule/core (= 0.68.5)
-  - React-RCTLinking (0.68.5):
-    - React-Codegen (= 0.68.5)
-    - React-Core/RCTLinkingHeaders (= 0.68.5)
-    - React-jsi (= 0.68.5)
-    - ReactCommon/turbomodule/core (= 0.68.5)
-  - React-RCTNetwork (0.68.5):
+    - RCTTypeSafety (= 0.68.6)
+    - React-Codegen (= 0.68.6)
+    - React-Core/RCTImageHeaders (= 0.68.6)
+    - React-jsi (= 0.68.6)
+    - React-RCTNetwork (= 0.68.6)
+    - ReactCommon/turbomodule/core (= 0.68.6)
+  - React-RCTLinking (0.68.6):
+    - React-Codegen (= 0.68.6)
+    - React-Core/RCTLinkingHeaders (= 0.68.6)
+    - React-jsi (= 0.68.6)
+    - ReactCommon/turbomodule/core (= 0.68.6)
+  - React-RCTNetwork (0.68.6):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.5)
-    - React-Codegen (= 0.68.5)
-    - React-Core/RCTNetworkHeaders (= 0.68.5)
-    - React-jsi (= 0.68.5)
-    - ReactCommon/turbomodule/core (= 0.68.5)
-  - React-RCTSettings (0.68.5):
+    - RCTTypeSafety (= 0.68.6)
+    - React-Codegen (= 0.68.6)
+    - React-Core/RCTNetworkHeaders (= 0.68.6)
+    - React-jsi (= 0.68.6)
+    - ReactCommon/turbomodule/core (= 0.68.6)
+  - React-RCTSettings (0.68.6):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.5)
-    - React-Codegen (= 0.68.5)
-    - React-Core/RCTSettingsHeaders (= 0.68.5)
-    - React-jsi (= 0.68.5)
-    - ReactCommon/turbomodule/core (= 0.68.5)
-  - React-RCTText (0.68.5):
-    - React-Core/RCTTextHeaders (= 0.68.5)
-  - React-RCTVibration (0.68.5):
+    - RCTTypeSafety (= 0.68.6)
+    - React-Codegen (= 0.68.6)
+    - React-Core/RCTSettingsHeaders (= 0.68.6)
+    - React-jsi (= 0.68.6)
+    - ReactCommon/turbomodule/core (= 0.68.6)
+  - React-RCTText (0.68.6):
+    - React-Core/RCTTextHeaders (= 0.68.6)
+  - React-RCTVibration (0.68.6):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Codegen (= 0.68.5)
-    - React-Core/RCTVibrationHeaders (= 0.68.5)
-    - React-jsi (= 0.68.5)
-    - ReactCommon/turbomodule/core (= 0.68.5)
-  - React-runtimeexecutor (0.68.5):
-    - React-jsi (= 0.68.5)
-  - ReactCommon/turbomodule/core (0.68.5):
+    - React-Codegen (= 0.68.6)
+    - React-Core/RCTVibrationHeaders (= 0.68.6)
+    - React-jsi (= 0.68.6)
+    - ReactCommon/turbomodule/core (= 0.68.6)
+  - React-runtimeexecutor (0.68.6):
+    - React-jsi (= 0.68.6)
+  - ReactCommon/turbomodule/core (0.68.6):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.68.5)
-    - React-Core (= 0.68.5)
-    - React-cxxreact (= 0.68.5)
-    - React-jsi (= 0.68.5)
-    - React-logger (= 0.68.5)
-    - React-perflogger (= 0.68.5)
-  - ReactTestApp-DevSupport (2.3.2):
+    - React-callinvoker (= 0.68.6)
+    - React-Core (= 0.68.6)
+    - React-cxxreact (= 0.68.6)
+    - React-jsi (= 0.68.6)
+    - React-logger (= 0.68.6)
+    - React-perflogger (= 0.68.6)
+  - ReactTestApp-DevSupport (2.3.7):
     - React-Core
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
   - RNCPicker (2.4.8):
     - React-Core
-  - RNSVG (12.5.0):
+  - RNSVG (12.5.1):
     - React-Core
   - Yoga (1.14.0)
 
@@ -605,47 +605,47 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
-  FBLazyVector: 2b47ff52037bd9ae07cc9b051c9975797814b736
-  FBReactNativeSpec: dd89c4a5591e20015aa55c6efbf9c7740a83efbf
+  FBLazyVector: 74b042924fe14da854ac4e87cefc417f583b22b1
+  FBReactNativeSpec: e783d9621f5f6b3fa7ee812a932ad51852ae42a7
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  FRNAppearanceAdditions: 88e8fdc98e8aef994df9ab0b04fc652c59a3b351
-  FRNAvatar: cbb9afacb90bcee65673e6d7a32eb63a900131eb
-  FRNDatePicker: 009ab6e4e003a9e5d720fb4aea27b94e6cc8a946
-  FRNFontMetrics: c756b9bb1627909a7673b68caf7a7b14239c212e
+  FRNAppearanceAdditions: 3b63bdc4a950d2c82c952c93c31296f2b56d7fc9
+  FRNAvatar: 963fe8b6f953a95c09066562fc6ddff3c2e7e1b7
+  FRNDatePicker: ed586a0eb1d0277d4cd0e29f5f98c68f213ded08
+  FRNFontMetrics: 381a8bfd71f14b2c4718b5120db5f57455b648a8
   glog: 476ee3e89abb49e07f822b48323c51c57124b572
-  MicrosoftFluentUI: f6db695718efb93f4ca9bdc366c00b80a1f91dba
+  MicrosoftFluentUI: dde98d8ed3fc306d9ddd0a6f0bc0c1f24fe5275e
   RCT-Folly: 4d8508a426467c48885f1151029bc15fa5d7b3b8
-  RCTRequired: 0f06b6068f530932d10e1a01a5352fad4eaacb74
-  RCTTypeSafety: b0ee81f10ef1b7d977605a2b266823dabd565e65
-  React: 3becd12bd51ea8a43bdde7e09d0f40fba7820e03
-  React-callinvoker: 11abfff50e6bf7a55b3a90b4dc2187f71f224593
-  React-Codegen: f8946ce0768fb8e92e092e30944489c4b2955b2d
-  React-Core: 203cdb6ee2657b198d97d41031c249161060e6ca
-  React-CoreModules: 6eb0c06a4a223fde2cb6a8d0f44f58b67e808942
-  React-cxxreact: afb0c6c07d19adbd850747fedeac20c6832d40b9
-  React-jsi: 14d37a6db2af2c1a49f6f5c2e4ee667c364ae45c
-  React-jsiexecutor: 45c0496ca8cef6b02d9fa0274c25cf458fe91a56
-  React-jsinspector: eb202e43b3879aba9a14f3f65788aec85d4e1ea9
-  React-logger: 98f663b292a60967ebbc6d803ae96c1381183b6d
+  RCTRequired: 92cbd71369a2de6add25fd2403ac39838f1b694f
+  RCTTypeSafety: 494e8af41d7410ed0b877210859ee3984f37e6b4
+  React: 59989499c0e8926a90d34a9ae0bdb2d1b5b53406
+  React-callinvoker: 8187db1c71cf2c1c66e8f7328a0cf77a2b255d94
+  React-Codegen: e806dc2f10ddae645d855cb58acf73ce41eb8ea5
+  React-Core: fc7339b493e368ae079850a4721bdf716cf3dba2
+  React-CoreModules: 2f54f6bbf2764044379332089fcbdaf79197021e
+  React-cxxreact: ee119270006794976e1ab271f0111a5a88b16bcf
+  React-jsi: ec691b2a475d13b1fd39f697145a526eeeb6661c
+  React-jsiexecutor: b4ce4afc5dd9c8fdd2ac59049ccf420f288ecef7
+  React-jsinspector: e396d5e56af08fce39f50571726b68a40f1e302d
+  React-logger: cec52b3f8fb0be0d47b2cb75dec69de60f2de3b6
   react-native-menu: 9fe07f72e075b250295eeae25425490cc9608951
-  react-native-slider: d2938a12c4e439a227c70eec65d119136eb4aeb5
-  React-perflogger: 0458a87ea9a7342079e7a31b0d32b3734fb8415f
-  React-RCTActionSheet: 22538001ea2926dea001111dd2846c13a0730bc9
-  React-RCTAnimation: 732ce66878d4aa151d56a0d142b1105aa12fd313
-  React-RCTBlob: 9cb9e3e9a41d27be34aaf89b0e0f52c7ca415d57
-  React-RCTImage: 6bd16627eb9c4bb79903c4cdec7c551266ee1a5b
-  React-RCTLinking: e9edfc8919c8fa9a3f3c7b34362811f58a2ebba4
-  React-RCTNetwork: 880eccd21bbe2660a0b63da5ccba75c46eceeaa6
-  React-RCTSettings: 8c85d8188c97d6c6bd470af6631a6c4555b79bb3
-  React-RCTText: bbd275ee287730c5acbab1aadc0db39c25c5c64e
-  React-RCTVibration: 9819a3bf6230e4b2a99877c21268b0b2416157a1
-  React-runtimeexecutor: b1f1995089b90696dbc2a7ffe0059a80db5c8eb1
-  ReactCommon: 149e2c0acab9bac61378da0db5b2880a1b5ff59b
-  ReactTestApp-DevSupport: 1646ce70be36400a60ca18608284f3f7099a35c1
+  react-native-slider: 33b8d190b59d4f67a541061bb91775d53d617d9d
+  React-perflogger: 46620fc6d1c3157b60ed28434e08f7fd7f3f3353
+  React-RCTActionSheet: b1f7e72a0ba760ec684df335c61f730b5179f5ff
+  React-RCTAnimation: d73b62d42867ab608dfb10e100d8b91106275b18
+  React-RCTBlob: b5f59693721d50967c35598158e6ca01b474c7de
+  React-RCTImage: 37cf34d0c2fbef2e0278d42a7c5e8ea06a9fed6b
+  React-RCTLinking: a11dced20019cf1c2ec7fd120f18b08f2851f79e
+  React-RCTNetwork: ba097188e5eac42e070029e7cedd9b978940833a
+  React-RCTSettings: 147073708a1c1bde521cf3af045a675682772726
+  React-RCTText: 23f76ebfb2717d181476432e5ecf1c6c4a104c5e
+  React-RCTVibration: be5f18ffc644f96f904e0e673ab639ca5d673ee8
+  React-runtimeexecutor: d5498cfb7059bf8397b6416db4777843f3f4c1e7
+  ReactCommon: 1974dab5108c79b40199f12a4833d2499b9f6303
+  ReactTestApp-DevSupport: 64fa48ee0faae120b9f11444be21ab2814a5c1fa
   ReactTestApp-Resources: ecba662266ac5af3e30e1e3004c0fa8c0298b61a
   RNCPicker: 0bf8ef8f7800524f32d2bb2a8bcadd53eda0ecd1
-  RNSVG: 6adc5c52d2488a476248413064b7f2832e639057
-  Yoga: c4d61225a466f250c35c1ee78d2d0b3d41fe661c
+  RNSVG: d7d7bc8229af3842c9cfc3a723c815a52cdd1105
+  Yoga: 7929b92b1828675c1bebeb114dae8cb8fa7ef6a3
 
 PODFILE CHECKSUM: b9fd154312c68d8d92a9ba6e8a2cac9fcf88b104
 

--- a/apps/fluent-tester/macos/Podfile.lock
+++ b/apps/fluent-tester/macos/Podfile.lock
@@ -1,95 +1,95 @@
 PODS:
   - boost (1.76.0)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.68.62)
-  - FBReactNativeSpec (0.68.62):
+  - FBLazyVector (0.68.65)
+  - FBReactNativeSpec (0.68.65):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.62)
-    - RCTTypeSafety (= 0.68.62)
-    - React-Core (= 0.68.62)
-    - React-jsi (= 0.68.62)
-    - ReactCommon/turbomodule/core (= 0.68.62)
+    - RCTRequired (= 0.68.65)
+    - RCTTypeSafety (= 0.68.65)
+    - React-Core (= 0.68.65)
+    - React-jsi (= 0.68.65)
+    - ReactCommon/turbomodule/core (= 0.68.65)
   - fmt (6.2.1)
-  - FRNAvatar (0.17.10):
-    - MicrosoftFluentUI (= 0.10.0)
+  - FRNAvatar (0.17.15):
+    - MicrosoftFluentUI (= 0.13.1)
     - React
-  - FRNCallout (0.21.55):
+  - FRNCallout (0.23.1):
     - React
-  - FRNCheckbox (0.13.32):
+  - FRNCheckbox (0.13.38):
     - React
-  - FRNMenuButton (0.10.22):
+  - FRNMenuButton (0.10.31):
     - React
-  - FRNRadioButton (0.16.29):
+  - FRNRadioButton (0.16.34):
     - React
   - glog (0.3.5)
-  - MicrosoftFluentUI (0.10.0):
-    - MicrosoftFluentUI/ActivityIndicator_ios (= 0.10.0)
-    - MicrosoftFluentUI/Appearance_mac (= 0.10.0)
-    - MicrosoftFluentUI/Avatar_ios (= 0.10.0)
-    - MicrosoftFluentUI/AvatarGroup_ios (= 0.10.0)
-    - MicrosoftFluentUI/AvatarView_mac (= 0.10.0)
-    - MicrosoftFluentUI/BadgeField_ios (= 0.10.0)
-    - MicrosoftFluentUI/BadgeView_mac (= 0.10.0)
-    - MicrosoftFluentUI/BarButtonItems_ios (= 0.10.0)
-    - MicrosoftFluentUI/BottomCommanding_ios (= 0.10.0)
-    - MicrosoftFluentUI/BottomSheet_ios (= 0.10.0)
-    - MicrosoftFluentUI/Button_ios (= 0.10.0)
-    - MicrosoftFluentUI/Button_mac (= 0.10.0)
-    - MicrosoftFluentUI/Calendar_ios (= 0.10.0)
-    - MicrosoftFluentUI/Card_ios (= 0.10.0)
-    - MicrosoftFluentUI/CardNudge_ios (= 0.10.0)
-    - MicrosoftFluentUI/CommandBar_ios (= 0.10.0)
-    - MicrosoftFluentUI/Core_ios (= 0.10.0)
-    - MicrosoftFluentUI/Core_mac (= 0.10.0)
-    - MicrosoftFluentUI/DatePicker_mac (= 0.10.0)
-    - MicrosoftFluentUI/Divider_ios (= 0.10.0)
-    - MicrosoftFluentUI/DotView_ios (= 0.10.0)
-    - MicrosoftFluentUI/Drawer_ios (= 0.10.0)
-    - MicrosoftFluentUI/DynamicColor_mac (= 0.10.0)
-    - MicrosoftFluentUI/EasyTapButton_ios (= 0.10.0)
-    - MicrosoftFluentUI/HUD_ios (= 0.10.0)
-    - MicrosoftFluentUI/IndeterminateProgressBar_ios (= 0.10.0)
-    - MicrosoftFluentUI/Label_ios (= 0.10.0)
-    - MicrosoftFluentUI/Link_mac (= 0.10.0)
-    - MicrosoftFluentUI/Navigation_ios (= 0.10.0)
-    - MicrosoftFluentUI/Notification_ios (= 0.10.0)
-    - MicrosoftFluentUI/Obscurable_ios (= 0.10.0)
-    - MicrosoftFluentUI/OtherCells_ios (= 0.10.0)
-    - MicrosoftFluentUI/PeoplePicker_ios (= 0.10.0)
-    - MicrosoftFluentUI/PersonaButton_ios (= 0.10.0)
-    - MicrosoftFluentUI/PersonaButtonCarousel_ios (= 0.10.0)
-    - MicrosoftFluentUI/PillButtonBar_ios (= 0.10.0)
-    - MicrosoftFluentUI/PopupMenu_ios (= 0.10.0)
-    - MicrosoftFluentUI/Presenters_ios (= 0.10.0)
-    - MicrosoftFluentUI/ResizingHandleView_ios (= 0.10.0)
-    - MicrosoftFluentUI/SegmentedControl_ios (= 0.10.0)
-    - MicrosoftFluentUI/Separator_ios (= 0.10.0)
-    - MicrosoftFluentUI/Separator_mac (= 0.10.0)
-    - MicrosoftFluentUI/Shimmer_ios (= 0.10.0)
-    - MicrosoftFluentUI/TabBar_ios (= 0.10.0)
-    - MicrosoftFluentUI/TableView_ios (= 0.10.0)
-    - MicrosoftFluentUI/Tooltip_ios (= 0.10.0)
-    - MicrosoftFluentUI/TouchForwardingView_ios (= 0.10.0)
-    - MicrosoftFluentUI/TwoLineTitleView_ios (= 0.10.0)
-    - MicrosoftFluentUI/Utilities_ios (= 0.10.0)
-  - MicrosoftFluentUI/Appearance_mac (0.10.0)
-  - MicrosoftFluentUI/AvatarView_mac (0.10.0):
+  - MicrosoftFluentUI (0.13.1):
+    - MicrosoftFluentUI/ActivityIndicator_ios (= 0.13.1)
+    - MicrosoftFluentUI/Appearance_mac (= 0.13.1)
+    - MicrosoftFluentUI/Avatar_ios (= 0.13.1)
+    - MicrosoftFluentUI/AvatarGroup_ios (= 0.13.1)
+    - MicrosoftFluentUI/AvatarView_mac (= 0.13.1)
+    - MicrosoftFluentUI/BadgeField_ios (= 0.13.1)
+    - MicrosoftFluentUI/BadgeView_mac (= 0.13.1)
+    - MicrosoftFluentUI/BarButtonItems_ios (= 0.13.1)
+    - MicrosoftFluentUI/BottomCommanding_ios (= 0.13.1)
+    - MicrosoftFluentUI/BottomSheet_ios (= 0.13.1)
+    - MicrosoftFluentUI/Button_ios (= 0.13.1)
+    - MicrosoftFluentUI/Button_mac (= 0.13.1)
+    - MicrosoftFluentUI/Calendar_ios (= 0.13.1)
+    - MicrosoftFluentUI/Card_ios (= 0.13.1)
+    - MicrosoftFluentUI/CardNudge_ios (= 0.13.1)
+    - MicrosoftFluentUI/CommandBar_ios (= 0.13.1)
+    - MicrosoftFluentUI/Core_ios (= 0.13.1)
+    - MicrosoftFluentUI/Core_mac (= 0.13.1)
+    - MicrosoftFluentUI/DatePicker_mac (= 0.13.1)
+    - MicrosoftFluentUI/Divider_ios (= 0.13.1)
+    - MicrosoftFluentUI/DotView_ios (= 0.13.1)
+    - MicrosoftFluentUI/Drawer_ios (= 0.13.1)
+    - MicrosoftFluentUI/DynamicColor_mac (= 0.13.1)
+    - MicrosoftFluentUI/EasyTapButton_ios (= 0.13.1)
+    - MicrosoftFluentUI/HUD_ios (= 0.13.1)
+    - MicrosoftFluentUI/IndeterminateProgressBar_ios (= 0.13.1)
+    - MicrosoftFluentUI/Label_ios (= 0.13.1)
+    - MicrosoftFluentUI/Link_mac (= 0.13.1)
+    - MicrosoftFluentUI/Navigation_ios (= 0.13.1)
+    - MicrosoftFluentUI/Notification_ios (= 0.13.1)
+    - MicrosoftFluentUI/Obscurable_ios (= 0.13.1)
+    - MicrosoftFluentUI/OtherCells_ios (= 0.13.1)
+    - MicrosoftFluentUI/PeoplePicker_ios (= 0.13.1)
+    - MicrosoftFluentUI/PersonaButton_ios (= 0.13.1)
+    - MicrosoftFluentUI/PersonaButtonCarousel_ios (= 0.13.1)
+    - MicrosoftFluentUI/PillButtonBar_ios (= 0.13.1)
+    - MicrosoftFluentUI/PopupMenu_ios (= 0.13.1)
+    - MicrosoftFluentUI/Presenters_ios (= 0.13.1)
+    - MicrosoftFluentUI/ResizingHandleView_ios (= 0.13.1)
+    - MicrosoftFluentUI/SegmentedControl_ios (= 0.13.1)
+    - MicrosoftFluentUI/Separator_ios (= 0.13.1)
+    - MicrosoftFluentUI/Separator_mac (= 0.13.1)
+    - MicrosoftFluentUI/Shimmer_ios (= 0.13.1)
+    - MicrosoftFluentUI/TabBar_ios (= 0.13.1)
+    - MicrosoftFluentUI/TableView_ios (= 0.13.1)
+    - MicrosoftFluentUI/Tooltip_ios (= 0.13.1)
+    - MicrosoftFluentUI/TouchForwardingView_ios (= 0.13.1)
+    - MicrosoftFluentUI/TwoLineTitleView_ios (= 0.13.1)
+    - MicrosoftFluentUI/Utilities_ios (= 0.13.1)
+  - MicrosoftFluentUI/Appearance_mac (0.13.1)
+  - MicrosoftFluentUI/AvatarView_mac (0.13.1):
     - MicrosoftFluentUI/Core_mac
     - MicrosoftFluentUI/DynamicColor_mac
-  - MicrosoftFluentUI/BadgeView_mac (0.10.0):
+  - MicrosoftFluentUI/BadgeView_mac (0.13.1):
     - MicrosoftFluentUI/Core_mac
     - MicrosoftFluentUI/DynamicColor_mac
-  - MicrosoftFluentUI/Button_mac (0.10.0):
+  - MicrosoftFluentUI/Button_mac (0.13.1):
     - MicrosoftFluentUI/Core_mac
-  - MicrosoftFluentUI/Core_mac (0.10.0)
-  - MicrosoftFluentUI/DatePicker_mac (0.10.0):
+  - MicrosoftFluentUI/Core_mac (0.13.1)
+  - MicrosoftFluentUI/DatePicker_mac (0.13.1):
     - MicrosoftFluentUI/Appearance_mac
     - MicrosoftFluentUI/Core_mac
-  - MicrosoftFluentUI/DynamicColor_mac (0.10.0):
+  - MicrosoftFluentUI/DynamicColor_mac (0.13.1):
     - MicrosoftFluentUI/Appearance_mac
-  - MicrosoftFluentUI/Link_mac (0.10.0):
+  - MicrosoftFluentUI/Link_mac (0.13.1):
     - MicrosoftFluentUI/Core_mac
-  - MicrosoftFluentUI/Separator_mac (0.10.0):
+  - MicrosoftFluentUI/Separator_mac (0.13.1):
     - MicrosoftFluentUI/Core_mac
   - RCT-Folly (2021.06.28.00-v2):
     - boost
@@ -102,276 +102,276 @@ PODS:
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
-  - RCTFocusZone (0.11.25):
+  - RCTFocusZone (0.11.30):
     - React
-  - RCTRequired (0.68.62)
-  - RCTTypeSafety (0.68.62):
-    - FBLazyVector (= 0.68.62)
+  - RCTRequired (0.68.65)
+  - RCTTypeSafety (0.68.65):
+    - FBLazyVector (= 0.68.65)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.62)
-    - React-Core (= 0.68.62)
-  - React (0.68.62):
-    - React-Core (= 0.68.62)
-    - React-Core/DevSupport (= 0.68.62)
-    - React-Core/RCTWebSocket (= 0.68.62)
-    - React-RCTActionSheet (= 0.68.62)
-    - React-RCTAnimation (= 0.68.62)
-    - React-RCTBlob (= 0.68.62)
-    - React-RCTImage (= 0.68.62)
-    - React-RCTLinking (= 0.68.62)
-    - React-RCTNetwork (= 0.68.62)
-    - React-RCTSettings (= 0.68.62)
-    - React-RCTText (= 0.68.62)
-    - React-RCTVibration (= 0.68.62)
-  - React-callinvoker (0.68.62)
-  - React-Codegen (0.68.62):
-    - FBReactNativeSpec (= 0.68.62)
+    - RCTRequired (= 0.68.65)
+    - React-Core (= 0.68.65)
+  - React (0.68.65):
+    - React-Core (= 0.68.65)
+    - React-Core/DevSupport (= 0.68.65)
+    - React-Core/RCTWebSocket (= 0.68.65)
+    - React-RCTActionSheet (= 0.68.65)
+    - React-RCTAnimation (= 0.68.65)
+    - React-RCTBlob (= 0.68.65)
+    - React-RCTImage (= 0.68.65)
+    - React-RCTLinking (= 0.68.65)
+    - React-RCTNetwork (= 0.68.65)
+    - React-RCTSettings (= 0.68.65)
+    - React-RCTText (= 0.68.65)
+    - React-RCTVibration (= 0.68.65)
+  - React-callinvoker (0.68.65)
+  - React-Codegen (0.68.65):
+    - FBReactNativeSpec (= 0.68.65)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.62)
-    - RCTTypeSafety (= 0.68.62)
-    - React-Core (= 0.68.62)
-    - React-jsi (= 0.68.62)
-    - React-jsiexecutor (= 0.68.62)
-    - ReactCommon/turbomodule/core (= 0.68.62)
-  - React-Core (0.68.62):
+    - RCTRequired (= 0.68.65)
+    - RCTTypeSafety (= 0.68.65)
+    - React-Core (= 0.68.65)
+    - React-jsi (= 0.68.65)
+    - React-jsiexecutor (= 0.68.65)
+    - ReactCommon/turbomodule/core (= 0.68.65)
+  - React-Core (0.68.65):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.62)
-    - React-cxxreact (= 0.68.62)
-    - React-jsi (= 0.68.62)
-    - React-jsiexecutor (= 0.68.62)
-    - React-perflogger (= 0.68.62)
+    - React-Core/Default (= 0.68.65)
+    - React-cxxreact (= 0.68.65)
+    - React-jsi (= 0.68.65)
+    - React-jsiexecutor (= 0.68.65)
+    - React-perflogger (= 0.68.65)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.68.62):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default
-    - React-cxxreact (= 0.68.62)
-    - React-jsi (= 0.68.62)
-    - React-jsiexecutor (= 0.68.62)
-    - React-perflogger (= 0.68.62)
-    - Yoga
-  - React-Core/Default (0.68.62):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.68.62)
-    - React-jsi (= 0.68.62)
-    - React-jsiexecutor (= 0.68.62)
-    - React-perflogger (= 0.68.62)
-    - Yoga
-  - React-Core/DevSupport (0.68.62):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.62)
-    - React-Core/RCTWebSocket (= 0.68.62)
-    - React-cxxreact (= 0.68.62)
-    - React-jsi (= 0.68.62)
-    - React-jsiexecutor (= 0.68.62)
-    - React-jsinspector (= 0.68.62)
-    - React-perflogger (= 0.68.62)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.68.62):
+  - React-Core/CoreModulesHeaders (0.68.65):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.62)
-    - React-jsi (= 0.68.62)
-    - React-jsiexecutor (= 0.68.62)
-    - React-perflogger (= 0.68.62)
+    - React-cxxreact (= 0.68.65)
+    - React-jsi (= 0.68.65)
+    - React-jsiexecutor (= 0.68.65)
+    - React-perflogger (= 0.68.65)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.68.62):
+  - React-Core/Default (0.68.65):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-cxxreact (= 0.68.65)
+    - React-jsi (= 0.68.65)
+    - React-jsiexecutor (= 0.68.65)
+    - React-perflogger (= 0.68.65)
+    - Yoga
+  - React-Core/DevSupport (0.68.65):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-Core/Default (= 0.68.65)
+    - React-Core/RCTWebSocket (= 0.68.65)
+    - React-cxxreact (= 0.68.65)
+    - React-jsi (= 0.68.65)
+    - React-jsiexecutor (= 0.68.65)
+    - React-jsinspector (= 0.68.65)
+    - React-perflogger (= 0.68.65)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.68.65):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.62)
-    - React-jsi (= 0.68.62)
-    - React-jsiexecutor (= 0.68.62)
-    - React-perflogger (= 0.68.62)
+    - React-cxxreact (= 0.68.65)
+    - React-jsi (= 0.68.65)
+    - React-jsiexecutor (= 0.68.65)
+    - React-perflogger (= 0.68.65)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.68.62):
+  - React-Core/RCTAnimationHeaders (0.68.65):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.62)
-    - React-jsi (= 0.68.62)
-    - React-jsiexecutor (= 0.68.62)
-    - React-perflogger (= 0.68.62)
+    - React-cxxreact (= 0.68.65)
+    - React-jsi (= 0.68.65)
+    - React-jsiexecutor (= 0.68.65)
+    - React-perflogger (= 0.68.65)
     - Yoga
-  - React-Core/RCTImageHeaders (0.68.62):
+  - React-Core/RCTBlobHeaders (0.68.65):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.62)
-    - React-jsi (= 0.68.62)
-    - React-jsiexecutor (= 0.68.62)
-    - React-perflogger (= 0.68.62)
+    - React-cxxreact (= 0.68.65)
+    - React-jsi (= 0.68.65)
+    - React-jsiexecutor (= 0.68.65)
+    - React-perflogger (= 0.68.65)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.68.62):
+  - React-Core/RCTImageHeaders (0.68.65):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.62)
-    - React-jsi (= 0.68.62)
-    - React-jsiexecutor (= 0.68.62)
-    - React-perflogger (= 0.68.62)
+    - React-cxxreact (= 0.68.65)
+    - React-jsi (= 0.68.65)
+    - React-jsiexecutor (= 0.68.65)
+    - React-perflogger (= 0.68.65)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.68.62):
+  - React-Core/RCTLinkingHeaders (0.68.65):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.62)
-    - React-jsi (= 0.68.62)
-    - React-jsiexecutor (= 0.68.62)
-    - React-perflogger (= 0.68.62)
+    - React-cxxreact (= 0.68.65)
+    - React-jsi (= 0.68.65)
+    - React-jsiexecutor (= 0.68.65)
+    - React-perflogger (= 0.68.65)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.68.62):
+  - React-Core/RCTNetworkHeaders (0.68.65):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.62)
-    - React-jsi (= 0.68.62)
-    - React-jsiexecutor (= 0.68.62)
-    - React-perflogger (= 0.68.62)
+    - React-cxxreact (= 0.68.65)
+    - React-jsi (= 0.68.65)
+    - React-jsiexecutor (= 0.68.65)
+    - React-perflogger (= 0.68.65)
     - Yoga
-  - React-Core/RCTTextHeaders (0.68.62):
+  - React-Core/RCTSettingsHeaders (0.68.65):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.62)
-    - React-jsi (= 0.68.62)
-    - React-jsiexecutor (= 0.68.62)
-    - React-perflogger (= 0.68.62)
+    - React-cxxreact (= 0.68.65)
+    - React-jsi (= 0.68.65)
+    - React-jsiexecutor (= 0.68.65)
+    - React-perflogger (= 0.68.65)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.68.62):
+  - React-Core/RCTTextHeaders (0.68.65):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.62)
-    - React-jsi (= 0.68.62)
-    - React-jsiexecutor (= 0.68.62)
-    - React-perflogger (= 0.68.62)
+    - React-cxxreact (= 0.68.65)
+    - React-jsi (= 0.68.65)
+    - React-jsiexecutor (= 0.68.65)
+    - React-perflogger (= 0.68.65)
     - Yoga
-  - React-Core/RCTWebSocket (0.68.62):
+  - React-Core/RCTVibrationHeaders (0.68.65):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.62)
-    - React-cxxreact (= 0.68.62)
-    - React-jsi (= 0.68.62)
-    - React-jsiexecutor (= 0.68.62)
-    - React-perflogger (= 0.68.62)
+    - React-Core/Default
+    - React-cxxreact (= 0.68.65)
+    - React-jsi (= 0.68.65)
+    - React-jsiexecutor (= 0.68.65)
+    - React-perflogger (= 0.68.65)
     - Yoga
-  - React-CoreModules (0.68.62):
+  - React-Core/RCTWebSocket (0.68.65):
+    - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.62)
-    - React-Codegen (= 0.68.62)
-    - React-Core/CoreModulesHeaders (= 0.68.62)
-    - React-jsi (= 0.68.62)
-    - React-RCTImage (= 0.68.62)
-    - ReactCommon/turbomodule/core (= 0.68.62)
-  - React-cxxreact (0.68.62):
+    - React-Core/Default (= 0.68.65)
+    - React-cxxreact (= 0.68.65)
+    - React-jsi (= 0.68.65)
+    - React-jsiexecutor (= 0.68.65)
+    - React-perflogger (= 0.68.65)
+    - Yoga
+  - React-CoreModules (0.68.65):
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - RCTTypeSafety (= 0.68.65)
+    - React-Codegen (= 0.68.65)
+    - React-Core/CoreModulesHeaders (= 0.68.65)
+    - React-jsi (= 0.68.65)
+    - React-RCTImage (= 0.68.65)
+    - ReactCommon/turbomodule/core (= 0.68.65)
+  - React-cxxreact (0.68.65):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.68.62)
-    - React-jsi (= 0.68.62)
-    - React-jsinspector (= 0.68.62)
-    - React-logger (= 0.68.62)
-    - React-perflogger (= 0.68.62)
-    - React-runtimeexecutor (= 0.68.62)
-  - React-jsi (0.68.62):
+    - React-callinvoker (= 0.68.65)
+    - React-jsi (= 0.68.65)
+    - React-jsinspector (= 0.68.65)
+    - React-logger (= 0.68.65)
+    - React-perflogger (= 0.68.65)
+    - React-runtimeexecutor (= 0.68.65)
+  - React-jsi (0.68.65):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-jsi/Default (= 0.68.62)
-  - React-jsi/Default (0.68.62):
+    - React-jsi/Default (= 0.68.65)
+  - React-jsi/Default (0.68.65):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-  - React-jsiexecutor (0.68.62):
+  - React-jsiexecutor (0.68.65):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.68.62)
-    - React-jsi (= 0.68.62)
-    - React-perflogger (= 0.68.62)
-  - React-jsinspector (0.68.62)
-  - React-logger (0.68.62):
+    - React-cxxreact (= 0.68.65)
+    - React-jsi (= 0.68.65)
+    - React-perflogger (= 0.68.65)
+  - React-jsinspector (0.68.65)
+  - React-logger (0.68.65):
     - glog
-  - React-perflogger (0.68.62)
-  - React-RCTActionSheet (0.68.62):
-    - React-Core/RCTActionSheetHeaders (= 0.68.62)
-  - React-RCTAnimation (0.68.62):
+  - React-perflogger (0.68.65)
+  - React-RCTActionSheet (0.68.65):
+    - React-Core/RCTActionSheetHeaders (= 0.68.65)
+  - React-RCTAnimation (0.68.65):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.62)
-    - React-Codegen (= 0.68.62)
-    - React-Core/RCTAnimationHeaders (= 0.68.62)
-    - React-jsi (= 0.68.62)
-    - ReactCommon/turbomodule/core (= 0.68.62)
-  - React-RCTBlob (0.68.62):
+    - RCTTypeSafety (= 0.68.65)
+    - React-Codegen (= 0.68.65)
+    - React-Core/RCTAnimationHeaders (= 0.68.65)
+    - React-jsi (= 0.68.65)
+    - ReactCommon/turbomodule/core (= 0.68.65)
+  - React-RCTBlob (0.68.65):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Codegen (= 0.68.62)
-    - React-Core/RCTBlobHeaders (= 0.68.62)
-    - React-Core/RCTWebSocket (= 0.68.62)
-    - React-jsi (= 0.68.62)
-    - React-RCTNetwork (= 0.68.62)
-    - ReactCommon/turbomodule/core (= 0.68.62)
-  - React-RCTImage (0.68.62):
+    - React-Codegen (= 0.68.65)
+    - React-Core/RCTBlobHeaders (= 0.68.65)
+    - React-Core/RCTWebSocket (= 0.68.65)
+    - React-jsi (= 0.68.65)
+    - React-RCTNetwork (= 0.68.65)
+    - ReactCommon/turbomodule/core (= 0.68.65)
+  - React-RCTImage (0.68.65):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.62)
-    - React-Codegen (= 0.68.62)
-    - React-Core/RCTImageHeaders (= 0.68.62)
-    - React-jsi (= 0.68.62)
-    - React-RCTNetwork (= 0.68.62)
-    - ReactCommon/turbomodule/core (= 0.68.62)
-  - React-RCTLinking (0.68.62):
-    - React-Codegen (= 0.68.62)
-    - React-Core/RCTLinkingHeaders (= 0.68.62)
-    - React-jsi (= 0.68.62)
-    - ReactCommon/turbomodule/core (= 0.68.62)
-  - React-RCTNetwork (0.68.62):
+    - RCTTypeSafety (= 0.68.65)
+    - React-Codegen (= 0.68.65)
+    - React-Core/RCTImageHeaders (= 0.68.65)
+    - React-jsi (= 0.68.65)
+    - React-RCTNetwork (= 0.68.65)
+    - ReactCommon/turbomodule/core (= 0.68.65)
+  - React-RCTLinking (0.68.65):
+    - React-Codegen (= 0.68.65)
+    - React-Core/RCTLinkingHeaders (= 0.68.65)
+    - React-jsi (= 0.68.65)
+    - ReactCommon/turbomodule/core (= 0.68.65)
+  - React-RCTNetwork (0.68.65):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.62)
-    - React-Codegen (= 0.68.62)
-    - React-Core/RCTNetworkHeaders (= 0.68.62)
-    - React-jsi (= 0.68.62)
-    - ReactCommon/turbomodule/core (= 0.68.62)
-  - React-RCTSettings (0.68.62):
+    - RCTTypeSafety (= 0.68.65)
+    - React-Codegen (= 0.68.65)
+    - React-Core/RCTNetworkHeaders (= 0.68.65)
+    - React-jsi (= 0.68.65)
+    - ReactCommon/turbomodule/core (= 0.68.65)
+  - React-RCTSettings (0.68.65):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.62)
-    - React-Codegen (= 0.68.62)
-    - React-Core/RCTSettingsHeaders (= 0.68.62)
-    - React-jsi (= 0.68.62)
-    - ReactCommon/turbomodule/core (= 0.68.62)
-  - React-RCTText (0.68.62):
-    - React-Core/RCTTextHeaders (= 0.68.62)
-  - React-RCTVibration (0.68.62):
+    - RCTTypeSafety (= 0.68.65)
+    - React-Codegen (= 0.68.65)
+    - React-Core/RCTSettingsHeaders (= 0.68.65)
+    - React-jsi (= 0.68.65)
+    - ReactCommon/turbomodule/core (= 0.68.65)
+  - React-RCTText (0.68.65):
+    - React-Core/RCTTextHeaders (= 0.68.65)
+  - React-RCTVibration (0.68.65):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Codegen (= 0.68.62)
-    - React-Core/RCTVibrationHeaders (= 0.68.62)
-    - React-jsi (= 0.68.62)
-    - ReactCommon/turbomodule/core (= 0.68.62)
-  - React-runtimeexecutor (0.68.62):
-    - React-jsi (= 0.68.62)
-  - ReactCommon/turbomodule/core (0.68.62):
+    - React-Codegen (= 0.68.65)
+    - React-Core/RCTVibrationHeaders (= 0.68.65)
+    - React-jsi (= 0.68.65)
+    - ReactCommon/turbomodule/core (= 0.68.65)
+  - React-runtimeexecutor (0.68.65):
+    - React-jsi (= 0.68.65)
+  - ReactCommon/turbomodule/core (0.68.65):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.68.62)
-    - React-Core (= 0.68.62)
-    - React-cxxreact (= 0.68.62)
-    - React-jsi (= 0.68.62)
-    - React-logger (= 0.68.62)
-    - React-perflogger (= 0.68.62)
-  - ReactTestApp-DevSupport (2.3.2):
+    - React-callinvoker (= 0.68.65)
+    - React-Core (= 0.68.65)
+    - React-cxxreact (= 0.68.65)
+    - React-jsi (= 0.68.65)
+    - React-logger (= 0.68.65)
+    - React-perflogger (= 0.68.65)
+  - ReactTestApp-DevSupport (2.3.7):
     - React-Core
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
   - RNCPicker (2.4.8):
     - React-Core
-  - RNSVG (12.5.0):
+  - RNSVG (12.5.1):
     - React-Core
   - Yoga (1.14.0)
 
@@ -512,47 +512,47 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: 613e39eac4239cc72b15421247b5ab05361266a2
   DoubleConversion: ed15e075aa758ac0e4c1f8b830bd4e4d40d669e8
-  FBLazyVector: 476cc84f9fec4a6988871e6af22fc484de505767
-  FBReactNativeSpec: 2936b6cdfd7e1f964105666fdb2e2d917ca38a86
+  FBLazyVector: 10bad64b5f98b1904f9768a01ff5c422139b126f
+  FBReactNativeSpec: 66963e743aadfbaa45bdd215f4e5434e08080d7b
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  FRNAvatar: cbb9afacb90bcee65673e6d7a32eb63a900131eb
-  FRNCallout: 0c30f8dcff541722151a4b74fab7e60ba63d3529
-  FRNCheckbox: bf387cb0c207f6f127b3673d98007d3cbdedb1f3
-  FRNMenuButton: c3b16b95b0ebd169d4ef4476b5988da5135d859b
-  FRNRadioButton: 6e86a5810c21d3f1938596c9e413a5d34e07d97a
+  FRNAvatar: 963fe8b6f953a95c09066562fc6ddff3c2e7e1b7
+  FRNCallout: 198d573180854d01d36c768118b4f9fb0be62741
+  FRNCheckbox: 2ff06e0a4ed9a130f3499713ce54304c822c4d48
+  FRNMenuButton: 06c509c67628ac9a903fed54deb3147f124cdaef
+  FRNRadioButton: b8b04bed41355c3c0af5002c63119329497ef7e5
   glog: 20113a0d46931b6f096cf8302c68691d75a456ff
-  MicrosoftFluentUI: f6db695718efb93f4ca9bdc366c00b80a1f91dba
+  MicrosoftFluentUI: dde98d8ed3fc306d9ddd0a6f0bc0c1f24fe5275e
   RCT-Folly: 5544a3ff21f4406e70e92a8711598e97fc81517c
-  RCTFocusZone: 7caf73a4751d23644070dcab259e699ece705bbd
-  RCTRequired: 023a1e179ee2f19716f408aa6139ab1519ca7c2a
-  RCTTypeSafety: 82dd668bad65235631a88afc7767a5a2975710f6
-  React: 7aeda534cd94a13bfe4ee41c54873b6e94e4dd5c
-  React-callinvoker: 92923c7c5728d0cf923edf28993aac12ff950bdd
-  React-Codegen: c9605b3292a3089a6c08d81a4ce91f56865de6fe
-  React-Core: bbc4cd945153924b7fdd561f65848ce939781390
-  React-CoreModules: 36ef084a60778dd7e6a475bd554c8f64afc05d84
-  React-cxxreact: d778321f58d8743f6f663f5ac6da9009130931b7
-  React-jsi: 4fd996624ef520667e114fcc3d2f1867196d0f47
-  React-jsiexecutor: 1862151d3f809499c82d7f66a3ca624b4d6b49d9
-  React-jsinspector: 39348b9a3417419aea646f41cba625e1a7bbbd30
-  React-logger: 7a2e45e85d0fe59edb6d4fb2cbcbb9981ab9486e
-  React-perflogger: 20ae52b52ce2c0e1e257e0c0502f8f08a0b43ff9
-  React-RCTActionSheet: 2a62f3135a621bbf90504a28205cf5ef05b27bea
-  React-RCTAnimation: 219eb987ed34c38cbf13096062da7ddc142f0fac
-  React-RCTBlob: e3fb25043782acd848669cac9a15270f5702256c
-  React-RCTImage: fd5acd0da73155da5d3af967987861ab8296abe5
-  React-RCTLinking: 0bc10a82b83569e85c0f971e5adf5a53856989b6
-  React-RCTNetwork: 72cf76e577b16ceb90964bbbda07b2f22817de57
-  React-RCTSettings: 83d48be06041a57485e59820f23b1050560dabe6
-  React-RCTText: 79b5b9221fceb445d4299003628c0dd0300fa8e2
-  React-RCTVibration: c25bc2b1d5bea3f2fd8bd1931c3a23df604c7a57
-  React-runtimeexecutor: 71d892141f53ed18c108d97ce49083d7792c8cca
-  ReactCommon: 2ac737725b34d197ba527a4055a842374633de3d
-  ReactTestApp-DevSupport: 1646ce70be36400a60ca18608284f3f7099a35c1
+  RCTFocusZone: 1ffa409a3d67ee71784d4d321c40220e248c2aab
+  RCTRequired: 294911af81deff399dd63b8da2c0538c96c3d57f
+  RCTTypeSafety: 11c2cdd6044ec4e83db2339dd169d9a5364b51e4
+  React: 336643db5a50b597a9ead56292592b0066725013
+  React-callinvoker: f552644c3afbf3988a7c5766644b10e82d2246d8
+  React-Codegen: 3c0bd968cae59c551b9735c9a9dbaa0df400fb54
+  React-Core: 20c70ab27242a8c1561f2484cfa2319e9794edd0
+  React-CoreModules: 460be4aaead5a68e1dbc6735a5ec68f113c742d8
+  React-cxxreact: c64892dd1540e67f2cf0661f569621ae0f99d9f1
+  React-jsi: 0f24bbdaf2a3bd2db893a8339a8f2f21f9e12ee5
+  React-jsiexecutor: 3bff284df065adc8b5ec270ae7f4882a986ea043
+  React-jsinspector: 170a05d04c3332cdf527fc11edaf9339946b2e52
+  React-logger: ab197d2f083fb6b3dac9094560e4c0c4eb4a4173
+  React-perflogger: eb1f5dc5d0b0a80668496e4bd18da9503bd076c9
+  React-RCTActionSheet: 4bda8dd5ea22934cf9f6a4d6ad2b092f141d29e6
+  React-RCTAnimation: e3df1c77992c017351fd246164559c042ab14a23
+  React-RCTBlob: 84a8dfd335cf1c2308029f24b6b9132100012e4a
+  React-RCTImage: 4a67a4607477ea8d4897b28923dec1cbf073dba3
+  React-RCTLinking: 3d2cfcc3c66c504c4ffb4d1066be4a977ed6d5e8
+  React-RCTNetwork: ba33ce2f501eecd6a8cd485f3363d91128a2d6a5
+  React-RCTSettings: dff68c603daa4df9b7605e4c16719c446f730747
+  React-RCTText: f7013b9981b316c46d17be0470d0bf8e198a1b5b
+  React-RCTVibration: 5ec4be2ac6c129a61ef3bc4709fe5abe794903cf
+  React-runtimeexecutor: da87ac4cfbc5b0bc996ac0e3254067aa1a3f2eab
+  ReactCommon: 2e3041d2587079d4155c5c8c58ae646737e9e85b
+  ReactTestApp-DevSupport: 64fa48ee0faae120b9f11444be21ab2814a5c1fa
   ReactTestApp-Resources: 8c0164a3cc5052418c92018e2af0e05d564aa307
   RNCPicker: 0bf8ef8f7800524f32d2bb2a8bcadd53eda0ecd1
-  RNSVG: 6adc5c52d2488a476248413064b7f2832e639057
-  Yoga: 6c7edb98bf534779ae3d0af1790018da859047c9
+  RNSVG: d7d7bc8229af3842c9cfc3a723c815a52cdd1105
+  Yoga: c99c256e5e031f07f7449c6857e079bbbc02fa4b
 
 PODFILE CHECKSUM: d3fe834dea1e24594a8ba545f70b5250bbc25c91
 

--- a/change/@fluentui-react-native-experimental-avatar-4f9098d7-8b3c-4247-8c7c-171c1811cf13.json
+++ b/change/@fluentui-react-native-experimental-avatar-4f9098d7-8b3c-4247-8c7c-171c1811cf13.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update native modules to FUA 0.13",
+  "packageName": "@fluentui-react-native/experimental-avatar",
+  "email": "mischreiber@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-native-date-picker-552368ba-eb4e-4d2a-9282-743b949d5c8a.json
+++ b/change/@fluentui-react-native-experimental-native-date-picker-552368ba-eb4e-4d2a-9282-743b949d5c8a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update native modules to FUA 0.13",
+  "packageName": "@fluentui-react-native/experimental-native-date-picker",
+  "email": "mischreiber@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-2cc70266-83df-4bd8-b9b6-7ce10751ead4.json
+++ b/change/@fluentui-react-native-tester-2cc70266-83df-4bd8-b9b6-7ce10751ead4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update native modules to FUA 0.13",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "mischreiber@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Avatar/FRNAvatar.podspec
+++ b/packages/experimental/Avatar/FRNAvatar.podspec
@@ -16,11 +16,11 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = "14.0"
   s.ios.source_files      = "ios/*.{swift,h,m}"
-  s.ios.dependency 'MicrosoftFluentUI', '0.10.0'
+  s.ios.dependency 'MicrosoftFluentUI', '0.13.1'
 
   s.osx.deployment_target = "10.15"
   s.osx.source_files      = "macos/*.{swift,h,m}"
-  s.osx.dependency 'MicrosoftFluentUI', '0.10.0'
+  s.osx.dependency 'MicrosoftFluentUI', '0.13.1'
 
   s.dependency 'React'
 end

--- a/packages/experimental/NativeDatePicker/FRNDatePicker.podspec
+++ b/packages/experimental/NativeDatePicker/FRNDatePicker.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = "14.0"
   s.ios.source_files      = "ios/*.{swift,h,m}"
-  s.ios.dependency 'MicrosoftFluentUI', '0.10.0'
+  s.ios.dependency 'MicrosoftFluentUI', '0.13.1'
 
 end


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Updating `MicrosoftFluentUI` for iOS and macOS from 0.10 to 0.13.

### Verification

No API changes for our native controls (Avatar and DateTimePicker), so no behavior changes.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
