### PR TITLE
macOS: Fix for menu items should be accessible when VoiceOver is enabled

### DIFF
--- a/change/@fluentui-react-native-menu-873df90c-0ff9-4b9e-85d7-7ef582634fd6.json
+++ b/change/@fluentui-react-native-menu-873df90c-0ff9-4b9e-85d7-7ef582634fd6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix VO bug in Menu",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/MenuList/MenuList.tsx
+++ b/packages/components/Menu/src/MenuList/MenuList.tsx
@@ -89,7 +89,6 @@ export const MenuList = compose<MenuListType>({
         Platform.OS === 'macos' ? (
           <Slots.root onMouseLeave={setFocusZoneFocus} onKeyDown={menuList.onListKeyDown}>
             <Slots.scrollView
-              accessibilityRole="menu"
               showsVerticalScrollIndicator={menuContext.hasMaxHeight}
               showsHorizontalScrollIndicator={menuContext.hasMaxWidth}
             >


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Currently menu items are not accessible through the VoiceOver command VO-shift-down, most likely due to the menu items are not recognized as children of the parent view. Let's make the scrollview not accessible so that VO focus would land on the first menu item instead.

### Verification

Before:
(Pressing the down arrow key moves VO focus to the first menu item here because I have the synchronize focus + VO cursor setting on, without it would get stuck instead)

https://github.com/microsoft/fluentui-react-native/assets/67026167/d3608cb5-fe3a-4a10-aace-94df04dd1dd3


After:


https://github.com/microsoft/fluentui-react-native/assets/67026167/4c3adbfa-55d9-4324-867e-36b8c5c4fb0e



### Pull request checklist



This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
