### PR TITLE
Fix align-deps warnings + upgrade react-native-test-app

### DIFF
--- a/apps/fluent-tester/package.json
+++ b/apps/fluent-tester/package.json
@@ -175,7 +175,9 @@
         "babel-preset-react-native",
         "metro-config",
         "react",
-        "svg"
+        "react-test-renderer",
+        "svg",
+        "test-app"
       ]
     }
   },

--- a/apps/fluent-tester/package.json
+++ b/apps/fluent-tester/package.json
@@ -65,6 +65,7 @@
     "@fluentui-react-native/merge-props": ">=0.5.3 <1.0.0",
     "@fluentui-react-native/notification": "0.21.49",
     "@fluentui-react-native/separator": "^0.14.22",
+    "@fluentui-react-native/spinner": "^0.2.12",
     "@fluentui-react-native/stack": ">=0.7.62 <1.0.0",
     "@fluentui-react-native/switch": "^0.8.38",
     "@fluentui-react-native/text": ">=0.19.30 <1.0.0",
@@ -81,7 +82,6 @@
     "@react-native-community/slider": "^4.2.0",
     "@react-native-menu/menu": "^0.1.2",
     "@react-native-picker/picker": "^2.2.1",
-    "@fluentui-react-native/spinner": "^0.2.12",
     "@warren-ms/react-native-icons": "^0.0.13",
     "react": "17.0.2",
     "react-native": "^0.68.0",
@@ -102,7 +102,7 @@
     "metro-config": "^0.67.0",
     "metro-react-native-babel-preset": "^0.67.0",
     "react-native-svg-transformer": "^1.0.0",
-    "react-native-test-app": "^2.0.2",
+    "react-native-test-app": "^2.3.16",
     "react-test-renderer": "17.0.2"
   },
   "peerDependencies": {

--- a/apps/win32/package.json
+++ b/apps/win32/package.json
@@ -105,11 +105,12 @@
         "react-native@0.68"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
-        "react",
-        "svg",
         "metro-config",
-        "babel-preset-react-native"
+        "react",
+        "react-test-renderer",
+        "svg"
       ]
     }
   }

--- a/change/@fluentui-react-native-interactive-hooks-46947197-a515-4fb8-9647-0e5bd1753b72.json
+++ b/change/@fluentui-react-native-interactive-hooks-46947197-a515-4fb8-9647-0e5bd1753b72.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "align-deps: Fix warnigns and issues",
+  "packageName": "@fluentui-react-native/interactive-hooks",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-3808bf4c-3b94-4454-b30d-46836e8ba132.json
+++ b/change/@fluentui-react-native-tester-3808bf4c-3b94-4454-b30d-46836e8ba132.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "align-deps: Fix warnigns and issues",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-win32-44a663bc-f379-499f-9391-08d6ea99ea5a.json
+++ b/change/@fluentui-react-native-tester-win32-44a663bc-f379-499f-9391-08d6ea99ea5a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "align-deps: Fix warnigns and issues",
+  "packageName": "@fluentui-react-native/tester-win32",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/utils/interactive-hooks/package.json
+++ b/packages/utils/interactive-hooks/package.json
@@ -47,7 +47,9 @@
   },
   "peerDependencies": {
     "react": "17.0.2",
-    "react-native": "^0.68.0"
+    "react-native": "^0.68.0",
+    "react-native-macos": "^0.68.0",
+    "react-native-windows": "^0.68.0"
   },
   "author": "",
   "license": "MIT",
@@ -64,6 +66,8 @@
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react"
       ]
     }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -19,10 +19,13 @@
     "directory": "scripts"
   },
   "peerDependencies": {
-    "just-scripts": "^1.8.0"
+    "just-scripts": "^1.8.0",
+    "react": "17.0.2"
   },
   "devDependencies": {
     "@react-native-community/cli": "^7.0.3",
+    "@react-native-community/cli-platform-android": "^7.0.1",
+    "@react-native-community/cli-platform-ios": "^7.0.1",
     "@rnx-kit/jest-preset": "^0.1.12",
     "@types/enzyme": "^3.10.5",
     "@types/es6-collections": "^0.5.29",
@@ -46,6 +49,7 @@
     "metro-config": "^0.67.0",
     "metro-react-native-babel-transformer": "^0.67.0",
     "prettier": "^2.4.1",
+    "react": "17.0.2",
     "react-native-svg-transformer": "^1.0.0",
     "react-test-renderer": "17.0.2",
     "rimraf": "^3.0.2",
@@ -75,9 +79,11 @@
         "react-native@0.68"
       ],
       "capabilities": [
+        "community/cli",
         "jest",
         "metro-config",
-        "metro-react-native-babel-transformer"
+        "metro-react-native-babel-transformer",
+        "react-test-renderer"
       ]
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4480,8 +4480,8 @@ appium-uiautomator2-driver@^2.12.3:
   dependencies:
     "@babel/runtime" "^7.0.0"
     appium-adb "^9.10.14"
-    appium-android-driver "^5.8.10"
-    appium-chromedriver "^5.3.1"
+    appium-android-driver "^5.8.7"
+    appium-chromedriver "^5.2.16"
     appium-uiautomator2-server "^5.7.2"
     asyncbox "^2.3.1"
     axios "^1.x"
@@ -5768,7 +5768,7 @@ cliui@^7.0.2:
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
-cliui@^8.0.1:
+cliui@^8.0.0, cliui@^8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
   integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
@@ -10607,7 +10607,7 @@ minimatch@~3.0.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
+minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6, minimist@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
@@ -12006,18 +12006,19 @@ react-native-svg@^12.3.0, react-native-svg@^12.5.0:
     css-select "^5.1.0"
     css-tree "^1.1.3"
 
-react-native-test-app@^2.0.2:
-  version "2.3.13"
-  resolved "https://registry.yarnpkg.com/react-native-test-app/-/react-native-test-app-2.3.13.tgz#1681f691f953b4b1a6b01ca39349fe459846ea3e"
-  integrity sha512-0etn7YpU/3Ubxu0kjHfZ5bCXrEXV191eTwGIKLj7eKiM+yQNtLpD3PqaWBbO1zdz8MQbKDkotk2Dqq91hXPVuA==
+react-native-test-app@^2.3.16:
+  version "2.3.16"
+  resolved "https://registry.yarnpkg.com/react-native-test-app/-/react-native-test-app-2.3.16.tgz#9ee48ccd62ad2a3f425d75d010de3ce0e0b127d4"
+  integrity sha512-NdLRhZqPdj1dNJTOlCo2Ezu2hdoU3YolrrTHokbWA7vPNMTCbdj0SltWg6gS6f+Bz1Z+ToBDOkhPt+Llj2s2Rg==
   dependencies:
     ajv "^8.0.0"
     chalk "^4.1.0"
+    cliui "^8.0.0"
     fast-xml-parser "^4.0.0"
+    minimist "^1.2.8"
     prompts "^2.4.0"
     semver "^7.3.5"
     uuid "^8.3.2"
-    yargs "^16.0.0"
 
 react-native-windows@^0.68.0:
   version "0.68.30"


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

Before starting the RN 0.71 upgrade, I noticed `yarn align-deps` had some warnings. This change fixed those warnings (and the issues that followed).
I also upgrade `react-native-test-app` to the latest that supports 0.71 for macOS. 

### Verification

CI should pass. This should be a relatively benign change given our `yarn.lock` file didn't change.  

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
