### PR TITLE
Fix NPM publish pipeline

### DIFF
--- a/apps/fluent-tester/package.json
+++ b/apps/fluent-tester/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@fluentui-react-native/android-theme": ">=0.17.2 <1.0.0",
     "@fluentui-react-native/apple-theme": ">=0.19.2 <1.0.0",
-    "@fluentui-react-native/avatar": "^1.8.8",
+    "@fluentui-react-native/avatar": "^1.8.9",
     "@fluentui-react-native/badge": ">=0.5.7 <1.0.0",
     "@fluentui-react-native/button": ">=0.32.48 <1.0.0",
     "@fluentui-react-native/default-theme": ">=0.18.2 <1.0.0",

--- a/change/@fluentui-react-native-avatar-293bf041-173d-41cb-987d-e73beec06d83.json
+++ b/change/@fluentui-react-native-avatar-293bf041-173d-41cb-987d-e73beec06d83.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix npm publish pipeline",
+  "packageName": "@fluentui-react-native/avatar",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-c5f04713-bbf0-412a-88d6-82f592729fdf.json
+++ b/change/@fluentui-react-native-tester-c5f04713-bbf0-412a-88d6-82f592729fdf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix npm publish pipeline",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Avatar/package.json
+++ b/packages/components/Avatar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/avatar",
-  "version": "1.8.8",
+  "version": "1.8.9",
   "description": "A cross-platform Avatar component using the Fluent Design System",
   "license": "MIT",
   "author": "Microsoft <fluentuinativeowners@microsoft.com>",


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

The publishing pipeline is blocked because it's trying to update @fluentui-react-native/avatar to 1.8.9 which already exists on the NPM registry:

```
ERROR: Attempting to bump to a version that already exists in the registry: @fluentui-react-native/avatar@1.8.9
```

 To fix this, I manually bumped @fluentui-react-native/avatar to 1.8.9

### Verification

I ran `yarn publish:beachball -b origin/unblockPublish` to verify this fixes the issue. The publish did not actually go through because I didn't provide an auth token but the error is resolved:

```
Validating package version - @fluentui-react-native/avatar@1.8.10
 OK!
.
.
.
Publishing - @fluentui-react-native/avatar@1.8.10 with tag .
publish command: publish --registry https://registry.npmjs.org/ --tag latest --loglevel warn --access restricted
Publishing "@fluentui-react-native/avatar" failed due to auth error:

npm ERR! code ENEEDAUTH
npm ERR! need auth This command requires you to be logged in to https://registry.npmjs.org/
npm ERR! need auth You need to authorize this machine using `npm adduser`
```

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
