### PR TITLE
Fix logic for non-main publish

### DIFF
--- a/.ado/azure-pipelines.publish.yml
+++ b/.ado/azure-pipelines.publish.yml
@@ -66,7 +66,7 @@ jobs:
         condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
 
       - script: |
-          yarn publish:beachball -- $(SkipNpmPublishArgs) $(SkipGitPushPublishArgs) -b origin/main -n $(npmAuth) --access public -y -t v%BUILD_SOURCEBRANCH:refs/heads/releases/=% -b origin/%BUILD_SOURCEBRANCH:refs/heads/=% --prerelease-prefix %BUILD_SOURCEBRANCH:refs/heads/releases/=%
+          yarn publish:beachball -- $(SkipNpmPublishArgs) $(SkipGitPushPublishArgs) -n $(npmAuth) --access public -y -t v$[replace(variables['Build.SourceBranch'],'refs/heads/releases/','')] -b origin/$[replace(variables['Build.SourceBranch'],'refs/heads/','')] --prerelease-prefix $[replace(variables['Build.SourceBranch'],'refs/heads/releases/','')]
         displayName: 'Publish NPM Packages (for other release branches)'
         condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/main'))
 


### PR DESCRIPTION
While running a test run of publishing a patch version of FURN I realized that the logic I copied from another repo only works on windows machines.  While the FURN publish runs on ubuntu.  So I'm changing the logic to use ADO expressions rather than CMD variable expansion.

(Also removing the duplicate specification of the branch parameter)