### PR TITLE
macOS: Tokenize MenuItemRadio

### DIFF
--- a/change/@fluentui-react-native-menu-d9ab8395-5d22-4d91-b97e-914c1ee63584.json
+++ b/change/@fluentui-react-native-menu-d9ab8395-5d22-4d91-b97e-914c1ee63584.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Tokenize MenuItemRadio",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/MenuItemRadio/MenuItemRadioTokens.macos.ts
+++ b/packages/components/Menu/src/MenuItemRadio/MenuItemRadioTokens.macos.ts
@@ -1,0 +1,54 @@
+import type { FontWeightValue, Theme } from '@fluentui-react-native/framework';
+import { globalTokens } from '@fluentui-react-native/theme-tokens';
+import type { TokenSettings } from '@fluentui-react-native/use-styling';
+
+import type { MenuItemRadioTokens } from './MenuItemRadio.types';
+
+export const defaultMenuItemRadioTokens: TokenSettings<MenuItemRadioTokens, Theme> = (t: Theme): MenuItemRadioTokens => ({
+  backgroundColor: t.colors.transparentBackground,
+  borderRadius: 5, // hardcoded for now to match NSMenu
+  checkmarkPadding: globalTokens.size20,
+  checkmarkSize: 16,
+  checkmarkVisibility: 0,
+  color: t.colors.neutralForeground1,
+  fontFamily: t.typography.families.primary,
+  fontSize: 13, // aligning with NSMenu font size
+  fontWeight: globalTokens.font.weight.regular as FontWeightValue,
+  gap: globalTokens.size40,
+  iconColor: t.colors.neutralForeground1,
+  iconSize: 16,
+  padding: globalTokens.size40,
+  paddingHorizontal: 5, // hardcoded for now to match NSMenu
+  paddingVertical: 3, // hardcoded for now to match NSMenu
+  pressed: {
+    backgroundColor: t.colors.menuItemBackgroundPressed,
+    color: t.colors.menuItemTextHovered,
+    iconColor: t.colors.menuItemTextHovered,
+    checked: {
+      checkmarkColor: t.colors.menuItemTextHovered,
+      checkmarkVisibility: 1,
+    },
+  },
+  disabled: {
+    backgroundColor: t.colors.menuBackground,
+    color: t.colors.disabledText,
+    iconColor: t.colors.disabledText,
+    checked: {
+      checkmarkColor: t.colors.disabledText,
+      checkmarkVisibility: 1,
+    },
+  },
+  focused: {
+    backgroundColor: t.colors.menuItemBackgroundHovered,
+    color: t.colors.menuItemTextHovered,
+    iconColor: t.colors.menuItemTextHovered,
+    checked: {
+      checkmarkColor: t.colors.menuItemTextHovered,
+      checkmarkVisibility: 1,
+    },
+  },
+  checked: {
+    checkmarkColor: t.colors.neutralForeground1,
+    checkmarkVisibility: 1,
+  },
+});


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Adding a tokens file for MenuItemRadio for macOS. Most of the token values are copied from MenuItemTokens
### Verification


| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://github.com/microsoft/fluentui-react-native/assets/67026167/ff1f93f1-e83f-476f-921e-22292c8d1681) |  ![image](https://github.com/microsoft/fluentui-react-native/assets/67026167/d0c5f13f-843f-48d5-b664-b1cebfe74084)|
|![image](https://github.com/microsoft/fluentui-react-native/assets/67026167/c9688d37-0dde-4da5-b544-48d198a6fbf2)|![image](https://github.com/microsoft/fluentui-react-native/assets/67026167/95ec3132-d4b7-4884-8f2b-e27cba01e8b7)|

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
