### PR TITLE
macOS: Update MenuItem text color

### DIFF
--- a/change/@fluentui-react-native-menu-514a742b-3cc9-45fe-a815-151f2eaa6941.json
+++ b/change/@fluentui-react-native-menu-514a742b-3cc9-45fe-a815-151f2eaa6941.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update MenuItem text color",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/MenuItem/MenuItemTokens.macos.ts
+++ b/packages/components/Menu/src/MenuItem/MenuItemTokens.macos.ts
@@ -7,7 +7,7 @@ export const defaultMenuItemTokens: TokenSettings<MenuItemTokens, Theme> = (t: T
   backgroundColor: t.colors.transparentBackground,
   borderRadius: 5, // hardcoded for now to match NSMenu
   checkmarkSize: 16,
-  color: t.colors.menuItemText, // hardcoded for now to match NSMenu
+  color: t.colors.neutralForeground1,
   fontFamily: t.typography.families.primary,
   fontSize: 13, // aligning with NSMenu font size
   fontWeight: globalTokens.font.weight.regular as FontWeightValue,

--- a/packages/components/Menu/src/MenuItem/MenuItemTokens.macos.ts
+++ b/packages/components/Menu/src/MenuItem/MenuItemTokens.macos.ts
@@ -14,7 +14,7 @@ export const defaultMenuItemTokens: TokenSettings<MenuItemTokens, Theme> = (t: T
   gap: globalTokens.size40,
   paddingHorizontal: 5, // hardcoded for now to match NSMenu
   paddingVertical: 3, // hardcoded for now to match NSMenu
-  submenuIndicatorColor: t.colors.neutralForeground2,
+  submenuIndicatorColor: t.colors.neutralForeground1,
   submenuIndicatorPadding: globalTokens.sizeNone,
   submenuIndicatorSize: 16,
   focused: {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Updating the menu text color to better align with NSMenu text color. I used the Digital color meter app to find the color value of NSMenu text and seems like the color token win32 uses is a close match. 
 
### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/67026167/220818419-2520eb7d-320d-4de1-b9eb-7b04c50518e8.png) | <img width="235" alt="Screenshot 2023-02-23 at 10 05 30 AM" src="https://user-images.githubusercontent.com/67026167/220945901-9ea8e027-2bc2-4a7a-a7fb-89eb2ce0e945.png"> |

NSMenu 
<img width="226" alt="image" src="https://user-images.githubusercontent.com/67026167/220819033-fdcbd062-d1ec-47dd-bff4-4c9d6cdd96c8.png">

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
