### PR TITLE
[macOS] Components don't focus on click

### DIFF
--- a/change/@fluentui-react-native-interactive-hooks-00476c7a-9659-4dcd-ae01-130251e854a1.json
+++ b/change/@fluentui-react-native-interactive-hooks-00476c7a-9659-4dcd-ae01-130251e854a1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "useOnPressWihFocus doesn't take focus on macOS",
+  "packageName": "@fluentui-react-native/interactive-hooks",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/utils/interactive-hooks/src/useOnPressWithFocus.ts
+++ b/packages/utils/interactive-hooks/src/useOnPressWithFocus.ts
@@ -5,19 +5,18 @@ import { Platform } from 'react-native';
 export type OnPressCallback = (args: GestureResponderEvent) => void;
 export type OnPressWithFocusCallback = (args: GestureResponderEvent) => void;
 
-/* Re-usable hook for pressable components.
- * This hook sets focus on a component after onPress behavior.
- *
- * PROPS:  focusRef - the ref used to set focus
- *         userCallback() - Callback provided by userProps for onPress behavior
- * RETURNS:
- *         onPressWithFocus() - Callback to set focus after calling the userCallback for onPress
+/**
+ * Sets focus on the focusRef after calling the userCallback for onPress, if that is an expected behavior on the platform
+ * @param focusRef the ref used to set focus, generally the ref of the component that is being pressed
+ * @param userCallback user-provided callback for onPress behavior
+ * @returns Hook that sets focus, then calls the user callback
  */
 export function useOnPressWithFocus(focusRef: React.RefObject<any>, userCallback: OnPressCallback): OnPressWithFocusCallback {
   const onPressWithFocus = React.useCallback(
     (args?: any) => {
       const platformSupportsFocus = ['windows', 'win32', 'macos'].includes(Platform.OS as string);
-      if (platformSupportsFocus) {
+      const takesFocusOnClick = ['windows', 'win32'].includes(Platform.OS as string);
+      if (platformSupportsFocus && takesFocusOnClick) {
         focusRef?.current?.focus();
       }
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Native macOS Appkit controls don't take focus on click. Let's not have FURN do the same. 

### Verification

Clicked around and things seem fine

https://github.com/microsoft/fluentui-react-native/assets/6722175/749a9230-afb0-4bfd-ac94-f1eebd4e8bf2


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
