### PR TITLE
[KeyCallback] Make event parameter non optional

### DIFF
--- a/change/@fluentui-react-native-interactive-hooks-64f19ae6-d192-4452-94ed-d64cdd010403.json
+++ b/change/@fluentui-react-native-interactive-hooks-64f19ae6-d192-4452-94ed-d64cdd010403.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[useKeyEvent] Make event parameter non optional",
+  "packageName": "@fluentui-react-native/interactive-hooks",
+  "email": "saadnajmi2@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/utils/interactive-hooks/src/useKeyProps.types.ts
+++ b/packages/utils/interactive-hooks/src/useKeyProps.types.ts
@@ -2,7 +2,7 @@ import type { NativeSyntheticEvent } from 'react-native';
 
 export type KeyPressEvent = NativeSyntheticEvent<any>;
 
-export type KeyCallback = (e?: KeyPressEvent) => void;
+export type KeyCallback = (e: KeyPressEvent) => void;
 
 export type KeyPressProps = {
   onKeyDown?: KeyCallback;


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [ ] android

### Description of changes

In product code, I saw the following error:
```
Type '(event: IKeyboardEvent) => void' is not assignable to type '((args: IKeyboardEvent) => void) & KeyCallback'.
  Type '(event: IKeyboardEvent) => void' is not assignable to type 'KeyCallback'.
    Types of parameters 'event' and 'e' are incompatible.
      Type 'KeyPressEvent | undefined' is not assignable to type 'IKeyboardEvent'.
        Type 'undefined' is not assignable to type 'IKeyboardEvent'.ts(2322)
```

Looking in React Native and React Native Windows, it seems that while things like `onFocus` / `onKeyDown` might be optional, their event parameters are not. Let's make this small fix.

### Verification

CI should pass

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
