### PR TITLE
Fix VoiceOver accessibility state for disabled button

### DIFF
--- a/change/@fluentui-react-native-button-f7f31813-e2cb-4822-b3a2-b7022ddd6727.json
+++ b/change/@fluentui-react-native-button-f7f31813-e2cb-4822-b3a2-b7022ddd6727.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Set disabled prop on button when not disabled",
+  "packageName": "@fluentui-react-native/button",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-menu-button-89b0528f-bb8d-4355-b9ed-af35f559f5e2.json
+++ b/change/@fluentui-react-native-experimental-menu-button-89b0528f-bb8d-4355-b9ed-af35f559f5e2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Set disabled prop on button when false",
+  "packageName": "@fluentui-react-native/experimental-menu-button",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-menu-73d8bdcc-4009-40b7-9c7b-c2fb7c7e2df7.json
+++ b/change/@fluentui-react-native-menu-73d8bdcc-4009-40b7-9c7b-c2fb7c7e2df7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Set disabled prop on button when false",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-menu-button-31e8bd1e-640c-4e91-adf4-e6f43750801d.json
+++ b/change/@fluentui-react-native-menu-button-31e8bd1e-640c-4e91-adf4-e6f43750801d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Set disabled prop on button when false",
+  "packageName": "@fluentui-react-native/menu-button",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-notification-96ec8100-438d-49a8-916d-8cc3f2ef2693.json
+++ b/change/@fluentui-react-native-notification-96ec8100-438d-49a8-916d-8cc3f2ef2693.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Set disabled prop on button when false",
+  "packageName": "@fluentui-react-native/notification",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Button/src/FAB/__snapshots__/FAB.test.tsx.snap
+++ b/packages/components/Button/src/FAB/__snapshots__/FAB.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Custom FAB with no shadow(iOS) 1`] = `
     {
       "busy": undefined,
       "checked": undefined,
-      "disabled": undefined,
+      "disabled": false,
       "expanded": undefined,
       "selected": undefined,
     }
@@ -119,7 +119,7 @@ exports[`Default FAB (iOS) 1`] = `
       {
         "busy": undefined,
         "checked": undefined,
-        "disabled": undefined,
+        "disabled": false,
         "expanded": undefined,
         "selected": undefined,
       }

--- a/packages/components/Button/src/ToggleButton/__snapshots__/ToggleButton.test.tsx.snap
+++ b/packages/components/Button/src/ToggleButton/__snapshots__/ToggleButton.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`ToggleButton default 1`] = `
     {
       "busy": undefined,
       "checked": undefined,
-      "disabled": undefined,
+      "disabled": false,
       "expanded": undefined,
       "selected": undefined,
     }

--- a/packages/components/Button/src/__snapshots__/Button.test.tsx.snap
+++ b/packages/components/Button/src/__snapshots__/Button.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Button component tests Button circular 1`] = `
     {
       "busy": undefined,
       "checked": undefined,
-      "disabled": undefined,
+      "disabled": false,
       "expanded": undefined,
       "selected": undefined,
     }
@@ -85,7 +85,7 @@ exports[`Button component tests Button composed 1`] = `
     {
       "busy": undefined,
       "checked": undefined,
-      "disabled": undefined,
+      "disabled": false,
       "expanded": undefined,
       "selected": undefined,
     }
@@ -164,7 +164,7 @@ exports[`Button component tests Button customized 1`] = `
     {
       "busy": undefined,
       "checked": undefined,
-      "disabled": undefined,
+      "disabled": false,
       "expanded": undefined,
       "selected": undefined,
     }
@@ -240,7 +240,7 @@ exports[`Button component tests Button default 1`] = `
     {
       "busy": undefined,
       "checked": undefined,
-      "disabled": undefined,
+      "disabled": false,
       "expanded": undefined,
       "selected": undefined,
     }
@@ -392,7 +392,7 @@ exports[`Button component tests Button large 1`] = `
     {
       "busy": undefined,
       "checked": undefined,
-      "disabled": undefined,
+      "disabled": false,
       "expanded": undefined,
       "selected": undefined,
     }
