### PR TITLE
Add LinkTokens.ios.ts

### DIFF
--- a/change/@fluentui-react-native-link-9bf34cab-9f91-4550-a914-a6d0e07e0ac9.json
+++ b/change/@fluentui-react-native-link-9bf34cab-9f91-4550-a914-a6d0e07e0ac9.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add LinkTokens.ios.ts",
+  "packageName": "@fluentui-react-native/link",
+  "email": "moniriv@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Link/src/LinkTokens.ios.ts
+++ b/packages/components/Link/src/LinkTokens.ios.ts
@@ -1,0 +1,20 @@
+import type { Theme } from '@fluentui-react-native/framework';
+import type { TokenSettings } from '@fluentui-react-native/use-styling';
+
+import type { LinkTokens } from './Link.types';
+
+export const defaultLinkTokens: TokenSettings<LinkTokens, Theme> = (t: Theme) =>
+  ({
+    color: t.colors.brandForeground1,
+    alignSelf: 'flex-start',
+    inline: {
+      textDecorationLine: 'underline',
+    },
+    disabled: {
+      color: t.colors.brandForeground1Disabled,
+      textDecorationLine: 'none',
+    },
+    pressed: {
+      color: t.colors.brandForeground1Pressed,
+    },
+  } as LinkTokens);


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Adding styling tokens for iOS.

### Verification

Built a local npm package, added the new package to test app. See styles applied to "Sort by" link below: 

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="289" alt="image" src="https://github.com/microsoft/fluentui-react-native/assets/44449640/aa3a5fe8-30a6-4e05-8599-ef36bfe22871">|<img width="289" alt="image" src="https://github.com/microsoft/fluentui-react-native/assets/44449640/723d1f98-20ad-42f8-8a82-9df881fa291d">

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
