### PR TITLE
[Tester] Fix picker - Android

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Common/StyledPicker.tsx
+++ b/apps/fluent-tester/src/TestComponents/Common/StyledPicker.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Platform } from 'react-native';
 import type { ColorValue } from 'react-native';
 
 import { useTheme } from '@fluentui-react-native/theme-types';
@@ -9,7 +10,12 @@ import { commonTestStyles as commonStyles } from './styles';
 export const StyledPicker = (props) => {
   const { prompt, selected, onChange, collection, style } = props;
   const theme = useTheme();
-  const pickerStyles = { color: theme.colors.inputText as ColorValue, alignSelf: 'flex-start', ...commonStyles.header, ...style };
+  const pickerStyles = {
+    color: theme.colors.inputText as ColorValue,
+    alignSelf: Platform.OS === 'ios' ? 'flex-start' : 'auto',
+    ...commonStyles.header,
+    ...style,
+  };
   const styleCollection = collection.map((value) => {
     return {
       label: value,

--- a/change/@fluentui-react-native-tester-03746863-e613-4e00-8fee-c185c2caacd6.json
+++ b/change/@fluentui-react-native-tester-03746863-e613-4e00-8fee-c185c2caacd6.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix android picker",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ayushsinghs@yahoo.in",
+  "dependentChangeType": "none"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [x] android

### Description of changes

MenuPicker had some changes in PR #2822 which left it broken for Android. Fixed that.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Screenshot_2023-05-11-11-29-04-48_3238b23fbbdef38ccf4a465a34706bab](https://github.com/microsoft/fluentui-react-native/assets/49569838/fddf1af1-4822-48bd-8246-afdcfe596464) | ![Screenshot_2023-05-11-11-29-37-68_3238b23fbbdef38ccf4a465a34706bab](https://github.com/microsoft/fluentui-react-native/assets/49569838/e796c8c8-7f23-4555-941d-4f694f380c1b) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
