### PR TITLE
[Menu] Ensure menu and submenus have same pointer capture logic

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Menu/MenuTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Menu/MenuTest.tsx
@@ -192,7 +192,7 @@ const SubmenuWithScrollView: React.FunctionComponent<MenuProps> = (props: MenuPr
 const MenuSubMenuWithScrollView: React.FunctionComponent = () => {
   return (
     <Stack style={stackStyle}>
-      <Menu openOnHover>
+      <Menu>
         <MenuTrigger>
           <Button>Test</Button>
         </MenuTrigger>

--- a/apps/fluent-tester/src/TestComponents/Menu/MenuTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Menu/MenuTest.tsx
@@ -160,6 +160,53 @@ const MenuSubMenu: React.FunctionComponent = () => {
   );
 };
 
+const SubmenuWithScrollView: React.FunctionComponent<MenuProps> = (props: MenuProps) => {
+  return (
+    <Menu {...props}>
+      <MenuTrigger>
+        <MenuItem>A second MenuItem trigger</MenuItem>
+      </MenuTrigger>
+      <MenuPopover maxHeight={200}>
+        <MenuList>
+          <MenuItem>A nested MenuItem</MenuItem>
+          <MenuItem>A nested MenuItem</MenuItem>
+          <MenuItem>A nested MenuItem</MenuItem>
+          <MenuItem>A nested MenuItem</MenuItem>
+          <MenuItem>A nested MenuItem</MenuItem>
+          <MenuItem>A nested MenuItem</MenuItem>
+          <MenuItem>A nested MenuItem</MenuItem>
+          <MenuItem>A nested MenuItem</MenuItem>
+          <MenuItem>A nested MenuItem</MenuItem>
+          <MenuItem>A nested MenuItem</MenuItem>
+          <MenuItem>A nested MenuItem</MenuItem>
+          <MenuItem>A nested MenuItem</MenuItem>
+          <MenuItem>A nested MenuItem</MenuItem>
+          <MenuItem>A nested MenuItem</MenuItem>
+          <MenuItem>A nested MenuItem</MenuItem>
+        </MenuList>
+      </MenuPopover>
+    </Menu>
+  );
+};
+
+const MenuSubMenuWithScrollView: React.FunctionComponent = () => {
+  return (
+    <Stack style={stackStyle}>
+      <Menu openOnHover>
+        <MenuTrigger>
+          <Button>Test</Button>
+        </MenuTrigger>
+        <MenuPopover>
+          <MenuList>
+            <MenuItem>A MenuItem</MenuItem>
+            <SubmenuWithScrollView />
+          </MenuList>
+        </MenuPopover>
+      </Menu>
+    </Stack>
+  );
+};
+
 const MenuOpenOnHover: React.FunctionComponent = () => {
   return (
     <Stack style={stackStyle}>
@@ -401,6 +448,13 @@ const menuSections: TestSection[] = [
     default: {
       name: 'Menu Submenu',
       component: MenuSubMenu,
+    },
+  }),
+  Platform.select({
+    android: null,
+    default: {
+      name: 'Menu Submenu with ScrollView',
+      component: MenuSubMenuWithScrollView,
     },
   }),
   {

--- a/change/@fluentui-react-native-menu-1c481681-549e-4c9f-a066-a579901a51bf.json
+++ b/change/@fluentui-react-native-menu-1c481681-549e-4c9f-a066-a579901a51bf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ensure menu and submenus have same pointer capture logic",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-15187c00-871b-4c80-a5a2-26aeefdce360.json
+++ b/change/@fluentui-react-native-tester-15187c00-871b-4c80-a5a2-26aeefdce360.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ensure menu and submenus have same pointer capture logic",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/Menu/Menu.types.ts
+++ b/packages/components/Menu/src/Menu/Menu.types.ts
@@ -65,6 +65,7 @@ export interface MenuState extends MenuProps {
   animationStarted?: boolean;
   menuSize?: MenuSizeType;
   testID?: string;
+  parentDoNotTakePointerCapture?: boolean;
 }
 
 export enum AndroidMenuStates {

--- a/packages/components/Menu/src/Menu/useMenu.ts
+++ b/packages/components/Menu/src/Menu/useMenu.ts
@@ -34,6 +34,12 @@ export const useMenu = (props: MenuProps): MenuState => {
   // the parent menu will close when the timeout passes.
   const parentPopoverHoverOutTimer = isSubmenu ? context.popoverHoverOutTimer : undefined;
 
+  // Submenus should have the same pointer capture logic as its parent menu
+  // to avoid conflicts with pointer capture events. We determine whether a
+  // menu and its submenus should take pointer capture based on whether the
+  // root menu opens on hover.
+  const parentDoNotTakePointerCapture = isSubmenu ? context.parentDoNotTakePointerCapture : props.openOnHover ? true : false;
+
   return {
     openOnHover,
     ...props,
@@ -46,6 +52,7 @@ export const useMenu = (props: MenuProps): MenuState => {
     isSubmenu,
     isControlled: isOpenControlled,
     parentPopoverHoverOutTimer,
+    parentDoNotTakePointerCapture,
   };
 };
 

--- a/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
+++ b/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
@@ -36,7 +36,7 @@ export const useMenuPopover = (props: MenuPopoverProps): MenuPopoverState => {
   // Initial focus behavior differs per platform, Windows platforms move focus
   // automatically onto first element of Callout
   const setInitialFocus = Platform.OS === ('win32' as any) || Platform.OS === 'windows';
-  const doNotTakePointerCapture = openOnHover;
+  const doNotTakePointerCapture = props.doNotTakePointerCapture ?? context.parentDoNotTakePointerCapture;
   const accessibilityRole = 'menu';
 
   const onMouseEnter = React.useCallback(() => {
@@ -87,6 +87,17 @@ export const useMenuPopover = (props: MenuPopoverProps): MenuPopoverState => {
     setCanFocusOnPopover(false);
   }, [setCanFocusOnPopover]);
 
+  // Prevents submenus that take initial focus from closing prematurely
+  // when the parent menu takes pointer capture and we still have
+  // the mouse hovered on the submenu trigger.
+  const onFocus = React.useCallback(() => {
+    if (isSubmenu && setInitialFocus && !doNotTakePointerCapture) {
+      clearTimeout(triggerHoverOutTimer);
+      clearTimeout(popoverHoverOutTimer);
+      clearTimeout(parentPopoverHoverOutTimer);
+    }
+  }, [parentPopoverHoverOutTimer, popoverHoverOutTimer, triggerHoverOutTimer, doNotTakePointerCapture, isSubmenu, setInitialFocus]);
+
   React.useEffect(() => {
     return function cleanup() {
       clearTimeout(popoverHoverOutTimer);
@@ -112,6 +123,7 @@ export const useMenuPopover = (props: MenuPopoverProps): MenuPopoverState => {
       accessible: shouldFocusOnContainer,
       focusable: canFocusOnPopover,
       onBlur,
+      onFocus,
     },
   };
 };

--- a/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
+++ b/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
@@ -87,9 +87,10 @@ export const useMenuPopover = (props: MenuPopoverProps): MenuPopoverState => {
     setCanFocusOnPopover(false);
   }, [setCanFocusOnPopover]);
 
-  // On win32, prevent the submenu from closing prematurely
-  // when the parent menu takes pointer capture and we still
-  // have mouse hover on the submenu trigger
+  // On win32, when the parent menu takes pointer capture and the
+  // submenu receives focus, prevent the submenu from closing in
+  // response to onHoverOut from the menu trigger by cancelling the
+  // triggerOnHoverOutTimer.
   const onFocus = React.useCallback(() => {
     if (Platform.OS === ('win32' as any) && isSubmenu && !doNotTakePointerCapture) {
       clearTimeout(triggerHoverOutTimer);

--- a/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
+++ b/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
@@ -87,16 +87,16 @@ export const useMenuPopover = (props: MenuPopoverProps): MenuPopoverState => {
     setCanFocusOnPopover(false);
   }, [setCanFocusOnPopover]);
 
-  // Prevents submenus that take initial focus from closing prematurely
-  // when the parent menu takes pointer capture and we still have
-  // the mouse hovered on the submenu trigger.
+  // On win32, prevent the submenu from closing prematurely
+  // when the parent menu takes pointer capture and we still
+  // have mouse hover on the submenu trigger
   const onFocus = React.useCallback(() => {
-    if (isSubmenu && setInitialFocus && !doNotTakePointerCapture) {
+    if (Platform.OS === ('win32' as any) && isSubmenu && !doNotTakePointerCapture) {
       clearTimeout(triggerHoverOutTimer);
       clearTimeout(popoverHoverOutTimer);
       clearTimeout(parentPopoverHoverOutTimer);
     }
-  }, [parentPopoverHoverOutTimer, popoverHoverOutTimer, triggerHoverOutTimer, doNotTakePointerCapture, isSubmenu, setInitialFocus]);
+  }, [isSubmenu, doNotTakePointerCapture, parentPopoverHoverOutTimer, popoverHoverOutTimer, triggerHoverOutTimer]);
 
   React.useEffect(() => {
     return function cleanup() {

--- a/packages/components/Menu/src/MenuTrigger/useMenuTrigger.ts
+++ b/packages/components/Menu/src/MenuTrigger/useMenuTrigger.ts
@@ -101,7 +101,7 @@ export const useMenuTrigger = (childProps: MenuTriggerChildProps): MenuTriggerSt
         // submenu when we hover off of the trigger before the submenu is
         // opened. Otherwise, the submenu can cancel this action (for more
         // context on why this is needed, check onFocus in useMenuPopover.ts)
-        if (Platform.OS === ('win32' as any) && isSubmenu && !open) {
+        if (Platform.OS === ('win32' as any) && isSubmenu && !parentDoNotTakePointerCapture && !open) {
           setTimeout(() => {
             setOpen(e, false /* isOpen */);
           }, hoverDelay);
@@ -115,7 +115,7 @@ export const useMenuTrigger = (childProps: MenuTriggerChildProps): MenuTriggerSt
 
       childOnHoverOut && childOnHoverOut(e);
     },
-    [childOnHoverOut, hoverDelay, openOnHover, setOpen, setTriggerHoverOutTimer, isSubmenu, open],
+    [childOnHoverOut, hoverDelay, openOnHover, setOpen, setTriggerHoverOutTimer, parentDoNotTakePointerCapture, isSubmenu, open],
   );
 
   const onClick = React.useCallback(


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Bug: On a menu that opens via click that has a submenu that opens on hover with a scroll bar, the submenu dismisses early when dragging the scrollbar.

Having different pointer capture logic for both the parent menu and submenu causes a bug where we're dismissing the submenu earlier than we want. More specifically, when we have a parent menu that opens via click and a submenu that opens via hover, the parent menu takes pointer capture (by default on win32) and the submenu is set to not take pointer capture since it opens on hover. I was not able to determine the exact order of events that causes the submenu to dismiss early when clicking on the scrollbar but the issue is resolved when the parent menu and submenu share the same pointer capture logic.

To do this, I added `parentDoNotTakePointerCapture` to the menu context so child menus can set their pointer capture logic accordingly. I also had to ensure we cleared out the hoverOut timers when a submenu that opens on hover is opened while we're still hovered on the menu trigger to prevent the submenu from flickering open and closed when the menus take pointer capture.

### Verification

Added an extra example case that has a menu with a submenu that opens on hover with a scrollview and manually tested the changes to verify the issue was fixed.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|![SubmenuDismissBug](https://user-images.githubusercontent.com/22876140/233122282-d3bc42a1-19f4-463f-aaa1-a4a4946d32a9.gif)|![SubmenuDissmisFix](https://user-images.githubusercontent.com/22876140/233122651-a8b076c0-47d3-42d4-8a92-8b95c607ab8b.gif)|

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
