### PR TITLE
[Checkbox] Fix checkbox a11y - screen readers doesn't announce undefined 'checked'

### DIFF
--- a/change/@fluentui-react-native-checkbox-ae068286-c9b5-40b3-a0ff-151b9e263620.json
+++ b/change/@fluentui-react-native-checkbox-ae068286-c9b5-40b3-a0ff-151b9e263620.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "make checkbox a11y annouce null/undefined state",
+  "packageName": "@fluentui-react-native/checkbox",
+  "email": "rohanpd.work@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Checkbox/src/useCheckbox.ts
+++ b/packages/components/Checkbox/src/useCheckbox.ts
@@ -107,7 +107,7 @@ export const useCheckbox = (props: CheckboxProps): CheckboxInfo => {
 
 const getAccessibilityState = memoize(getAccessibilityStateWorker);
 function getAccessibilityStateWorker(disabled: boolean, checked: boolean, required: boolean, accessibilityState?: AccessibilityState) {
-  checked = checked ?? false; // Make the value of checked as false when checked is undefined or null for screen reader to annouce 'unchecked'
+  checked = checked ?? false; // Make the value of checked as false when checked is undefined or null for screen reader to announce 'unchecked'
   if (accessibilityState) {
     return { disabled, checked, required, ...accessibilityState };
   }

--- a/packages/components/Checkbox/src/useCheckbox.ts
+++ b/packages/components/Checkbox/src/useCheckbox.ts
@@ -107,6 +107,7 @@ export const useCheckbox = (props: CheckboxProps): CheckboxInfo => {
 
 const getAccessibilityState = memoize(getAccessibilityStateWorker);
 function getAccessibilityStateWorker(disabled: boolean, checked: boolean, required: boolean, accessibilityState?: AccessibilityState) {
+  checked = checked ?? false; // Make the value of checked as false when checked is undefined or null for screen reader to annouce 'unchecked'
   if (accessibilityState) {
     return { disabled, checked, required, ...accessibilityState };
   }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

On the undefined state of the 'checked' on Checkbox such as : 
`      <Checkbox label="Unchecked checkbox (undefined)" onChange={onChangeUncontrolled} />
` where default is not passed as well , the screen reader skip announcing the state of the checkbox as "not checked". 

This PR targets to fix it by adding false value of 'checked' property when it is null or undefined.

### Verification
Tested with Screen reader. No visual change. 


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [x] Voiceover
- [ ] Internationalization and Right-to-left Layouts
