### PR TITLE
Update TabList package.json

### DIFF
--- a/change/@fluentui-react-native-tablist-c3698181-e197-4805-bb75-1621a6fa0f58.json
+++ b/change/@fluentui-react-native-tablist-c3698181-e197-4805-bb75-1621a6fa0f58.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "manually update TabList package",
+  "packageName": "@fluentui-react-native/tablist",
+  "email": "joannaquu@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/TabList/package.json
+++ b/packages/experimental/TabList/package.json
@@ -26,12 +26,12 @@
     "directory": "packages/experimental/TabList"
   },
   "dependencies": {
-    "@fluentui-react-native/framework": "0.10.0",
+    "@fluentui-react-native/framework": "0.11.0",
     "@fluentui-react-native/interactive-hooks": ">=0.24.2 <1.0.0",
     "@fluentui-react-native/focus-zone": ">=0.12.3 <1.0.0",
     "@fluentui-react-native/text": ">=0.21.2 <1.0.0",
     "@fluentui-react-native/tokens": ">=0.21.0 <1.0.0",
-    "@fluentui-react-native/use-styling": ">=0.10.0 <1.0.0",
+    "@fluentui-react-native/use-styling": ">=0.11.0 <1.0.0",
     "@fluentui-react-native/icon": "0.19.2",
     "@fluentui-react-native/adapters": "0.11.0",
     "tslib": "^2.3.1"


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

#2889 had an issue publishing npm packages because version numbers were out of sync in `TabList`'s `package.json`. Manually updating them to fix the issue. 
<img width="599" alt="Screenshot 2023-06-21 at 2 11 14 PM" src="https://github.com/microsoft/fluentui-react-native/assets/55368679/4d3297ba-443d-4f86-a34f-cca1de3b43ee">

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
