### PR TITLE
[macOS] [FRNCallout] Fix switching betwen target and anchorRect

### DIFF
--- a/change/@fluentui-react-native-callout-11e991a5-b1b7-465a-955c-4b10a1ce41c0.json
+++ b/change/@fluentui-react-native-callout-11e991a5-b1b7-465a-955c-4b10a1ce41c0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[macOS] [FRNCallout] Fix switching betwen `target` and `anchorRect`",
+  "packageName": "@fluentui-react-native/callout",
+  "email": "nakambo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Callout/macos/CalloutView.swift
+++ b/packages/components/Callout/macos/CalloutView.swift
@@ -6,7 +6,8 @@ class CalloutView: RCTView, CalloutWindowLifeCycleDelegate {
 
 	@objc public var target: NSNumber? {
 		didSet {
-			guard let targetView = bridge?.uiManager.view(forReactTag: target) else {
+			let targetView = bridge?.uiManager.view(forReactTag: target)
+			if (targetView == nil && target != nil) {
 				preconditionFailure("Invalid target react tag")
 			}
 			anchorView = targetView
@@ -169,9 +170,15 @@ class CalloutView: RCTView, CalloutWindowLifeCycleDelegate {
 			return
 		}
 
-		// Prefer anchorRect over anchorView if available
-		let anchorScreenRect = anchorRect.equalTo(.null) ? calculateAnchorViewScreenRect() : calculateAnchorRectScreenRect()
+		// Prefer anchorView over anchorRect if available
+		let anchorScreenRect = anchorView != nil ? calculateAnchorViewScreenRect() : calculateAnchorRectScreenRect()
 		let calloutScreenRect = bestCalloutRect(relativeTo: anchorScreenRect)
+
+		// Because we immediately update the rect as props come in, there's a possibility that we have neither
+		// of anchorRect and target. Don't update until we have at least one.
+		guard !calloutScreenRect.isEmpty else {
+			return
+		}
 
 		proxyView.frame.origin = .zero
 		calloutWindow.setFrame(calloutScreenRect, display: false)
@@ -347,7 +354,7 @@ class CalloutView: RCTView, CalloutWindowLifeCycleDelegate {
 
 	// MARK: Private variables
 
-	/// The view the Callout is presented from, if anchorRect is nil.
+	/// The view the Callout is presented from.
 	private var anchorView: NSView?
 
 	/// The  view we forward Callout's Children to. It's hosted within the CalloutWindow's

--- a/packages/components/Callout/macos/CalloutView.swift
+++ b/packages/components/Callout/macos/CalloutView.swift
@@ -8,7 +8,7 @@ class CalloutView: RCTView, CalloutWindowLifeCycleDelegate {
 		didSet {
 			let targetView = bridge?.uiManager.view(forReactTag: target)
 			if (targetView == nil && target != nil) {
-				preconditionFailure("Invalid target react tag")
+				preconditionFailure("Invalid target")
 			}
 			anchorView = targetView
 			updateCalloutFrameToAnchor()


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Native code isn't equipped to handle dynamically changing between these if the callout is already rendered (on screen).

* We assume given a `target`, there's always a valid `NSView`. That's a reasonable assumption, but when switching from `target` to `anchorRect`, we need to handle `nil` for target
* `calculateAnchorViewScreenRect` assumes there's a valid `anchorView`. Again a reasonable assumption, but then code also assumes if there's no `target`, there MUST be a `anchorRect`. We can remove the assumption that there's an `anchorView` when `calculateAnchorViewScreenRect` is called, but I think I like switching the precedence better, because that makes the Mac behavior consistent with Win32 (Office), which will only fall back to `anchorRect` if other methods of obtaining an anchor (like `target`) fail.
* There's an unfortunate assumption that every time a property changes, we're going to be in a valid state. That depends on the ordering the property changes come in -- for example, in the scenario from going from `target` to `anchorRect`, if first the new `anchorRect` is specified, and then the old `target` is cleared, we're good. In the other sequence, we have no anchor in the transient state. Let's not update the anchor in such a scenario, until we get to a "good" state.

### Verification

Testing:

* No more crashes when switching between anchors, with #2951 

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
