### PR TITLE
<Spinner> switch to RN Native Antive Container for animation

### DIFF
--- a/change/@fluentui-react-native-spinner-f358a800-981f-44ff-93ea-bf9c00ee7dba.json
+++ b/change/@fluentui-react-native-spinner-f358a800-981f-44ff-93ea-bf9c00ee7dba.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "switch to RN Native Antive Container for animation",
+  "packageName": "@fluentui-react-native/spinner",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Spinner/src/Spinner.win32.tsx
+++ b/packages/experimental/Spinner/src/Spinner.win32.tsx
@@ -8,6 +8,7 @@ import { TextV1 as Text } from '@fluentui-react-native/text';
 import { Path, Svg } from 'react-native-svg';
 import type { SvgProps } from 'react-native-svg';
 
+import { RCTNativeAnimatedContainer } from './consts.win32';
 import { stylingSettings } from './Spinner.styling.win32';
 import { spinnerName } from './Spinner.types';
 import type { SpinnerProps, SpinnerType, SpinnerSvgProps } from './Spinner.types.win32';
@@ -46,7 +47,8 @@ const getTailPath = (diameter: number, width: number, color: ColorValue) => {
     y: diameter / 2,
   };
   const innerRadius = diameter / 2 - width / 2;
-  const path = `M${start.x} ${start.y} a${innerRadius} ${innerRadius} 0 0 1 -${innerRadius} ${innerRadius}`;
+  const path = `M${start.x} ${start.y} a${innerRadius} ${innerRadius} 0 0 0 -${innerRadius} -${innerRadius}`;
+
   return <Path d={path} stroke={color} strokeWidth={width} strokeLinecap="round" fillOpacity={0} />;
 };
 
@@ -79,7 +81,13 @@ const spinnerTailContainer: React.FunctionComponent<SpinnerProps> = (props: Spin
    *return <RCTNativeAnimatedSpinner {...{ ...props, style: { position: 'absolute', height: diameterSizeMap[size], width: diameterSizeMap[size], overflow: 'hidden' } }} />;
    */
   return (
-    <View {...props} style={{ position: 'absolute', height: diameterSizeMap[size], width: diameterSizeMap[size], overflow: 'hidden' }} />
+    <RCTNativeAnimatedContainer
+      {...{
+        ...props,
+        nativeAnimationClass: 'NativeAnimatedSpinner',
+        style: { position: 'absolute', height: diameterSizeMap[size], width: diameterSizeMap[size], overflow: 'hidden' },
+      }}
+    />
   );
 };
 

--- a/packages/experimental/Spinner/src/consts.win32.ts
+++ b/packages/experimental/Spinner/src/consts.win32.ts
@@ -1,2 +1,2 @@
 import { ensureNativeComponent } from '@fluentui-react-native/component-cache';
-export const RCTNativeAnimatedSpinner = ensureNativeComponent('RCTNativeAnimatedSpinner');
+export const RCTNativeAnimatedContainer = ensureNativeComponent('RCTNativeAnimatedContainer');


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
- Rotate spinner start location
- Change from <View> to <RNNativeAnimationContainer> to support native animation

To be merged after native side changes are checked in

### Verification

https://github.com/microsoft/fluentui-react-native/assets/12578599/df430d6f-791b-4965-92fa-59b7b9a676b2


### Pull request checklist

This PR has considered (when applicable):
- [X] Automated Tests
- [X] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
