### PR TITLE
Fix min-height token value being overriden in second render stage + update default values to align with spec.

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Divider/DividerTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Divider/DividerTest.tsx
@@ -63,9 +63,9 @@ export const VerticalDividers: React.FunctionComponent = () => (
     </View>
     <Divider />
     <View style={dividerTestStyles.verticalDividerContainer}>
-      <CustomText>The divider to the right of me should have a min height of 24px</CustomText>
+      <CustomText>The divider to the right of me should have a min height of 20px</CustomText>
       <Divider vertical />
-      <CustomText>The divider to the left of me should have a min height of 24px</CustomText>
+      <CustomText>The divider to the left of me should have a min height of 20px</CustomText>
     </View>
   </Stack>
 );

--- a/change/@fluentui-react-native-divider-7e8f222e-b8ad-402d-9f41-8c4e4968cc6a.json
+++ b/change/@fluentui-react-native-divider-7e8f222e-b8ad-402d-9f41-8c4e4968cc6a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix incorrect min-height default token value",
+  "packageName": "@fluentui-react-native/divider",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-54932336-cc7a-4b1d-bf3d-bfbd0bec7594.json
+++ b/change/@fluentui-react-native-tester-54932336-cc7a-4b1d-bf3d-bfbd0bec7594.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update divider test page",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Divider/SPEC.md
+++ b/packages/experimental/Divider/SPEC.md
@@ -220,7 +220,7 @@ type DividerLayoutTokens = {
   minWidth?: string | number;
   maxWidth?: string | number;
   /**
-   * For min-height, there are different default values:
+   * For minHeight, there are different default values:
    * @default 0 for horizontal dividers
    * @default 20 for vertical dividers without children
    * @default 84 for vertical divicers with children

--- a/packages/experimental/Divider/SPEC.md
+++ b/packages/experimental/Divider/SPEC.md
@@ -223,7 +223,7 @@ type DividerLayoutTokens = {
    * For minHeight, there are different default values:
    * @default 0 for horizontal dividers
    * @default 20 for vertical dividers without children
-   * @default 84 for vertical divicers with children
+   * @default 84 for vertical dividers with children
    */
   minHeight?: string | number;
   maxHeight?: string | number;

--- a/packages/experimental/Divider/SPEC.md
+++ b/packages/experimental/Divider/SPEC.md
@@ -219,6 +219,12 @@ type DividerLayoutTokens = {
    */
   minWidth?: string | number;
   maxWidth?: string | number;
+  /**
+   * For min-height, there are different default values:
+   * @default 0 for horizontal dividers
+   * @default 20 for vertical dividers without children
+   * @default 84 for vertical divicers with children
+   */
   minHeight?: string | number;
   maxHeight?: string | number;
   /**

--- a/packages/experimental/Divider/src/Divider.styling.ts
+++ b/packages/experimental/Divider/src/Divider.styling.ts
@@ -1,11 +1,13 @@
 import { useMemo } from 'react';
-import type { ViewProps, ColorValue } from 'react-native';
+import type { ViewProps, ColorValue, StyleProp, ViewStyle } from 'react-native';
 import { Platform } from 'react-native';
 
+import { memoize, mergeStyles } from '@fluentui-react-native/framework';
 import type { Theme } from '@fluentui-react-native/framework';
 import type { IconPropsV1 as IconProps } from '@fluentui-react-native/icon';
 import type { TextProps } from '@fluentui-react-native/text';
 import { fontStyles } from '@fluentui-react-native/tokens';
+import { globalTokens } from '@fluentui-react-native/theme-tokens';
 
 import type { DividerTokens, DividerProps, DividerAppearance } from './Divider.types';
 
@@ -167,3 +169,28 @@ export const colorsFromAppearance = (
     }
   }
 };
+
+/**
+ * At the second render stage, if the minHeight token isn't set, we calculate and memoize a default value based on whether the
+ * Divider is vertical and has content.
+ */
+export const getRootStyle = memoize(getRootStyleWorker);
+function getRootStyleWorker(rootStyle: StyleProp<ViewStyle>, isVertical: boolean, hasContent: boolean): StyleProp<ViewStyle> {
+  let minHeight = 0;
+  if (isVertical) {
+    minHeight = hasContent ? 84 : globalTokens.size200;
+  }
+  return mergeStyles(rootStyle, { minHeight });
+}
+
+/**
+ * At the second render stage, if there is not content passed, we override the existing beforeLine style to make the line take up
+ * the entirity of root.
+ */
+export const getBeforeLineStyle = memoize(getBeforeLineStyleWorker);
+function getBeforeLineStyleWorker(beforeLineStyle: StyleProp<ViewStyle>, hasContent: boolean): StyleProp<ViewStyle> {
+  if (!hasContent) {
+    return mergeStyles(beforeLineStyle, { flex: 1 });
+  }
+  return beforeLineStyle;
+}

--- a/packages/experimental/Divider/src/Divider.styling.ts
+++ b/packages/experimental/Divider/src/Divider.styling.ts
@@ -6,8 +6,8 @@ import { memoize, mergeStyles } from '@fluentui-react-native/framework';
 import type { Theme } from '@fluentui-react-native/framework';
 import type { IconPropsV1 as IconProps } from '@fluentui-react-native/icon';
 import type { TextProps } from '@fluentui-react-native/text';
-import { fontStyles } from '@fluentui-react-native/tokens';
 import { globalTokens } from '@fluentui-react-native/theme-tokens';
+import { fontStyles } from '@fluentui-react-native/tokens';
 
 import type { DividerTokens, DividerProps, DividerAppearance } from './Divider.types';
 

--- a/packages/experimental/Divider/src/Divider.tsx
+++ b/packages/experimental/Divider/src/Divider.tsx
@@ -35,7 +35,7 @@ export const Divider = compressible<DividerProps, DividerTokens>((props: Divider
   [tokens, cache] = patchTokens(tokens, cache, {
     flexAfter: props.alignContent === 'end' ? 0 : 1,
     flexBefore: props.alignContent === 'start' ? 0 : 1,
-    minHeight: props.vertical ? globalTokens.size240 : 0,
+    minHeight: props.vertical ? globalTokens.size200 : 0,
     ...colorsFromAppearance(props.appearance, tokens, theme),
   });
 

--- a/packages/experimental/Divider/src/Divider.tsx
+++ b/packages/experimental/Divider/src/Divider.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { View } from 'react-native';
 import type { ViewProps } from 'react-native';
 
-import { withSlots, compressible, useSlot, useFluentTheme, patchTokens, mergeStyles } from '@fluentui-react-native/framework';
+import { withSlots, compressible, useSlot, useFluentTheme, patchTokens } from '@fluentui-react-native/framework';
 import type { UseTokens } from '@fluentui-react-native/framework';
 import { IconV1 as Icon } from '@fluentui-react-native/icon';
 import type { IconPropsV1 as IconProps } from '@fluentui-react-native/icon';

--- a/packages/experimental/Divider/src/Divider.tsx
+++ b/packages/experimental/Divider/src/Divider.tsx
@@ -10,9 +10,8 @@ import { IconV1 as Icon } from '@fluentui-react-native/icon';
 import type { IconPropsV1 as IconProps } from '@fluentui-react-native/icon';
 import { TextV1 as Text } from '@fluentui-react-native/text';
 import type { TextProps } from '@fluentui-react-native/text';
-import { globalTokens } from '@fluentui-react-native/theme-tokens';
 
-import { colorsFromAppearance, useDividerSlotProps } from './Divider.styling';
+import { colorsFromAppearance, getBeforeLineStyle, getRootStyle, useDividerSlotProps } from './Divider.styling';
 import { dividerName } from './Divider.types';
 import type { DividerProps, DividerTokens } from './Divider.types';
 import { useDividerTokens } from './DividerTokens';
@@ -65,19 +64,11 @@ export const Divider = compressible<DividerProps, DividerTokens>((props: Divider
     let finalRootProps = rootProps;
 
     if (!tokens.minHeight) {
-      let minHeight = 0;
-      if (props.vertical) {
-        minHeight = hasContent ? 84 : globalTokens.size200;
-      }
-      finalRootProps = { ...rootProps, style: mergeStyles(rootProps.style, { minHeight }) };
+      finalRootProps = { ...rootProps, style: getRootStyle(rootProps.style, final.vertical, hasContent) };
     }
 
-    // If there's no content, then the before line should always take up the full width / height of the root slot
-    let finalBeforeLineProps = beforeLineProps;
-
-    if (!hasContent) {
-      finalBeforeLineProps = { ...beforeLineProps, style: mergeStyles(beforeLineProps.style, { flex: 1 }) };
-    }
+    // If there's no content, then we change the beforeLine style to have a flex of 1 because it will always
+    const finalBeforeLineProps = { ...beforeLineProps, style: getBeforeLineStyle(beforeLineProps.style, hasContent) };
 
     return (
       <RootSlot {...finalRootProps}>

--- a/packages/experimental/Divider/src/Divider.tsx
+++ b/packages/experimental/Divider/src/Divider.tsx
@@ -35,7 +35,6 @@ export const Divider = compressible<DividerProps, DividerTokens>((props: Divider
   [tokens, cache] = patchTokens(tokens, cache, {
     flexAfter: props.alignContent === 'end' ? 0 : 1,
     flexBefore: props.alignContent === 'start' ? 0 : 1,
-    minHeight: props.vertical ? globalTokens.size200 : 0,
     ...colorsFromAppearance(props.appearance, tokens, theme),
   });
 
@@ -63,9 +62,13 @@ export const Divider = compressible<DividerProps, DividerTokens>((props: Divider
     const hasContent = textContent !== undefined || props.icon !== undefined;
 
     // This style must be set here because we need to know if text content is passed in the final render to set the height correctly
+    let minHeight = 0;
+    if (props.vertical) {
+      minHeight = hasContent ? 84 : globalTokens.size200;
+    }
     const mergedRootProps = {
       ...rootProps,
-      style: mergeStyles(rootProps.style, props.vertical && hasContent ? { minHeight: 84 } : {}),
+      style: mergeStyles(rootProps.style, { minHeight }),
     };
 
     // If there's no content, then the before line should always take up the full width / height of the root slot

--- a/packages/experimental/Divider/src/Divider.tsx
+++ b/packages/experimental/Divider/src/Divider.tsx
@@ -62,24 +62,26 @@ export const Divider = compressible<DividerProps, DividerTokens>((props: Divider
     const hasContent = textContent !== undefined || props.icon !== undefined;
 
     // This style must be set here because we need to know if text content is passed in the final render to set the height correctly
-    let minHeight = 0;
-    if (props.vertical) {
-      minHeight = hasContent ? 84 : globalTokens.size200;
+    let finalRootProps = rootProps;
+
+    if (!tokens.minHeight) {
+      let minHeight = 0;
+      if (props.vertical) {
+        minHeight = hasContent ? 84 : globalTokens.size200;
+      }
+      finalRootProps = { ...rootProps, style: mergeStyles(rootProps.style, { minHeight }) };
     }
-    const mergedRootProps = {
-      ...rootProps,
-      style: mergeStyles(rootProps.style, { minHeight }),
-    };
 
     // If there's no content, then the before line should always take up the full width / height of the root slot
-    const mergedBeforeProps = {
-      ...beforeLineProps,
-      style: mergeStyles(beforeLineProps.style, !hasContent ? { flex: 1 } : {}),
-    };
+    let finalBeforeLineProps = beforeLineProps;
+
+    if (!hasContent) {
+      finalBeforeLineProps = { ...beforeLineProps, style: mergeStyles(beforeLineProps.style, { flex: 1 }) };
+    }
 
     return (
-      <RootSlot {...mergedRootProps}>
-        <BeforeLineSlot {...mergedBeforeProps} />
+      <RootSlot {...finalRootProps}>
+        <BeforeLineSlot {...finalBeforeLineProps} />
         {hasContent && (
           <>
             <WrapperSlot>

--- a/packages/experimental/Divider/src/DividerTokens.ts
+++ b/packages/experimental/Divider/src/DividerTokens.ts
@@ -10,6 +10,5 @@ export const useDividerTokens = buildUseTokens<DividerTokens>(() => ({
   flexBefore: 1,
   minLineSize: globalTokens.size80,
   minWidth: 0,
-  minHeight: 0,
   thickness: 1,
 }));

--- a/packages/experimental/Divider/src/__tests__/Divider.test.tsx
+++ b/packages/experimental/Divider/src/__tests__/Divider.test.tsx
@@ -4,7 +4,7 @@ import { checkReRender } from '@fluentui-react-native/test-tools';
 import * as renderer from 'react-test-renderer';
 
 import { Divider } from '../Divider';
-import { DividerProps } from '../Divider.types';
+import type { DividerProps } from '../Divider.types';
 
 describe('Divider component tests', () => {
   it('Divider default', () => {

--- a/packages/experimental/Divider/src/__tests__/Divider.test.tsx
+++ b/packages/experimental/Divider/src/__tests__/Divider.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { checkReRender } from '@fluentui-react-native/test-tools';
 import * as renderer from 'react-test-renderer';
 
 import { Divider } from '../Divider';
@@ -93,5 +94,9 @@ describe('Divider component tests', () => {
     };
     const tree = renderer.create(<CustomDivider {...props}>Hello</CustomDivider>).toJSON();
     expect(tree).toMatchSnapshot();
+  });
+
+  it('Divider re-renders correctly', () => {
+    checkReRender(() => <Divider />, 2);
   });
 });

--- a/packages/experimental/Divider/src/__tests__/Divider.test.tsx
+++ b/packages/experimental/Divider/src/__tests__/Divider.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 
-import { checkReRender } from '@fluentui-react-native/test-tools';
 import * as renderer from 'react-test-renderer';
 
 import { Divider } from '../Divider';
@@ -55,9 +54,5 @@ describe('Divider component tests', () => {
   it('Divider with icon', () => {
     const tree = renderer.create(<Divider icon={{ fontSource: { fontFamily: 'Arial', codepoint: 0x2663, fontSize: 32 } }} />).toJSON();
     expect(tree).toMatchSnapshot();
-  });
-
-  it('Divider re-renders correctly', () => {
-    checkReRender(() => <Divider />, 2);
   });
 });

--- a/packages/experimental/Divider/src/__tests__/Divider.test.tsx
+++ b/packages/experimental/Divider/src/__tests__/Divider.test.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import * as renderer from 'react-test-renderer';
 
 import { Divider } from '../Divider';
+import { DividerProps } from '../Divider.types';
 
 describe('Divider component tests', () => {
   it('Divider default', () => {
@@ -53,6 +54,44 @@ describe('Divider component tests', () => {
 
   it('Divider with icon', () => {
     const tree = renderer.create(<Divider icon={{ fontSource: { fontFamily: 'Arial', codepoint: 0x2663, fontSize: 32 } }} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('Divider with all props + tokens set', () => {
+    const CustomDivider = Divider.customize({
+      contentColor: 'red',
+      contentPadding: 10,
+      flexAfter: 2,
+      flexBefore: 1,
+      lineColor: 'blue',
+      minLineSize: 10,
+      thickness: 2,
+      minHeight: 40,
+      minWidth: 10,
+      maxHeight: 200,
+      maxWidth: 200,
+      padding: 10,
+      paddingVertical: 10,
+      paddingHorizontal: 10,
+      paddingStart: 10,
+      paddingEnd: 10,
+      fontFamily: 'serif',
+      fontSize: 10,
+      fontWeight: '600',
+      fontLineHeight: 2,
+      fontLetterSpacing: 0.1,
+      fontStyle: 'italic',
+      textDecorationLine: 'line-through',
+      variant: 'body1',
+    });
+    const props: DividerProps = {
+      alignContent: 'start',
+      appearance: 'strong',
+      icon: { fontSource: { fontFamily: 'Arial', codepoint: 0x2663, fontSize: 32 } },
+      insetSize: 16,
+      vertical: true,
+    };
+    const tree = renderer.create(<CustomDivider {...props}>Hello</CustomDivider>).toJSON();
     expect(tree).toMatchSnapshot();
   });
 });

--- a/packages/experimental/Divider/src/__tests__/__snapshots__/Divider.test.tsx.snap
+++ b/packages/experimental/Divider/src/__tests__/__snapshots__/Divider.test.tsx.snap
@@ -312,7 +312,7 @@ exports[`Divider component tests Vertical Divider 1`] = `
       "flexDirection": "column",
       "height": "100%",
       "justifyContent": "center",
-      "minHeight": 24,
+      "minHeight": 20,
       "minWidth": 0,
       "paddingVertical": 0,
     }
@@ -342,7 +342,7 @@ exports[`Divider component tests Vertical Divider with Inset 1`] = `
       "flexDirection": "column",
       "height": "100%",
       "justifyContent": "center",
-      "minHeight": 24,
+      "minHeight": 20,
       "minWidth": 0,
       "paddingVertical": 16,
     }

--- a/packages/experimental/Divider/src/__tests__/__snapshots__/Divider.test.tsx.snap
+++ b/packages/experimental/Divider/src/__tests__/__snapshots__/Divider.test.tsx.snap
@@ -87,6 +87,84 @@ exports[`Divider component tests Divider default 1`] = `
 </View>
 `;
 
+exports[`Divider component tests Divider with all props + tokens set 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "height": "100%",
+      "justifyContent": "center",
+      "maxHeight": 200,
+      "maxWidth": 200,
+      "minHeight": 40,
+      "minWidth": 10,
+      "padding": 10,
+      "paddingEnd": 10,
+      "paddingHorizontal": 10,
+      "paddingStart": 10,
+      "paddingVertical": 16,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "borderColor": "blue",
+        "borderLeftWidth": 2,
+        "borderStyle": "solid",
+        "flex": 0,
+        "flexBasis": 10,
+        "minHeight": 10,
+      }
+    }
+  />
+  <View
+    style={
+      Object {
+        "flex": 0,
+        "paddingVertical": 10,
+      }
+    }
+  >
+    <Text
+      ellipsizeMode="tail"
+      numberOfLines={0}
+      onAccessibilityTap={[Function]}
+      style={
+        Object {
+          "color": "red",
+          "fontFamily": "System",
+          "fontSize": 10,
+          "fontStyle": "italic",
+          "fontWeight": "600",
+          "letterSpacing": 0.1,
+          "lineHeight": 2,
+          "margin": 0,
+          "textAlign": "center",
+          "textDecorationLine": "line-through",
+        }
+      }
+    >
+      Hello
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "borderColor": "blue",
+        "borderLeftWidth": 2,
+        "borderStyle": "solid",
+        "flex": 1,
+        "flexBasis": 10,
+        "minHeight": 10,
+      }
+    }
+  />
+</View>
+`;
+
 exports[`Divider component tests Divider with icon 1`] = `
 <View
   style={


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

After taking another look at the original Divider spec, I realized that  the min-height token value for childless vertical dividers was wrong. This commit changes the height from 24 -> 20, removes references to  that in the tester, and adds documentation.

This commit also fixes logic for determining the divider minHeight. Previously, if a user set the minHeight token via customize, that value would be overriden for the defaults determined in the second render stage.

### Verification

Before:
![Before](https://user-images.githubusercontent.com/15683103/222622266-d3b947c0-66ce-4381-a717-dfda51095b54.png)

After:
![After](https://user-images.githubusercontent.com/15683103/222622263-6126f638-d30b-4dab-b971-0f2291bb320c.png)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
