### PR TITLE
[Mobile - Theme] Fix neutralForeground1 in Tester

### DIFF
--- a/apps/fluent-tester/src/FluentTesterApp.tsx
+++ b/apps/fluent-tester/src/FluentTesterApp.tsx
@@ -25,10 +25,9 @@ export const FluentTesterApp: React.FunctionComponent<FluentTesterProps> = (prop
         colors: { brandBackground2: 'red' }, // Overrides the buttonBackground color token, all other colors are kept in-tact.
       };
     },
-    (theme: Theme) => {
+    () => {
       return {
         colors: {
-          neutralForeground1: theme.colors.brandBackground2, // neutralBackground1 is 'red' in theme here because of previous recipe applied.
           hostColorPink: 'pink', // New custom color key.
           hostColorBrandText: 'purple', // New custom color key.
           hostColorButtonBackground: 'yellow', // New custom color key.

--- a/apps/fluent-tester/src/FluentTesterApp.tsx
+++ b/apps/fluent-tester/src/FluentTesterApp.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 import { Platform } from 'react-native';
 
 import { useHorizontalSizeClass } from '@fluentui-react-native/experimental-appearance-additions';
-import type { Theme } from '@fluentui-react-native/framework';
 import { ThemeReference, ThemeProvider } from '@fluentui-react-native/theme';
 
 import type { FluentTesterProps } from './FluentTester';

--- a/change/@fluentui-react-native-tester-f69265b2-a195-4367-9de3-d0d581859996.json
+++ b/change/@fluentui-react-native-tester-f69265b2-a195-4367-9de3-d0d581859996.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix neutralforeground1",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "rohanpd.work@gmail.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [x] android

### Description of changes

Fixes neutralForeground1 in Tester App.  
'red' color was applied to neutralForeground1 across Fluent Tester. 

Regression of this pr : #2668 

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![MicrosoftTeams-image (35)](https://user-images.githubusercontent.com/30728574/224545759-ee3d1e44-bc94-4974-b421-a4db21f04b59.png) | ![MicrosoftTeams-image (36)](https://user-images.githubusercontent.com/30728574/224545783-7b6f3f0e-c70a-4dcc-a3f4-e7b5d7270b12.png) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
