### PR TITLE
fix: some packages benefit from `"sideEffects": false`

### DIFF
--- a/change/@fluentui-react-native-badge-a22bfee2-74a8-4f0b-b3d1-c6e0181b2efc.json
+++ b/change/@fluentui-react-native-badge-a22bfee2-74a8-4f0b-b3d1-c6e0181b2efc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Declare `\"sideEffects\": false` to help improve tree shaking",
+  "packageName": "@fluentui-react-native/badge",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-button-c992e5d1-e4e9-474c-b7cd-329bf41131eb.json
+++ b/change/@fluentui-react-native-button-c992e5d1-e4e9-474c-b7cd-329bf41131eb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Declare `\"sideEffects\": false` to help improve tree shaking",
+  "packageName": "@fluentui-react-native/button",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-checkbox-5cf932c1-cdb0-4668-a09b-4e925d91ae91.json
+++ b/change/@fluentui-react-native-checkbox-5cf932c1-cdb0-4668-a09b-4e925d91ae91.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Declare `\"sideEffects\": false` to help improve tree shaking",
+  "packageName": "@fluentui-react-native/checkbox",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-menu-7d17d5b1-2429-48a6-8cca-6084e229b866.json
+++ b/change/@fluentui-react-native-menu-7d17d5b1-2429-48a6-8cca-6084e229b866.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Declare `\"sideEffects\": false` to help improve tree shaking",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-radio-group-d0967af4-310a-4e45-aa11-14dffda86895.json
+++ b/change/@fluentui-react-native-radio-group-d0967af4-310a-4e45-aa11-14dffda86895.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Declare `\"sideEffects\": false` to help improve tree shaking",
+  "packageName": "@fluentui-react-native/radio-group",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Badge/package.json
+++ b/packages/components/Badge/package.json
@@ -49,6 +49,7 @@
     "react-native": "^0.71.0",
     "react-native-svg": "^13.7.0"
   },
+  "sideEffects": false,
   "rnx-kit": {
     "kitType": "library",
     "alignDeps": {

--- a/packages/components/Button/package.json
+++ b/packages/components/Button/package.json
@@ -59,6 +59,7 @@
   },
   "author": "",
   "license": "MIT",
+  "sideEffects": false,
   "rnx-kit": {
     "kitType": "library",
     "alignDeps": {

--- a/packages/components/Checkbox/package.json
+++ b/packages/components/Checkbox/package.json
@@ -57,6 +57,7 @@
   },
   "author": "",
   "license": "MIT",
+  "sideEffects": false,
   "rnx-kit": {
     "kitType": "library",
     "alignDeps": {

--- a/packages/components/Menu/package.json
+++ b/packages/components/Menu/package.json
@@ -55,6 +55,7 @@
   },
   "author": "",
   "license": "MIT",
+  "sideEffects": false,
   "rnx-kit": {
     "kitType": "library",
     "alignDeps": {

--- a/packages/components/RadioGroup/package.json
+++ b/packages/components/RadioGroup/package.json
@@ -55,6 +55,7 @@
   },
   "author": "",
   "license": "MIT",
+  "sideEffects": false,
   "rnx-kit": {
     "kitType": "library",
     "alignDeps": {


### PR DESCRIPTION
### Platforms Impacted

- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

Declare `"sideEffects": false` in some packages that are known to not have side effects.

### Verification

I've tested this in an app internally and saw the following savings:

| Package | Reduction (in bytes) |
| :-- | --: |
| badge | 21740 |
| button | 16293 |
| checkbox | 11799 |
| menu | 7092 |
| radio-group | 9879 |

Total savings: 66803 bytes

There are probably more packages we can declare free of side effects, but these are the ones I've checked for now.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
