### PR TITLE
Fix FluentTester StrokeWidthTest page so strokeWidth 0.5 is visible

### DIFF
--- a/apps/fluent-tester/src/TestComponents/StrokeWidth/StrokeWidthTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/StrokeWidth/StrokeWidthTest.tsx
@@ -24,7 +24,6 @@ const getThemedStyles = themedStyleSheet((t: Theme) => {
       height: 100,
       backgroundColor: isLightMode ? globalTokens.color.grey80 : globalTokens.color.grey10,
       display: 'flex',
-      justifyContent: 'center',
       marginTop: 8,
     },
   };
@@ -41,10 +40,11 @@ const StrokeWidthTestComponent: React.FunctionComponent<StrokeWidthTestComponent
   const isLightMode = getCurrentAppearance(theme.host.appearance, 'light') === 'light';
   const exampleStrokeStyle = React.useMemo(
     () => ({
-      height: props.strokeWidth,
-      backgroundColor: isLightMode ? globalTokens.color.grey10 : globalTokens.color.grey80,
+      height: 50,
+      borderBottomWidth: props.strokeWidth,
+      borderColor: isLightMode ? globalTokens.color.grey10 : globalTokens.color.grey80,
     }),
-    [props.strokeWidth],
+    [props.strokeWidth, isLightMode],
   );
 
   return (

--- a/change/@fluentui-react-native-tester-42f4b333-bab0-4b27-bb87-292cc84fd321.json
+++ b/change/@fluentui-react-native-tester-42f4b333-bab0-4b27-bb87-292cc84fd321.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix StrokeWidthTest so strokeWidth05 is visible",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

On the stroke width token test page, stroke width 0.5 was not showing up. Initially thought this was due to display resolution, but I realized this was actually because the test page was attempting to use a view of height 0.5 to show what a stroke width of height 0.5 would look like, and height =0.5 doesn't seem to be a valid view height. 

Updated the stroke width test to show the strokeWidth sizes with the bottom borderWidth of a view, rather than the height of a view itself. 

The old view that had height = stroke width height was updated to have a height of 50, which is half the height of the parent view, and was updated to always be aligned to the top of its parent view. This ensures the bottom border of the view is in the middle of the parent view.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| S![image](https://github.com/microsoft/fluentui-react-native/assets/78454019/18539529-d2d4-460b-8632-b1b9a77024c5) | ![image](https://github.com/microsoft/fluentui-react-native/assets/78454019/f13d3f6f-2019-4581-b96e-66a9a8d0d61f) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
