### PR TITLE
[macOS] [Callout] Fixing anchor rect

### DIFF
--- a/change/@fluentui-react-native-callout-0259837f-0479-4913-919c-cb733ac99651.json
+++ b/change/@fluentui-react-native-callout-0259837f-0479-4913-919c-cb733ac99651.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[macOS] [Callout] Fixing anchor rect",
+  "packageName": "@fluentui-react-native/callout",
+  "email": "nakambo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Callout/macos/CalloutView.swift
+++ b/packages/components/Callout/macos/CalloutView.swift
@@ -183,7 +183,7 @@ class CalloutView: RCTView, CalloutWindowLifeCycleDelegate {
 			preconditionFailure("No window found")
 		}
 
-		guard let screenFrame = window.screen?.visibleFrame ?? NSScreen.main?.visibleFrame else {
+		if (window.screen == nil) {
 			preconditionFailure("No screen Available")
 		}
 
@@ -193,16 +193,14 @@ class CalloutView: RCTView, CalloutWindowLifeCycleDelegate {
 		while (!rootView.isReactRootView()) {
 			rootView = rootView.reactSuperview()
 		}
-		let rootViewBoundsInWindow = rootView.convert(rootView.bounds, to: nil)
-		let rootViewRectInScreenCoordinates = window.convertToScreen(rootViewBoundsInWindow)
 
-		// macOS uses a flipped Y coordinate (I.E: (0,0) is on the bottom left of the screen). However,
-		// React Native assumes a standard Y coordinate. Let's flip the Y coordinate of our rect to match
-		let anchorScreenRectOrigin = NSPoint(
-			x: rootViewRectInScreenCoordinates.origin.x + self.anchorRect.origin.x,
-			y: screenFrame.height - (rootViewRectInScreenCoordinates.origin.y + self.anchorRect.origin.y)
-		)
-		let anchorRectInScreenCoordinates = NSRect(origin: anchorScreenRectOrigin, size: anchorRect.size)
+		let anchorRect = self.anchorRect
+
+		// Since the root view is flipped, we already have anchorRect in the "correct"
+		// (i.e. flipped) coordinate space. Since we need to provide screen rects to Apple,
+		// we will once again arrive at the "correct" (not flipped) coordinate space.
+		let anchorRectInWindow = rootView.convert(anchorRect, to: nil)
+		let anchorRectInScreenCoordinates = window.convertToScreen(anchorRectInWindow)
 
 		return anchorRectInScreenCoordinates
 	}

--- a/packages/components/Callout/macos/FRNCalloutManager.m
+++ b/packages/components/Callout/macos/FRNCalloutManager.m
@@ -8,7 +8,7 @@
 + (NSRect)screenRect:(id)json
 {
 	CGFloat x = [RCTConvert CGFloat:json[@"screenX"]];
-	CGFloat y = [RCTConvert CGFloat:json[@"screenX"]];
+	CGFloat y = [RCTConvert CGFloat:json[@"screenY"]];
 	CGFloat width = [RCTConvert CGFloat:json[@"width"]];
 	CGFloat height = [RCTConvert CGFloat:json[@"height"]];
 	return NSMakeRect(x, y, width, height);

--- a/packages/components/Callout/src/Callout.types.ts
+++ b/packages/components/Callout/src/Callout.types.ts
@@ -1,5 +1,4 @@
 import type * as React from 'react';
-// SAAD - Looks like ScreenRect got renamed.
 import type { KeyboardMetrics, ViewStyle } from 'react-native';
 
 import type { IViewProps } from '@fluentui-react-native/adapters';


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Two problems, two changes:

* Wrong conversion from JSON (we're putting X coordinate from JSON in Y)
* Wrong conversion between coordinate spaces

### Verification

Manually. Setting the anchor (especially with a (1,1) size) works as expected, same as Win32.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
