### PR TITLE
Execute focus before calling callback

### DIFF
--- a/change/@fluentui-react-native-interactive-hooks-858c4654-a19e-43b6-ad38-bfd68d98751a.json
+++ b/change/@fluentui-react-native-interactive-hooks-858c4654-a19e-43b6-ad38-bfd68d98751a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Execute focus before calling callback",
+  "packageName": "@fluentui-react-native/interactive-hooks",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/utils/interactive-hooks/src/useOnPressWithFocus.ts
+++ b/packages/utils/interactive-hooks/src/useOnPressWithFocus.ts
@@ -16,12 +16,12 @@ export type OnPressWithFocusCallback = (args: GestureResponderEvent) => void;
 export function useOnPressWithFocus(focusRef: React.RefObject<any>, userCallback: OnPressCallback): OnPressWithFocusCallback {
   const onPressWithFocus = React.useCallback(
     (args?: any) => {
-      userCallback?.(args);
-
       const platformSupportsFocus = ['windows', 'win32', 'macos'].includes(Platform.OS as string);
       if (platformSupportsFocus) {
         focusRef?.current?.focus();
       }
+
+      userCallback?.(args);
     },
     [userCallback, focusRef],
   );


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [ ] android

### Description of changes

We should be moving focus before the callback executes in case a user-provided callback wants to move focus somewhere else.

### Verification

Booted test app and tested Button, Menu, Checkbox.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
