### PR TITLE
[Menu] Always pass in a ref to FocusZone

### DIFF
--- a/change/@fluentui-react-native-menu-a33a6909-670b-4cbd-8f8b-76f4c6ba534e.json
+++ b/change/@fluentui-react-native-menu-a33a6909-670b-4cbd-8f8b-76f4c6ba534e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Always pass in a ref to FocusZone",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/MenuList/MenuList.tsx
+++ b/packages/components/Menu/src/MenuList/MenuList.tsx
@@ -66,9 +66,7 @@ export const MenuList = compose<MenuListType>({
               <Slots.focusZone
                 componentRef={focusZoneRef}
                 focusZoneDirection={'vertical'}
-                // For submenus, setting defaultTabbableElement to null will let FZ set focus on the first key view.
-                // For root menu, let's set focus on the container to block FZ setting focus on the first key view.
-                defaultTabbableElement={menuContext.isSubmenu ? null : focusZoneRef} // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                defaultTabbableElement={focusZoneRef} // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                 // @ts-ignore FocusZone takes ViewProps, but that isn't defined on it's type.
                 enableFocusRing={false}
               >


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This is a partial revert of #2489, specifically the change where no ref is passed in if a submenu is being rendered, so that we delegate focusing on the first menu item to FocusZone. This introduced an intermittent bug where focus is completely lost when opening a submenu. Let's revert the change for now until we have a more comprehensive fix. 

### Verification

https://user-images.githubusercontent.com/67026167/219757706-6755a750-843c-4d93-aebc-8c47b291f6be.mov




| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [X] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
