### PR TITLE
Add special handling for shimmer colors that use OpaqueColorValue

### DIFF
--- a/change/@fluentui-react-native-experimental-shimmer-5a32ec95-0ccd-4259-afea-d75c547b7733.json
+++ b/change/@fluentui-react-native-experimental-shimmer-5a32ec95-0ccd-4259-afea-d75c547b7733.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add special handling for shimmer colors that use OpaqueColorValue such as PlatformColor",
+  "packageName": "@fluentui-react-native/experimental-shimmer",
+  "email": "patboyd@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

react-native-svg has special handling for colors used in gradients (both linear and radial) that combines stop color and stop opacity into a single value before passing it to the native component.  It does so by invoking `processColor` and will bail out if the color provided is an `OpaqueColorValue` such as one provided by `PlatformColor`.  This change to Shimmer will avoid the bail out no-render effect by not using a gradient at all in these cases.  The choice to do so in part comes from a primary source of `PlatformColor` usage: high contrast colors.  Since gradients aren't useful for high contrast scenarios, showing a simple blank rectangle shimmer is an effective short-term replacement.  Properly fixing this issue will require upstream work in react-native-svg across platforms to de-couple the stop color and stop opacity natively on all platforms, which can that be consumed by fluentui-react-native and additionally fixed for react-native-win32.

This change could be mirrored to the cross-platform version of the Shimmer and was limited to the Win32 implementation for simplicity and verification purposes.

### Verification

Tested manually with the Shimmer test page and a test change that won't be committed to the test page.

Example screenshot of effect from test page below; PlatformColor('Highlight') used on the top shimmer.
<img width="282" alt="image" src="https://github.com/microsoft/fluentui-react-native/assets/41588892/6fa7b313-6e8b-44a3-a95e-5c0ee5197aa2">


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
