### PR TITLE
Fix repo link to unblock PR checks

### DIFF
--- a/change/@fluentui-react-native-checkbox-106526b0-5982-4c34-b3ae-3141c78351e3.json
+++ b/change/@fluentui-react-native-checkbox-106526b0-5982-4c34-b3ae-3141c78351e3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update apple developer repo link",
+  "packageName": "@fluentui-react-native/checkbox",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Checkbox/README.md
+++ b/packages/components/Checkbox/README.md
@@ -6,6 +6,5 @@ Checkbox V1 supported platformsL win32
 
 Checkbox V0 Supported Platforms: Android, iOS, macOS, web, windows, win32
 
-Note that on iOS, the more common control to use is a Switch
-https://developer.apple.com/design/human-interface-guidelines/ios/controls/switches/
-https://reactnative.dev/docs/switch
+Note that on iOS, the more common control to use is a Toggle
+https://developer.apple.com/design/human-interface-guidelines/toggles

--- a/packages/components/Checkbox/README.md
+++ b/packages/components/Checkbox/README.md
@@ -6,5 +6,5 @@ Checkbox V1 supported platformsL win32
 
 Checkbox V0 Supported Platforms: Android, iOS, macOS, web, windows, win32
 
-Note that on iOS, the more common control to use is a Toggle
-https://developer.apple.com/design/human-interface-guidelines/toggles
+Note that on iOS, the more common control to use is a Switch
+https://developer.apple.com/design/human-interface-guidelines/toggles/#Switches


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

Replace https://developer.apple.com/design/human-interface-guidelines/ios/controls/switches/ with what I'm guessing is the new page, https://developer.apple.com/design/human-interface-guidelines/toggles/#Switches

### Verification

PR checks should pass

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
