### PR TITLE
[E2E Tests] Clean up uninstall task / Chip & Input - Android 

### DIFF
--- a/.ado/templates/e2e-testing-android.yml
+++ b/.ado/templates/e2e-testing-android.yml
@@ -45,9 +45,3 @@ steps:
       platform: 'android'
       buildArtifacts: variables['task.Build.status']
       directory: $(Build.SourcesDirectory)/apps/E2E
-
-  - script: |
-      yarn appium driver uninstall uiautomator2
-    workingDirectory: apps/E2E
-    displayName: 'Uninstall appium driver'
-    condition: succeeded()

--- a/.ado/templates/e2e-testing-ios.yml
+++ b/.ado/templates/e2e-testing-ios.yml
@@ -29,9 +29,3 @@ steps:
       platform: 'ios'
       buildArtifacts: variables['task.Build.status']
       directory: $(Build.SourcesDirectory)/apps/E2E
-
-  - script: |
-      yarn appium driver uninstall xcuitest
-    workingDirectory: apps/E2E
-    displayName: 'Uninstall appium driver'
-    condition: succeeded()

--- a/.ado/templates/e2e-testing-macos.yml
+++ b/.ado/templates/e2e-testing-macos.yml
@@ -29,9 +29,3 @@ steps:
       platform: 'macos'
       buildArtifacts: variables['task.Build.status']
       directory: $(Build.SourcesDirectory)/apps/E2E
-
-  - script: |
-      yarn appium driver uninstall mac2
-    workingDirectory: apps/E2E
-    displayName: 'Uninstall appium driver'
-    condition: succeeded()

--- a/.ado/templates/e2e-testing-win32.yml
+++ b/.ado/templates/e2e-testing-win32.yml
@@ -43,9 +43,3 @@ steps:
       platform: 'win32'
       buildArtifacts: variables['task.Build.status']
       directory: $(Build.SourcesDirectory)/apps/win32
-
-  - script: |
-      yarn appium driver uninstall windows
-    workingDirectory: apps/win32
-    displayName: 'Uninstall appium driver'
-    condition: succeeded()

--- a/apps/E2E/src/Chip/pages/ChipPageObject.ts
+++ b/apps/E2E/src/Chip/pages/ChipPageObject.ts
@@ -1,7 +1,23 @@
 import { BasePage, By } from '../../common/BasePage';
+import { AndroidAttribute } from '../../common/consts';
 import { CHIP_TESTPAGE, CHIP_TEST_COMPONENT, CHIP_TEXT, HOMEPAGE_CHIP_BUTTON } from '../consts';
 
 class ChipPageObject extends BasePage {
+  /******************************************************************/
+  /**************** UI Element Interaction Methods ******************/
+  /******************************************************************/
+  async verifyTextContent(text: string): Promise<boolean> {
+    return await this.compareAttribute(this._callbackText, AndroidAttribute.Text, text);
+  }
+
+  /* Waits for the text content to get updated to new string.
+   * Returns true if new string is attained. */
+  async waitForStringUpdate(newState: string, errorMessage: string): Promise<boolean> {
+    if (!(await this.verifyTextContent(newState))) {
+      await this.waitForCondition(async () => await this.verifyTextContent(newState), errorMessage);
+    }
+    return await this.verifyTextContent(newState);
+  }
   /*****************************************/
   /**************** Getters ****************/
   /*****************************************/

--- a/apps/E2E/src/Chip/specs/Chip.spec.android.ts
+++ b/apps/E2E/src/Chip/specs/Chip.spec.android.ts
@@ -1,4 +1,3 @@
-import { AndroidAttribute } from '../../common/consts';
 import { CHIP_CALLBACK_TEXT_END_STATE, CHIP_CALLBACK_TEXT_START_STATE } from '../consts';
 import ChipPageObject from '../pages/ChipPageObject';
 
@@ -25,15 +24,12 @@ describe('Chip Functional Testing', () => {
 
   it('Validate OnPress() callback was fired -> Click', async () => {
     /* Verify that the callback text is in start state */
-    await expect(
-      await ChipPageObject.compareAttribute(ChipPageObject._callbackText, AndroidAttribute.Text, CHIP_CALLBACK_TEXT_START_STATE),
-    ).toBeTruthy();
+    await expect(await ChipPageObject.verifyTextContent(CHIP_CALLBACK_TEXT_START_STATE)).toBeTruthy();
 
     /* Click the Chip and verify callback text gets updated */
     await ChipPageObject.click(ChipPageObject._primaryComponent);
-    await expect(
-      await ChipPageObject.compareAttribute(ChipPageObject._callbackText, AndroidAttribute.Text, CHIP_CALLBACK_TEXT_END_STATE),
-    ).toBeTruthy();
+    await expect(await ChipPageObject.waitForStringUpdate(CHIP_CALLBACK_TEXT_END_STATE, 'OnPress callback failing.')).toBeTruthy();
+    await expect(await ChipPageObject.verifyTextContent(CHIP_CALLBACK_TEXT_END_STATE)).toBeTruthy();
     await expect(await ChipPageObject.didAssertPopup()).toBeFalsy(ChipPageObject.ERRORMESSAGE_ASSERT);
   });
 });

--- a/apps/E2E/src/Input/pages/InputPageObject.ts
+++ b/apps/E2E/src/Input/pages/InputPageObject.ts
@@ -13,8 +13,7 @@ class InputPageObject extends BasePage {
   /**************** UI Element Interaction Methods ******************/
   /******************************************************************/
   async verifyTextContent(text: string): Promise<boolean> {
-    const callbackText = await this._callbackText;
-    return (await callbackText.getAttribute(AndroidAttribute.Text)) == text;
+    return await this.compareAttribute(this._callbackText, AndroidAttribute.Text, text);
   }
 
   async typeText(text: string): Promise<void> {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Changes are made commit wise for easier review -

1. Input uses getAttribute to compare text content, replacing it with compareAttribute from basePage instead based on this [comment](https://github.com/microsoft/fluentui-react-native/pull/2875#discussion_r1242465133).
2. Chip test was lacking waiters, added function for that. Placed the compareAttribute fn inside a verifyTextContent wrapper for better readability and ease of usage. 
3.  Currently all the platforms run the uninstall task for appium drivers, this is unnecessary and has been failing with a timeout intermittently. Removing it.  

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
