### PR TITLE
[Menu] Implement N of M on submenu trigger

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Menu/MenuTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Menu/MenuTest.tsx
@@ -318,7 +318,7 @@ const MenuNofM: React.FunctionComponent = () => {
             <MenuItem disabled>A disabled MenuItem</MenuItem>
             <MenuItem accessibilityPositionInSet={9}>A plain MenuItem</MenuItem>
             <MenuDivider />
-            {Platform.OS !== 'android' && <MenuWithCustomMenuTrigger accessibilityPositionInSet={16} accessibilitySetSize={7} />}
+            {Platform.OS !== 'android' && <Submenu accessibilityPositionInSet={16} accessibilitySetSize={7} />}
             <MenuItem disabled accessibilitySetSize={2}>
               A disabled MenuItem
             </MenuItem>
@@ -351,7 +351,7 @@ const MenuWithCustomMenuTrigger: React.FunctionComponent<MenuProps> = (props: Me
             <MenuItem disabled>A disabled MenuItem</MenuItem>
             <MenuItem accessibilityPositionInSet={9}>A plain MenuItem</MenuItem>
             <MenuDivider />
-            {Platform.OS !== 'android' && <MenuWithCustomMenuTrigger />}
+            {Platform.OS !== 'android' && <Submenu />}
             <MenuItem disabled accessibilitySetSize={2}>
               A disabled MenuItem
             </MenuItem>

--- a/apps/fluent-tester/src/TestComponents/Menu/MenuTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Menu/MenuTest.tsx
@@ -318,7 +318,7 @@ const MenuNofM: React.FunctionComponent = () => {
             <MenuItem disabled>A disabled MenuItem</MenuItem>
             <MenuItem accessibilityPositionInSet={9}>A plain MenuItem</MenuItem>
             <MenuDivider />
-            {Platform.OS !== 'android' && <Submenu accessibilityPositionInSet={16} accessibilitySetSize={7} />}
+            {Platform.OS !== 'android' && <MenuWithCustomMenuTrigger accessibilityPositionInSet={16} accessibilitySetSize={7} />}
             <MenuItem disabled accessibilitySetSize={2}>
               A disabled MenuItem
             </MenuItem>
@@ -332,7 +332,7 @@ const MenuNofM: React.FunctionComponent = () => {
 
 const CustomMenuTrigger: React.FunctionComponent = () => {
   return (
-    <View style={{ borderColor: 'purple', borderWidth: 3 }}>
+    <View style={{ backgroundColor: 'purple', width: 80, flexDirection: 'row', justifyContent: 'center' }}>
       <MenuTrigger>
         <Button>Test</Button>
       </MenuTrigger>
@@ -340,10 +340,10 @@ const CustomMenuTrigger: React.FunctionComponent = () => {
   );
 };
 
-const MenuWithCustomMenuTrigger: React.FunctionComponent = () => {
+const MenuWithCustomMenuTrigger: React.FunctionComponent<MenuProps> = (props: MenuProps) => {
   return (
     <Stack style={stackStyle}>
-      <Menu>
+      <Menu {...props}>
         <CustomMenuTrigger />
         <MenuPopover>
           <MenuList>
@@ -351,7 +351,7 @@ const MenuWithCustomMenuTrigger: React.FunctionComponent = () => {
             <MenuItem disabled>A disabled MenuItem</MenuItem>
             <MenuItem accessibilityPositionInSet={9}>A plain MenuItem</MenuItem>
             <MenuDivider />
-            {Platform.OS !== 'android' && <Submenu accessibilityPositionInSet={16} accessibilitySetSize={7} />}
+            {Platform.OS !== 'android' && <MenuWithCustomMenuTrigger />}
             <MenuItem disabled accessibilitySetSize={2}>
               A disabled MenuItem
             </MenuItem>

--- a/change/@fluentui-react-native-menu-f26f51a3-6f92-42fc-8ee1-e29f3087b13f.json
+++ b/change/@fluentui-react-native-menu-f26f51a3-6f92-42fc-8ee1-e29f3087b13f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "set n of m on submenu trigger",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-3710ecce-25f3-4761-b0f6-405ff546952b.json
+++ b/change/@fluentui-react-native-tester-3710ecce-25f3-4761-b0f6-405ff546952b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "set n of m on submenu trigger",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/MenuTrigger/useMenuTrigger.ts
+++ b/packages/components/Menu/src/MenuTrigger/useMenuTrigger.ts
@@ -76,21 +76,19 @@ export const useMenuTrigger = (childProps: MenuTriggerChildProps): MenuTriggerSt
   );
 
   const accessibilityPositionInSet = React.useMemo(() => {
-    const baseAccessibilityPositionInSet = context.accessibilityPositionInSet;
     if (childAccessibilityPositionInSet) {
       return childAccessibilityPositionInSet;
     }
 
-    return baseAccessibilityPositionInSet;
+    return context.accessibilityPositionInSet;
   }, [childAccessibilityPositionInSet, context.accessibilityPositionInSet]);
 
   const accessibilitySetSize = React.useMemo(() => {
-    const baseAccessibilitySetSize = context.accessibilitySetSize;
     if (childAccessibilitySetSize) {
       return childAccessibilitySetSize;
     }
 
-    return baseAccessibilitySetSize;
+    return context.accessibilitySetSize;
   }, [childAccessibilitySetSize, context.accessibilitySetSize]);
 
   const onHoverIn = React.useCallback(

--- a/packages/components/Menu/src/MenuTrigger/useMenuTrigger.ts
+++ b/packages/components/Menu/src/MenuTrigger/useMenuTrigger.ts
@@ -75,22 +75,6 @@ export const useMenuTrigger = (childProps: MenuTriggerChildProps): MenuTriggerSt
     [childOnAccessibilityAction, setOpen],
   );
 
-  const accessibilityPositionInSet = React.useMemo(() => {
-    if (childAccessibilityPositionInSet) {
-      return childAccessibilityPositionInSet;
-    }
-
-    return context.accessibilityPositionInSet;
-  }, [childAccessibilityPositionInSet, context.accessibilityPositionInSet]);
-
-  const accessibilitySetSize = React.useMemo(() => {
-    if (childAccessibilitySetSize) {
-      return childAccessibilitySetSize;
-    }
-
-    return context.accessibilitySetSize;
-  }, [childAccessibilitySetSize, context.accessibilitySetSize]);
-
   const onHoverIn = React.useCallback(
     (e: InteractionEvent) => {
       if (openOnHover) {
@@ -141,8 +125,8 @@ export const useMenuTrigger = (childProps: MenuTriggerChildProps): MenuTriggerSt
       accessibilityState,
       accessibilityActions,
       onAccessibilityAction,
-      accessibilityPositionInSet, // win32
-      accessibilitySetSize, // win32
+      accessibilityPositionInSet: childAccessibilityPositionInSet ?? context.accessibilityPositionInSet, // win32
+      accessibilitySetSize: childAccessibilitySetSize ?? context.accessibilitySetSize, // win32
     },
     hasSubmenu: context.isSubmenu,
   };

--- a/packages/components/Menu/src/MenuTrigger/useMenuTrigger.ts
+++ b/packages/components/Menu/src/MenuTrigger/useMenuTrigger.ts
@@ -31,6 +31,8 @@ export const useMenuTrigger = (childProps: MenuTriggerChildProps): MenuTriggerSt
     accessibilityActions: childAccessibilityActions,
     accessibilityState: childAccessibilityState,
     onAccessibilityAction: childOnAccessibilityAction,
+    accessibilityPositionInSet: childAccessibilityPositionInSet, // win32
+    accessibilitySetSize: childAccessibilitySetSize, // win32
     onClick: childOnClick,
     onHoverIn: childOnHoverIn,
     onHoverOut: childOnHoverOut,
@@ -72,6 +74,24 @@ export const useMenuTrigger = (childProps: MenuTriggerChildProps): MenuTriggerSt
     },
     [childOnAccessibilityAction, setOpen],
   );
+
+  const accessibilityPositionInSet = React.useMemo(() => {
+    const baseAccessibilityPositionInSet = context.accessibilityPositionInSet;
+    if (childAccessibilityPositionInSet) {
+      return childAccessibilityPositionInSet;
+    }
+
+    return baseAccessibilityPositionInSet;
+  }, [childAccessibilityPositionInSet, context.accessibilityPositionInSet]);
+
+  const accessibilitySetSize = React.useMemo(() => {
+    const baseAccessibilitySetSize = context.accessibilitySetSize;
+    if (childAccessibilitySetSize) {
+      return childAccessibilitySetSize;
+    }
+
+    return baseAccessibilitySetSize;
+  }, [childAccessibilitySetSize, context.accessibilitySetSize]);
 
   const onHoverIn = React.useCallback(
     (e: InteractionEvent) => {
@@ -123,6 +143,8 @@ export const useMenuTrigger = (childProps: MenuTriggerChildProps): MenuTriggerSt
       accessibilityState,
       accessibilityActions,
       onAccessibilityAction,
+      accessibilityPositionInSet, // win32
+      accessibilitySetSize, // win32
     },
     hasSubmenu: context.isSubmenu,
   };


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Re-implements N of M on submenu triggers that was previously reverted by #2725. This implementation does not cause any rendering issues that were present with the previous implementation and implements it in a better way. The n of m properties can be overridden by passing n of m props to the submenu (as demonstrated in the N of M example in the test app).

### Verification

Added examples to the test app that demonstrate default n of m properties are set on submenu triggers and that those props can be overridden. Also added test cases that show that is works for customized menu triggers.

Default N of M set on submenu trigger:

<img width="1003" alt="Screenshot 2023-04-27 at 2 19 24 PM" src="https://user-images.githubusercontent.com/22876140/234957329-8754daaf-dbb5-42a5-a709-d082681f3c0e.png">


Overridden N of M values set on submenu trigger:

<img width="1018" alt="Screenshot 2023-04-27 at 2 18 38 PM" src="https://user-images.githubusercontent.com/22876140/234957315-67ee5480-0fa8-4bcc-b2e8-950dc2748407.png">


Without Change:

<img width="986" alt="Screenshot 2023-04-27 at 2 24 15 PM" src="https://user-images.githubusercontent.com/22876140/234957346-6bc07fa0-ebe9-451c-98b5-2fd0a7210571.png">



### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [x] Voiceover
- [ ] Internationalization and Right-to-left Layouts
