### PR TITLE
Make 'Escape' stop event propagation in `MenuPopover` key handlers.

### DIFF
--- a/change/@fluentui-react-native-menu-88664d88-ad9e-4f9b-bbab-a84067b9cbfe.json
+++ b/change/@fluentui-react-native-menu-88664d88-ad9e-4f9b-bbab-a84067b9cbfe.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add 'Escape' to list of keys stopping event propagation in MenuPopover key handlers.",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
+++ b/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
@@ -67,6 +67,7 @@ export const useMenuPopover = (props: MenuPopoverProps): MenuPopoverState => {
         case 'Tab':
         case 'Home':
         case 'End':
+        case 'Escape':
           e.stopPropagation();
       }
     },
@@ -85,6 +86,7 @@ export const useMenuPopover = (props: MenuPopoverProps): MenuPopoverState => {
         case 'Tab':
         case 'Home':
         case 'End':
+        case 'Escape':
           e.stopPropagation();
       }
     },

--- a/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
+++ b/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
@@ -7,6 +7,7 @@ import type { MenuPopoverProps, MenuPopoverState } from './MenuPopover.types';
 import { useMenuContext } from '../context/menuContext';
 
 const controlledDismissBehaviors = ['preventDismissOnKeyDown', 'preventDismissOnClickOutside'] as DismissBehaviors[];
+const stopPropagationKeys = ['ArrowUp', 'ArrowDown', 'Tab', 'Home', 'End', 'Escape'] as const;
 
 export const useMenuPopover = (props: MenuPopoverProps): MenuPopoverState => {
   const context = useMenuContext();
@@ -61,14 +62,8 @@ export const useMenuPopover = (props: MenuPopoverProps): MenuPopoverState => {
 
       // Mark key events that move selection as handled.
       // These key events are handled on the native side.
-      switch (e.nativeEvent.key) {
-        case 'ArrowUp':
-        case 'ArrowDown':
-        case 'Tab':
-        case 'Home':
-        case 'End':
-        case 'Escape':
-          e.stopPropagation();
+      if (stopPropagationKeys.includes(e.nativeEvent.key)) {
+        e.stopPropagation();
       }
     },
     [onKeyDownProp],
@@ -80,14 +75,8 @@ export const useMenuPopover = (props: MenuPopoverProps): MenuPopoverState => {
 
       // Mark key events that move selection as handled.
       // These key events are handled on the native side.
-      switch (e.nativeEvent.key) {
-        case 'ArrowUp':
-        case 'ArrowDown':
-        case 'Tab':
-        case 'Home':
-        case 'End':
-        case 'Escape':
-          e.stopPropagation();
+      if (stopPropagationKeys.includes(e.nativeEvent.key)) {
+        e.stopPropagation();
       }
     },
     [onKeyUpProp],


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

For 'Escape' keypresses in an opened MenuPopover, the keypress event should not propagate to parent components on bubbling up. Currently, parents to Menus will receive keyboard events if a user presses 'Escape' in a MenuPopover. 

This PR fixes this by adding 'Escape' to a list of keys that stop keyboard event propagation in MenuPopover to parent components.

### Verification

Video of corrected behavior. I first cycle through escape on the menutrigger, which calls the parent view's keydown handler, changing the border color. I then open the popover and press escape, while not cycling through the border colors because the event is not propagated to the parent view.

https://user-images.githubusercontent.com/15683103/222019176-dd05332a-4013-4fa7-8eb4-e0900a101076.mp4

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
