### PR TITLE
Remove hover state styling from MenuItems to avoid lingering background after blur

### DIFF
--- a/change/@fluentui-react-native-menu-cbd8cff6-2835-40ab-8b8b-6af9425db286.json
+++ b/change/@fluentui-react-native-menu-cbd8cff6-2835-40ab-8b8b-6af9425db286.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "remove hover state styling from menuItems",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/MenuItem/MenuItemTokens.win32.ts
+++ b/packages/components/Menu/src/MenuItem/MenuItemTokens.win32.ts
@@ -23,12 +23,6 @@ export const defaultMenuItemTokens: TokenSettings<MenuItemTokens, Theme> = (t: T
   submenuIndicatorColor: t.colors.neutralForeground1,
   submenuIndicatorPadding: globalTokens.size20,
   submenuIndicatorSize: 16,
-  hovered: {
-    backgroundColor: t.colors.neutralBackground1Hover,
-    color: t.colors.neutralForeground1Hover,
-    iconColor: t.colors.neutralForeground1Hover,
-    submenuIndicatorColor: t.colors.neutralForeground1Hover,
-  },
   pressed: {
     backgroundColor: t.colors.neutralBackground1Pressed,
     color: t.colors.neutralForeground1Pressed,

--- a/packages/components/Menu/src/MenuItemCheckbox/MenuItemCheckboxTokens.win32.ts
+++ b/packages/components/Menu/src/MenuItemCheckbox/MenuItemCheckboxTokens.win32.ts
@@ -22,15 +22,6 @@ export const defaultMenuItemCheckboxTokens: TokenSettings<MenuItemCheckboxTokens
   maxWidth: 300,
   padding: globalTokens.size40,
   paddingHorizontal: globalTokens.size80,
-  hovered: {
-    backgroundColor: t.colors.neutralBackground1Hover,
-    color: t.colors.neutralForeground1Hover,
-    iconColor: t.colors.neutralForeground1Hover,
-    checked: {
-      checkmarkColor: t.colors.neutralForeground1Hover,
-      checkmarkVisibility: 1,
-    },
-  },
   pressed: {
     backgroundColor: t.colors.neutralBackground1Pressed,
     color: t.colors.neutralForeground1Pressed,


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
This is a win32 specific fix (doesn't repro on other platforms) to address the lingering hover effect after focus indicator has moved to a different item with keyboarding.

By removing styling entirely from hover, hover event, which calls focus event lets focused state handle styling.

### Verification
Tested on FURN tester

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/12578599/223585563-e48e4283-e7ec-47e2-a822-d80787a2d9e7.png)
 | 
![Screenshot 2023-03-08 003551](https://user-images.githubusercontent.com/12578599/223588823-417c9b66-b1d6-42d9-a177-f1009f99f615.png)
 |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
