### PR TITLE
[Menu] Delay triggerHoverOut timeouts

### DIFF
--- a/change/@fluentui-react-native-menu-0882e8de-774e-4b94-bea8-1718689ca9ad.json
+++ b/change/@fluentui-react-native-menu-0882e8de-774e-4b94-bea8-1718689ca9ad.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Delay triggerHoverOut timeouts",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "amchiu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/MenuList/useMenuList.ts
+++ b/packages/components/Menu/src/MenuList/useMenuList.ts
@@ -112,6 +112,12 @@ export const useMenuList = (_props: MenuListProps): MenuListState => {
     [isSubmenu, setOpen, triggerRef],
   );
 
+  React.useEffect(() => {
+    return function cleanup() {
+      clearTimeout(context.triggerHoverOutTimer);
+    };
+  });
+
   return {
     props: {
       ...context,

--- a/packages/components/Menu/src/MenuTrigger/useMenuTrigger.ts
+++ b/packages/components/Menu/src/MenuTrigger/useMenuTrigger.ts
@@ -114,12 +114,6 @@ export const useMenuTrigger = (childProps: MenuTriggerChildProps): MenuTriggerSt
 
   const ref = useMergedRefs(triggerRef, childComponentRef);
 
-  React.useEffect(() => {
-    return function cleanup() {
-      clearTimeout(triggerHoverOutTimer);
-    };
-  });
-
   return {
     props: {
       onClick,


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS
- [X] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Back in #1838, clearing the triggerHoverOut timeouts at menuTrigger unmount causes a weird hover bug where submenu is shown when mouse hover is away from its parent item. Not entirely sure why that is, my guess is that there may be a timing issue between when the component unmounts and the timer is set. Moving the cleanup function to MenuList gets rid of the bug and no React errors related to state changes.
### Verification

Before:

https://user-images.githubusercontent.com/67026167/222540532-b9f90b79-c6e3-417c-be54-7868552d7d1b.mov

After:

https://user-images.githubusercontent.com/67026167/222540599-7b823e2f-483d-44c9-ace9-5ea307237d2c.mov



### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
