### PR TITLE
[Callout][macOS] Implement DismissBehaviors

### DIFF
--- a/change/@fluentui-react-native-callout-70d80d23-faae-4dce-9ffb-2d0baa0dd89e.json
+++ b/change/@fluentui-react-native-callout-70d80d23-faae-4dce-9ffb-2d0baa0dd89e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[Callout][macOS] Implement DismissBehaviors",
+  "packageName": "@fluentui-react-native/callout",
+  "email": "saadnajmi2@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Callout/macos/FRNCalloutManager.h
+++ b/packages/components/Callout/macos/FRNCalloutManager.h
@@ -2,3 +2,10 @@
 #import <React/RCTUIManager.h>
 #import <React/RCTView.h>
 #import <React/RCTViewManager.h>
+
+typedef NS_OPTIONS(NSUInteger, FRNCalloutPreventDismiss) {
+    FRNCalloutPreventDismissNone            = 0,
+    FRNCalloutPreventDismissOnKeyDown       = 1 << 0,
+    FRNCalloutPreventDismissOnClickOutside  = 1 << 1,
+};
+

--- a/packages/components/Callout/macos/FRNCalloutManager.m
+++ b/packages/components/Callout/macos/FRNCalloutManager.m
@@ -1,5 +1,7 @@
 #import <FRNCalloutManager.h>
 
+@class FRNCalloutView;
+
 @implementation RCTConvert (FRNCalloutAdditions)
 
 // RCTConvert does not properly convert a JS screenRect into a native CGRect/NSRect,
@@ -32,6 +34,7 @@ RCT_ENUM_CONVERTER(NSRectEdge, (@{
 	@"bottomRightEdge": @(NSRectEdgeMinY),
 }), NSRectEdgeMaxY, integerValue);
 
+
 @end
 
 @interface RCT_EXTERN_MODULE(FRNCalloutManager, RCTViewManager)
@@ -41,6 +44,8 @@ RCT_EXPORT_VIEW_PROPERTY(target, NSNumber)
 RCT_EXPORT_VIEW_PROPERTY(anchorRect, screenRect)
 
 RCT_EXPORT_VIEW_PROPERTY(directionalHint, NSRectEdge)
+
+RCT_EXPORT_VIEW_PROPERTY(dismissBehaviors, NSArray<NSString *>)
 
 RCT_EXPORT_VIEW_PROPERTY(onShow, RCTDirectEventBlock)
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

TODO: Implement `preventDismissOnKeyDown` (currently behaves as if this is true)
### Description of changes

Implement the previously windows only prop `DismissBehaviors`

### Verification

Verified that clicks no longer dismiss

https://github.com/microsoft/fluentui-react-native/assets/6722175/81f9e474-2243-4ca0-bcdd-e534bcd89c68


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
