### PR TITLE
macOS: Make menu container VO accessible

### DIFF
--- a/change/@fluentui-react-native-menu-e866b6a5-ab65-445b-8c82-fc4e622bac55.json
+++ b/change/@fluentui-react-native-menu-e866b6a5-ab65-445b-8c82-fc4e622bac55.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Make menu container VO accessible",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "amchiu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/MenuList/MenuList.tsx
+++ b/packages/components/Menu/src/MenuList/MenuList.tsx
@@ -60,6 +60,7 @@ export const MenuList = compose<MenuListType>({
         Platform.OS === 'macos' ? (
           <Slots.root>
             <Slots.scrollView
+              accessibilityRole="menu"
               showsVerticalScrollIndicator={menuContext.hasMaxHeight}
               showsHorizontalScrollIndicator={menuContext.hasMaxWidth}
             >


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This change makes a few improvements around VO:
1. VO recognizes the menu container as "menu" 
2. VO cursor lands on the menu container instead of the first menu item
3. VO + Right arrow opens a submenu

### Verification

(how the change was tested, including both manual and automated tests)
Before: 


https://user-images.githubusercontent.com/67026167/221032225-fcb1593f-4d3b-49b2-a3f2-32bde8a53350.mov


After:

https://user-images.githubusercontent.com/67026167/221031946-38719881-679c-428f-a721-bea2b7a77cbc.mov


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [X] Keyboard Accessibility
- [X] Voiceover
- [ ] Internationalization and Right-to-left Layouts
