### PR TITLE
Stop propagation of handled MenuItem events

### DIFF
--- a/change/@fluentui-react-native-menu-e218fe85-67d9-42c9-96a8-2169a054edee.json
+++ b/change/@fluentui-react-native-menu-e218fe85-67d9-42c9-96a8-2169a054edee.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Stop propagating handled menu button events",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/MenuItem/useMenuItem.ts
+++ b/packages/components/Menu/src/MenuItem/useMenuItem.ts
@@ -49,6 +49,8 @@ export const useMenuItem = (props: MenuItemProps): MenuItemInfo => {
       if (isArrowClose) {
         onArrowClose?.(e);
       }
+
+      e.stopPropagation();
     },
     [componentRef, disabled, hasSubmenu, onArrowClose, onClick, setOpen, shouldPersist],
   );

--- a/packages/components/Menu/src/MenuItemCheckbox/useMenuItemCheckbox.ts
+++ b/packages/components/Menu/src/MenuItemCheckbox/useMenuItemCheckbox.ts
@@ -24,6 +24,8 @@ export const useMenuItemCheckbox = (props: MenuItemCheckboxProps): MenuItemCheck
       if (!disabled) {
         onCheckedChange(e, name, !checked);
       }
+
+      e.stopPropagation();
     },
     [checked, disabled, name, onCheckedChange],
   );
@@ -89,6 +91,8 @@ export const useMenuCheckboxInteraction = (
       if (isArrowClose) {
         onArrowClose?.(e);
       }
+
+      e.stopPropagation();
     },
     [disabled, isSubmenu, onArrowClose, toggleCallback],
   );
@@ -107,6 +111,8 @@ export const useMenuCheckboxInteraction = (
         }
         onAccessibilityAction && onAccessibilityAction(event);
       }
+
+      event.stopPropagation();
     },
     [disabled, toggleCallback, onAccessibilityAction],
   );

--- a/packages/components/Menu/src/MenuItemRadio/useMenuItemRadio.ts
+++ b/packages/components/Menu/src/MenuItemRadio/useMenuItemRadio.ts
@@ -24,6 +24,8 @@ export const useMenuItemRadio = (props: MenuItemCheckboxProps): MenuItemCheckbox
           setOpen(e, false /*isOpen*/, true /*bubble*/);
         }
       }
+
+      e.stopPropagation();
     },
     [disabled, name, selectRadio, setOpen, shouldPersist],
   );


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Client reports double handling of invocation of MenuItem events. Stopping propagation of said events.

### Verification

Will test with tester.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
