### PR TITLE
Fix various Divider bugs uncovered before upcoming Test Pass

### DIFF
--- a/change/@fluentui-react-native-divider-7666fa9d-91c5-4550-8111-c3b4f753a668.json
+++ b/change/@fluentui-react-native-divider-7666fa9d-91c5-4550-8111-c3b4f753a668.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix various divider bugs",
+  "packageName": "@fluentui-react-native/divider",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Divider/src/Divider.tsx
+++ b/packages/experimental/Divider/src/Divider.tsx
@@ -63,14 +63,20 @@ export const Divider = compressible<DividerProps, DividerTokens>((props: Divider
     const hasContent = textContent !== undefined || props.icon !== undefined;
 
     // This style must be set here because we need to know if text content is passed in the final render to set the height correctly
-    const mergedProps = {
+    const mergedRootProps = {
       ...rootProps,
-      style: mergeStyles(rootProps.style, props.vertical && textContent ? { minHeight: 84 } : {}),
+      style: mergeStyles(rootProps.style, props.vertical && hasContent ? { minHeight: 84 } : {}),
+    };
+
+    // If there's no content, then the before line should always take up the full width / height of the root slot
+    const mergedBeforeProps = {
+      ...beforeLineProps,
+      style: mergeStyles(beforeLineProps.style, !hasContent ? { flex: 1 } : {}),
     };
 
     return (
-      <RootSlot {...mergedProps}>
-        <BeforeLineSlot />
+      <RootSlot {...mergedRootProps}>
+        <BeforeLineSlot {...mergedBeforeProps} />
         {hasContent && (
           <>
             <WrapperSlot>

--- a/packages/experimental/Divider/src/DividerTokens.ts
+++ b/packages/experimental/Divider/src/DividerTokens.ts
@@ -8,10 +8,8 @@ export const useDividerTokens = buildUseTokens<DividerTokens>(() => ({
   contentPadding: globalTokens.size120,
   flexAfter: 1,
   flexBefore: 1,
-  insetSize: 0,
   minLineSize: globalTokens.size80,
   minWidth: 0,
   minHeight: 0,
-  textVariant: 'secondaryStandard',
   thickness: 1,
 }));

--- a/packages/experimental/Divider/src/index.ts
+++ b/packages/experimental/Divider/src/index.ts
@@ -1,2 +1,10 @@
 export { Divider } from './Divider';
-export { DividerTokens, DividerProps, DividerSlotProps, DividerType } from './Divider.types';
+export {
+  DividerTokens,
+  DividerProps,
+  DividerSlotProps,
+  DividerType,
+  DividerAppearance,
+  DividerAlignment,
+  DividerInsetSize,
+} from './Divider.types';


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This PR has small fixes for bugs found when preparing the bug bash branch:
- Fix start-aligned dividers with no content not rendering a full line.
- Fix vertical dividers with icons not having the correct default minimum height.
- Removed old default token values.
- All Divider types should now be exported from Divider.types and index.js.

### Verification

Tested on bug-bash branch. 

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
