### PR TITLE
[Switch] Font truncated a11y issue fix

### DIFF
--- a/change/@fluentui-react-native-switch-c6e6f1fe-042e-4368-88e9-09d358647280.json
+++ b/change/@fluentui-react-native-switch-c6e6f1fe-042e-4368-88e9-09d358647280.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix switch font ally",
+  "packageName": "@fluentui-react-native/switch",
+  "email": "rohanpd.work@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Switch/src/Switch.styling.ts
+++ b/packages/experimental/Switch/src/Switch.styling.ts
@@ -20,6 +20,8 @@ export const switchStates: (keyof SwitchTokens)[] = [
   'disabled',
 ];
 
+const isMobile = Platform.OS === 'android' || Platform.OS === 'ios';
+
 export const stylingSettings: UseStylingOptions<SwitchProps, SwitchSlotProps, SwitchTokens> = {
   tokens: [defaultSwitchTokens, switchName],
   states: switchStates,
@@ -103,6 +105,7 @@ export const stylingSettings: UseStylingOptions<SwitchProps, SwitchSlotProps, Sw
       (tokens: SwitchTokens, theme: Theme) => ({
         style: {
           color: tokens.color,
+          ...(isMobile && { flexShrink: 1 }),
           ...fontStyles.from(tokens, theme),
         },
       }),

--- a/packages/experimental/Switch/src/__tests__/__snapshots__/Switch.test.tsx.snap
+++ b/packages/experimental/Switch/src/__tests__/__snapshots__/Switch.test.tsx.snap
@@ -61,6 +61,7 @@ exports[`Switch Default 1`] = `
     style={
       Object {
         "color": "#242424",
+        "flexShrink": 1,
         "fontFamily": "Segoe UI",
         "fontSize": 13,
         "fontWeight": "400",
@@ -177,6 +178,7 @@ exports[`Switch Disabled 1`] = `
     style={
       Object {
         "color": "#e0e0e0",
+        "flexShrink": 1,
         "fontFamily": "Segoe UI",
         "fontSize": 13,
         "fontWeight": "400",


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [x] android

### Description of changes

On font size increase the label text was getting truncated. 
In this examples the fourth example disabled default unchecked switch.  "FalseTest" was getting hidden inside screen. 

### Verification

Visual Verification after font size increase. 

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![MicrosoftTeams-image (26)](https://user-images.githubusercontent.com/30728574/220338571-077a93b0-84cf-4e17-bbda-a9b7413189a2.png)| ![MicrosoftTeams-image (25)](https://user-images.githubusercontent.com/30728574/220338804-2c8126fa-4c96-4e7a-8515-6cb947fe62ba.png) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
