### PR TITLE
Fix win32 publish pipeline

### DIFF
--- a/.ado/templates/win32-nuget-publish.yml
+++ b/.ado/templates/win32-nuget-publish.yml
@@ -14,13 +14,18 @@ steps:
       yarn buildci
     displayName: 'Building the repo'
 
+  - script: |
+      yarn bundle
+    workingDirectory: apps/win32
+    displayName: 'Bundling FluentTester Win32 app'
+
   # Pack the NuGet package
   - task: CmdLine@1
     displayName: 'Create NuGet package for FluentTester Win32 bundle.'
     inputs:
-        filename: nuget
-        arguments: 'pack Microsoft.FluentUI.FluentTesterWin32.nuspec -OutputDirectory $(Build.ArtifactStagingDirectory) -OutputFileNamesWithoutVersion -Verbosity detailed -Version $(Build.BuildNumber) -properties CommitId=$(Build.SourceVersion)'
-        workingFolder: 'apps/win32/nuget'
+      filename: nuget
+      arguments: 'pack Microsoft.FluentUI.FluentTesterWin32.nuspec -OutputDirectory $(Build.ArtifactStagingDirectory) -OutputFileNamesWithoutVersion -Verbosity detailed -Version $(Build.BuildNumber) -properties CommitId=$(Build.SourceVersion)'
+      workingFolder: 'apps/win32/nuget'
 
   # Pack the NuGet package
   - task: CmdLine@1


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Win32 FluentTester NuGet Publish task fails due to missing bundle file -
![image](https://user-images.githubusercontent.com/49569838/235602032-0f0d21b0-4f45-48eb-9a71-5587100d0a46.png)

This was caused due to removal of bundling in the "buildci" command in this PR #2792 
Adding explicit bundling task in the win32 publish PR.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
