### PR TITLE
[Menu] Enable pointer capture on MenuPopover to be overridden

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Menu/MenuTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Menu/MenuTest.tsx
@@ -160,6 +160,53 @@ const MenuSubMenu: React.FunctionComponent = () => {
   );
 };
 
+const SubmenuWithScrollView: React.FunctionComponent<MenuProps> = (props: MenuProps) => {
+  return (
+    <Menu {...props}>
+      <MenuTrigger>
+        <MenuItem>A second MenuItem trigger</MenuItem>
+      </MenuTrigger>
+      <MenuPopover maxHeight={200}>
+        <MenuList>
+          <MenuItem>A nested MenuItem</MenuItem>
+          <MenuItem>A nested MenuItem</MenuItem>
+          <MenuItem>A nested MenuItem</MenuItem>
+          <MenuItem>A nested MenuItem</MenuItem>
+          <MenuItem>A nested MenuItem</MenuItem>
+          <MenuItem>A nested MenuItem</MenuItem>
+          <MenuItem>A nested MenuItem</MenuItem>
+          <MenuItem>A nested MenuItem</MenuItem>
+          <MenuItem>A nested MenuItem</MenuItem>
+          <MenuItem>A nested MenuItem</MenuItem>
+          <MenuItem>A nested MenuItem</MenuItem>
+          <MenuItem>A nested MenuItem</MenuItem>
+          <MenuItem>A nested MenuItem</MenuItem>
+          <MenuItem>A nested MenuItem</MenuItem>
+          <MenuItem>A nested MenuItem</MenuItem>
+        </MenuList>
+      </MenuPopover>
+    </Menu>
+  );
+};
+
+const MenuSubMenuWithScrollView: React.FunctionComponent = () => {
+  return (
+    <Stack style={stackStyle}>
+      <Menu>
+        <MenuTrigger>
+          <Button>Test</Button>
+        </MenuTrigger>
+        <MenuPopover doNotTakePointerCapture={true}>
+          <MenuList>
+            <MenuItem>A MenuItem</MenuItem>
+            <SubmenuWithScrollView />
+          </MenuList>
+        </MenuPopover>
+      </Menu>
+    </Stack>
+  );
+};
+
 const MenuOpenOnHover: React.FunctionComponent = () => {
   return (
     <Stack style={stackStyle}>
@@ -374,6 +421,13 @@ const menuSections: TestSection[] = [
     name: 'Menu Radioitem',
     component: MenuRadioItem,
   },
+  Platform.select({
+    android: null,
+    default: {
+      name: 'Menu Submenu with ScrollView',
+      component: MenuSubMenuWithScrollView,
+    },
+  }),
   Platform.select({
     android: null,
     default: {

--- a/change/@fluentui-react-native-menu-460a39c7-e99c-4fa1-b064-2bc256656208.json
+++ b/change/@fluentui-react-native-menu-460a39c7-e99c-4fa1-b064-2bc256656208.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "enable pointer capture to be overwritten",
+  "comment": "enable pointer capture to be overridden",
   "packageName": "@fluentui-react-native/menu",
   "email": "krsiler@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-native-menu-460a39c7-e99c-4fa1-b064-2bc256656208.json
+++ b/change/@fluentui-react-native-menu-460a39c7-e99c-4fa1-b064-2bc256656208.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "enable pointer capture to be overwritten",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-13d9c418-5891-4a87-a96b-6caf188f739d.json
+++ b/change/@fluentui-react-native-tester-13d9c418-5891-4a87-a96b-6caf188f739d.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "enable pointer capture to be overwritten",
+  "comment": "enable pointer capture to be overridden",
   "packageName": "@fluentui-react-native/tester",
   "email": "krsiler@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-native-tester-13d9c418-5891-4a87-a96b-6caf188f739d.json
+++ b/change/@fluentui-react-native-tester-13d9c418-5891-4a87-a96b-6caf188f739d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "enable pointer capture to be overwritten",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
+++ b/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
@@ -36,7 +36,7 @@ export const useMenuPopover = (props: MenuPopoverProps): MenuPopoverState => {
   // Initial focus behavior differs per platform, Windows platforms move focus
   // automatically onto first element of Callout
   const setInitialFocus = Platform.OS === ('win32' as any) || Platform.OS === 'windows';
-  const doNotTakePointerCapture = openOnHover;
+  const doNotTakePointerCapture = props.doNotTakePointerCapture ?? openOnHover;
   const accessibilityRole = 'menu';
 
   const onMouseEnter = React.useCallback(() => {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Bug: On a menu that opens via click that has a submenu that opens on hover with a scroll bar, the submenu dismisses early when dragging the scrollbar. 

This is due to the different pointer capture logic set on the parent menu and the submenu. To fix this, I'm enabling the user to pass in a value for doNotTakePointerCapture on MenuPopover so that they have more control and can set doNotTakePointerCapture to true on the parent menu when it has a submenu that opens on hover.

### Verification

Added an extra example case that has a menu with a submenu that opens on hover with a scrollview and manually tested the changes to verify the issue was fixed.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
