### PR TITLE
removed other layouts tests for win32

### DIFF
--- a/apps/fluent-tester/src/TestComponents/RadioGroupV1/RadioGroupV1Test.tsx
+++ b/apps/fluent-tester/src/TestComponents/RadioGroupV1/RadioGroupV1Test.tsx
@@ -30,6 +30,13 @@ const radioGroupV1Sections: TestSection[] = [
   },
   ...Platform.select({
     android: [null],
+    native: [
+      {
+        name: 'RadioGroup with Label Subtext',
+        testID: RADIOGROUPV1_TESTPAGE,
+        component: SubtextRadioGroup,
+      },
+    ],
     default: [
       {
         name: 'RadioGroup with Label Subtext',

--- a/packages/experimental/RadioGroup/SPEC.md
+++ b/packages/experimental/RadioGroup/SPEC.md
@@ -281,7 +281,7 @@ export interface RadioGroupProps extends Pick<FocusZoneProps, 'isCircularNavigat
   /**
    * The position of the label relative to the indicator.
    *
-   * 'horizontal' and 'horizontal-stacked' are not supported from Fluent Android, renders as-is.
+   * 'horizontal' and 'horizontal-stacked' are not supported from Fluent Android and Win32, renders as-is.
    *
    * @default vertical
    */
@@ -324,7 +324,7 @@ export interface RadioProps extends PressablePropsExtended {
    * This defaults to 'after' unless the Radio is inside a RadioGroup with layout horizontal-stacked,
    * in which case it defaults to 'below'
    *
-   * 'below' is not supported from Fluent Android, renders as-is.
+   * 'below' is not supported from Fluent Android and Win32, renders as-is.
    * @default after
    */
   labelPosition?: 'after' | 'below';

--- a/packages/experimental/RadioGroup/SPEC.md
+++ b/packages/experimental/RadioGroup/SPEC.md
@@ -157,9 +157,9 @@ const radiogroup = (
 
 ### Horizontal RadioGroup
 
-Win32:
+The horizontal layout is not supported on Win32 and Android.
 
-![Horizontal RadioGroup Example on Win32](./assets/horizontal_radiogroup.png)
+![Horizontal RadioGroup Example](./assets/horizontal_radiogroup.png)
 
 ```tsx
 const onChange = React.useCallback((key: string) => {
@@ -178,9 +178,9 @@ const radiogroup = (
 
 ### Horizontal-Stacked RadioGroup
 
-Win32:
+The horizontal-stacked layout is not supported on Win32 and Android.
 
-![Horizontal-Stacked RadioGroup Example on Win32](./assets/horizontal_stacked_radiogroup.png)
+![Horizontal-Stacked RadioGroup Example](./assets/horizontal_stacked_radiogroup.png)
 
 ```tsx
 const onChange = React.useCallback((key: string) => {

--- a/packages/experimental/RadioGroup/src/Radio/Radio.types.ts
+++ b/packages/experimental/RadioGroup/src/Radio/Radio.types.ts
@@ -195,7 +195,7 @@ export interface RadioProps extends PressablePropsExtended {
    * This defaults to 'after' unless the Radio is inside a RadioGroup with layout horizontal-stacked,
    * in which case it defaults to 'below'
    *
-   * 'below' is not supported from Fluent Android, renders as-is.
+   * 'below' is not supported from Fluent Android and Win32, renders as-is.
    * @default after
    */
   labelPosition?: 'after' | 'below';

--- a/packages/experimental/RadioGroup/src/RadioGroup/RadioGroup.types.ts
+++ b/packages/experimental/RadioGroup/src/RadioGroup/RadioGroup.types.ts
@@ -120,7 +120,7 @@ export interface RadioGroupProps extends Pick<FocusZoneProps, 'isCircularNavigat
 
   /**
    * The position of the label relative to the indicator.
-   * 'horizontal' and 'horizontal-stacked' are not supported from Fluent Android, renders as-is.
+   * 'horizontal' and 'horizontal-stacked' are not supported from Fluent Android and Win32, renders as-is.
    *
    * @default vertical
    */


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Removed "other" layouts (horizontal and horizontal-stacked) from win32 tester app. Added a comment in the spec and to the layout and labelPosition props that these layouts are not supported in win32. We decided that these "other" layouts are not really seen in win32 so it is better not to expose these layouts to partners until a use case is identified specifically for the win32 platform. The logic and props are left as is for other platforms to use and in the case we want to make it available for win32 in the future.

### Verification

Manually tested that the horizontal and horizontal-stacked layout tests are removed from the win32 tester app.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