@@ -469,7 +469,7 @@ exports[`Button component tests Button primary 1`] = `
     {
       "busy": undefined,
       "checked": undefined,
-      "disabled": undefined,
+      "disabled": false,
       "expanded": undefined,
       "selected": undefined,
     }
@@ -546,7 +546,7 @@ exports[`Button component tests Button small 1`] = `
     {
       "busy": undefined,
       "checked": undefined,
-      "disabled": undefined,
+      "disabled": false,
       "expanded": undefined,
       "selected": undefined,
     }
@@ -623,7 +623,7 @@ exports[`Button component tests Button square 1`] = `
     {
       "busy": undefined,
       "checked": undefined,
-      "disabled": undefined,
+      "disabled": false,
       "expanded": undefined,
       "selected": undefined,
     }
@@ -700,7 +700,7 @@ exports[`Button component tests Button subtle 1`] = `
     {
       "busy": undefined,
       "checked": undefined,
-      "disabled": undefined,
+      "disabled": false,
       "expanded": undefined,
       "selected": undefined,
     }

--- a/packages/components/Button/src/useButton.ts
+++ b/packages/components/Button/src/useButton.ts
@@ -90,7 +90,12 @@ export const useButton = (props: ButtonProps): ButtonInfo => {
       ...onKeyProps,
       ...(Platform.OS === ('win32' as any) && { onKeyDown: onKeyDown }),
       ...pressable.props, // allow user key events to override those set by us
-      disabled: isDisabled,
+      /**
+       * https://github.com/facebook/react-native/issues/34986
+       * Due to a bug in React Native, unconditionally passing this may cause unnecessary re-renders.
+       * Therefore, let's only pass it in if it's defined to limit this issue.
+       */
+      ...(isDisabled !== undefined && { disabled: isDisabled }),
       accessible: accessible ?? true,
       accessibilityRole: accessibilityRole || 'button',
       onAccessibilityTap: props.onAccessibilityTap || (!hasTogglePattern ? props.onClick : undefined),

--- a/packages/components/Button/src/useButton.ts
+++ b/packages/components/Button/src/useButton.ts
@@ -90,12 +90,7 @@ export const useButton = (props: ButtonProps): ButtonInfo => {
       ...onKeyProps,
       ...(Platform.OS === ('win32' as any) && { onKeyDown: onKeyDown }),
       ...pressable.props, // allow user key events to override those set by us
-      /**
-       * https://github.com/facebook/react-native/issues/34986
-       * Due to a bug in React Native, unconditionally passing this may cause unnecessary re-renders.
-       * Therefore, let's only pass it in if it's defined to limit this issue.
-       */
-      ...(isDisabled && { disabled: isDisabled }),
+      disabled: isDisabled,
       accessible: accessible ?? true,
       accessibilityRole: accessibilityRole || 'button',
       onAccessibilityTap: props.onAccessibilityTap || (!hasTogglePattern ? props.onClick : undefined),

--- a/packages/components/Menu/src/__tests__/__snapshots__/Menu.test.tsx.snap
+++ b/packages/components/Menu/src/__tests__/__snapshots__/Menu.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`Menu component tests Menu default 1`] = `
     {
       "busy": undefined,
       "checked": undefined,
-      "disabled": undefined,
+      "disabled": false,
       "expanded": false,
       "selected": undefined,
     }
@@ -121,7 +121,7 @@ exports[`Menu component tests Menu defaultOpen 1`] = `
     {
       "busy": undefined,
       "checked": undefined,
-      "disabled": undefined,
+      "disabled": false,
       "expanded": true,
       "selected": undefined,
     }
@@ -224,7 +224,7 @@ exports[`Menu component tests Menu open 1`] = `
     {
       "busy": undefined,
       "checked": undefined,
-      "disabled": undefined,
+      "disabled": false,
       "expanded": true,
       "selected": undefined,
     }
@@ -327,7 +327,7 @@ exports[`Menu component tests Menu open checkbox and divider 1`] = `
     {
       "busy": undefined,
       "checked": undefined,
-      "disabled": undefined,
+      "disabled": false,
       "expanded": true,
       "selected": undefined,
     }
@@ -430,7 +430,7 @@ exports[`Menu component tests Menu open checkbox checked 1`] = `
     {
       "busy": undefined,
       "checked": undefined,
-      "disabled": undefined,
+      "disabled": false,
       "expanded": true,
       "selected": undefined,
     }
@@ -533,7 +533,7 @@ exports[`Menu component tests Menu open checkbox defaultChecked 1`] = `
     {
       "busy": undefined,
       "checked": undefined,
-      "disabled": undefined,
+      "disabled": false,
       "expanded": true,
       "selected": undefined,
     }
@@ -636,7 +636,7 @@ exports[`Menu component tests Menu open radio 1`] = `
     {
       "busy": undefined,
       "checked": undefined,
-      "disabled": undefined,
+      "disabled": false,
       "expanded": true,
       "selected": undefined,
     }
@@ -739,7 +739,7 @@ exports[`Menu component tests Menu submenu 1`] = `
     {
       "busy": undefined,
       "checked": undefined,
-      "disabled": undefined,
+      "disabled": false,
       "expanded": true,
       "selected": undefined,
     }
@@ -842,7 +842,7 @@ exports[`Menu open menu group and menu header 1`] = `
     {
       "busy": undefined,
       "checked": undefined,
-      "disabled": undefined,
+      "disabled": false,
       "expanded": true,
       "selected": undefined,
     }

--- a/packages/components/MenuButton/src/__tests__/__snapshots__/MenuButton.test.tsx.snap
+++ b/packages/components/MenuButton/src/__tests__/__snapshots__/MenuButton.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`ContextualMenu default 1`] = `
     {
       "busy": undefined,
       "checked": undefined,
-      "disabled": undefined,
+      "disabled": false,
       "expanded": undefined,
       "selected": undefined,
     }

--- a/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
+++ b/packages/components/Notification/src/__tests__/__snapshots__/Notification.test.tsx.snap
@@ -92,7 +92,7 @@ exports[`Notification component tests Notification default 1`] = `
         {
           "busy": undefined,
           "checked": undefined,
-          "disabled": undefined,
+          "disabled": false,
           "expanded": undefined,
           "selected": undefined,
         }

--- a/packages/experimental/MenuButton/src/__tests__/__snapshots__/MenuButton.test.tsx.snap
+++ b/packages/experimental/MenuButton/src/__tests__/__snapshots__/MenuButton.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`ContextualMenu default 1`] = `
     {
       "busy": undefined,
       "checked": undefined,
-      "disabled": undefined,
+      "disabled": false,
       "expanded": undefined,
       "selected": undefined,
     }


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Noticed that when a button is initially disabled, but the state changes to no longer be disabled, VoiceOver will still think that the button is disabled. 
- when the button is first disabled, Voiceover will announce "<Title of button>, **dimmed**, button"
- when the button switches to no longer being Disabled, Voiceover will announce the same thing - but it should not announce "dimmed".

The issue was that we weren't updating the accessibilityState in react native when it changed to "disabled". Fixed by updating one of the checks so that we set the disabled prop both if it's true and if it's false. 

### Verification

Set up a test in Fluent tester - the top button will toggle between disabled/not disabled for the button below it. 
After the fix, Voiceover will no longer say "dimmed" when the button is not disabled.

Before

https://github.com/microsoft/fluentui-react-native/assets/78454019/c339cb40-779a-4027-9e7c-faea775579ac

After

https://github.com/microsoft/fluentui-react-native/assets/78454019/01ab10a3-5506-446d-ae2c-20a6861b46ba

Also validated that when the button switches back to being disabled, Voiceover announces "dimmed" again.


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
