### PR TITLE
Update Switch Documentation + Comments

### DIFF
--- a/change/@fluentui-react-native-switch-75318127-a7fb-43e9-8414-10c181aa3b69.json
+++ b/change/@fluentui-react-native-switch-75318127-a7fb-43e9-8414-10c181aa3b69.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update Switch docs to reflect latest changes",
+  "packageName": "@fluentui-react-native/switch",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Switch/SPEC.md
+++ b/packages/components/Switch/SPEC.md
@@ -49,6 +49,7 @@ The `Switch` component has six slots. The slots behave as follows:
 - `thumb` - By default a circle. Its location informs the user of the Switch's toggle state.
 - `toggleContainer` - Container for the thumb and track.
 - `onOffText` - If specified, renders the the toggle state of the Switch as text.
+- `onOffTextContainer` - If `onText` or `offText` are passed, this is the container that holds such text.
 
 The slots can be modified using the `compose` function on the `Switch`. For more information on using the `compose` API, please see [this page](../../framework/composition/README.md).
 
@@ -96,9 +97,7 @@ export interface SwitchProps extends Omit<PressablePropsExtended 'onPress'> {
   onText?: string;
 
   /**
-   * Sets the position of the Switch's label. The position value 'after' is mutually
-   * exclusive with the onText and offText props. This is due to variable width
-   * of the text props causing the Switch's position to change when it shouldn't.
+   * The position of the label relative to the Switch.
    * Note : 'before' , 'above' are not supported on Android
    */
   labelPosition?: 'before' | 'above' | 'after';

--- a/packages/components/Switch/src/Switch.types.ts
+++ b/packages/components/Switch/src/Switch.types.ts
@@ -176,10 +176,8 @@ export interface SwitchProps extends Omit<PressablePropsExtended, 'onPress'> {
   onText?: string;
 
   /**
-   * The position of the label relative to the Switch. The position value 'after' is mutually
-   * exclusive with the onText and offText props. This is due to variable width
-   * of the text props causing the Switch's position to change when it shouldn't.
-   * Note :'before', 'above' are not supported on Android
+   * The position of the label relative to the Switch.
+   * Note : 'before' , 'above' are not supported on Android
    */
   labelPosition?: 'before' | 'above' | 'after';
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

PR #2731 introduced changes to Switch behavior regarding the `onText` and `offText` props. This PR updates code comments and the SPEC.md to reflect the latest changes.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
