### PR TITLE
[Android] Reduce flaky tests

### DIFF
--- a/apps/E2E/src/CheckboxV1/specs/CheckboxV1.spec.android.ts
+++ b/apps/E2E/src/CheckboxV1/specs/CheckboxV1.spec.android.ts
@@ -53,15 +53,15 @@ describe('CheckboxV1 Functional Testing', () => {
     /* Validate the Checkbox is initially toggled OFF */
     await expect(await CheckboxV1PageObject.isCheckboxCheckedAndroid()).toBeFalsy();
 
-    /* Click on the Checkbox to toggle on */
+    /* Click on the Checkbox to toggle ON */
     await CheckboxV1PageObject.click(CheckboxV1PageObject._primaryComponent);
-
     expect(await CheckboxV1PageObject.didOnChangeCallbackFire('Callback failed to fire via click.')).toBeTruthy();
 
     /* Validate the Checkbox is toggled ON */
     expect(await CheckboxV1PageObject.isCheckboxCheckedAndroid()).toBeTruthy();
 
     await CheckboxV1PageObject.click(CheckboxV1PageObject._primaryComponent);
+    expect(await CheckboxV1PageObject.didOnChangeCallbackFire('Callback failed to fire via click.')).toBeFalsy();
 
     /* Validate the Checkbox is toggled OFF */
     expect(await CheckboxV1PageObject.isCheckboxCheckedAndroid()).toBeFalsy();

--- a/apps/E2E/src/Input/specs/Input.spec.android.ts
+++ b/apps/E2E/src/Input/specs/Input.spec.android.ts
@@ -62,6 +62,8 @@ describe('Input Functional Testing', () => {
 
   it('Validate error state was achieved', async () => {
     await InputPageObject.click(InputPageObject._primaryComponent);
+    await expect(await InputPageObject.didAssertPopup()).toBeFalsy(InputPageObject.ERRORMESSAGE_ASSERT);
+
     await InputPageObject.typeText(INPUT_TYPE_STRING);
     await expect(await InputPageObject.verifyTextContent(INPUT_ERROR_STRING)).toBeTruthy();
     await expect(await InputPageObject.didAssertPopup()).toBeFalsy(InputPageObject.ERRORMESSAGE_ASSERT);
@@ -69,6 +71,8 @@ describe('Input Functional Testing', () => {
 
   it('Validate accessory icon OnPress() callback was fired -> Click', async () => {
     await InputPageObject.click(InputPageObject._accessoryButton);
+    await expect(await InputPageObject.didAssertPopup()).toBeFalsy(InputPageObject.ERRORMESSAGE_ASSERT);
+
     await expect(await InputPageObject.verifyTextContent(INPUT_ONCLICK_STRING)).toBeTruthy();
     await expect(await InputPageObject.didAssertPopup()).toBeFalsy(InputPageObject.ERRORMESSAGE_ASSERT);
   });

--- a/change/@fluentui-react-native-e2e-testing-3a2e3fb5-86fd-4320-b654-61f7017c9923.json
+++ b/change/@fluentui-react-native-e2e-testing-3a2e3fb5-86fd-4320-b654-61f7017c9923.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Handle flaky tests Android",
+  "packageName": "@fluentui-react-native/e2e-testing",
+  "email": "ayushsinghs@yahoo.in",
+  "dependentChangeType": "none"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [x] android

### Description of changes

Input tests and Checkbox tests have been a bit flaky on Android. This was caused due to text updating slower than the text verification function. Have added additional checks for crash after any interactions, this will add a small delay preventing the issue.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
