### PR TITLE
Color tokens test page updates

### DIFF
--- a/apps/fluent-tester/src/TestComponents/ColorTokens/ColorTokenTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/ColorTokens/ColorTokenTest.tsx
@@ -53,11 +53,6 @@ const styles = StyleSheet.create({
   colorDescriptionNamePadding: { paddingRight: 5 },
 });
 
-const getSwatchColorStyle = (colorName: string, colorValue: ColorValue): ViewStyle => {
-  styles[colorName] = styles[colorName] || { backgroundColor: colorValue };
-  return styles[colorName];
-};
-
 type ColorTokenProps = { colorValue: ColorValue; colorName: string };
 const ColorToken: React.FunctionComponent<ColorTokenProps> = (p: ColorTokenProps) => {
   if (p.colorValue === undefined) {
@@ -68,7 +63,7 @@ const ColorToken: React.FunctionComponent<ColorTokenProps> = (p: ColorTokenProps
   return (
     <View style={styles.swatchItem}>
       <View
-        style={[getSwatchColorStyle(p.colorName, p.colorValue), themedStyles.swatch]}
+        style={[{ backgroundColor: p.colorValue }, themedStyles.swatch]}
         /* For Android E2E testing purposes, testProps must be passed in after accessibilityLabel. */
         {...testProps(COLORTOKENS_TEST_COMPONENT)}
       />
@@ -89,7 +84,6 @@ const getSwatch = (item) => {
 
 const AliasColorTokensSwatchList: React.FunctionComponent = () => {
   const theme = useTheme();
-
   const aliasColorTokens = theme.colors;
 
   const aggregator = React.useCallback(

--- a/apps/fluent-tester/src/TestComponents/ColorTokens/ColorTokenTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/ColorTokens/ColorTokenTest.tsx
@@ -3,14 +3,11 @@ import type { ViewStyle, ColorValue } from 'react-native';
 import { View, StyleSheet, Platform } from 'react-native';
 
 import { Text, ToggleButton } from '@fluentui/react-native';
-import { createAliasTokens } from '@fluentui-react-native/default-theme';
 import type { SvgIconProps } from '@fluentui-react-native/icon';
 import { globalTokens } from '@fluentui-react-native/theme-tokens';
 import type { Theme } from '@fluentui-react-native/theme-types';
 import { useTheme } from '@fluentui-react-native/theme-types';
 import { themedStyleSheet } from '@fluentui-react-native/themed-stylesheet';
-import { getCurrentAppearance } from '@fluentui-react-native/theming-utils';
-import { createOfficeAliasTokens } from '@fluentui-react-native/win32-theme';
 import type { SvgProps } from 'react-native-svg';
 import Svg, { G, Path } from 'react-native-svg';
 
@@ -93,16 +90,7 @@ const getSwatch = (item) => {
 const AliasColorTokensSwatchList: React.FunctionComponent = () => {
   const theme = useTheme();
 
-  const isOfficeTheme =
-    theme.name === 'White' ||
-    theme.name === 'Colorful' ||
-    theme.name === 'DarkGray' ||
-    theme.name === 'Black' ||
-    theme.name === 'HighContrast';
-
-  const aliasColorTokens = isOfficeTheme
-    ? createOfficeAliasTokens(theme.name)
-    : createAliasTokens(getCurrentAppearance(theme.host.appearance, 'light'));
+  const aliasColorTokens = theme.colors;
 
   const aggregator = React.useCallback(
     (colorName: string) => {

--- a/apps/fluent-tester/src/TestComponents/ColorTokens/ColorTokenTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/ColorTokens/ColorTokenTest.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type { ViewStyle, ColorValue } from 'react-native';
+import type { ColorValue } from 'react-native';
 import { View, StyleSheet, Platform } from 'react-native';
 
 import { Text, ToggleButton } from '@fluentui/react-native';

--- a/change/@fluentui-react-native-tester-65ff602e-287a-4447-a531-dd27e008f12a.json
+++ b/change/@fluentui-react-native-tester-65ff602e-287a-4447-a531-dd27e008f12a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Color tokens test updates",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "78454019+lyzhan7@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

1. The color tokens test page was showing either 1) tokens from the win32 theme if the theme was a win32 theme or 2) tokens created using default theme code. For macOS, we were showing macOS tokens, but these tokens were going through default theme code rather than macOS theme code. This resulted in some expected tokens not showing up, and in some tokens showing up as undefined. Let's just show all the tokens in theme - this should at least make sense for every platform. 
2. I noticed that the swatch color wasn't updating when switching from light/dark mode. This was because when we were re-rendering after a light/dark mode switch, we would check first to see if a color with that same colorName was defined already (which it would be, but with the wrong light/dark mode). I updated this code so that we just update the color of the swatch every time we render - if there's a better way to do this though please let me know. 

Notes: 
- After this change, at least on macOS, there are more tokens shown in the color token test page. This is because the tokens we expose through the theme contain 1) tokens from the pipeline/design-tokens repo, as well as 2) tokens we define in FURN, which we should remove at some point. Previous to this change we were only showing tokens from 1), but now we are showing both. All the 2) tokens should be removed at some point.
- Some of the 2) tokens (defined in FURN) show up as [object Object] - either because they are DynamicColorMacOS or they are PlatformColor. Given that we should remove them at some point, I've left them as is. 

### Verification

Before:

https://github.com/microsoft/fluentui-react-native/assets/78454019/f26c31a3-e44a-4d92-b6da-12ea9f16d37e


After:

https://github.com/microsoft/fluentui-react-native/assets/78454019/70318b6c-eb1f-4c20-84cb-f0c55fc1bec9




### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
