### PR TITLE
Bug Fix - Enabling Voice Access for "Press to Alert" button in Pressable Test

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Pressable/PressableTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Pressable/PressableTest.tsx
@@ -98,7 +98,7 @@ const PressComponent: React.FunctionComponent<ViewProps> = (props: ViewProps) =>
     <Stack focusable={false}>
       <View
         accessible
-        accessibilityLabel={'Press'}
+        accessibilityLabel={'Press to alert'}
         onAccessibilityTap={onInvoke}
         accessibilityRole="button"
         focusable={true}

--- a/apps/fluent-tester/src/TestComponents/Pressable/PressableTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Pressable/PressableTest.tsx
@@ -90,9 +90,22 @@ const PressComponent: React.FunctionComponent<ViewProps> = (props: ViewProps) =>
     [pressProps],
   );
 
+  const onInvoke = React.useCallback(() => {
+    Alert.alert('Alert.', 'Object has been pressed.');
+  }, []);
+
   return (
     <Stack focusable={false}>
-      <View focusable={true} {...pressProps} onTouchEnd={onTouchEnd} style={pressState.pressed ? styles.pressed : styles.notPressed} />
+      <View
+        accessible
+        accessibilityLabel={'Press'}
+        onAccessibilityTap={onInvoke}
+        accessibilityRole="button"
+        focusable={true}
+        {...pressProps}
+        onTouchEnd={onTouchEnd}
+        style={pressState.pressed ? styles.pressed : styles.notPressed}
+      />
     </Stack>
   );
 };

--- a/change/@fluentui-react-native-tester-8a95beb6-ee57-4af6-a2e7-2ef6bd8b5b30.json
+++ b/change/@fluentui-react-native-tester-8a95beb6-ee57-4af6-a2e7-2ef6bd8b5b30.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fixed accessibility props in pressable test for press to alert button",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "gulnazsayed@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

The bug was in Pressable Test where "Press to Alert" button was not accessible via voice access. The fix was adding the correct accessibility props to PressComponent and writing an onInvoke callback, similar to the behavior of the onTouchEnd callback, which is passed into onAccessibilityTap that only takes a (() => void) callback type.

### Verification

Tested manually to see if the bug repros. The "Press to Alert" button is now accessible via voice access when you say "Click Press to Alert"

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [x] Voiceover
- [ ] Internationalization and Right-to-left Layouts
