### PR TITLE
<Spinner>add spinner tail svg without native animation - win32

### DIFF
--- a/change/@fluentui-react-native-spinner-9deed6bb-d7c0-4600-bab7-b0f5d7d2a244.json
+++ b/change/@fluentui-react-native-spinner-9deed6bb-d7c0-4600-bab7-b0f5d7d2a244.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add spinner tail svg without native animation",
+  "packageName": "@fluentui-react-native/spinner",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Spinner/src/Spinner.styling.win32.ts
+++ b/packages/experimental/Spinner/src/Spinner.styling.win32.ts
@@ -27,5 +27,14 @@ export const stylingSettings: UseStylingOptions<SpinnerProps, SpinnerSlotProps, 
       }),
       ['size', 'trackColor', 'width', 'height'],
     ),
+    tail: buildProps(
+      (tokens: SpinnerTokens) => ({
+        size: tokens.size,
+        tailColor: tokens.tailColor,
+        viewBoxWidth: tokens.width,
+        viewBoxHeight: tokens.height,
+      }),
+      ['size', 'tailColor', 'width', 'height'],
+    ),
   },
 };

--- a/packages/experimental/Spinner/src/Spinner.win32.tsx
+++ b/packages/experimental/Spinner/src/Spinner.win32.tsx
@@ -8,23 +8,22 @@ import { TextV1 as Text } from '@fluentui-react-native/text';
 import { Path, Svg } from 'react-native-svg';
 import type { SvgProps } from 'react-native-svg';
 
-import { RCTNativeAnimatedSpinner } from './consts.win32';
+// import { RCTNativeAnimatedSpinner } from './consts.win32';
 import { stylingSettings } from './Spinner.styling.win32';
 import { spinnerName } from './Spinner.types';
 import type { SpinnerProps, SpinnerType, SpinnerSvgProps } from './Spinner.types.win32';
 import { diameterSizeMap, lineThicknessSizeMap, getDefaultSize } from './SpinnerTokens.win32';
 import { useSpinner } from './useSpinner';
-// TODO: getTailPath, tailSvg
 
 const getTrackPath = (diameter: number, width: number, color: ColorValue) => {
   const start = {
     x: width / 2,
-    y: diameter / 2 + width / 2,
+    y: diameter / 2,
   };
-
-  const path = `M${start.x} ${start.y} a${diameter / 2} ${diameter / 2} 0 1 0 ${diameter} 0 a${diameter / 2} ${
-    diameter / 2
-  } 0 1 0 -${diameter} 0}`;
+  const innerRadius = diameter / 2 - width / 2;
+  const path = `M${start.x} ${start.y} a${innerRadius} ${innerRadius} 0 1 0 ${innerRadius * 2} 0 a${innerRadius} ${innerRadius} 0 1 0 -${
+    innerRadius * 2
+  } 0}`;
   return <Path d={path} stroke={color} strokeWidth={width} strokeLinecap="round" fillOpacity={0} />;
 };
 
@@ -37,7 +36,31 @@ const trackSvg: React.FunctionComponent<SpinnerSvgProps> = (props: SpinnerSvgPro
       width: diameterSizeMap[size],
     },
   };
-  const path = getTrackPath(diameterSizeMap[size] - lineThicknessSizeMap[size], lineThicknessSizeMap[size], trackColor);
+  const path = getTrackPath(diameterSizeMap[size], lineThicknessSizeMap[size], trackColor);
+
+  return <Svg {...svgProps}>{path}</Svg>;
+};
+
+const getTailPath = (diameter: number, width: number, color: ColorValue) => {
+  const start = {
+    x: diameter - width / 2,
+    y: diameter / 2,
+  };
+  const innerRadius = diameter / 2 - width / 2;
+  const path = `M${start.x} ${start.y} a${innerRadius} ${innerRadius} 0 0 1 -${innerRadius} ${innerRadius}`;
+  return <Path d={path} stroke={color} strokeWidth={width} strokeLinecap="round" fillOpacity={0} />;
+};
+
+/* Track is a full circle with a transparent fill */
+const tailSvg: React.FunctionComponent<SpinnerSvgProps> = (props: SpinnerSvgProps) => {
+  const { size, tailColor } = props;
+  const svgProps: SvgProps = {
+    style: {
+      height: diameterSizeMap[size],
+      width: diameterSizeMap[size],
+    },
+  };
+  const path = getTailPath(diameterSizeMap[size], lineThicknessSizeMap[size], tailColor);
 
   return <Svg {...svgProps}>{path}</Svg>;
 };
