### PR TITLE
[Menu] Implement N of M pattern on items

### DIFF
--- a/change/@fluentui-react-native-menu-aca07e1d-dfb8-4b56-9277-c6892ec6f593.json
+++ b/change/@fluentui-react-native-menu-aca07e1d-dfb8-4b56-9277-c6892ec6f593.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix n of m MenuItems",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/MenuList/MenuList.tsx
+++ b/packages/components/Menu/src/MenuList/MenuList.tsx
@@ -58,6 +58,19 @@ export const MenuList = compose<MenuListType>({
     }, []);
 
     return (_final: MenuListProps, children: React.ReactNode) => {
+      const childrenWithSet = React.Children.map(children, (child, index: number) => {
+        if (React.isValidElement(child)) {
+          return React.cloneElement(child, {
+            accessibilityPositionInSet: index, // win32
+            accessibilityPosInSet: index, // windows
+            accessibilitySetSize: React.Children.toArray(children).length, //win32
+            accessibilitySizeOfSet: React.Children.toArray(children).length, //windows
+          } as any);
+        }
+
+        return child;
+      });
+
       const content =
         Platform.OS === 'macos' ? (
           <Slots.root>
@@ -73,16 +86,16 @@ export const MenuList = compose<MenuListType>({
                 // @ts-ignore FocusZone takes ViewProps, but that isn't defined on it's type.
                 enableFocusRing={false}
               >
-                {children}
+                {childrenWithSet}
               </Slots.focusZone>
             </Slots.scrollView>
           </Slots.root>
         ) : menuContext.hasMaxHeight ? (
           <Slots.root style={menuContext.minWidth ? { minWidth: menuContext.minWidth } : {}}>
-            <Slots.scrollView>{children}</Slots.scrollView>
+            <Slots.scrollView>{childrenWithSet}</Slots.scrollView>
           </Slots.root>
         ) : (
-          <Slots.root style={menuContext.minWidth ? { minWidth: menuContext.minWidth } : {}}>{children}</Slots.root>
+          <Slots.root style={menuContext.minWidth ? { minWidth: menuContext.minWidth } : {}}>{childrenWithSet}</Slots.root>
         );
 
       return <MenuListProvider value={menuListContextValue}>{content}</MenuListProvider>;


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [x] windows
- [ ] android

### Description of changes

Implementing population of N of M props for MenuItems so that

This change is done in the MenuList. The render function calculates n and m and fills out the appropriate props for both windows and win32.

### Verification

Checked with tester, need to test a little more.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
