### PR TITLE
[Android] Theme picker - Fix accessibility on dropdown and remove blank option in L/D mode

### DIFF
--- a/apps/fluent-tester/src/theme/ThemePickers.android.tsx
+++ b/apps/fluent-tester/src/theme/ThemePickers.android.tsx
@@ -53,7 +53,7 @@ export const ThemePickers: React.FunctionComponent = () => {
 
   type DropdownEntry = { label: string; value: string };
 
-  type DropdownProps = { initial: string; onValueChange: (value: string) => void; options: DropdownEntry[] };
+  type DropdownProps = { initial: string; onValueChange: (value: string) => void; options: DropdownEntry[]; accessibilityLabel?: string };
 
   const dropdownProps: Omit<PickerProps, 'onValueChange' | 'selectedValue'> = {
     style: themedPickerStyles.dropdown,
@@ -61,13 +61,20 @@ export const ThemePickers: React.FunctionComponent = () => {
   };
 
   const Dropdown = (props: DropdownProps) => {
-    const { initial, onValueChange, options } = props;
+    const { initial, onValueChange, options, accessibilityLabel } = props;
+    console.log(options);
     return (
       <View style={themedPickerStyles.dropdownBorder}>
-        <Picker selectedValue={initial} onValueChange={onValueChange} dropdownIconColor={theme.colors.defaultIcon} {...dropdownProps}>
-          {options.map((entry: DropdownEntry, index: number) => (
-            <Picker.Item label={entry.label} value={entry.value} key={`entry${index}`} />
-          ))}
+        <Picker
+          selectedValue={initial}
+          onValueChange={onValueChange}
+          dropdownIconColor={theme.colors.defaultIcon}
+          {...dropdownProps}
+          accessibilityLabel={accessibilityLabel}
+        >
+          {options.map(
+            (entry: DropdownEntry, index: number) => entry && <Picker.Item label={entry.label} value={entry.value} key={`entry${index}`} />,
+          )}
         </Picker>
       </View>
     );
@@ -77,12 +84,22 @@ export const ThemePickers: React.FunctionComponent = () => {
     <View style={themedPickerStyles.pickerRoot}>
       <View style={themedPickerStyles.picker}>
         <PickerLabel>Theme: </PickerLabel>
-        <Dropdown initial={testerTheme.themeName} onValueChange={onThemeSelected} options={themeChoices} />
+        <Dropdown
+          accessibilityLabel="Theme Selector"
+          initial={testerTheme.themeName}
+          onValueChange={onThemeSelected}
+          options={themeChoices}
+        />
       </View>
 
       <View style={themedPickerStyles.picker}>
         <PickerLabel>Light/Dark: </PickerLabel>
-        <Dropdown initial={testerTheme.appearance} onValueChange={onAppearanceChange} options={lightnessOptions} />
+        <Dropdown
+          accessibilityLabel="Light/Dark Selector"
+          initial={testerTheme.appearance}
+          onValueChange={onAppearanceChange}
+          options={lightnessOptions}
+        />
       </View>
     </View>
   );

--- a/apps/fluent-tester/src/theme/ThemePickers.android.tsx
+++ b/apps/fluent-tester/src/theme/ThemePickers.android.tsx
@@ -62,7 +62,6 @@ export const ThemePickers: React.FunctionComponent = () => {
 
   const Dropdown = (props: DropdownProps) => {
     const { initial, onValueChange, options, accessibilityLabel } = props;
-    console.log(options);
     return (
       <View style={themedPickerStyles.dropdownBorder}>
         <Picker

--- a/change/@fluentui-react-native-tester-f2763a36-fc79-4c64-ba37-ca4d1bb96ebb.json
+++ b/change/@fluentui-react-native-tester-f2763a36-fc79-4c64-ba37-ca4d1bb96ebb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix accessibility on dropdown and remove blank option in L/D mode",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ayushsinghs@yahoo.in",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted

- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [x] android

### Description of changes

Fix accessibility bug where the "Theme" and "Light/Dark" were not being announced by talkback.
Removed extra blank option appearing in "Light/Dark" dropdown.

### Verification

Talkback verified.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Screenshot_2023-07-06-19-43-18-45_3238b23fbbdef38ccf4a465a34706bab](https://github.com/microsoft/fluentui-react-native/assets/49569838/0911addd-2eb0-4d36-a00d-bd2076c7e90c) | ![Screenshot_2023-07-06-19-43-30-53_3238b23fbbdef38ccf4a465a34706bab](https://github.com/microsoft/fluentui-react-native/assets/49569838/ee333132-fde1-457d-b777-c23afc68993e) |

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [x] Documentation and examples
- [x] Keyboard Accessibility
- [x] Voiceover
- [ ] Internationalization and Right-to-left Layouts
