### PR TITLE
Only call `ref.current.focus()` if the platform supports it.

### DIFF
--- a/change/@fluentui-react-native-interactive-hooks-7e7228ba-5e22-41e2-8b7a-9697ad2f07ff.json
+++ b/change/@fluentui-react-native-interactive-hooks-7e7228ba-5e22-41e2-8b7a-9697ad2f07ff.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Only call focus if the platform supports it.",
+  "packageName": "@fluentui-react-native/interactive-hooks",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/utils/interactive-hooks/src/useOnPressWithFocus.ts
+++ b/packages/utils/interactive-hooks/src/useOnPressWithFocus.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type { GestureResponderEvent } from 'react-native';
+import { GestureResponderEvent, Platform } from 'react-native';
 
 export type OnPressCallback = (args: GestureResponderEvent) => void;
 export type OnPressWithFocusCallback = (args: GestureResponderEvent) => void;
@@ -15,8 +15,12 @@ export type OnPressWithFocusCallback = (args: GestureResponderEvent) => void;
 export function useOnPressWithFocus(focusRef: React.RefObject<any>, userCallback: OnPressCallback): OnPressWithFocusCallback {
   const onPressWithFocus = React.useCallback(
     (args?: any) => {
-      userCallback && userCallback(args);
-      focusRef?.current?.focus();
+      userCallback?.(args);
+
+      const platformSupportsFocus = ['windows', 'win32', 'macos'].includes(Platform.OS as string);
+      if (platformSupportsFocus) {
+        focusRef?.current?.focus?.();
+      }
     },
     [userCallback, focusRef],
   );


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

After #2669 we were getting a Redbox on iOS that `focus()` didn't exist as a ViewManager command. This is because our hook `useOnPressWithFocus` was calling focus() when that is only valid on desktop platforms. This fix is a simple platform check to ensure we only call focus() if the platform supports it. 

### Verification

iOS no longer Redboxes on any button press.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