@@ -51,14 +74,26 @@ export const spinnerLookup = (layer: string, userProps: SpinnerProps): boolean =
   );
 };
 
+const spinnerTailContainer: React.FunctionComponent<SpinnerProps> = (props: SpinnerProps) => {
+  const { size } = props;
+  /* TODO: Add back in when native animated spinner is ready
+   *return <RCTNativeAnimatedSpinner {...{ ...props, style: { position: 'absolute', height: diameterSizeMap[size], width: diameterSizeMap[size], overflow: 'hidden' } }} />;
+   */
+  return (
+    <View
+      {...{ ...props, style: { position: 'absolute', height: diameterSizeMap[size], width: diameterSizeMap[size], overflow: 'hidden' } }}
+    />
+  );
+};
+
 export const Spinner = compose<SpinnerType>({
   displayName: spinnerName,
   ...stylingSettings,
   slots: {
     root: View,
     track: trackSvg,
-    tail: Svg,
-    tailContainer: RCTNativeAnimatedSpinner,
+    tail: tailSvg,
+    tailContainer: spinnerTailContainer,
     label: Text,
   },
   useRender: (props: SpinnerProps, useSlots: UseSlots<SpinnerType>) => {
@@ -70,6 +105,9 @@ export const Spinner = compose<SpinnerType>({
       return (
         <Slots.root {...mergedProps}>
           <Slots.track />
+          <Slots.tailContainer>
+            <Slots.tail />
+          </Slots.tailContainer>
         </Slots.root>
       );
     };

--- a/packages/experimental/Spinner/src/Spinner.win32.tsx
+++ b/packages/experimental/Spinner/src/Spinner.win32.tsx
@@ -8,7 +8,6 @@ import { TextV1 as Text } from '@fluentui-react-native/text';
 import { Path, Svg } from 'react-native-svg';
 import type { SvgProps } from 'react-native-svg';
 
-// import { RCTNativeAnimatedSpinner } from './consts.win32';
 import { stylingSettings } from './Spinner.styling.win32';
 import { spinnerName } from './Spinner.types';
 import type { SpinnerProps, SpinnerType, SpinnerSvgProps } from './Spinner.types.win32';
@@ -80,9 +79,7 @@ const spinnerTailContainer: React.FunctionComponent<SpinnerProps> = (props: Spin
    *return <RCTNativeAnimatedSpinner {...{ ...props, style: { position: 'absolute', height: diameterSizeMap[size], width: diameterSizeMap[size], overflow: 'hidden' } }} />;
    */
   return (
-    <View
-      {...{ ...props, style: { position: 'absolute', height: diameterSizeMap[size], width: diameterSizeMap[size], overflow: 'hidden' } }}
-    />
+    <View {...props} style={{ position: 'absolute', height: diameterSizeMap[size], width: diameterSizeMap[size], overflow: 'hidden' }} />
   );
 };
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [X] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
Add a tail slot with a temporary <View> container which will eventually replaced with a native container that will handle the rotating animation on the native side. This PR simply adds the inanimate tail on top of the track that was checked in through a separate [PR](https://github.com/microsoft/fluentui-react-native/pull/2747)

### Verification
![spinner with tail](https://user-images.githubusercontent.com/12578599/235278339-6d09520f-a339-4a10-bc94-307bdbecaadf.png)

### Pull request checklist

This PR has considered (when applicable):
- [X] Automated Tests
- [X] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
