### PR TITLE
Fix TabList keyboarding, focus, and accessibility + Icon fix. 

### DIFF
--- a/apps/fluent-tester/src/TestComponents/TabList/TabListTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/TabList/TabListTest.tsx
@@ -56,12 +56,12 @@ const TabListVerticalTest: React.FunctionComponent = () => {
 const TabListAppearanceTest: React.FunctionComponent = () => {
   return (
     <View style={styles.container}>
-      {/* <Header>Transparent Appearance</Header> */}
+      <Header>Transparent Appearance</Header>
       <PaddedTabList appearance="transparent">
         <Tab tabKey="hello">Tab 1</Tab>
         <Tab tabKey="world">Tab 2</Tab>
       </PaddedTabList>
-      {/* <Header>Subtle Appearance</Header> */}
+      <Header>Subtle Appearance</Header>
       <PaddedTabList appearance="subtle">
         <Tab tabKey="hello">Tab 1</Tab>
         <Tab tabKey="world">Tab 2</Tab>

--- a/apps/fluent-tester/src/TestComponents/TabList/TabListTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/TabList/TabListTest.tsx
@@ -56,12 +56,12 @@ const TabListVerticalTest: React.FunctionComponent = () => {
 const TabListAppearanceTest: React.FunctionComponent = () => {
   return (
     <View style={styles.container}>
-      <Header>Transparent Appearance</Header>
+      {/* <Header>Transparent Appearance</Header> */}
       <PaddedTabList appearance="transparent">
         <Tab tabKey="hello">Tab 1</Tab>
         <Tab tabKey="world">Tab 2</Tab>
       </PaddedTabList>
-      <Header>Subtle Appearance</Header>
+      {/* <Header>Subtle Appearance</Header> */}
       <PaddedTabList appearance="subtle">
         <Tab tabKey="hello">Tab 1</Tab>
         <Tab tabKey="world">Tab 2</Tab>

--- a/apps/fluent-tester/src/TestComponents/TabList/TabListTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/TabList/TabListTest.tsx
@@ -87,6 +87,23 @@ const TabListDisabledTest: React.FunctionComponent = () => {
   );
 };
 
+const TabListIconTest: React.FunctionComponent = () => {
+  const iconProp = {
+    fontSource: {
+      fontFamily: 'Arial',
+      codepoint: 0x2663,
+    },
+  };
+  return (
+    <TabList>
+      <Tab icon={iconProp} tabKey="withIcon">
+        Tab Item
+      </Tab>
+      <Tab icon={iconProp} tabKey="iconOnly" />
+    </TabList>
+  );
+};
+
 const sections: TestSection[] = [
   {
     name: 'Size',
@@ -103,6 +120,10 @@ const sections: TestSection[] = [
   {
     name: 'Disabled',
     component: TabListDisabledTest,
+  },
+  {
+    name: 'Icon',
+    component: TabListIconTest,
   },
 ];
 

--- a/change/@fluentui-react-native-tablist-03faa5e6-ba50-4b1c-9c05-b27e65e6695a.json
+++ b/change/@fluentui-react-native-tablist-03faa5e6-ba50-4b1c-9c05-b27e65e6695a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix keyboarding, a11y, and icon rendering for TabList and Tab",
+  "packageName": "@fluentui-react-native/tablist",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-1acddc42-c328-4d11-9ca0-e04a8a7bba68.json
+++ b/change/@fluentui-react-native-tester-1acddc42-c328-4d11-9ca0-e04a8a7bba68.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add Icon examples for TabList",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/TabList/src/Tab/Tab.styling.ts
+++ b/packages/experimental/TabList/src/Tab/Tab.styling.ts
@@ -42,14 +42,6 @@ export const stylingSettings: UseStylingOptions<TabProps, TabSlotProps, TabToken
       }),
       ['iconColor', 'iconSize'],
     ),
-    iconPadding: buildProps(
-      (tokens: TabTokens) => ({
-        style: {
-          width: tokens.iconMargin,
-        },
-      }),
-      ['iconMargin'],
-    ),
     stack: buildProps(
       (tokens: TabTokens) => ({
         style: {

--- a/packages/experimental/TabList/src/Tab/Tab.styling.ts
+++ b/packages/experimental/TabList/src/Tab/Tab.styling.ts
@@ -28,20 +28,27 @@ export const stylingSettings: UseStylingOptions<TabProps, TabSlotProps, TabToken
       (tokens: TabTokens, theme: Theme) => ({
         style: {
           color: tokens.color,
+          marginLeft: tokens.contentMarginLeft,
+          marginRight: tokens.contentMarginRight,
           ...fontStyles.from(tokens, theme),
         },
       }),
-      ['color', ...fontStyles.keys],
+      ['color', 'contentMarginLeft', 'contentMarginRight', ...fontStyles.keys],
     ),
     icon: buildProps(
       (tokens: TabTokens) => ({
         color: tokens.iconColor,
         size: tokens.iconSize,
+      }),
+      ['iconColor', 'iconSize'],
+    ),
+    iconPadding: buildProps(
+      (tokens: TabTokens) => ({
         style: {
-          marginRight: tokens.iconMargin,
+          width: tokens.iconMargin,
         },
       }),
-      ['iconColor', 'iconSize', 'iconMargin'],
+      ['iconMargin'],
     ),
     stack: buildProps(
       (tokens: TabTokens) => ({

--- a/packages/experimental/TabList/src/Tab/Tab.styling.ts
+++ b/packages/experimental/TabList/src/Tab/Tab.styling.ts
@@ -24,16 +24,24 @@ export const stylingSettings: UseStylingOptions<TabProps, TabSlotProps, TabToken
       }),
       ['flexDirection', 'backgroundColor', ...borderStyles.keys],
     ),
+    contentContainer: buildProps(
+      (tokens: TabTokens) => ({
+        style: {
+          flexDirection: 'row',
+          paddingStart: tokens.contentMarginStart,
+          paddingEnd: tokens.contentMarginEnd,
+        },
+      }),
+      ['contentMarginEnd', 'contentMarginStart'],
+    ),
     content: buildProps(
       (tokens: TabTokens, theme: Theme) => ({
         style: {
           color: tokens.color,
-          marginLeft: tokens.contentMarginLeft,
-          marginRight: tokens.contentMarginRight,
           ...fontStyles.from(tokens, theme),
         },
       }),
-      ['color', 'contentMarginLeft', 'contentMarginRight', ...fontStyles.keys],
+      ['color', ...fontStyles.keys],
     ),
     icon: buildProps(
       (tokens: TabTokens) => ({

--- a/packages/experimental/TabList/src/Tab/Tab.tsx
+++ b/packages/experimental/TabList/src/Tab/Tab.tsx
@@ -1,11 +1,12 @@
 /** @jsxRuntime classic */
 /** @jsx withSlots */
+/** @jsxFrag */
 import * as React from 'react';
 import { Pressable, View } from 'react-native';
 
 import type { UseSlots } from '@fluentui-react-native/framework';
 import { compose, mergeProps, withSlots } from '@fluentui-react-native/framework';
-import { Icon } from '@fluentui-react-native/icon';
+import { IconV1 as Icon } from '@fluentui-react-native/icon';
 import { TextV1 as Text } from '@fluentui-react-native/text';
 
 import { stylingSettings } from './Tab.styling';
@@ -20,9 +21,10 @@ const tabLookup = (layer: string, state: TabState, props: TabProps, tablistConte
   return (
     state[layer] ||
     props[layer] ||
+    tablistContext[layer] ||
     layer === tablistContext.appearance ||
     layer === tablistContext.size ||
-    (layer === 'vertical' && tablistContext.vertical)
+    (layer === 'hasIcon' && props.icon)
   );
 };
 
@@ -33,6 +35,7 @@ export const Tab = compose<TabType>({
     root: Pressable,
     stack: View,
     icon: Icon,
+    iconPadding: View,
     indicator: TabIndicator,
     content: Text,
   },
@@ -63,7 +66,7 @@ export const Tab = compose<TabType>({
         <Slots.root {...mergedProps}>
           <Slots.stack>
             {icon && <Slots.icon {...icon} />}
-            <Slots.content>{text}</Slots.content>
+            {text && <Slots.content>{text}</Slots.content>}
           </Slots.stack>
           <Slots.indicator />
         </Slots.root>

--- a/packages/experimental/TabList/src/Tab/Tab.tsx
+++ b/packages/experimental/TabList/src/Tab/Tab.tsx
@@ -35,7 +35,6 @@ export const Tab = compose<TabType>({
     root: Pressable,
     stack: View,
     icon: Icon,
-    iconPadding: View,
     indicator: TabIndicator,
     content: Text,
   },
@@ -53,6 +52,7 @@ export const Tab = compose<TabType>({
         return null;
       }
 
+      // Only support text as content for now.
       let text = '';
       React.Children.forEach(children, (child) => {
         if (typeof child === 'string') {
@@ -62,11 +62,15 @@ export const Tab = compose<TabType>({
 
       const { icon, tabKey, ...mergedProps } = mergeProps(tab.props, final, { accessibilityLabel: final.accessibilityLabel || text });
 
+      if (__DEV__ && !text && !icon) {
+        console.warn('A Tab component must render content. Text, an icon, or both should at least be passed in.');
+      }
+
       return (
         <Slots.root {...mergedProps}>
           <Slots.stack>
             {icon && <Slots.icon {...icon} />}
-            {text && <Slots.content>{text}</Slots.content>}
+            <Slots.content>{text}</Slots.content>
           </Slots.stack>
           <Slots.indicator />
         </Slots.root>

--- a/packages/experimental/TabList/src/Tab/Tab.tsx
+++ b/packages/experimental/TabList/src/Tab/Tab.tsx
@@ -70,7 +70,7 @@ export const Tab = compose<TabType>({
         <Slots.root {...mergedProps}>
           <Slots.stack>
             {icon && <Slots.icon {...icon} />}
-            <Slots.content>{text}</Slots.content>
+            {text && <Slots.content accessible={false}>{text}</Slots.content>}
           </Slots.stack>
           <Slots.indicator />
         </Slots.root>

--- a/packages/experimental/TabList/src/Tab/Tab.tsx
+++ b/packages/experimental/TabList/src/Tab/Tab.tsx
@@ -60,7 +60,9 @@ export const Tab = compose<TabType>({
         }
       });
 
-      const { icon, tabKey, ...mergedProps } = mergeProps(tab.props, final, { accessibilityLabel: final.accessibilityLabel || text });
+      const { icon, tabKey, ...mergedProps } = mergeProps(tab.props, final, {
+        accessibilityLabel: tab.props.accessibilityLabel || final.accessibilityLabel || text,
+      });
 
       if (__DEV__ && !text && !icon) {
         console.warn('A Tab component must render content. Text, an icon, or both should at least be passed in.');

--- a/packages/experimental/TabList/src/Tab/Tab.tsx
+++ b/packages/experimental/TabList/src/Tab/Tab.tsx
@@ -36,6 +36,7 @@ export const Tab = compose<TabType>({
     stack: View,
     icon: Icon,
     indicator: TabIndicator,
+    contentContainer: View,
     content: Text,
   },
   useRender: (userProps: TabProps, useSlots: UseSlots<TabType>) => {
@@ -52,27 +53,43 @@ export const Tab = compose<TabType>({
         return null;
       }
 
-      // Only support text as content for now.
-      let text = '';
+      // Get label for Tab to use if there's no accessibilityLabel prop passed in.
+      let label = '';
+      let hasChildren = false;
       React.Children.forEach(children, (child) => {
-        if (typeof child === 'string') {
-          text = child;
+        if (child !== null) {
+          hasChildren = true;
+          if (typeof child === 'string') {
+            label = child;
+          }
         }
       });
 
       const { icon, tabKey, ...mergedProps } = mergeProps(tab.props, final, {
-        accessibilityLabel: tab.props.accessibilityLabel || final.accessibilityLabel || text,
+        accessibilityLabel: tab.props.accessibilityLabel || final.accessibilityLabel || label,
       });
 
-      if (__DEV__ && !text && !icon) {
-        console.warn('A Tab component must render content. Text, an icon, or both should at least be passed in.');
+      if (__DEV__ && !hasChildren && !icon) {
+        console.warn('A Tab component must render content. Children, an icon, or both should be passed in.');
       }
 
       return (
         <Slots.root {...mergedProps}>
           <Slots.stack>
             {icon && <Slots.icon {...icon} />}
-            {text && <Slots.content accessible={false}>{text}</Slots.content>}
+            {hasChildren && (
+              <Slots.contentContainer>
+                {React.Children.map(children, (child, i) =>
+                  typeof child === 'string' ? (
+                    <Slots.content accessible={false} key={i}>
+                      {child}
+                    </Slots.content>
+                  ) : (
+                    child
+                  ),
+                )}
+              </Slots.contentContainer>
+            )}
           </Slots.stack>
           <Slots.indicator />
         </Slots.root>

--- a/packages/experimental/TabList/src/Tab/Tab.types.ts
+++ b/packages/experimental/TabList/src/Tab/Tab.types.ts
@@ -19,14 +19,14 @@ export const tabName = 'Tab';
 
 export interface TabTokens extends FontTokens, IBorderTokens, IForegroundColorTokens, IBackgroundColorTokens, LayoutTokens {
   /**
-   * Horizontal left margin of the tab text. If an icon and text are both rendered, this is the margin beween the icon and text.
+   * Horizontal start margin of the tab text. If an icon and text are both rendered, this is the margin beween the icon and text.
    */
-  contentMarginLeft?: number;
+  contentMarginStart?: number;
 
   /**
-   * Horizontal right margin of the tab text.
+   * Horizontal end margin of the tab text.
    */
-  contentMarginRight?: number;
+  contentMarginEnd?: number;
 
   /**
    * Controls order and direction of tab content and indicator.
@@ -128,6 +128,7 @@ export interface TabSlotProps {
   icon: IconProps;
   stack: IViewProps;
   indicator: TabIndicatorProps;
+  contentContainer: IViewProps;
   content: TextProps;
 }
 

--- a/packages/experimental/TabList/src/Tab/Tab.types.ts
+++ b/packages/experimental/TabList/src/Tab/Tab.types.ts
@@ -19,9 +19,14 @@ export const tabName = 'Tab';
 
 export interface TabTokens extends FontTokens, IBorderTokens, IForegroundColorTokens, IBackgroundColorTokens, LayoutTokens {
   /**
-   * Horizontal margin of the tab text.
+   * Horizontal left margin of the tab text. If an icon and text are both rendered, this is the margin beween the icon and text.
    */
-  contentMarginHorizontal?: number;
+  contentMarginLeft?: number;
+
+  /**
+   * Horizontal right margin of the tab text.
+   */
+  contentMarginRight?: number;
 
   /**
    * Controls order and direction of tab content and indicator.
@@ -54,11 +59,6 @@ export interface TabTokens extends FontTokens, IBorderTokens, IForegroundColorTo
   iconColor?: string;
 
   /**
-   * If there is Tab content, this is the margin of the icon relative to the content.
-   */
-  iconMargin?: number;
-
-  /**
    * The size of the icon.
    */
   iconSize?: number;
@@ -87,6 +87,7 @@ export interface TabTokens extends FontTokens, IBorderTokens, IForegroundColorTo
   pressed?: TabTokens;
   disabled?: TabTokens;
   selected?: TabTokens;
+  hasIcon?: TabTokens;
 }
 
 export interface TabProps extends Omit<PressablePropsExtended, 'onPress'> {

--- a/packages/experimental/TabList/src/Tab/TabTokens.ts
+++ b/packages/experimental/TabList/src/Tab/TabTokens.ts
@@ -24,8 +24,8 @@ export const defaultTabTokens: TokenSettings<TabTokens, Theme> = (t: Theme) =>
     indicatorThickness: 2,
     borderWidth: 2,
     borderRadius: 4,
-    contentMarginLeft: 2,
-    contentMarginRight: 2,
+    contentMarginStart: 2,
+    contentMarginEnd: 2,
     flexDirection: 'column',
     borderColor: t.colors.transparentStroke,
     color: t.colors.neutralForeground2,
@@ -141,6 +141,6 @@ export const defaultTabTokens: TokenSettings<TabTokens, Theme> = (t: Theme) =>
       borderColor: t.colors.neutralForeground1,
     },
     hasIcon: {
-      contentMarginLeft: 8,
+      contentMarginStart: 8,
     },
   } as TabTokens);

--- a/packages/experimental/TabList/src/Tab/TabTokens.ts
+++ b/packages/experimental/TabList/src/Tab/TabTokens.ts
@@ -15,6 +15,7 @@ export const tabStates: (keyof TabTokens)[] = [
   'pressed',
   'transparent',
   'subtle',
+  'hasIcon',
 ];
 
 export const defaultTabTokens: TokenSettings<TabTokens, Theme> = (t: Theme) =>
@@ -23,7 +24,8 @@ export const defaultTabTokens: TokenSettings<TabTokens, Theme> = (t: Theme) =>
     indicatorThickness: 2,
     borderWidth: 2,
     borderRadius: 4,
-    contentMarginHorizontal: 2,
+    contentMarginLeft: 2,
+    contentMarginRight: 2,
     flexDirection: 'column',
     borderColor: t.colors.transparentStroke,
     color: t.colors.neutralForeground2,
@@ -137,5 +139,8 @@ export const defaultTabTokens: TokenSettings<TabTokens, Theme> = (t: Theme) =>
     },
     focused: {
       borderColor: t.colors.neutralForeground1,
+    },
+    hasIcon: {
+      contentMarginLeft: 8,
     },
   } as TabTokens);

--- a/packages/experimental/TabList/src/Tab/useTab.ts
+++ b/packages/experimental/TabList/src/Tab/useTab.ts
@@ -21,7 +21,6 @@ export const useTab = (props: TabProps): TabInfo => {
   const defaultComponentRef = React.useRef<IFocusable>(null);
   const {
     accessibilityActions,
-    accessibilityLabel,
     accessibilityPositionInSet,
     accessibilitySetSize,
     accessibilityState,
@@ -80,6 +79,7 @@ export const useTab = (props: TabProps): TabInfo => {
 
   return {
     props: {
+      ...props,
       ...pressable.props,
       accessible: accessible ?? true,
       accessibilityRole: 'tab',

--- a/packages/experimental/TabList/src/Tab/useTab.ts
+++ b/packages/experimental/TabList/src/Tab/useTab.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type { AccessibilityState } from 'react-native';
+import type { AccessibilityActionEvent, AccessibilityState } from 'react-native';
 
 import { memoize } from '@fluentui-react-native/framework';
 import type { IFocusable } from '@fluentui-react-native/interactive-hooks';
@@ -28,6 +28,7 @@ export const useTab = (props: TabProps): TabInfo => {
     componentRef = defaultComponentRef,
     disabled,
     icon,
+    onAccessibilityAction,
     tabKey,
     ...rest
   } = props;
@@ -52,15 +53,18 @@ export const useTab = (props: TabProps): TabInfo => {
   const onKeyUpProps = useKeyProps(changeSelection, ' ', 'Enter');
 
   // Used when creating accessibility properties in mergeSettings below.
-  const onAccessibilityAction = React.useCallback(
-    (event: { nativeEvent: { actionName: any } }) => {
-      switch (event.nativeEvent.actionName) {
-        case 'Select':
-          changeSelection();
-          break;
+  const onAccessibilityActionProp = React.useCallback(
+    (event: AccessibilityActionEvent) => {
+      if (!disabled) {
+        switch (event.nativeEvent.actionName) {
+          case 'Select':
+            changeSelection();
+            break;
+        }
+        onAccessibilityAction && onAccessibilityAction(event);
       }
     },
-    [changeSelection],
+    [changeSelection, disabled, onAccessibilityAction],
   );
 
   const accessibilityActionsProp = React.useMemo(
@@ -90,7 +94,7 @@ export const useTab = (props: TabProps): TabInfo => {
       disabled: info.disabled || props.disabled,
       focusable: !disabled ?? true,
       icon: icon,
-      onAccessibilityAction: onAccessibilityAction,
+      onAccessibilityAction: onAccessibilityActionProp,
       ref: useViewCommandFocus(componentRef),
       tabKey: tabKey,
       ...onKeyUpProps,

--- a/packages/experimental/TabList/src/Tab/useTab.ts
+++ b/packages/experimental/TabList/src/Tab/useTab.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import type { AccessibilityState } from 'react-native';
 
 import { memoize } from '@fluentui-react-native/framework';
 import type { IFocusable } from '@fluentui-react-native/interactive-hooks';
@@ -7,17 +8,31 @@ import { usePressableState, useKeyProps, useOnPressWithFocus, useViewCommandFocu
 import type { TabProps, TabInfo } from './Tab.types';
 import { TabListContext } from '../TabList/TabList';
 
+const defaultAccessibilityActions = [{ name: 'Select' }];
+
 /**
- * Re-usable hook for TabsItem.
- * This hook configures tabs item props and state for TabsItem.
+ * Re-usable hook for Tab.
+ * This hook configures tabs item props and state for Tab.
  *
- * @param props user props sent to TabsItem
- * @returns configured props and state for TabsItem
+ * @param props user props sent to Tab
+ * @returns configured props and state for Tab
  */
 export const useTab = (props: TabProps): TabInfo => {
   const defaultComponentRef = React.useRef<IFocusable>(null);
-  const { accessibilityLabel, accessible, componentRef = defaultComponentRef, tabKey, disabled, icon, ...rest } = props;
-  // Grabs the context information from Tabs (currently selected TabsItem and client's onTabsClick callback).
+  const {
+    accessibilityActions,
+    accessibilityLabel,
+    accessibilityPositionInSet,
+    accessibilitySetSize,
+    accessibilityState,
+    accessible,
+    componentRef = defaultComponentRef,
+    disabled,
+    icon,
+    tabKey,
+    ...rest
+  } = props;
+  // Grabs the context information from Tabs (currently selected Tab and client's onTabSelect callback).
   const info = React.useContext(TabListContext);
 
   const changeSelection = React.useCallback(() => {
@@ -49,7 +64,12 @@ export const useTab = (props: TabProps): TabInfo => {
     [changeSelection],
   );
 
-  /* We use the componentRef of the currently selected tabsItem to maintain the default tabbable
+  const accessibilityActionsProp = React.useMemo(
+    () => (accessibilityActions ? [...defaultAccessibilityActions, ...accessibilityActions] : defaultAccessibilityActions),
+    [accessibilityActions],
+  );
+
+  /* We use the componentRef of the currently selected tab to maintain the default tabbable
   element in Tabs. Since the componentRef isn't generated until after initial render,
   we must update it once here. */
   React.useEffect(() => {
@@ -63,14 +83,16 @@ export const useTab = (props: TabProps): TabInfo => {
       ...pressable.props,
       accessible: accessible ?? true,
       accessibilityRole: 'tab',
-      disabled: info.disabled || props.disabled || false,
+      accessibilityActions: accessibilityActionsProp,
+      accessibilityPositionInSet: accessibilityPositionInSet ?? info.tabKeys.findIndex((key) => key === tabKey) + 1,
+      accessibilityState: getAccessibilityState(disabled, info.selectedKey === tabKey, accessibilityState),
+      accessibilitySetSize: accessibilitySetSize ?? info.tabKeys.length,
+      disabled: info.disabled || props.disabled,
       focusable: !disabled ?? true,
-      accessibilityState: getAccessibilityState(disabled, info.selectedKey === tabKey),
-      accessibilityActions: [{ name: 'Select' }],
+      icon: icon,
       onAccessibilityAction: onAccessibilityAction,
       ref: useViewCommandFocus(componentRef),
       tabKey: tabKey,
-      icon: icon,
       ...onKeyUpProps,
     },
     state: {
@@ -81,6 +103,9 @@ export const useTab = (props: TabProps): TabInfo => {
 };
 
 const getAccessibilityState = memoize(getAccessibilityStateWorker);
-function getAccessibilityStateWorker(disabled: boolean, selected: boolean) {
+function getAccessibilityStateWorker(disabled: boolean, selected: boolean, accessibilityState?: AccessibilityState): AccessibilityState {
+  if (accessibilityState) {
+    return { disabled, selected, ...accessibilityState };
+  }
   return { disabled, selected };
 }

--- a/packages/experimental/TabList/src/TabList/TabList.styling.ts
+++ b/packages/experimental/TabList/src/TabList/TabList.styling.ts
@@ -9,22 +9,14 @@ export const stylingSettings: UseStylingOptions<TabListProps, TabListSlotProps, 
   tokens: [defaultTabListTokens, tabListName],
   states: ['vertical'],
   slotProps: {
-    root: buildProps(
+    stack: buildProps(
       (tokens: TabListTokens, theme: Theme) => ({
         style: {
-          display: 'flex',
+          flexDirection: tokens.direction,
           ...layoutStyles.from(tokens, theme),
         },
       }),
-      [...layoutStyles.keys],
-    ),
-    stack: buildProps(
-      (tokens) => ({
-        style: {
-          flexDirection: tokens.direction,
-        },
-      }),
-      ['direction'],
+      ['direction', ...layoutStyles.keys],
     ),
   },
 };

--- a/packages/experimental/TabList/src/TabList/TabList.tsx
+++ b/packages/experimental/TabList/src/TabList/TabList.tsx
@@ -1,7 +1,7 @@
 /** @jsxRuntime classic */
 /** @jsx withSlots */
 import * as React from 'react';
-import { Pressable, View } from 'react-native';
+import { View } from 'react-native';
 
 import { FocusZone } from '@fluentui-react-native/focus-zone';
 import type { UseSlots } from '@fluentui-react-native/framework';
@@ -31,7 +31,6 @@ export const TabList = compose<TabListType>({
   displayName: tabListName,
   ...stylingSettings,
   slots: {
-    root: Pressable,
     container: FocusZone,
     stack: View,
   },
@@ -48,7 +47,7 @@ export const TabList = compose<TabListType>({
         return null;
       }
 
-      const { defaultTabbableElement, isCircularNavigation, ...mergedProps } = mergeProps(tabs.props, final);
+      const { disabled, defaultTabbableElement, isCircularNavigation, ...mergedProps } = mergeProps(tabs.props, final);
 
       // Populate the tabKeys array.
       if (children) {
@@ -68,15 +67,9 @@ export const TabList = compose<TabListType>({
           // Passes in the selected key and a hook function to update the newly selected tab and call the client's onTabsClick callback.
           value={tabs.state.context}
         >
-          <Slots.root {...mergedProps}>
-            <Slots.container
-              disabled={final.disabled}
-              defaultTabbableElement={defaultTabbableElement}
-              isCircularNavigation={isCircularNavigation}
-            >
-              <Slots.stack>{children}</Slots.stack>
-            </Slots.container>
-          </Slots.root>
+          <Slots.container disabled={disabled} defaultTabbableElement={defaultTabbableElement} isCircularNavigation={isCircularNavigation}>
+            <Slots.stack {...mergedProps}>{children}</Slots.stack>
+          </Slots.container>
         </TabListContext.Provider>
       );
     };

--- a/packages/experimental/TabList/src/TabList/TabList.types.ts
+++ b/packages/experimental/TabList/src/TabList/TabList.types.ts
@@ -116,9 +116,8 @@ export interface TabListInfo {
   state: TabListState;
 }
 export interface TabListSlotProps {
-  root: React.PropsWithRef<IViewProps>;
   container?: FocusZoneProps;
-  stack: IViewProps;
+  stack: React.PropsWithRef<IViewProps>;
 }
 
 export interface TabListType {

--- a/packages/experimental/TabList/src/TabList/useTabList.ts
+++ b/packages/experimental/TabList/src/TabList/useTabList.ts
@@ -1,28 +1,30 @@
 import * as React from 'react';
-import type { View } from 'react-native';
+import type { View, AccessibilityState } from 'react-native';
 
+import { memoize } from '@fluentui-react-native/framework';
 import { useSelectedKey } from '@fluentui-react-native/interactive-hooks';
 
 import type { TabListProps, TabListInfo, TabListState } from './TabList.types';
 
 /**
- * Re-usable hook for Tabs.
- * This hook configures tabs props and state for Tabs.
+ * Re-usable hook for TabList.
+ * This hook configures props and state for TabList.
  *
- * @param props user props sent to Tabs
- * @returns configured props and state for Tabs
+ * @param props user props sent to TabList
+ * @returns configured props and state for TabList
  */
 export const useTabList = (props: TabListProps): TabListInfo => {
   const defaultComponentRef = React.useRef(null);
   const {
     accessible,
-    disabled = false,
     appearance = 'transparent',
+    accessibilityState,
     componentRef = defaultComponentRef,
-    isCircularNavigation,
-    selectedKey,
-    onTabSelect,
     defaultSelectedKey,
+    disabled = false,
+    isCircularNavigation,
+    onTabSelect,
+    selectedKey,
     size = 'medium',
     vertical = false,
   } = props;
@@ -55,6 +57,7 @@ export const useTabList = (props: TabListProps): TabListInfo => {
     props: {
       ...props,
       accessible: accessible ?? true,
+      accessibilityState: getAccessibilityState(disabled, accessibilityState),
       accessibilityRole: 'tablist',
       appearance: appearance,
       componentRef: componentRef,
@@ -66,3 +69,11 @@ export const useTabList = (props: TabListProps): TabListInfo => {
     state: { ...state },
   };
 };
+
+const getAccessibilityState = memoize(getAccessibilityStateWorker);
+function getAccessibilityStateWorker(disabled: boolean, accessibilityState?: AccessibilityState): AccessibilityState {
+  if (accessibilityState) {
+    return { disabled, ...accessibilityState };
+  }
+  return { disabled };
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This PR makes multiple fixes to TabList:
- Fix Icon not rendering properly. Icon should now have correct color tokens and margins.
- Fix keyboarding and focus. TabList root is no longer focusable, and users are now no longer able to focus on and control disabled TabLists and Tab elements.
- Set and expose a11y properties for Tab and TabList. 

### Verification

Informal testing through Tester app. Below is an image of a TabList with icons.
![image](https://github.com/microsoft/fluentui-react-native/assets/15683103/aabe51aa-6f3f-44e0-b7e1-04d886d97c87)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [x] Keyboard Accessibility
- [x] Voiceover
- [ ] Internationalization and Right-to-left Layouts
