### PR TITLE
fix: windows bump WindowsTargetPlatformMinVersion for Expander

### DIFF
--- a/change/@fluentui-react-native-experimental-expander-5dbc49f2-9249-454c-823b-0c80e37c3888.json
+++ b/change/@fluentui-react-native-experimental-expander-5dbc49f2-9249-454c-823b-0c80e37c3888.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bump expander's windows min",
+  "packageName": "@fluentui-react-native/experimental-expander",
+  "email": "tatianakapos@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Expander/windows/ReactNativeExpander/ReactNativeExpander.vcxproj
+++ b/packages/experimental/Expander/windows/ReactNativeExpander/ReactNativeExpander.vcxproj
@@ -15,7 +15,7 @@
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.19041.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.16299.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="ReactNativeWindowsProps">


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [X] windows
- [ ] android

### Description of changes

In RNW .72, we bump WinUI from 2.7 to 2.8 which targets a higher TargetPlatformMinVersion. This PR bumps the WindowsTargetPlatformMinVersion to the correct version for RNW .72

### Verification

tested with react native windows gallery

