### PR TITLE
[Bug fixes] Button-FAB/Shimmer/Ripple Color

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Button/ButtonVariantTestSection.mobile.tsx
+++ b/apps/fluent-tester/src/TestComponents/Button/ButtonVariantTestSection.mobile.tsx
@@ -32,11 +32,11 @@ export const ButtonVariantTest: React.FunctionComponent = () => {
       <Button appearance="subtle" disabled style={commonTestStyles.vmargin}>
         Subtle Disabled
       </Button>
-      <FAB icon={iconProps} iconOnly disabled style={commonTestStyles.vmargin} />
+      <FAB icon={iconProps} iconOnly disabled style={commonTestStyles.vmargin} accessibilityLabel="FAB" />
       <FAB icon={iconProps} style={commonTestStyles.vmargin} showContent={showFABText} onClick={flipFABcontent}>
         Click Me!
       </FAB>
-      <FAB appearance="subtle" iconOnly disabled icon={iconProps} style={commonTestStyles.vmargin} />
+      <FAB appearance="subtle" iconOnly disabled icon={iconProps} style={commonTestStyles.vmargin} accessibilityLabel="FAB" />
       <FAB appearance="subtle" icon={iconProps} style={commonTestStyles.vmargin} showContent={showFABText} onClick={flipFABcontent}>
         Click Me!
       </FAB>

--- a/change/@fluentui-react-native-button-2dba494e-e1b8-4853-91b1-e8e537752cfe.json
+++ b/change/@fluentui-react-native-button-2dba494e-e1b8-4853-91b1-e8e537752cfe.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix icon accessible in button/fab",
+  "packageName": "@fluentui-react-native/button",
+  "email": "ayushsinghs@yahoo.in",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-radio-group-5078cf4d-b7c6-4459-a072-493f9ffffe80.json
+++ b/change/@fluentui-react-native-experimental-radio-group-5078cf4d-b7c6-4459-a072-493f9ffffe80.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Ripple color change",
+  "packageName": "@fluentui-react-native/experimental-radio-group",
+  "email": "ayushsinghs@yahoo.in",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-shimmer-31dcdaa0-6925-4494-8831-c9bf1dd08970.json
+++ b/change/@fluentui-react-native-experimental-shimmer-31dcdaa0-6925-4494-8831-c9bf1dd08970.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Shimmer fixes",
+  "packageName": "@fluentui-react-native/experimental-shimmer",
+  "email": "ayushsinghs@yahoo.in",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-tester-7d1c711f-8794-4926-9b44-d5c5e9d464f3.json
+++ b/change/@fluentui-react-native-tester-7d1c711f-8794-4926-9b44-d5c5e9d464f3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Bug fixes",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ayushsinghs@yahoo.in",
+  "dependentChangeType": "none"
+}

