### PR TITLE
Allow styling of Divider text via Divider Tokens

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Divider/DividerTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Divider/DividerTest.tsx
@@ -11,15 +11,23 @@ import TestSvg from '../../../assets/test.svg';
 import { CustomisedMobileDividers, MobileDividers } from './MobileDividerTest';
 
 const isMobile = Platform.OS === 'android' || Platform.OS === 'ios';
-const CustomDivider = Divider.customize({ thickness: 3, paddingVertical: 4 });
+const PaddedDivider = Divider.customize({ paddingVertical: 4, thickness: 2 });
 const CustomText = Text.customize({ margin: 8 });
 
-const RedDivider = Divider.customize({ contentColor: 'red', lineColor: 'red' });
+const ColoredDivider = Divider.customize({ contentColor: '#bf5700', lineColor: '#bf5700' });
+const ThickDivider = Divider.customize({ thickness: 3 });
+const TextVariantDivider = Divider.customize({ textVariant: 'subtitle2Strong' });
+const StyledTextDivider = Divider.customize({ textSize: 100, textItalic: true, textUnderline: true });
 
 const dividerTestStyles = StyleSheet.create({
   verticalDividerContainer: {
     marginVertical: 8,
     flexDirection: 'row',
+    justifyContent: 'space-evenly',
+  },
+  horizontalDividerContainer: {
+    height: 120,
+    flexDirection: 'column',
     justifyContent: 'space-evenly',
   },
 });
@@ -30,9 +38,9 @@ export const HorizontalDividers: React.FunctionComponent = () => (
     <Divider />
     <CustomText>Regular divider with no content above.</CustomText>
     <Divider>Divider with text content.</Divider>
-    <Divider insetSize={16}>Colored divider with text + inset.</Divider>
-    <CustomDivider alignContent="start">I am a start-aligned divider with a thickness = 3</CustomDivider>
-    <CustomDivider alignContent="end">I am a end-aligned divider with a thickness = 3</CustomDivider>
+    <Divider insetSize={16}>Divider with text + inset.</Divider>
+    <PaddedDivider alignContent="start">I am a start-aligned divider</PaddedDivider>
+    <PaddedDivider alignContent="end">I am a end-aligned divider</PaddedDivider>
   </Stack>
 );
 
