### PR TITLE
Remove Button text and after-icon from rendering in UIA tree

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Button/ButtonTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Button/ButtonTest.tsx
@@ -64,10 +64,6 @@ const buttonSections: TestSection[] = [
       },
     ],
   }),
-  {
-    name: 'E2E Button Testing',
-    component: E2EButtonTest,
-  },
 ];
 
 const e2eSections: TestSection[] = [

--- a/change/@fluentui-react-native-button-0a1eca1f-c7b0-4537-b479-53e3051ca253.json
+++ b/change/@fluentui-react-native-button-0a1eca1f-c7b0-4537-b479-53e3051ca253.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove button text and after-icon from UIA tree",
+  "packageName": "@fluentui-react-native/button",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-menu-button-e6e8d11f-3cf8-40f7-b00f-18df926a256a.json
+++ b/change/@fluentui-react-native-experimental-menu-button-e6e8d11f-3cf8-40f7-b00f-18df926a256a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update snapshots",
+  "packageName": "@fluentui-react-native/experimental-menu-button",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-menu-0f16f572-558a-4c41-8ed6-271f640524ca.json
+++ b/change/@fluentui-react-native-menu-0f16f572-558a-4c41-8ed6-271f640524ca.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update snapshots",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-notification-ae4df84a-2d7b-4b79-9fab-2539a3773b8d.json
+++ b/change/@fluentui-react-native-notification-ae4df84a-2d7b-4b79-9fab-2539a3773b8d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update snapshots",
+  "packageName": "@fluentui-react-native/notification",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-8fcf805f-e2d4-41f3-aca9-30257f68ed02.json
+++ b/change/@fluentui-react-native-tester-8fcf805f-e2d4-41f3-aca9-30257f68ed02.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove duplicate Button test section.",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Button/src/Button.tsx
+++ b/packages/components/Button/src/Button.tsx
@@ -83,9 +83,15 @@ export const Button = compose<ButtonType>({
           {loading && <ActivityIndicator />}
           {shouldShowIcon && iconPosition === 'before' && <Slots.icon {...iconProps} accessible={false} />}
           {React.Children.map(children, (child) =>
-            typeof child === 'string' ? <Slots.content key="content">{child}</Slots.content> : child,
+            typeof child === 'string' ? (
+              <Slots.content accessible={false} key="content">
+                {child}
+              </Slots.content>
+            ) : (
+              child
+            ),
           )}
-          {shouldShowIcon && iconPosition === 'after' && <Slots.icon {...iconProps} />}
+          {shouldShowIcon && iconPosition === 'after' && <Slots.icon {...iconProps} accessible={false} />}
         </React.Fragment>
       );
 

--- a/packages/components/Button/src/CompoundButton/CompoundButton.tsx
+++ b/packages/components/Button/src/CompoundButton/CompoundButton.tsx
@@ -64,14 +64,24 @@ export const CompoundButton = compose<CompoundButtonType>({
       return (
         <Slots.root {...mergedProps} accessibilityLabel={label}>
           {loading && <ActivityIndicator />}
-          {shouldShowIcon && iconPosition === 'before' && <Slots.icon {...iconProps} />}
+          {shouldShowIcon && iconPosition === 'before' && <Slots.icon {...iconProps} accessible={false} />}
           <Slots.contentContainer>
             {React.Children.map(children, (child) =>
-              typeof child === 'string' ? <Slots.content key="content">{child}</Slots.content> : child,
+              typeof child === 'string' ? (
+                <Slots.content accessible={false} key="content">
+                  {child}
+                </Slots.content>
+              ) : (
+                child
+              ),
             )}
-            {secondaryContent && <Slots.secondaryContent key="secondaryContent">{secondaryContent}</Slots.secondaryContent>}
+            {secondaryContent && (
+              <Slots.secondaryContent accessible={false} key="secondaryContent">
+                {secondaryContent}
+              </Slots.secondaryContent>
+            )}
           </Slots.contentContainer>
-          {shouldShowIcon && iconPosition === 'after' && <Slots.icon {...iconProps} />}
+          {shouldShowIcon && iconPosition === 'after' && <Slots.icon {...iconProps} accessible={false} />}
         </Slots.root>
       );
     };

--- a/packages/components/Button/src/FAB/FAB.mobile.tsx
+++ b/packages/components/Button/src/FAB/FAB.mobile.tsx
@@ -80,7 +80,13 @@ export const FAB = compose<FABType>({
           {icon && <Slots.icon {...iconProps} accessible={false} />}
           {showContent &&
             React.Children.map(children, (child) =>
-              typeof child === 'string' ? <Slots.content key="content">{child}</Slots.content> : child,
+              typeof child === 'string' ? (
+                <Slots.content accessible={false} key="content">
+                  {child}
+                </Slots.content>
+              ) : (
+                child
+              ),
             )}
         </React.Fragment>
       );

--- a/packages/components/Button/src/FAB/__snapshots__/FAB.test.tsx.snap
+++ b/packages/components/Button/src/FAB/__snapshots__/FAB.test.tsx.snap
@@ -50,6 +50,7 @@ exports[`Custom FAB with no shadow(iOS) 1`] = `
     ♣
   </Text>
   <Text
+    accessible={false}
     ellipsizeMode="tail"
     numberOfLines={0}
     style={
@@ -148,6 +149,7 @@ exports[`Default FAB (iOS) 1`] = `
       ♣
     </Text>
     <Text
+      accessible={false}
       ellipsizeMode="tail"
       numberOfLines={0}
       style={

--- a/packages/components/Button/src/ToggleButton/ToggleButton.tsx
+++ b/packages/components/Button/src/ToggleButton/ToggleButton.tsx
@@ -55,11 +55,17 @@ export const ToggleButton = compose<ToggleButtonType>({
       return (
         <Slots.root {...mergedProps} accessibilityLabel={label}>
           {loading && <ActivityIndicator />}
-          {shouldShowIcon && iconPosition === 'before' && <Slots.icon {...iconProps} />}
+          {shouldShowIcon && iconPosition === 'before' && <Slots.icon {...iconProps} accessible={false} />}
           {React.Children.map(children, (child) =>
-            typeof child === 'string' ? <Slots.content key="content">{child}</Slots.content> : child,
+            typeof child === 'string' ? (
+              <Slots.content accessible={false} key="content">
+                {child}
+              </Slots.content>
+            ) : (
+              child
+            ),
           )}
-          {shouldShowIcon && iconPosition === 'after' && <Slots.icon {...iconProps} />}
+          {shouldShowIcon && iconPosition === 'after' && <Slots.icon {...iconProps} accessible={false} />}
         </Slots.root>
       );
     };

--- a/packages/components/Button/src/ToggleButton/__snapshots__/ToggleButton.test.tsx.snap
+++ b/packages/components/Button/src/ToggleButton/__snapshots__/ToggleButton.test.tsx.snap
@@ -49,6 +49,7 @@ exports[`ToggleButton default 1`] = `
   }
 >
   <Text
+    accessible={false}
     ellipsizeMode="tail"
     numberOfLines={0}
     style={

--- a/packages/components/Button/src/__snapshots__/Button.test.tsx.snap
+++ b/packages/components/Button/src/__snapshots__/Button.test.tsx.snap
@@ -37,6 +37,7 @@ exports[`Button component tests Button circular 1`] = `
   }
 >
   <Text
+    accessible={false}
     ellipsizeMode="tail"
     numberOfLines={0}
     style={
@@ -94,6 +95,7 @@ exports[`Button component tests Button composed 1`] = `
   }
 >
   <Text
+    accessible={false}
     style={
       Object {
         "color": "#ffffff",
@@ -154,6 +156,7 @@ exports[`Button component tests Button customized 1`] = `
   }
 >
   <Text
+    accessible={false}
     ellipsizeMode="tail"
     numberOfLines={0}
     style={
@@ -211,6 +214,7 @@ exports[`Button component tests Button default 1`] = `
   }
 >
   <Text
+    accessible={false}
     ellipsizeMode="tail"
     numberOfLines={0}
     style={
@@ -273,6 +277,7 @@ exports[`Button component tests Button disabled 1`] = `
   }
 >
   <Text
+    accessible={false}
     ellipsizeMode="tail"
     numberOfLines={0}
     style={
@@ -331,6 +336,7 @@ exports[`Button component tests Button large 1`] = `
   }
 >
   <Text
+    accessible={false}
     ellipsizeMode="tail"
     numberOfLines={0}
     style={
@@ -389,6 +395,7 @@ exports[`Button component tests Button primary 1`] = `
   }
 >
   <Text
+    accessible={false}
     ellipsizeMode="tail"
     numberOfLines={0}
     style={
@@ -447,6 +454,7 @@ exports[`Button component tests Button small 1`] = `
   }
 >
   <Text
+    accessible={false}
     ellipsizeMode="tail"
     numberOfLines={0}
     style={
@@ -505,6 +513,7 @@ exports[`Button component tests Button square 1`] = `
   }
 >
   <Text
+    accessible={false}
     ellipsizeMode="tail"
     numberOfLines={0}
     style={
@@ -563,6 +572,7 @@ exports[`Button component tests Button subtle 1`] = `
   }
 >
   <Text
+    accessible={false}
     ellipsizeMode="tail"
     numberOfLines={0}
     style={

--- a/packages/components/Menu/src/__tests__/__snapshots__/Menu.test.tsx.snap
+++ b/packages/components/Menu/src/__tests__/__snapshots__/Menu.test.tsx.snap
@@ -67,6 +67,7 @@ exports[`Menu component tests Menu default 1`] = `
   }
 >
   <Text
+    accessible={false}
     ellipsizeMode="tail"
     numberOfLines={0}
     onAccessibilityTap={[Function]}
@@ -156,6 +157,7 @@ exports[`Menu component tests Menu defaultOpen 1`] = `
   }
 >
   <Text
+    accessible={false}
     ellipsizeMode="tail"
     numberOfLines={0}
     onAccessibilityTap={[Function]}
@@ -245,6 +247,7 @@ exports[`Menu component tests Menu open 1`] = `
   }
 >
   <Text
+    accessible={false}
     ellipsizeMode="tail"
     numberOfLines={0}
     onAccessibilityTap={[Function]}
@@ -334,6 +337,7 @@ exports[`Menu component tests Menu open checkbox and divider 1`] = `
   }
 >
   <Text
+    accessible={false}
     ellipsizeMode="tail"
     numberOfLines={0}
     onAccessibilityTap={[Function]}
@@ -423,6 +427,7 @@ exports[`Menu component tests Menu open checkbox checked 1`] = `
   }
 >
   <Text
+    accessible={false}
     ellipsizeMode="tail"
     numberOfLines={0}
     onAccessibilityTap={[Function]}
@@ -512,6 +517,7 @@ exports[`Menu component tests Menu open checkbox defaultChecked 1`] = `
   }
 >
   <Text
+    accessible={false}
     ellipsizeMode="tail"
     numberOfLines={0}
     onAccessibilityTap={[Function]}
@@ -601,6 +607,7 @@ exports[`Menu component tests Menu open radio 1`] = `
   }
 >
   <Text
+    accessible={false}
     ellipsizeMode="tail"
     numberOfLines={0}
     onAccessibilityTap={[Function]}
@@ -690,6 +697,7 @@ exports[`Menu component tests Menu submenu 1`] = `
   }
 >
   <Text
+    accessible={false}
     ellipsizeMode="tail"
     numberOfLines={0}
     onAccessibilityTap={[Function]}

--- a/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
+++ b/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
@@ -137,6 +137,7 @@ exports[`Notification component tests Notification default 1`] = `
       }
     >
       <Text
+        accessible={false}
         ellipsizeMode="tail"
         numberOfLines={0}
         style={

--- a/packages/experimental/MenuButton/src/__tests__/__snapshots__/MenuButton.test.tsx.snap
+++ b/packages/experimental/MenuButton/src/__tests__/__snapshots__/MenuButton.test.tsx.snap
@@ -51,6 +51,7 @@ exports[`ContextualMenu default 1`] = `
   }
 >
   <Text
+    accessible={false}
     ellipsizeMode="tail"
     numberOfLines={0}
     onAccessibilityTap={[Function]}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Currently, Button child text and the icon rendering after text are visible within the windows UIA tree. These nodes are not necessary, because of the Button `accessibilityLabel` prop, and can be removed from the tree.

This PR does so by setting both slot's `accessible` prop to `false` on the regular, compound, and FAB buttons.

This PR also removes a duplicate Button test section in the Fluent Tester.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before](https://user-images.githubusercontent.com/15683103/222603997-d87536bb-ab72-42f6-9751-b9684ed2662e.png) | ![after](https://user-images.githubusercontent.com/15683103/222603979-b10b971c-a7ff-4448-b1db-4467a5077937.png) |

| Before (compound)                                      | After (compound)                                      |
|----------------------------------------------|--------------------------------------------|
| ![compound_before](https://user-images.githubusercontent.com/15683103/223300376-e4f25a6f-d99a-4142-b870-53f03a900fb4.png) | ![compound_after](https://user-images.githubusercontent.com/15683103/223300416-56bc5f98-ac60-4d65-bbed-c41a4edb1625.png) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
