### PR TITLE
Fix Shimmer's animation direction for RTL

### DIFF
--- a/change/@fluentui-react-native-experimental-shimmer-05e64c7e-1996-42dc-b299-f651b017fdf6.json
+++ b/change/@fluentui-react-native-experimental-shimmer-05e64c7e-1996-42dc-b299-f651b017fdf6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "update Shimmer direction for rtl",
+  "packageName": "@fluentui-react-native/experimental-shimmer",
+  "email": "joannaquu@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Shimmer/src/Shimmer.tsx
+++ b/packages/experimental/Shimmer/src/Shimmer.tsx
@@ -53,12 +53,15 @@ export const Shimmer = compose<ShimmerType>({
      * Different angles are handled by rotating this gradient.
      * The startValue is used to control the start position of the gradient animation, it is set as -2 to make sure it is starts off the screen for any angle.
      * Similarly the endValue is set to 3 to make sure the gradient animation exits the entire screen for any angle.
+     * In RTL, startValue and endValue are flipped to ensure that the animation moves from right to left.
      */
-    const startValue = useRef(new Animated.Value(-2)).current;
+    const startValue = I18nManager.isRTL ? 3 : -2;
+    const endValue = I18nManager.isRTL ? -2 : 3;
+    const x1 = useRef(new Animated.Value(startValue)).current;
     const shimmerAnimation = useCallback(() => {
       Animated.loop(
-        Animated.timing(startValue, {
-          toValue: 3,
+        Animated.timing(x1, {
+          toValue: endValue,
           duration: memoizedShimmerData.duration,
           delay: memoizedShimmerData.delay,
           useNativeDriver: true,
@@ -105,7 +108,7 @@ export const Shimmer = compose<ShimmerType>({
       return (
         <Slots.root {...mergedProps}>
           <Defs>
-            <AnimatedLinearGradient id="gradient" x1={startValue} x2="-1" gradientTransform={`rotate(${memoizedShimmerData.angle})`}>
+            <AnimatedLinearGradient id="gradient" x1={x1} x2="-1" gradientTransform={`rotate(${memoizedShimmerData.angle})`}>
               <Stop offset="10%" stopColor={memoizedShimmerData.shimmerColor} stopOpacity={memoizedShimmerData.shimmerColorOpacity} />
               <Stop
                 offset="20%"


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [ ] win32 (Office)
- [x] windows
- [x] android

### Description of changes

Updated `Shimmer` so that in RTL, the animation also travels from right to left.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before](https://github.com/microsoft/fluentui-react-native/assets/55368679/3f76989e-8f59-4908-b326-165d161ae9f2) | ![after](https://github.com/microsoft/fluentui-react-native/assets/55368679/97da3b51-6b1f-4363-b42d-a6d512f3aa36) |
| ![b](https://github.com/microsoft/fluentui-react-native/assets/55368679/6149a177-35f7-415a-a4e7-47a2dff22b8d) | ![a](https://github.com/microsoft/fluentui-react-native/assets/55368679/d185aaa3-0c91-47c2-95db-4cfd656f0cb5) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
