### PR TITLE
fix: fix packages depending on `use-subscription`

### DIFF
--- a/change/@fluentui-react-native-experimental-appearance-additions-ac337f8c-3f68-4c2a-b82f-a1c48aaa907a.json
+++ b/change/@fluentui-react-native-experimental-appearance-additions-ac337f8c-3f68-4c2a-b82f-a1c48aaa907a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix package using `use-subscription` at runtime but does not correctly declare dependencies",
+  "packageName": "@fluentui-react-native/experimental-appearance-additions",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-native-font-metrics-a2f4914f-457e-4f1e-962c-9db92eee0875.json
+++ b/change/@fluentui-react-native-experimental-native-font-metrics-a2f4914f-457e-4f1e-962c-9db92eee0875.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix package using `use-subscription` at runtime but does not correctly declare dependencies",
+  "packageName": "@fluentui-react-native/experimental-native-font-metrics",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/AppearanceAdditions/package.json
+++ b/packages/experimental/AppearanceAdditions/package.json
@@ -28,14 +28,16 @@
     "url": "https://github.com/microsoft/fluentui-react-native.git",
     "directory": "packages/experimental/AppearanceAdditions"
   },
+  "dependencies": {
+    "use-subscription": ">=1.0.0 <1.6.0"
+  },
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/framework": "0.10.0",
     "@fluentui-react-native/scripts": "^0.1.1",
     "@types/use-subscription": "1.0.0",
     "react": "18.2.0",
-    "react-native": "^0.71.0",
-    "use-subscription": ">=1.0.0 <1.6.0"
+    "react-native": "^0.71.0"
   },
   "peerDependencies": {
     "react": "18.2.0",

--- a/packages/experimental/NativeFontMetrics/package.json
+++ b/packages/experimental/NativeFontMetrics/package.json
@@ -28,13 +28,15 @@
     "url": "https://github.com/microsoft/fluentui-react-native.git",
     "directory": "packages/experimental/NativeFontMetrics"
   },
+  "dependencies": {
+    "use-subscription": ">=1.0.0 <1.6.0"
+  },
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "^0.1.1",
     "@fluentui-react-native/scripts": "^0.1.1",
     "@types/use-subscription": "1.0.0",
     "react": "18.2.0",
-    "react-native": "^0.71.0",
-    "use-subscription": ">=1.0.0 <1.6.0"
+    "react-native": "^0.71.0"
   },
   "peerDependencies": {
     "react": "18.2.0",


### PR DESCRIPTION
### Platforms Impacted

- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

It's currently not possible to consume `@fluentui-react-native/experimental-appearance-additions` or `@fluentui-react-native/experimental-native-font-metrics` because they don't correctly declare dependency on `use-subscription`.

### Verification

n/a

### Pull request checklist

n/a