### PR TITLE
[Menu] Override onHoverOut to call onBlur

### DIFF
--- a/change/@fluentui-react-native-menu-4ef47219-4466-4f8a-ab31-6dac32894d13.json
+++ b/change/@fluentui-react-native-menu-4ef47219-4466-4f8a-ab31-6dac32894d13.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Override onHoverOut to call onBlur",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/MenuItem/useMenuItem.ts
+++ b/packages/components/Menu/src/MenuItem/useMenuItem.ts
@@ -35,7 +35,7 @@ export const useMenuItem = (props: MenuItemProps): MenuItemInfo => {
         ((isRtl && e.nativeEvent.key === 'ArrowLeft') || (!isRtl && e.nativeEvent.key === 'ArrowRight'));
 
       if (!disabled && (!isArrowKey || isArrowOpen)) {
-        onBlur();
+        onBlur(e);
         onClick?.(e);
       }
 

--- a/packages/components/Menu/src/MenuItem/useMenuItem.ts
+++ b/packages/components/Menu/src/MenuItem/useMenuItem.ts
@@ -52,6 +52,20 @@ export const useMenuItem = (props: MenuItemProps): MenuItemInfo => {
   );
 
   const pressable = usePressableState({ ...rest, onPress: onInvoke });
+  const { onBlur, onHoverOut, ...restPressableProps } = pressable.props;
+  const onHoverOutModified = React.useCallback(
+    (e) => {
+      onBlur(e);
+      onHoverOut && onHoverOut(e);
+    },
+    [onBlur, onHoverOut],
+  );
+
+  const pressablePropsModified = {
+    onBlur,
+    onHoverOut: onHoverOutModified,
+    ...restPressableProps,
+  };
   const itemRef = useViewCommandFocus(componentRef);
   const keys = disabled ? [] : isSubmenu ? submenuTriggerKeys : triggerKeys;
 
@@ -62,7 +76,7 @@ export const useMenuItem = (props: MenuItemProps): MenuItemInfo => {
 
   return {
     props: {
-      ...pressable.props,
+      ...pressablePropsModified,
       accessible: true,
       accessibilityRole: 'menuitem',
       onAccessibilityTap: props.onAccessibilityTap || onInvoke,
@@ -100,8 +114,6 @@ export const useHoverFocusEffect = (hovered: boolean, componentRef: React.Mutabl
   React.useLayoutEffect(() => {
     if (hovered) {
       componentRef?.current?.focus();
-    } else {
-      componentRef?.current?.blur();
     }
   }, [hovered, componentRef]);
 };

--- a/packages/components/Menu/src/MenuItem/useMenuItem.ts
+++ b/packages/components/Menu/src/MenuItem/useMenuItem.ts
@@ -22,7 +22,8 @@ export const useMenuItem = (props: MenuItemProps): MenuItemInfo => {
   const shouldPersist = persistOnClick ?? persistOnItemClick;
 
   const hasSubmenu = isSubmenu && isTrigger;
-
+  const pressable = usePressableState({ ...rest });
+  const { onBlur, onHoverOut, onPress, ...restPressableProps } = pressable.props;
   const onInvoke = React.useCallback(
     (e: InteractionEvent) => {
       const isRtl = I18nManager.isRTL;
@@ -34,7 +35,7 @@ export const useMenuItem = (props: MenuItemProps): MenuItemInfo => {
         ((isRtl && e.nativeEvent.key === 'ArrowLeft') || (!isRtl && e.nativeEvent.key === 'ArrowRight'));
 
       if (!disabled && (!isArrowKey || isArrowOpen)) {
-        componentRef?.current?.blur();
+        onBlur();
         onClick?.(e);
       }
 
@@ -48,11 +49,9 @@ export const useMenuItem = (props: MenuItemProps): MenuItemInfo => {
         onArrowClose?.(e);
       }
     },
-    [componentRef, disabled, hasSubmenu, onArrowClose, onClick, setOpen, shouldPersist],
+    [disabled, hasSubmenu, onArrowClose, onBlur, onClick, setOpen, shouldPersist],
   );
 
-  const pressable = usePressableState({ ...rest, onPress: onInvoke });
-  const { onBlur, onHoverOut, ...restPressableProps } = pressable.props;
   const onHoverOutModified = React.useCallback(
     (e) => {
       // Focus is removed on macOS while win32 keeps it
@@ -67,6 +66,7 @@ export const useMenuItem = (props: MenuItemProps): MenuItemInfo => {
   const pressablePropsModified = {
     onBlur,
     onHoverOut: onHoverOutModified,
+    onPress: onInvoke,
     ...restPressableProps,
   };
   const itemRef = useViewCommandFocus(componentRef);

--- a/packages/components/Menu/src/MenuItem/useMenuItem.ts
+++ b/packages/components/Menu/src/MenuItem/useMenuItem.ts
@@ -55,7 +55,10 @@ export const useMenuItem = (props: MenuItemProps): MenuItemInfo => {
   const { onBlur, onHoverOut, ...restPressableProps } = pressable.props;
   const onHoverOutModified = React.useCallback(
     (e) => {
-      onBlur(e);
+      // Focus is removed on macOS while win32 keeps it
+      if (Platform.OS === 'macos') {
+        onBlur(e);
+      }
       onHoverOut && onHoverOut(e);
     },
     [onBlur, onHoverOut],


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This change addresses a bug on Mac where keyboard focus is lost when mouse hover moves away from menu, which results in broken keyboard navigation. Calling .blur() on menu item fully removes keyboard focus which causes FocusZone to no-op, so let's override onBlur from Pressable that disables focus instead.

Note: This behavior aligns with Contextual Menu, though ideally we'd want focus to be reset to the first item.
### Verification

(how the change was tested, including both manual and automated tests)

Before:

https://user-images.githubusercontent.com/67026167/222189733-b840f191-117d-4458-b50f-a81ccf336e9b.mov

After:


https://user-images.githubusercontent.com/67026167/222189970-ed44a92a-b725-4183-953c-7ac849b8da50.mov



### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [X] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
