### PR TITLE
Add additional brand color check

### DIFF
--- a/change/@fluentui-react-native-win32-theme-fce8dc2b-9f69-422f-bdcc-c9589734c991.json
+++ b/change/@fluentui-react-native-win32-theme-fce8dc2b-9f69-422f-bdcc-c9589734c991.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add additional brand color check",
+  "packageName": "@fluentui-react-native/win32-theme",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/theming/win32-theme/src/createBrandedThemeWithAlias.ts
+++ b/packages/theming/win32-theme/src/createBrandedThemeWithAlias.ts
@@ -59,7 +59,7 @@ function getAppColors(primaryColor: ColorValue) {
       return globalTokens.color.excel;
     } else if (primaryColor.toLowerCase() === '#d83b01') {
       return globalTokens.color.office;
-    } else if (primaryColor.toLowerCase() === '#80397b') {
+    } else if (primaryColor.toLowerCase() === '#80397b' || primaryColor.toLowerCase() === '#7719aa') {
       return globalTokens.color.oneNote;
     } else if (primaryColor.toLowerCase() === '#0078d4') {
       return globalTokens.color.outlook;


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Seems like the color for OneNote has changed, so adding an additional color check. This should fix a bug where in OneNote the brand tokens are not the expected color.
The brand stuff in general should probably be revamped, but that's a story for another day