### PR TITLE
Update iOS menu picker to use @react-native-menu/menu instead of @react-native-picker/picker

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Avatar/BasicAvatar.tsx
+++ b/apps/fluent-tester/src/TestComponents/Avatar/BasicAvatar.tsx
@@ -60,11 +60,29 @@ export const StandardUsage: FunctionComponent = () => {
           Set {outOfOffice ? ' In office' : ' Out of office'}
         </ToggleButton>
 
-        <StyledPicker prompt="Size" selected={imageSize.toString()} onChange={onSizeChange} collection={avatarSizesForPicker} />
-        <StyledPicker prompt="Active" selected={active} onChange={onActiveChange} collection={avatarActive} />
+        <StyledPicker
+          style={commonStyles.vmargin}
+          prompt="Size"
+          selected={imageSize.toString()}
+          onChange={onSizeChange}
+          collection={avatarSizesForPicker}
+        />
+        <StyledPicker style={commonStyles.vmargin} prompt="Active" selected={active} onChange={onActiveChange} collection={avatarActive} />
         {active === 'active' && <Text>Active appearance is ring</Text>}
-        <StyledPicker prompt="Avatar Color" selected={avatarColor} onChange={onAvatarColorChange} collection={avatarColors} />
-        <StyledPicker prompt="Presence status" selected={presence} onChange={onPresenceChange} collection={allPresences} />
+        <StyledPicker
+          style={commonStyles.vmargin}
+          prompt="Avatar Color"
+          selected={avatarColor}
+          onChange={onAvatarColorChange}
+          collection={avatarColors}
+        />
+        <StyledPicker
+          style={commonStyles.vmargin}
+          prompt="Presence status"
+          selected={presence}
+          onChange={onPresenceChange}
+          collection={allPresences}
+        />
       </View>
       <View style={commonStyles.pickerControlled}>
         <Avatar

--- a/apps/fluent-tester/src/TestComponents/Common/MenuPicker.android.tsx
+++ b/apps/fluent-tester/src/TestComponents/Common/MenuPicker.android.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+
+import { Picker } from '@react-native-picker/picker';
+
+import type { CollectionItem, MenuPickerProps } from './MenuPicker.types';
+import { testProps } from './TestProps';
+export { CollectionItem, MenuPickerProps };
+
+/*
+ * The MenuPicker was created because the RN Core Picker was deprecated (preventing us from updating to RN 0.66).
+ * MenuPicker uses the community Picker package for iOS/Win32 and our own Picker for Win32/MacOS.
+ */
+
+export const MenuPicker: React.FunctionComponent<MenuPickerProps> = (props: MenuPickerProps) => {
+  const { prompt, selected, onChange, collection, style, testID } = props;
+  let selectedItemKey;
+
+  collection.forEach((item) => {
+    if (item.value == selected) {
+      selectedItemKey = item.value;
+    }
+  });
+
+  return (
+    <Picker
+      prompt={prompt}
+      selectedValue={selectedItemKey}
+      onValueChange={(value: string, index: number) => onChange(value, index)}
+      style={{ ...style }}
+      /* For Android E2E testing purposes, testProps must be passed in after accessibilityLabel. */
+      {...testProps(testID)}
+    >
+      {collection.map((item, index) => (
+        <Picker.Item
+          label={item.label}
+          key={index}
+          value={item.value} /* For Android E2E testing purposes, testProps must be passed in after accessibilityLabel. */
+          {...testProps(item.testID)}
+        />
+      ))}
+    </Picker>
+  );
+};

--- a/apps/fluent-tester/src/TestComponents/Common/MenuPicker.android.tsx
+++ b/apps/fluent-tester/src/TestComponents/Common/MenuPicker.android.tsx
@@ -8,7 +8,7 @@ export { CollectionItem, MenuPickerProps };
 
 /*
  * The MenuPicker was created because the RN Core Picker was deprecated (preventing us from updating to RN 0.66).
- * MenuPicker uses the community Picker package for iOS/Win32 and our own Picker for Win32/MacOS.
+ * MenuPicker uses the community Picker package for Android
  */
 
 export const MenuPicker: React.FunctionComponent<MenuPickerProps> = (props: MenuPickerProps) => {

--- a/apps/fluent-tester/src/TestComponents/Common/MenuPicker.ios.tsx
+++ b/apps/fluent-tester/src/TestComponents/Common/MenuPicker.ios.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import { View, StyleSheet } from 'react-native';
+
+import { ButtonV1 as Button } from '@fluentui-react-native/button';
+import { useFluentTheme } from '@fluentui-react-native/framework';
+import { Text } from '@fluentui-react-native/text';
+import { MenuView } from '@react-native-menu/menu';
+import type { MenuAction } from '@react-native-menu/menu';
+import { SvgXml } from 'react-native-svg';
+
+import type { CollectionItem, MenuPickerProps } from './MenuPicker.types';
+import { testProps } from './TestProps';
+
+export { CollectionItem, MenuPickerProps };
+
+/*
+ * The MenuPicker was created because the RN Core Picker was deprecated (preventing us from updating to RN 0.66).
+ * MenuPicker uses the community Picker package for iOS/Win32 and our own Picker for Win32/MacOS.
+ */
+
+const chevronXml = `
+<svg width="12" height="16" viewBox="0 0 11 6">
+  <path fill='currentColor' d='M0.646447 0.646447C0.841709 0.451184 1.15829 0.451184 1.35355 0.646447L5.5 4.79289L9.64645 0.646447C9.84171 0.451185 10.1583 0.451185 10.3536 0.646447C10.5488 0.841709 10.5488 1.15829 10.3536 1.35355L5.85355 5.85355C5.65829 6.04882 5.34171 6.04882 5.14645 5.85355L0.646447 1.35355C0.451184 1.15829 0.451184 0.841709 0.646447 0.646447Z' />
+</svg>`;
+
+const styles = StyleSheet.create({
+  menuPickerPromptText: {
+    marginBottom: 4,
+  },
+  menuPickerIconPadding: {
+    paddingLeft: 12,
+  },
+});
+
+export const MenuPicker: React.FunctionComponent<MenuPickerProps> = (props: MenuPickerProps) => {
+  const { prompt, selected, onChange, collection, style, testID } = props;
+  let selectedItemKey;
+
+  collection.forEach((item) => {
+    if (item.value == selected) {
+      selectedItemKey = item.value;
+    }
+  });
+
+  const pickerOptions: MenuAction[] = collection.map((item) => ({
+    id: item.label,
+    title: item.label,
+    state: item.value === selected ? 'on' : 'off',
+  }));
+
+  const theme = useFluentTheme();
+
+  return (
+    <MenuView
+      title={prompt}
+      onPressAction={({ nativeEvent }) => {
+        onChange(nativeEvent.event);
+      }}
+      actions={pickerOptions}
+      style={style}
+      /* For Android E2E testing purposes, testProps must be passed in after accessibilityLabel. */
+      {...testProps(testID)}
+    >
+      <Text variant="bodySemibold" style={styles.menuPickerPromptText}>
+        {prompt}
+      </Text>
+      <Button appearance="outline">
+        <Text variant="bodySemibold">{selectedItemKey}</Text>
+        <View style={styles.menuPickerIconPadding}>
+          <SvgXml xml={chevronXml} color={theme.colors.bodyText} />
+        </View>
+      </Button>
+    </MenuView>
+  );
+};

--- a/apps/fluent-tester/src/TestComponents/Common/MenuPicker.ios.tsx
+++ b/apps/fluent-tester/src/TestComponents/Common/MenuPicker.ios.tsx
@@ -15,7 +15,7 @@ export { CollectionItem, MenuPickerProps };
 
 /*
  * The MenuPicker was created because the RN Core Picker was deprecated (preventing us from updating to RN 0.66).
- * MenuPicker uses the community Picker package for iOS/Win32 and our own Picker for Win32/MacOS.
+ * MenuPicker uses the community MenuView package for iOS
  */
 
 const chevronXml = `

--- a/apps/fluent-tester/src/TestComponents/Common/MenuPicker.tsx
+++ b/apps/fluent-tester/src/TestComponents/Common/MenuPicker.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 
-import { Picker } from '@react-native-picker/picker';
+import { ButtonV1 as Button } from '@fluentui-react-native/button';
+import { Text } from '@fluentui-react-native/text';
+import { MenuView } from '@react-native-menu/menu';
+import type { MenuAction } from '@react-native-menu/menu';
 
 import type { CollectionItem, MenuPickerProps } from './MenuPicker.types';
 import { testProps } from './TestProps';
@@ -21,23 +24,25 @@ export const MenuPicker: React.FunctionComponent<MenuPickerProps> = (props: Menu
     }
   });
 
+  const pickerOptions: MenuAction[] = collection.map((item) => ({
+    id: item.label,
+    title: item.label,
+    state: item.value === selected ? 'on' : 'off',
+  }));
+
   return (
-    <Picker
-      prompt={prompt}
-      selectedValue={selectedItemKey}
-      onValueChange={(value: string, index: number) => onChange(value, index)}
-      style={{ ...style }}
+    <MenuView
+      title={prompt}
+      onPressAction={({ nativeEvent }) => {
+        onChange(nativeEvent.event);
+      }}
+      actions={pickerOptions}
+      style={style}
       /* For Android E2E testing purposes, testProps must be passed in after accessibilityLabel. */
       {...testProps(testID)}
     >
-      {collection.map((item, index) => (
-        <Picker.Item
-          label={item.label}
-          key={index}
-          value={item.value} /* For Android E2E testing purposes, testProps must be passed in after accessibilityLabel. */
-          {...testProps(item.testID)}
-        />
-      ))}
-    </Picker>
+      <Text variant="bodySemibold">{prompt}</Text>
+      <Button appearance="primary">{selectedItemKey}</Button>
+    </MenuView>
   );
 };

--- a/apps/fluent-tester/src/TestComponents/Common/MenuPicker.tsx
+++ b/apps/fluent-tester/src/TestComponents/Common/MenuPicker.tsx
@@ -1,18 +1,36 @@
 import * as React from 'react';
+import { View, StyleSheet } from 'react-native';
 
 import { ButtonV1 as Button } from '@fluentui-react-native/button';
+import { useFluentTheme } from '@fluentui-react-native/framework';
 import { Text } from '@fluentui-react-native/text';
 import { MenuView } from '@react-native-menu/menu';
 import type { MenuAction } from '@react-native-menu/menu';
+import { SvgXml } from 'react-native-svg';
 
 import type { CollectionItem, MenuPickerProps } from './MenuPicker.types';
 import { testProps } from './TestProps';
+
 export { CollectionItem, MenuPickerProps };
 
 /*
  * The MenuPicker was created because the RN Core Picker was deprecated (preventing us from updating to RN 0.66).
  * MenuPicker uses the community Picker package for iOS/Win32 and our own Picker for Win32/MacOS.
  */
+
+const chevronXml = `
+<svg width="12" height="16" viewBox="0 0 11 6">
+  <path fill='currentColor' d='M0.646447 0.646447C0.841709 0.451184 1.15829 0.451184 1.35355 0.646447L5.5 4.79289L9.64645 0.646447C9.84171 0.451185 10.1583 0.451185 10.3536 0.646447C10.5488 0.841709 10.5488 1.15829 10.3536 1.35355L5.85355 5.85355C5.65829 6.04882 5.34171 6.04882 5.14645 5.85355L0.646447 1.35355C0.451184 1.15829 0.451184 0.841709 0.646447 0.646447Z' />
+</svg>`;
+
+const styles = StyleSheet.create({
+  menuPickerPromptText: {
+    marginBottom: 4,
+  },
+  menuPickerIconPadding: {
+    paddingLeft: 12,
+  },
+});
 
 export const MenuPicker: React.FunctionComponent<MenuPickerProps> = (props: MenuPickerProps) => {
   const { prompt, selected, onChange, collection, style, testID } = props;
@@ -30,6 +48,8 @@ export const MenuPicker: React.FunctionComponent<MenuPickerProps> = (props: Menu
     state: item.value === selected ? 'on' : 'off',
   }));
 
+  const theme = useFluentTheme();
+
   return (
     <MenuView
       title={prompt}
@@ -41,8 +61,15 @@ export const MenuPicker: React.FunctionComponent<MenuPickerProps> = (props: Menu
       /* For Android E2E testing purposes, testProps must be passed in after accessibilityLabel. */
       {...testProps(testID)}
     >
-      <Text variant="bodySemibold">{prompt}</Text>
-      <Button appearance="primary">{selectedItemKey}</Button>
+      <Text variant="bodySemibold" style={styles.menuPickerPromptText}>
+        {prompt}
+      </Text>
+      <Button appearance="outline">
+        <Text variant="bodySemibold">{selectedItemKey}</Text>
+        <View style={styles.menuPickerIconPadding}>
+          <SvgXml xml={chevronXml} color={theme.colors.bodyText} />
+        </View>
+      </Button>
     </MenuView>
   );
 };

--- a/apps/fluent-tester/src/TestComponents/Common/MenuPicker.tsx
+++ b/apps/fluent-tester/src/TestComponents/Common/MenuPicker.tsx
@@ -1,75 +1,11 @@
-import * as React from 'react';
-import { View, StyleSheet } from 'react-native';
-
-import { ButtonV1 as Button } from '@fluentui-react-native/button';
-import { useFluentTheme } from '@fluentui-react-native/framework';
-import { Text } from '@fluentui-react-native/text';
-import { MenuView } from '@react-native-menu/menu';
-import type { MenuAction } from '@react-native-menu/menu';
-import { SvgXml } from 'react-native-svg';
-
 import type { CollectionItem, MenuPickerProps } from './MenuPicker.types';
-import { testProps } from './TestProps';
-
 export { CollectionItem, MenuPickerProps };
 
 /*
  * The MenuPicker was created because the RN Core Picker was deprecated (preventing us from updating to RN 0.66).
- * MenuPicker uses the community Picker package for iOS/Win32 and our own Picker for Win32/MacOS.
  */
 
-const chevronXml = `
-<svg width="12" height="16" viewBox="0 0 11 6">
-  <path fill='currentColor' d='M0.646447 0.646447C0.841709 0.451184 1.15829 0.451184 1.35355 0.646447L5.5 4.79289L9.64645 0.646447C9.84171 0.451185 10.1583 0.451185 10.3536 0.646447C10.5488 0.841709 10.5488 1.15829 10.3536 1.35355L5.85355 5.85355C5.65829 6.04882 5.34171 6.04882 5.14645 5.85355L0.646447 1.35355C0.451184 1.15829 0.451184 0.841709 0.646447 0.646447Z' />
-</svg>`;
-
-const styles = StyleSheet.create({
-  menuPickerPromptText: {
-    marginBottom: 4,
-  },
-  menuPickerIconPadding: {
-    paddingLeft: 12,
-  },
-});
-
-export const MenuPicker: React.FunctionComponent<MenuPickerProps> = (props: MenuPickerProps) => {
-  const { prompt, selected, onChange, collection, style, testID } = props;
-  let selectedItemKey;
-
-  collection.forEach((item) => {
-    if (item.value == selected) {
-      selectedItemKey = item.value;
-    }
-  });
-
-  const pickerOptions: MenuAction[] = collection.map((item) => ({
-    id: item.label,
-    title: item.label,
-    state: item.value === selected ? 'on' : 'off',
-  }));
-
-  const theme = useFluentTheme();
-
-  return (
-    <MenuView
-      title={prompt}
-      onPressAction={({ nativeEvent }) => {
-        onChange(nativeEvent.event);
-      }}
-      actions={pickerOptions}
-      style={style}
-      /* For Android E2E testing purposes, testProps must be passed in after accessibilityLabel. */
-      {...testProps(testID)}
-    >
-      <Text variant="bodySemibold" style={styles.menuPickerPromptText}>
-        {prompt}
-      </Text>
-      <Button appearance="outline">
-        <Text variant="bodySemibold">{selectedItemKey}</Text>
-        <View style={styles.menuPickerIconPadding}>
-          <SvgXml xml={chevronXml} color={theme.colors.bodyText} />
-        </View>
-      </Button>
-    </MenuView>
-  );
+export const MenuPicker: React.FunctionComponent<MenuPickerProps> = (_props: MenuPickerProps) => {
+  console.warn('Platform not supported');
+  return null;
 };

--- a/apps/fluent-tester/src/TestComponents/Common/StyledPicker.tsx
+++ b/apps/fluent-tester/src/TestComponents/Common/StyledPicker.tsx
@@ -7,9 +7,9 @@ import { MenuPicker } from './MenuPicker';
 import { commonTestStyles as commonStyles } from './styles';
 
 export const StyledPicker = (props) => {
-  const { prompt, selected, onChange, collection } = props;
+  const { prompt, selected, onChange, collection, style } = props;
   const theme = useTheme();
-  const pickerStyles = { color: theme.colors.inputText as ColorValue, ...commonStyles.header };
+  const pickerStyles = { color: theme.colors.inputText as ColorValue, alignSelf: 'flex-start', ...commonStyles.header, ...style };
   const styleCollection = collection.map((value) => {
     return {
       label: value,

--- a/apps/fluent-tester/src/TestComponents/Common/TestProps.tsx
+++ b/apps/fluent-tester/src/TestComponents/Common/TestProps.tsx
@@ -6,7 +6,7 @@ import { Platform } from 'react-native';
  * Because of this, we're adding the testProps function that takes in a unique identifier and returns the correct prop based on the platform
  * (testID for Win32, Windows, macOS, iOS; accessibilityId for Android).
  *
- * If explict accessibilityLabel is being used for other platforms, apply testProps after it to override it for Android.
+ * If explicit accessibilityLabel is being used for other platforms, apply testProps after it to override it for Android.
  * @param id The string to be used as the test identifier
  * @returns an object with the correct test identifier prop based on platform
  */

--- a/change/@fluentui-react-native-tester-f77cf871-191d-4229-a80b-6628054c8946.json
+++ b/change/@fluentui-react-native-tester-f77cf871-191d-4229-a80b-6628054c8946.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update MenuPicker to use a MenuView instead of Picker",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Replaced usage of @react-native-picker/picker with @react-native-menu/menu.

@react-native-picker/picker was not very usable in iOS. It took up a lot more space than necessary, making it difficult to scroll down any pages that had a lot of pickers. In dark mode the text would not show up.

@react-native-menu/menu was already being used for the iOS/android theme picker. Was able to use this to make the picker look more like the macOS dropdown component. 

Will be easier to review commit by commit.

### Verification


https://user-images.githubusercontent.com/78454019/236397204-8de381b8-eb62-4f90-8021-eb59d1b7b144.mov


https://user-images.githubusercontent.com/78454019/236397215-2ee70262-84ec-4bca-94b5-50da8dc47867.mov



### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
