### PR TITLE
[Button][win32] Only fire Button onClick with keyboard if keyDown event was received first

### DIFF
--- a/change/@fluentui-react-native-button-1caa0736-505a-44c5-9d5d-43a4cc2d916b.json
+++ b/change/@fluentui-react-native-button-1caa0736-505a-44c5-9d5d-43a4cc2d916b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add more guards to handling key press behavior",
+  "packageName": "@fluentui-react-native/button",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-interactive-hooks-5e8cc8ab-6cf5-457b-9f0d-caed3f08efc5.json
+++ b/change/@fluentui-react-native-interactive-hooks-5e8cc8ab-6cf5-457b-9f0d-caed3f08efc5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Change modifier key handling",
+  "packageName": "@fluentui-react-native/interactive-hooks",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Button/src/useButton.ts
+++ b/packages/components/Button/src/useButton.ts
@@ -32,14 +32,14 @@ export const useButton = (props: ButtonProps): ButtonInfo => {
   } = props;
 
   const isDisabled = !!disabled || !!loading;
-  const [isKeyPressed, setIsKeyPressed] = React.useState<boolean>(false);
+  const [isProcessingKeyboardInvocation, setIsProcessingKeyboardInvocation] = React.useState<boolean>(false);
 
   // GH #1336: Set focusRef to null if button is disabled to prevent getting keyboard focus.
   const focusRef = isDisabled ? null : componentRef;
   const onClickWithFocus = useOnPressWithFocus(focusRef, onClick);
   const onBlurInner = React.useCallback(
     (e) => {
-      setIsKeyPressed(false);
+      setIsProcessingKeyboardInvocation(false);
       onBlur?.(e);
     },
     [onBlur],
@@ -48,8 +48,8 @@ export const useButton = (props: ButtonProps): ButtonInfo => {
 
   const onKeyDownInner = React.useCallback(
     (e) => {
-      if ((!disabled && e.nativeEvent.key === 'Enter') || e.nativeEvent.key === ' ') {
-        setIsKeyPressed(true);
+      if (!disabled && (e.nativeEvent.key === 'Enter' || e.nativeEvent.key === ' ')) {
+        setIsProcessingKeyboardInvocation(true);
       }
       onKeyDown?.(e);
     },
@@ -57,12 +57,12 @@ export const useButton = (props: ButtonProps): ButtonInfo => {
   );
   const onKeyPress = React.useCallback(
     (e) => {
-      if (isKeyPressed) {
+      if (isProcessingKeyboardInvocation) {
         onClick?.(e);
-        setIsKeyPressed(false);
+        setIsProcessingKeyboardInvocation(false);
       }
     },
-    [isKeyPressed, onClick],
+    [isProcessingKeyboardInvocation, onClick],
   );
   const onKeyProps = useKeyProps(shouldOnlyFireIfPressed ? onKeyPress : onClick, ' ', 'Enter');
 
@@ -108,7 +108,7 @@ export const useButton = (props: ButtonProps): ButtonInfo => {
     },
     state: {
       ...pressable.state,
-      pressed: pressable.state.pressed || isKeyPressed,
+      pressed: pressable.state.pressed || isProcessingKeyboardInvocation,
       measuredWidth: baseWidth,
       measuredHeight: baseHeight,
       shouldUseTwoToneFocusBorder: shouldUseTwoToneFocusBorder,

--- a/packages/components/Button/src/useButton.ts
+++ b/packages/components/Button/src/useButton.ts
@@ -24,7 +24,6 @@ export const useButton = (props: ButtonProps): ButtonInfo => {
     disabled,
     onBlur,
     onClick,
-    onKeyDown,
     loading,
     enableFocusRing,
     focusable,
@@ -46,14 +45,13 @@ export const useButton = (props: ButtonProps): ButtonInfo => {
   );
   const pressable = usePressableState({ ...rest, onPress: onClickWithFocus, onBlur: shouldOnlyFireIfPressed ? onBlurInner : onBlur });
 
-  const onKeyDownInner = React.useCallback(
+  const onKeyDown = React.useCallback(
     (e) => {
       if (!disabled && (e.nativeEvent.key === 'Enter' || e.nativeEvent.key === ' ')) {
         setIsProcessingKeyboardInvocation(true);
       }
-      onKeyDown?.(e);
     },
-    [disabled, onKeyDown],
+    [disabled],
   );
   const onKeyPress = React.useCallback(
     (e) => {
@@ -87,8 +85,8 @@ export const useButton = (props: ButtonProps): ButtonInfo => {
   return {
     props: {
       ...onKeyProps,
+      ...(Platform.OS === ('win32' as any) && { onKeyDown: onKeyDown }),
       ...pressable.props, // allow user key events to override those set by us
-      ...(Platform.OS === ('win32' as any) ? { onKeyDown: onKeyDownInner } : { onKeyDown: onKeyDown }),
       /**
        * https://github.com/facebook/react-native/issues/34986
        * Due to a bug in React Native, unconditionally passing this may cause unnecessary re-renders.

--- a/packages/utils/interactive-hooks/src/useKeyProps.ts
+++ b/packages/utils/interactive-hooks/src/useKeyProps.ts
@@ -5,23 +5,30 @@ import { memoize } from '@fluentui-react-native/memo-cache';
 
 import type { KeyCallback, KeyPressEvent, KeyPressProps } from './useKeyProps.types';
 
+const shouldExcludeAllModifierKeys = Platform.OS === 'macos';
+
 /**
- * Verifies if nativeEvent contains modifier key.
+ * Verifies if nativeEvent contains modifier key. The modifier keys that should
+ * be taken into account differ based on platform
  * @param nativeEvent
  * @returns `true` if one or more of modifier keys are `true`
  */
-export const isModifierKey = (nativeEvent: any): boolean => {
-  return (
-    nativeEvent &&
-    (nativeEvent.alt ||
-      nativeEvent.altKey ||
-      nativeEvent.ctrl ||
-      nativeEvent.ctrlKey ||
-      nativeEvent.meta ||
-      nativeEvent.metaKey ||
-      nativeEvent.shift ||
-      nativeEvent.shiftKey)
-  );
+const isModifierKey = (nativeEvent: any): boolean => {
+  if (shouldExcludeAllModifierKeys) {
+    return (
+      nativeEvent &&
+      (nativeEvent.alt ||
+        nativeEvent.altKey ||
+        nativeEvent.ctrl ||
+        nativeEvent.ctrlKey ||
+        nativeEvent.meta ||
+        nativeEvent.metaKey ||
+        nativeEvent.shift ||
+        nativeEvent.shiftKey)
+    );
+  } else {
+    return nativeEvent && (nativeEvent.alt || nativeEvent.altKey || nativeEvent.meta || nativeEvent.metaKey);
+  }
 };
 
 function keyPressCallback(userCallback?: KeyCallback, ...keys: string[]) {

--- a/packages/utils/interactive-hooks/src/useKeyProps.ts
+++ b/packages/utils/interactive-hooks/src/useKeyProps.ts
@@ -5,7 +5,7 @@ import { memoize } from '@fluentui-react-native/memo-cache';
 
 import type { KeyCallback, KeyPressEvent, KeyPressProps } from './useKeyProps.types';
 
-const shouldExcludeAllModifierKeys = Platform.OS === 'macos';
+const shouldAllowShiftCtrlKeys = Platform.OS === ('win32' as any);
 
 /**
  * Verifies if nativeEvent contains modifier key. The modifier keys that should
@@ -14,7 +14,9 @@ const shouldExcludeAllModifierKeys = Platform.OS === 'macos';
  * @returns `true` if one or more of modifier keys are `true`
  */
 const isModifierKey = (nativeEvent: any): boolean => {
-  if (shouldExcludeAllModifierKeys) {
+  if (shouldAllowShiftCtrlKeys) {
+    return nativeEvent && (nativeEvent.alt || nativeEvent.altKey || nativeEvent.meta || nativeEvent.metaKey);
+  } else {
     return (
       nativeEvent &&
       (nativeEvent.alt ||
@@ -26,8 +28,6 @@ const isModifierKey = (nativeEvent: any): boolean => {
         nativeEvent.shift ||
         nativeEvent.shiftKey)
     );
-  } else {
-    return nativeEvent && (nativeEvent.alt || nativeEvent.altKey || nativeEvent.meta || nativeEvent.metaKey);
   }
 };
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

The current button behavior on key press in win32 is causing issues. Specifically, there are cases where Buttons can be invoked accidentally because focus moves to the Button due to another action and then the enter or space button is released.
The native button would only fire for key presses if it detected a keyDown first, so we're going to mimic that behavior for Buttons in win32. ~Native buttons also adopt pressed coloring while keyDown, so that has been applied as well.~ Undoing this change since it's causing E2E failures

The mimicking is done by adding another state which tracks if the button is pressed via keys. This state is cleared when the key is released or when focus moves away from the button.

Another change in behavior is that key presses on win32 buttons will go through with shift or ctrl pressed, so making that behavior change for win32.

### Verification

Tested with tester against behavior of native Button

- Tested tabbing
- Tested clicking
- Tested enter invokes a Button, adds pressed coloring
- Tested pressing enter, tabbing from button1 to button2, and then releasing enter doesn't execute button2
- Tested that pressing enter, tabbing away and then back, and then releasing enter doesn't execute button
- Tested keyboard with mouse interactions (like pressing enter, clicking, and then releasing enter) align with native
- Tested invoking a button with shift & enter
- Tested space interactions
- It is expected that the button executes twice if you press enter, press down via mouse, release enter, and release mouse. This aligns with native behavior.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
