### PR TITLE
Fix various issues with checkbox focus on windows

### DIFF
--- a/apps/fluent-tester/docs/windows.md
+++ b/apps/fluent-tester/docs/windows.md
@@ -16,7 +16,8 @@
 ## Running the App
 
 1. Run `yarn` from the root of the repo
-2. From this directory, simply `yarn windows`
+2. From this directory, run `yarn install-windows-test-app`
+3. From this directory, simply `yarn windows`
 
 ## Debugging
 

--- a/change/@fluentui-react-native-checkbox-313c8ce1-ca63-41a6-a7d5-7d532e9e205d.json
+++ b/change/@fluentui-react-native-checkbox-313c8ce1-ca63-41a6-a7d5-7d532e9e205d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix checkbox focus issues on windows",
+  "packageName": "@fluentui-react-native/checkbox",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-interactive-hooks-7c9f5abc-5e1e-452d-b1b1-05a54d53302d.json
+++ b/change/@fluentui-react-native-interactive-hooks-7c9f5abc-5e1e-452d-b1b1-05a54d53302d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "useViewCommandFocus does not need to replace focus/blur methods except on win32",
+  "packageName": "@fluentui-react-native/interactive-hooks",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-792b98c9-180f-4eb4-abd1-301f4f62c987.json
+++ b/change/@fluentui-react-native-tester-792b98c9-180f-4eb4-abd1-301f4f62c987.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix checkbox focus issues on windows",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Checkbox/src/deprecated/Checkbox.tsx
+++ b/packages/components/Checkbox/src/deprecated/Checkbox.tsx
@@ -100,6 +100,7 @@ export const Checkbox = compose<ICheckboxType>({
         accessibilityActions: [{ name: 'Toggle', label: checkboxSelectActionLabel }],
         focusable: focusable ?? !state.disabled,
         onAccessibilityAction: onAccessibilityAction,
+        enableFocusRing: false,
         ...onKeyProps,
       },
       // Temporary checkmark until SVG functionality

--- a/packages/utils/interactive-hooks/src/useViewCommandFocus.ts
+++ b/packages/utils/interactive-hooks/src/useViewCommandFocus.ts
@@ -1,14 +1,12 @@
 import * as React from 'react';
 import type { View } from 'react-native';
-import { findNodeHandle, UIManager } from 'react-native';
 
 import { setAndForwardRef } from './setAndForwardRef';
 
 export type IFocusable = View;
 /**
- * A hook to add an imperative focus method to functional components which simply dispatch a focus command to
- * something View-derived on the native side.  In practice, this effectively applies to all components in our Win32
- * react native implementation.
+ * We need the win32 version of this hook to work around an lack of a UIManager.focus implementation.
+ * On other platforms this hook is unnecessary.
  * @param forwardRef - The componentRef from your component's props where you're exposing a imperative focus method.
  * @returns The inner View-type you're rendering that you want to dispatch to & focus on.
  */
@@ -25,24 +23,6 @@ export function useViewCommandFocus(
     getForwardedRef: () => forwardedRef,
     setLocalRef: (localRef: any) => {
       focusRef.current = localRef;
-
-      /**
-       * Add focus() and blur() as callable functions to the forwarded reference.
-       */
-      if (localRef) {
-        localRef.focus = () => {
-          const commands = UIManager.getViewManagerConfig('RCTView')?.Commands;
-          if (commands != null && 'focus' in commands) {
-            UIManager.dispatchViewManagerCommand(findNodeHandle(localRef), commands.focus, null);
-          }
-        };
-        localRef.blur = () => {
-          const commands = UIManager.getViewManagerConfig('RCTView')?.Commands;
-          if (commands != null && 'blur' in commands) {
-            UIManager.dispatchViewManagerCommand(findNodeHandle(localRef), commands.blur, null);
-          }
-        };
-      }
     },
   });
   return _setNativeRef;


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

enableFocusRing defaults to true on non-win32 platforms, so it needs to be set to false to prevent multiple focus visuals showing in CheckBox.

Added an additional step in how to run fluent-tester for windows.

Modified useViewCommandFocus to prevent overriding the implementation of ref.focus.  -- The current implementation does not work on windows.


### Verification

in progress....

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
