### PR TITLE
Don't bundle in JS PR

### DIFF
--- a/.ado/azure-pipelines.yml
+++ b/.ado/azure-pipelines.yml
@@ -5,7 +5,7 @@ variables:
   CI: true
 
 jobs:
-  # Dedicated task to build and bundle JS code, including jest tests, snapshot testing, and linting, because these things can be super
+  # Dedicated task to build JS code, including jest tests, snapshot testing, and linting, because these things can be super
   # time consuming they don't need to run on every CI pass, instead do a dedicated JS loop to make the platform specific tests start quicker
   - job: JSPR
     displayName: JS PR

--- a/lage.config.js
+++ b/lage.config.js
@@ -3,7 +3,7 @@ module.exports = {
   pipeline: {
     ['build-tools']: ['^build-tools'],
     build: ['build-tools', '^build'],
-    buildci: ['build', 'test', 'depcheck', 'bundle'],
+    buildci: ['build', 'test', 'depcheck'],
     bundle: ['build-tools', 'build'],
     clean: [],
     depcheck: ['build-tools'],


### PR DESCRIPTION
Our JS PR has been taking a while. We can probably skip bundling, since we do that in each platform check. 
Feel free to reject this PR if it's not one we like. I was curious how much time it saved us.