--- a/packages/components/Button/src/Button.tsx
+++ b/packages/components/Button/src/Button.tsx
@@ -79,7 +79,7 @@ export const Button = compose<ButtonType>({
       const buttonContent = (
         <React.Fragment>
           {loading && <ActivityIndicator />}
-          {shouldShowIcon && iconPosition === 'before' && <Slots.icon {...iconProps} />}
+          {shouldShowIcon && iconPosition === 'before' && <Slots.icon {...iconProps} accessible={false} />}
           {React.Children.map(children, (child) =>
             typeof child === 'string' ? <Slots.content key="content">{child}</Slots.content> : child,
           )}

--- a/packages/components/Button/src/ButtonColorTokens.android.ts
+++ b/packages/components/Button/src/ButtonColorTokens.android.ts
@@ -8,7 +8,7 @@ export const defaultButtonColorTokens: TokenSettings<ButtonTokens, Theme> = (t: 
      * 'primary', 'accent' and if no appearance is mentioned, picks this.
      */
     backgroundColor: t.colors.brandBackground,
-    rippleColor: 'transparent',
+    rippleColor: '#D4D4D4',
     color: t.colors.neutralForegroundOnColor,
     iconColor: t.colors.neutralForegroundOnColor,
     disabled: {
@@ -30,7 +30,7 @@ export const defaultButtonColorTokens: TokenSettings<ButtonTokens, Theme> = (t: 
     },
     subtle: {
       backgroundColor: 'transparent',
-      rippleColor: 'transparent',
+      rippleColor: '#D4D4D4',
       color: t.colors.brandForeground1,
       iconColor: t.colors.brandForeground1,
       disabled: {
@@ -53,7 +53,7 @@ export const defaultButtonColorTokens: TokenSettings<ButtonTokens, Theme> = (t: 
     },
     outline: {
       backgroundColor: 'transparent',
-      rippleColor: 'transparent',
+      rippleColor: '#D4D4D4',
       color: t.colors.brandForeground1,
       iconColor: t.colors.brandForeground1,
       borderColor: t.colors.brandStroke1,

--- a/packages/components/Button/src/FAB/FAB.android.tsx
+++ b/packages/components/Button/src/FAB/FAB.android.tsx
@@ -1,1 +1,1 @@
-export { FAB } from './FABCore';
+export { FAB } from './FAB.mobile';

--- a/packages/components/Button/src/FAB/FAB.ios.tsx
+++ b/packages/components/Button/src/FAB/FAB.ios.tsx
@@ -1,1 +1,1 @@
-export { FAB } from './FABCore';
+export { FAB } from './FAB.mobile';

--- a/packages/components/Button/src/FAB/FAB.mobile.tsx
+++ b/packages/components/Button/src/FAB/FAB.mobile.tsx
@@ -75,7 +75,7 @@ export const FAB = compose<FABType>({
 
       const buttonContent = (
         <React.Fragment>
-          {icon && <Slots.icon {...iconProps} />}
+          {icon && <Slots.icon {...iconProps} accessible={false} />}
           {showContent &&
             React.Children.map(children, (child) =>
               typeof child === 'string' ? <Slots.content key="content">{child}</Slots.content> : child,

--- a/packages/components/Button/src/FAB/FABColorTokens.ts
+++ b/packages/components/Button/src/FAB/FABColorTokens.ts
@@ -7,7 +7,7 @@ export const defaultFABColorTokens: TokenSettings<FABTokens, Theme> = (t: Theme)
   backgroundColor: t.colors.brandBackground,
   color: t.colors.neutralForegroundOnColor,
   iconColor: t.colors.neutralForegroundOnColor,
-  rippleColor: 'transparent', //Android Only
+  rippleColor: '#D4D4D4', //Android Only
   disabled: {
     backgroundColor: t.colors.neutralBackground5,
     color: t.colors.neutralForegroundDisabled,
@@ -29,7 +29,7 @@ export const defaultFABColorTokens: TokenSettings<FABTokens, Theme> = (t: Theme)
     backgroundColor: t.colors.neutralBackground5,
     color: t.colors.brandForeground1,
     iconColor: t.colors.brandForeground1,
-    rippleColor: 'transparent',
+    rippleColor: '#D4D4D4',
     disabled: {
       backgroundColor: t.colors.neutralBackgroundDisabled,
       color: t.colors.neutralForegroundDisabled,

--- a/packages/components/Button/src/FAB/__snapshots__/FAB.test.tsx.snap
+++ b/packages/components/Button/src/FAB/__snapshots__/FAB.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`Custom FAB with no shadow(iOS) 1`] = `
   }
 >
   <Text
-    accessible={true}
+    accessible={false}
     style={
       Object {
         "color": "#fff",
@@ -167,7 +167,7 @@ exports[`Default FAB (iOS) 1`] = `
     }
   >
     <Text
-      accessible={true}
+      accessible={false}
       style={
         Object {
           "color": "#fff",

--- a/packages/experimental/RadioGroup/src/Radio/RadioTokens.android.ts
+++ b/packages/experimental/RadioGroup/src/Radio/RadioTokens.android.ts
@@ -35,7 +35,7 @@ export const defaultRadioTokens: TokenSettings<RadioTokens, Theme> = (t: Theme) 
 
     disabled: {
       // Unselected, Disabled
-      rippleColor: 'transparent',
+      rippleColor: '#D4D4D4',
       radioBorder: t.colors.neutralStrokeDisabled,
       radioVisibility: 0,
       color: t.colors.neutralForegroundDisabled1,

--- a/packages/experimental/RadioGroup/src/Radio/RadioTokens.ios.ts
+++ b/packages/experimental/RadioGroup/src/Radio/RadioTokens.ios.ts
@@ -37,7 +37,7 @@ export const defaultRadioTokens: TokenSettings<RadioTokens, Theme> = (t: Theme) 
 
     disabled: {
       // Unselected, Disabled
-      rippleColor: 'transparent',
+      rippleColor: '#D4D4D4',
       radioBorder: t.colors.neutralStrokeDisabled,
       radioVisibility: 0,
       color: t.colors.neutralForegroundDisabled1,

--- a/packages/experimental/Shimmer/src/Shimmer.styling.ts
+++ b/packages/experimental/Shimmer/src/Shimmer.styling.ts
@@ -6,11 +6,13 @@ import { defaultShimmerTokens } from './ShimmerTokens';
 
 export const stylingSettings: UseStylingOptions<ShimmerProps, ShimmerSlotProps, ShimmerTokens> = {
   tokens: [defaultShimmerTokens, shimmerName],
+  tokensThatAreAlsoProps: 'all',
   slotProps: {
     root: buildProps(
       (tokens: ShimmerTokens) => ({
         accessibilityRole: 'progressbar',
         accessible: true,
+        style: { overflow: 'hidden', backgroundColor: tokens.backgroundColor },
         angle: tokens.angle,
         delay: tokens.delay,
         duration: tokens.duration,
@@ -19,7 +21,16 @@ export const stylingSettings: UseStylingOptions<ShimmerProps, ShimmerSlotProps, 
         shimmerWaveColor: tokens.shimmerWaveColor,
         shimmerWaveColorOpacity: tokens.shimmerWaveColorOpacity,
       }),
-      ['angle', 'delay', 'duration', 'shimmerColor', 'shimmerColorOpacity', 'shimmerWaveColor', 'shimmerWaveColorOpacity'],
+      [
+        'angle',
+        'delay',
+        'duration',
+        'shimmerColor',
+        'shimmerColorOpacity',
+        'shimmerWaveColor',
+        'shimmerWaveColorOpacity',
+        'backgroundColor',
+      ],
     ),
   },
 };

--- a/packages/experimental/Shimmer/src/Shimmer.tsx
+++ b/packages/experimental/Shimmer/src/Shimmer.tsx
@@ -19,6 +19,7 @@ export const Shimmer = compose<ShimmerType>({
   },
   useRender: (props: ShimmerProps, useSlots: UseSlots<ShimmerType>) => {
     const Slots = useSlots(props);
+    props = mergeProps(props, Slots.root({}).props);
     const AnimatedLinearGradient = Animated.createAnimatedComponent(LinearGradient);
     const tokens = useStyling(props).root;
     const memoizedShimmerData = useMemo(
@@ -50,11 +51,11 @@ export const Shimmer = compose<ShimmerType>({
      * The startValue is used to control the start position of the gradient animation, it is set as -1 to make sure it is starts off the screen for any angle.
      * Similarly the endValue is set to 2 to make sure the gradient animation exits the entire screen for any angle.
      */
-    const startValue = useRef(new Animated.Value(-1)).current;
+    const startValue = useRef(new Animated.Value(-2)).current;
     const shimmerAnimation = useCallback(() => {
       Animated.loop(
         Animated.timing(startValue, {
-          toValue: 2,
+          toValue: 3,
           duration: memoizedShimmerData.duration,
           delay: memoizedShimmerData.delay,
           useNativeDriver: true,

--- a/packages/experimental/Shimmer/src/Shimmer.tsx
+++ b/packages/experimental/Shimmer/src/Shimmer.tsx
@@ -48,8 +48,8 @@ export const Shimmer = compose<ShimmerType>({
 
     /* The shimmer animation is implemented using a LinearGradient which travels from left to right.
      * Different angles are handled by rotating this gradient.
-     * The startValue is used to control the start position of the gradient animation, it is set as -1 to make sure it is starts off the screen for any angle.
-     * Similarly the endValue is set to 2 to make sure the gradient animation exits the entire screen for any angle.
+     * The startValue is used to control the start position of the gradient animation, it is set as -2 to make sure it is starts off the screen for any angle.
+     * Similarly the endValue is set to 3 to make sure the gradient animation exits the entire screen for any angle.
      */
     const startValue = useRef(new Animated.Value(-2)).current;
     const shimmerAnimation = useCallback(() => {

--- a/packages/experimental/Shimmer/src/__snapshots__/Shimmer.test.tsx.snap
+++ b/packages/experimental/Shimmer/src/__snapshots__/Shimmer.test.tsx.snap
@@ -21,6 +21,9 @@ exports[`Shimmer component tests Shimmer default 1`] = `
         "borderWidth": 0,
       },
       Object {
+        "overflow": "hidden",
+      },
+      Object {
         "flex": 0,
         "height": "100%",
         "width": "100%",
@@ -53,7 +56,7 @@ exports[`Shimmer component tests Shimmer default 1`] = `
         }
         gradientUnits={0}
         name="gradient"
-        x1={-1}
+        x1={-2}
         x2="-1"
         y1="0%"
         y2="0%"
@@ -144,6 +147,7 @@ exports[`Shimmer component tests Shimmer with style prop 1`] = `
       },
       Object {
         "height": 100,
+        "overflow": "hidden",
         "width": 300,
       },
       Object {
@@ -179,7 +183,7 @@ exports[`Shimmer component tests Shimmer with style prop 1`] = `
         }
         gradientUnits={0}
         name="gradient"
-        x1={-1}
+        x1={-2}
         x2="-1"
         y1="0%"
         y2="0%"


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

Bug fixes -
- Make Button test page more accessible (Android).
- Fix Button/FAB icon being accessible (All plats).
- Rename FABCore to FAB.mobile maintaining parity with other files.
- Change rippleColor to '#D4D4D4' for visibility on dark mode and consistency (Android).
- Fix Shimmer background not applying (All plats except win32).
- Fix Shimmer.customize not working (All plats except win32).


### Verification

Accessibility works as expected.
Shimmer customize works as expected.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Screenshot_2023-02-23-10-59-54-92_3238b23fbbdef38ccf4a465a34706bab](https://user-images.githubusercontent.com/49569838/220828451-495195d2-ee0c-4cf9-a0f5-dfd501c044ff.jpg) | ![Screenshot_2023-02-23-10-56-56-14_3238b23fbbdef38ccf4a465a34706bab](https://user-images.githubusercontent.com/49569838/220828413-96515f57-6bf3-4834-b0ea-986ca46784ef.jpg) |

The background was not applied before, it is now being applied.
The first two shimmers in the 'Customized Shimmer' section are supposed to look the same. One uses customize API and the other uses props to achieve the same result.
Note - The 'Customized Shimmer' section does not render on Android tester app, images are added for reference.

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
