### PR TITLE
[Callout] Fix callout reanchoring from `target` to `anchorRect`

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Callout/CalloutTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Callout/CalloutTest.tsx
@@ -3,7 +3,7 @@ import type { KeyboardMetrics } from 'react-native';
 import { Text, View, Switch, ScrollView } from 'react-native';
 
 import { Button, Callout, Separator, Pressable, StealthButton } from '@fluentui/react-native';
-import type { IFocusable, RestoreFocusEvent, DismissBehaviors } from '@fluentui/react-native';
+import type { IFocusable, RestoreFocusEvent, DismissBehaviors, ICalloutProps } from '@fluentui/react-native';
 
 import { E2ECalloutTest } from './CalloutE2ETest';
 import { CALLOUT_TESTPAGE } from '../../../../E2E/src/Callout/consts';
@@ -66,7 +66,7 @@ const StandardCallout: React.FunctionComponent = () => {
   const greenTargetRef = React.useRef<View>(null);
   const decoyBtn1Ref = React.useRef<IFocusable>(null);
   const decoyBtn2Ref = React.useRef<IFocusable>(null);
-  const [anchorRef, setAnchorRef] = React.useState(redTargetRef);
+  const [anchorRef, setAnchorRef] = React.useState<React.RefObject<View> | undefined>(redTargetRef);
   const [hoveredTargetsCount, setHoveredTargetsCount] = React.useState(0);
   const [displayCountHoveredTargets, setDisplayCountHoveredTargets] = React.useState(0);
 
@@ -146,6 +146,17 @@ const StandardCallout: React.FunctionComponent = () => {
     setAnchorRef(anchorRef === redTargetRef ? greenTargetRef : anchorRef === greenTargetRef ? blueTargetRef : redTargetRef);
   }, [anchorRef]);
 
+  const switchTargetRefOrRect = React.useCallback(() => {
+    // Switch between RGB views or a fixed anchor
+    setAnchorRef(anchorRef === redTargetRef || anchorRef === greenTargetRef || anchorRef == blueTargetRef ? undefined : redTargetRef);
+  }, [anchorRef]);
+
+  React.useEffect(() => {
+    if (!showStandardCallout && anchorRef === undefined) {
+      setAnchorRef(redTargetRef);
+    }
+  }, [anchorRef, setAnchorRef, showStandardCallout]);
+
   const onShowStandardCallout = React.useCallback(() => {
     setIsStandardCalloutVisible(true);
   }, []);
@@ -202,6 +213,13 @@ const StandardCallout: React.FunctionComponent = () => {
   const addButton = React.useCallback(() => {
     setScrollviewContents((arr) => [...arr, 1]);
   }, [setScrollviewContents]);
+
+  const calloutTargetOrAnchor: Partial<ICalloutProps> = {};
+  if (anchorRef) {
+    calloutTargetOrAnchor.target = anchorRef;
+  } else {
+    calloutTargetOrAnchor.anchorRect = { screenX: 50, screenY: 50, width: 1, height: 1 };
+  }
 
   return (
     <View>
@@ -317,7 +335,7 @@ const StandardCallout: React.FunctionComponent = () => {
         <Callout
           {...{
             doNotTakePointerCapture: openCalloutOnHoverAnchor ?? undefined,
-            target: anchorRef,
+            ...calloutTargetOrAnchor,
             onDismiss: onDismissStandardCallout,
             onShow: onShowStandardCallout,
             ...(customRestoreFocus && { onRestoreFocus: onRestoreFocusStandardCallout }),
@@ -335,6 +353,7 @@ const StandardCallout: React.FunctionComponent = () => {
               <View style={fluentTesterStyles.scrollViewContainer}>
                 <ScrollView contentContainerStyle={fluentTesterStyles.scrollViewStyle} showsVerticalScrollIndicator={true}>
                   <StealthButton content="click to change anchor" onClick={toggleCalloutRef} />
+                  <StealthButton content="click to switch between anchor and rect" onClick={switchTargetRefOrRect} />
                   <StealthButton content="Click to add a button" style={fluentTesterStyles.testListItem} onClick={addButton} />
                   <StealthButton content="Click to remove a button" style={fluentTesterStyles.testListItem} onClick={removeButton} />
                   {scrollviewContents.map((value) => {
@@ -346,6 +365,7 @@ const StandardCallout: React.FunctionComponent = () => {
               //else
               <View style={{ padding: 20, backgroundColor: calloutHovered ? 'lightgreen' : 'pink' }}>
                 <Button content="click to change anchor" onClick={toggleCalloutRef} />
+                <Button content="click to switch between anchor and rect" onClick={switchTargetRefOrRect} />
               </View>
             )}
           </Pressable>

--- a/change/@fluentui-react-native-callout-58831af3-37ee-4f37-8458-3744692158a3.json
+++ b/change/@fluentui-react-native-callout-58831af3-37ee-4f37-8458-3744692158a3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[Callout] Fix anchor not updating when going from `target` to `anchorRect`",
+  "packageName": "@fluentui-react-native/callout",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-746d9033-1982-4209-8b5f-1310a357e672.json
+++ b/change/@fluentui-react-native-tester-746d9033-1982-4209-8b5f-1310a357e672.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[Callout] Fix anchor not updating when going from `target` to `anchorRect`",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Callout/src/Callout.tsx
+++ b/packages/components/Callout/src/Callout.tsx
@@ -31,6 +31,9 @@ export const Callout = compose<ICalloutType>({
       } else if (target?.current) {
         // Pass the tagID for a valid ref `target`
         setNativeTarget(findNodeHandle(target.current));
+      } else {
+        // Clear `target` so we may fall back on `anchorRect` if provided
+        setNativeTarget(null);
       }
     }, [target]);
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

The callout doesn't reanchor when it has rendered with a `target` anchor and new props specify `anchorRect`. It would seem native code never gets an update that `target` isn't specified anymore, because we don't update internal state used to populate that prop -- so fixing that.

Also making changes to the test page to validate the dynamic changing of anchor.

### Verification

Manually, using the updated test page. New behavior video: https://github.com/microsoft/fluentui-react-native/assets/72474613/d64107b7-caa3-4301-81bc-3f9b50d87a74

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