@@ -43,10 +51,10 @@ export const VerticalDividers: React.FunctionComponent = () => (
       <Divider vertical />
       <CustomText>Divider with an inset {'->'}</CustomText>
       <Divider vertical insetSize={16} />
-      <CustomDivider vertical>Thick divider with text</CustomDivider>
-      <RedDivider vertical alignContent="start">
+      <PaddedDivider vertical>Divider with text</PaddedDivider>
+      <Divider vertical alignContent="start">
         Start-aligned divider
-      </RedDivider>
+      </Divider>
       <Divider vertical alignContent="end">
         End-aligned divider
       </Divider>
@@ -62,10 +70,10 @@ export const VerticalDividers: React.FunctionComponent = () => (
 
 export const DividersWithAppearance: React.FunctionComponent = () => (
   <Stack style={commonTestStyles.stack}>
-    <CustomDivider appearance="default">Default divider</CustomDivider>
-    <CustomDivider appearance="subtle">Subtle divider</CustomDivider>
-    <CustomDivider appearance="brand">Branded divider</CustomDivider>
-    <CustomDivider appearance="strong">Strong divider</CustomDivider>
+    <PaddedDivider appearance="default">Default divider</PaddedDivider>
+    <PaddedDivider appearance="subtle">Subtle divider</PaddedDivider>
+    <PaddedDivider appearance="brand">Branded divider</PaddedDivider>
+    <PaddedDivider appearance="strong">Strong divider</PaddedDivider>
   </Stack>
 );
 
@@ -82,6 +90,23 @@ export const DividersWithIcons: React.FunctionComponent = () => (
   </Stack>
 );
 
+export const CustomDividers: React.FunctionComponent = () => (
+  <Stack style={commonTestStyles.stack}>
+    <View style={dividerTestStyles.horizontalDividerContainer}>
+      <ColoredDivider>Divider with color</ColoredDivider>
+      <ThickDivider>Divider with thickness</ThickDivider>
+      <TextVariantDivider>Divider with text variant</TextVariantDivider>
+      <StyledTextDivider>Divider with text styling</StyledTextDivider>
+    </View>
+    <View style={dividerTestStyles.verticalDividerContainer}>
+      <ColoredDivider vertical>Divider with color</ColoredDivider>
+      <ThickDivider vertical>Divider with thickness</ThickDivider>
+      <TextVariantDivider vertical>Divider with text variant</TextVariantDivider>
+      <StyledTextDivider vertical>Divider with text styling</StyledTextDivider>
+    </View>
+  </Stack>
+);
+
 const dividerSections: TestSection[] = [
   {
     name: 'Horizontal Dividers',
@@ -95,6 +120,10 @@ const dividerSections: TestSection[] = [
   {
     name: 'Divider Appearances',
     component: DividersWithAppearance,
+  },
+  {
+    name: 'Custom Dividers',
+    component: CustomDividers,
   },
   {
     name: 'Dividers with Icons',

--- a/change/@fluentui-react-native-divider-ae4c0912-edf1-4824-b7ee-2f0d07194502.json
+++ b/change/@fluentui-react-native-divider-ae4c0912-edf1-4824-b7ee-2f0d07194502.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added styling tokens for styling Divider text",
+  "packageName": "@fluentui-react-native/divider",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-f4eb630a-aea8-41d1-80e9-cc6fba093810.json
+++ b/change/@fluentui-react-native-tester-f4eb630a-aea8-41d1-80e9-cc6fba093810.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add examples for customized dividers",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Divider/SPEC.md
+++ b/packages/experimental/Divider/SPEC.md
@@ -154,6 +154,31 @@ export interface DividerTokens extends LayoutTokens {
    */
   minLineSize?: number;
   /**
+   * If text is rendered in the divider, this flag controls whether it is italicized or not.
+   */
+  textItalic?: TextProps['italic'];
+  /**
+   * If text is rendered in the divider, this controls its size.
+   */
+  textSize?: TextProps['size'];
+  /**
+   * If text is rendered in the divider, this flag, if true, renders a strikethrough line.
+   */
+  textStrikethrough?: TextProps['strikethrough'];
+  /**
+   * If text is rendered in the divider, this flag, if true, renders an underline.
+   */
+  textUnderline?: TextProps['underline'];
+  /**
+   * If text is rendered in the divider, this will render the text as the given Typography variant.
+   * @default 'secondaryStandard
+   */
+  textVariant?: TextProps['variant'];
+  /**
+   * If text is rendered in the divider, this controls its weight (how bold it appears).
+   */
+  textWeight?: TextProps['weight'];
+  /**
    * The thickness of the Divider lines
    * @default 1
    */

--- a/packages/experimental/Divider/src/Divider.styling.ts
+++ b/packages/experimental/Divider/src/Divider.styling.ts
@@ -113,12 +113,24 @@ export const useDividerSlotProps = (props: DividerProps, tokens: DividerTokens) 
 
   const textProps: TextProps = useMemo(
     () => ({
-      style: {
-        color: tokens.contentColor,
-        textAlign: 'center',
-      },
+      align: 'center',
+      color: tokens.contentColor,
+      italic: tokens.textItalic,
+      size: tokens.textSize,
+      strikethrough: tokens.textStrikethrough,
+      underline: tokens.textUnderline,
+      variant: tokens.textVariant,
+      weight: tokens.textWeight,
     }),
-    [tokens.contentColor],
+    [
+      tokens.contentColor,
+      tokens.textItalic,
+      tokens.textSize,
+      tokens.textStrikethrough,
+      tokens.textUnderline,
+      tokens.textVariant,
+      tokens.textWeight,
+    ],
   );
 
   const iconProps: IconProps = useMemo(

--- a/packages/experimental/Divider/src/Divider.types.ts
+++ b/packages/experimental/Divider/src/Divider.types.ts
@@ -72,6 +72,31 @@ export interface DividerTokens extends LayoutTokens {
    */
   minLineSize?: number;
   /**
+   * If text is rendered in the divider, this flag controls whether it is italicized or not.
+   */
+  textItalic?: TextProps['italic'];
+  /**
+   * If text is rendered in the divider, this controls its size.
+   */
+  textSize?: TextProps['size'];
+  /**
+   * If text is rendered in the divider, this flag, if true, renders a strikethrough line.
+   */
+  textStrikethrough?: TextProps['strikethrough'];
+  /**
+   * If text is rendered in the divider, this flag, if true, renders an underline.
+   */
+  textUnderline?: TextProps['underline'];
+  /**
+   * If text is rendered in the divider, this will render the text as the given Typography variant.
+   * @default 'secondaryStandard
+   */
+  textVariant?: TextProps['variant'];
+  /**
+   * If text is rendered in the divider, this controls its weight (how bold it appears).
+   */
+  textWeight?: TextProps['weight'];
+  /**
    * The thickness of the Divider lines
    * @default 1
    */

--- a/packages/experimental/Divider/src/DividerTokens.ts
+++ b/packages/experimental/Divider/src/DividerTokens.ts
@@ -11,5 +11,6 @@ export const useDividerTokens = buildUseTokens<DividerTokens>(() => ({
   minLineSize: globalTokens.size80,
   minWidth: 0,
   minHeight: 0,
+  textVariant: 'secondaryStandard',
   thickness: 1,
 }));

--- a/packages/experimental/Divider/src/__tests__/__snapshots__/Divider.test.tsx.snap
+++ b/packages/experimental/Divider/src/__tests__/__snapshots__/Divider.test.tsx.snap
@@ -43,9 +43,13 @@ exports[`Divider component tests Divider default 1`] = `
           "color": "#424242",
           "fontFamily": "Segoe UI",
           "fontSize": 12,
+          "fontStyle": undefined,
           "fontWeight": "400",
+          "letterSpacing": undefined,
+          "lineHeight": undefined,
           "margin": 0,
           "textAlign": "center",
+          "textDecorationLine": undefined,
         }
       }
     >


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

The Divider component on the web allows users to customize many things about the divider, including text styles, using CSS. Currently, the FURN divider lacks this customization.

This PR adds more styling tokens to the Divider allowing for text customization,bringing parity with what is possible on native vs web. 

These changes also have resulted in updated test snapshots and an added section on the Divider page in the test app. 

### Verification

New styles: 
![image](https://user-images.githubusercontent.com/15683103/220432086-5c0f4339-82b0-43a0-977a-4046e5cbe569.png)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
