### PR TITLE
Add more snapshot tests to Divider

### DIFF
--- a/change/@fluentui-react-native-divider-6c405729-199a-486d-a295-66f75f0a8084.json
+++ b/change/@fluentui-react-native-divider-6c405729-199a-486d-a295-66f75f0a8084.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add more snapshot testing examples",
+  "packageName": "@fluentui-react-native/divider",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Divider/src/__tests__/Divider.test.tsx
+++ b/packages/experimental/Divider/src/__tests__/Divider.test.tsx
@@ -5,13 +5,57 @@ import { checkReRender } from '@fluentui-react-native/test-tools';
 
 describe('Divider component tests', () => {
   it('Divider default', () => {
-    const tree = renderer.create(<Divider>Your component</Divider>).toJSON();
+    const tree = renderer.create(<Divider />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('Vertical Divider', () => {
+    const tree = renderer.create(<Divider vertical />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('Subtle Divider', () => {
+    const tree = renderer.create(<Divider appearance="subtle" />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('Branded Divider', () => {
+    const tree = renderer.create(<Divider appearance="brand" />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('Strong Divider', () => {
+    const tree = renderer.create(<Divider appearance="strong" />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('Horizontal Divider with Inset', () => {
+    const tree = renderer.create(<Divider insetSize={16} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('Vertical Divider with Inset', () => {
+    const tree = renderer.create(<Divider vertical insetSize={16} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('Custom Divider', () => {
+    const CustomDivider = Divider.customize({ thickness: 3, lineColor: 'red', contentColor: 'blue' });
+    const tree = renderer.create(<CustomDivider />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('Divider with text', () => {
+    const tree = renderer.create(<Divider>Lorem Ipsum</Divider>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('Divider with icon', () => {
+    const tree = renderer.create(<Divider icon={{ fontSource: { fontFamily: 'Arial', codepoint: 0x2663, fontSize: 32 } }} />).toJSON();
     expect(tree).toMatchSnapshot();
   });
 
   it('Divider re-renders correctly', () => {
-    checkReRender(() => <Divider>Render twice</Divider>, 2);
+    checkReRender(() => <Divider />, 2);
   });
-
-  // Feel free to add more tests here
 });

--- a/packages/experimental/Divider/src/__tests__/__snapshots__/Divider.test.tsx.snap
+++ b/packages/experimental/Divider/src/__tests__/__snapshots__/Divider.test.tsx.snap
@@ -1,6 +1,155 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Divider component tests Branded Divider 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "minHeight": 0,
+      "minWidth": 0,
+      "paddingHorizontal": 0,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "borderColor": "#0078d4",
+        "borderStyle": "solid",
+        "borderTopWidth": 1,
+        "flex": 1,
+        "flexBasis": 8,
+        "minWidth": 8,
+      }
+    }
+  />
+</View>
+`;
+
+exports[`Divider component tests Custom Divider 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "minHeight": 0,
+      "minWidth": 0,
+      "paddingHorizontal": 0,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "borderColor": "red",
+        "borderStyle": "solid",
+        "borderTopWidth": 3,
+        "flex": 1,
+        "flexBasis": 8,
+        "minWidth": 8,
+      }
+    }
+  />
+</View>
+`;
+
 exports[`Divider component tests Divider default 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "minHeight": 0,
+      "minWidth": 0,
+      "paddingHorizontal": 0,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "borderColor": "#e0e0e0",
+        "borderStyle": "solid",
+        "borderTopWidth": 1,
+        "flex": 1,
+        "flexBasis": 8,
+        "minWidth": 8,
+      }
+    }
+  />
+</View>
+`;
+
+exports[`Divider component tests Divider with icon 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "minHeight": 0,
+      "minWidth": 0,
+      "paddingHorizontal": 0,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "borderColor": "#e0e0e0",
+        "borderStyle": "solid",
+        "borderTopWidth": 1,
+        "flex": 1,
+        "flexBasis": 8,
+        "minWidth": 8,
+      }
+    }
+  />
+  <View
+    style={
+      Object {
+        "flex": 0,
+        "paddingHorizontal": 12,
+      }
+    }
+  >
+    <Text
+      accessible={true}
+      style={
+        Object {
+          "color": "#424242",
+          "fontFamily": "Arial",
+          "fontSize": 32,
+        }
+      }
+    >
+      ♣
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "borderColor": "#e0e0e0",
+        "borderStyle": "solid",
+        "borderTopWidth": 1,
+        "flex": 1,
+        "flexBasis": 8,
+        "minWidth": 8,
+      }
+    }
+  />
+</View>
+`;
+
+exports[`Divider component tests Divider with text 1`] = `
 <View
   style={
     Object {
@@ -49,7 +198,7 @@ exports[`Divider component tests Divider default 1`] = `
         }
       }
     >
-      Your component
+      Lorem Ipsum
     </Text>
   </View>
   <View
@@ -61,6 +210,153 @@ exports[`Divider component tests Divider default 1`] = `
         "flex": 1,
         "flexBasis": 8,
         "minWidth": 8,
+      }
+    }
+  />
+</View>
+`;
+
+exports[`Divider component tests Horizontal Divider with Inset 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "minHeight": 0,
+      "minWidth": 0,
+      "paddingHorizontal": 16,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "borderColor": "#e0e0e0",
+        "borderStyle": "solid",
+        "borderTopWidth": 1,
+        "flex": 1,
+        "flexBasis": 8,
+        "minWidth": 8,
+      }
+    }
+  />
+</View>
+`;
+
+exports[`Divider component tests Strong Divider 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "minHeight": 0,
+      "minWidth": 0,
+      "paddingHorizontal": 0,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "borderColor": "#d1d1d1",
+        "borderStyle": "solid",
+        "borderTopWidth": 1,
+        "flex": 1,
+        "flexBasis": 8,
+        "minWidth": 8,
+      }
+    }
+  />
+</View>
+`;
+
+exports[`Divider component tests Subtle Divider 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "minHeight": 0,
+      "minWidth": 0,
+      "paddingHorizontal": 0,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "borderColor": "#f0f0f0",
+        "borderStyle": "solid",
+        "borderTopWidth": 1,
+        "flex": 1,
+        "flexBasis": 8,
+        "minWidth": 8,
+      }
+    }
+  />
+</View>
+`;
+
+exports[`Divider component tests Vertical Divider 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "height": "100%",
+      "justifyContent": "center",
+      "minHeight": 24,
+      "minWidth": 0,
+      "paddingVertical": 0,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "borderColor": "#e0e0e0",
+        "borderLeftWidth": 1,
+        "borderStyle": "solid",
+        "flex": 1,
+        "flexBasis": 8,
+        "minHeight": 8,
+      }
+    }
+  />
+</View>
+`;
+
+exports[`Divider component tests Vertical Divider with Inset 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "height": "100%",
+      "justifyContent": "center",
+      "minHeight": 24,
+      "minWidth": 0,
+      "paddingVertical": 16,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "borderColor": "#e0e0e0",
+        "borderLeftWidth": 1,
+        "borderStyle": "solid",
+        "flex": 1,
+        "flexBasis": 8,
+        "minHeight": 8,
       }
     }
   />


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

As of now, the only snapshot test running is the boilerplate test outputted by the component generator.

This PR adds more snapshot testing for different variants of the Divider. 

### Verification

Test passes during build. 

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
