### PR TITLE
[Callout][macOS] Implement setInitialFocus

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Callout/CalloutTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Callout/CalloutTest.tsx
@@ -19,7 +19,7 @@ const StandardCallout: React.FunctionComponent = () => {
   const [calloutHovered, setCalloutHovered] = React.useState(false);
 
   const [shouldSetInitialFocus, setShouldSetInitialFocus] = React.useState(true);
-  const onInitialFocusChange = React.useCallback((value) => setShouldSetInitialFocus(value), []);
+  const onInitialFocusChange = React.useCallback((value: boolean) => setShouldSetInitialFocus(value), []);
 
   const [customRestoreFocus, setCustomRestoreFocus] = React.useState(false);
   const onRestoreFocusChange = React.useCallback((value) => setCustomRestoreFocus(value), []);

--- a/change/@fluentui-react-native-callout-0179adfd-80d6-4b80-81e5-66562ef756c8.json
+++ b/change/@fluentui-react-native-callout-0179adfd-80d6-4b80-81e5-66562ef756c8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[Callout] Implement setInitialFocus for macOS",
+  "packageName": "@fluentui-react-native/callout",
+  "email": "saadnajmi2@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-menu-f0c89c8d-24c0-43be-af0f-0349043bc323.json
+++ b/change/@fluentui-react-native-menu-f0c89c8d-24c0-43be-af0f-0349043bc323.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[Callout] Implement setInitialFocus for macOS",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "saadnajmi2@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-0cd47252-8270-49c0-8595-1f27fc5e79d4.json
+++ b/change/@fluentui-react-native-tester-0cd47252-8270-49c0-8595-1f27fc5e79d4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[Callout] Implement setInitialFocus for macOS",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "saadnajmi2@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Callout/macos/CalloutView.swift
+++ b/packages/components/Callout/macos/CalloutView.swift
@@ -26,7 +26,7 @@ class CalloutView: RCTView, CalloutWindowLifeCycleDelegate {
 		}
 	}
 
-    @objc public var setInitialFocus: Bool = false
+	@objc public var setInitialFocus: Bool = false
 
 	@objc public var onShow: RCTDirectEventBlock?
 
@@ -94,9 +94,9 @@ class CalloutView: RCTView, CalloutWindowLifeCycleDelegate {
 
 		updateCalloutFrameToAnchor()
 		calloutWindow.orderFront(self)
-        if (setInitialFocus) {
-            calloutWindow.makeKey()
-        }
+		if (setInitialFocus) {
+		    calloutWindow.makeKey()
+		}
 
 		// Dismiss the Callout if the window is no longer active.
 		NotificationCenter.default.addObserver(self, selector: #selector(dismissCallout), name: NSApplication.didResignActiveNotification, object: nil)

--- a/packages/components/Callout/macos/CalloutView.swift
+++ b/packages/components/Callout/macos/CalloutView.swift
@@ -26,6 +26,8 @@ class CalloutView: RCTView, CalloutWindowLifeCycleDelegate {
 		}
 	}
 
+    @objc public var setInitialFocus: Bool = false
+
 	@objc public var onShow: RCTDirectEventBlock?
 
 	@objc public var onDismiss: RCTDirectEventBlock?
@@ -91,7 +93,10 @@ class CalloutView: RCTView, CalloutWindowLifeCycleDelegate {
 		}
 
 		updateCalloutFrameToAnchor()
-		calloutWindow.makeKeyAndOrderFront(self)
+		calloutWindow.orderFront(self)
+        if (setInitialFocus) {
+            calloutWindow.makeKey()
+        }
 
 		// Dismiss the Callout if the window is no longer active.
 		NotificationCenter.default.addObserver(self, selector: #selector(dismissCallout), name: NSApplication.didResignActiveNotification, object: nil)

--- a/packages/components/Callout/macos/FRNCalloutManager.m
+++ b/packages/components/Callout/macos/FRNCalloutManager.m
@@ -42,6 +42,8 @@ RCT_EXPORT_VIEW_PROPERTY(anchorRect, screenRect)
 
 RCT_EXPORT_VIEW_PROPERTY(directionalHint, NSRectEdge)
 
+RCT_EXPORT_VIEW_PROPERTY(setInitialFocus, BOOL)
+
 RCT_EXPORT_VIEW_PROPERTY(onShow, RCTDirectEventBlock)
 
 RCT_EXPORT_VIEW_PROPERTY(onDismiss, RCTDirectEventBlock)

--- a/packages/components/Callout/src/Callout.types.ts
+++ b/packages/components/Callout/src/Callout.types.ts
@@ -199,8 +199,9 @@ export interface ICalloutProps extends IViewProps, ICalloutTokens {
   onShow?: () => void;
 
   /**
-   * @platform win32
-   * If true then the callout will attempt to focus the first focusable element that it contains.
+   * Determines whether the Callout sets focus when displayed.
+   * On macOS, this determines whether the Callout becomes the key window.
+   * On win32: If true then the callout will attempt to focus the first focusable element that it contains.
    * If it doesn't find an element, no focus will be set. This means that it's the contents responsibility
    * to either set focus or have focusable items.
    */

--- a/packages/components/Callout/src/Callout.types.ts
+++ b/packages/components/Callout/src/Callout.types.ts
@@ -200,7 +200,7 @@ export interface ICalloutProps extends IViewProps, ICalloutTokens {
 
   /**
    * Determines whether the Callout sets focus when displayed.
-   * On macOS, this determines whether the Callout becomes the key window.
+   * On macOS: this determines whether the Callout becomes the key window.
    * On win32: If true then the callout will attempt to focus the first focusable element that it contains.
    * If it doesn't find an element, no focus will be set. This means that it's the contents responsibility
    * to either set focus or have focusable items.

--- a/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
+++ b/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
@@ -33,9 +33,7 @@ export const useMenuPopover = (props: MenuPopoverProps): MenuPopoverState => {
   const dismissBehaviors = isControlled ? controlledDismissBehaviors : undefined;
   const directionalHint = getDirectionalHint(isSubmenu, I18nManager.isRTL);
 
-  // Initial focus behavior differs per platform, Windows platforms move focus
-  // automatically onto first element of Callout
-  const setInitialFocus = Platform.OS === ('win32' as any) || Platform.OS === 'windows';
+  const setInitialFocus = true;
   const doNotTakePointerCapture = props.doNotTakePointerCapture ?? openOnHover;
   const accessibilityRole = 'menu';
 

--- a/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
+++ b/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { I18nManager, Platform } from 'react-native';
+import { I18nManager } from 'react-native';
 
 import type { DirectionalHint, DismissBehaviors } from '@fluentui-react-native/callout';
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

We have a scenario where we want to present a Callout without it becoming the Key Window (so that say, it doesn't take keyboard focus away from a TextInput). We can re-use the previously win32 only prop `setInitialFocus` to implement this.

### Verification

Re-used the existing test page test. Also verified that <Menu> still got focus.

https://github.com/microsoft/fluentui-react-native/assets/6722175/f6e35fa5-080a-4c16-8a83-8b0a72c9bd50

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
