### PR TITLE
Add E2E tests for required property on CheckboxV1 and RadioGroupV1

### DIFF
--- a/apps/E2E/src/CheckboxV1/specs/CheckboxV1.spec.win.ts
+++ b/apps/E2E/src/CheckboxV1/specs/CheckboxV1.spec.win.ts
@@ -53,6 +53,22 @@ describe('CheckboxV1 Accessibility Testing', () => {
 
     await expect(await CheckboxV1PageObject.didAssertPopup()).toBeFalsy(CheckboxV1PageObject.ERRORMESSAGE_ASSERT);
   });
+
+  it('Set "required" prop. Validate "IsRequiredForForm" element attribute is true.', async () => {
+    await expect(
+      await CheckboxV1PageObject.compareAttribute(CheckboxV1PageObject._secondaryComponent, Attribute.IsRequiredForForm, 'True'),
+    ).toBeTruthy();
+
+    await expect(await CheckboxV1PageObject.didAssertPopup()).toBeFalsy(CheckboxV1PageObject.ERRORMESSAGE_ASSERT);
+  });
+
+  it('Do NOT set "required" prop. Validate "IsRequiredForForm" element attribute is false.', async () => {
+    await expect(
+      await CheckboxV1PageObject.compareAttribute(CheckboxV1PageObject._primaryComponent, Attribute.IsRequiredForForm, 'False'),
+    ).toBeTruthy();
+
+    await expect(await CheckboxV1PageObject.didAssertPopup()).toBeFalsy(CheckboxV1PageObject.ERRORMESSAGE_ASSERT);
+  });
 });
 
 describe('CheckboxV1 Functional Testing', () => {

--- a/apps/E2E/src/CheckboxV1/specs/CheckboxV1.spec.win.ts
+++ b/apps/E2E/src/CheckboxV1/specs/CheckboxV1.spec.win.ts
@@ -1,4 +1,4 @@
-import { CHECKBOX_A11Y_ROLE, Keys, Attribute } from '../../common/consts';
+import { CHECKBOX_A11Y_ROLE, Keys, Attribute, AttributeValue } from '../../common/consts';
 import { CHECKBOXV1_TEST_COMPONENT_LABEL, CHECKBOXV1_ACCESSIBILITY_LABEL } from '../consts';
 import CheckboxV1PageObject from '../pages/CheckboxV1PageObject';
 
@@ -56,7 +56,11 @@ describe('CheckboxV1 Accessibility Testing', () => {
 
   it('Set "required" prop. Validate "IsRequiredForForm" element attribute is true.', async () => {
     await expect(
-      await CheckboxV1PageObject.compareAttribute(CheckboxV1PageObject._secondaryComponent, Attribute.IsRequiredForForm, 'True'),
+      await CheckboxV1PageObject.compareAttribute(
+        CheckboxV1PageObject._secondaryComponent,
+        Attribute.IsRequiredForForm,
+        AttributeValue.true,
+      ),
     ).toBeTruthy();
 
     await expect(await CheckboxV1PageObject.didAssertPopup()).toBeFalsy(CheckboxV1PageObject.ERRORMESSAGE_ASSERT);
@@ -64,7 +68,11 @@ describe('CheckboxV1 Accessibility Testing', () => {
 
   it('Do NOT set "required" prop. Validate "IsRequiredForForm" element attribute is false.', async () => {
     await expect(
-      await CheckboxV1PageObject.compareAttribute(CheckboxV1PageObject._primaryComponent, Attribute.IsRequiredForForm, 'False'),
+      await CheckboxV1PageObject.compareAttribute(
+        CheckboxV1PageObject._primaryComponent,
+        Attribute.IsRequiredForForm,
+        AttributeValue.false,
+      ),
     ).toBeTruthy();
 
     await expect(await CheckboxV1PageObject.didAssertPopup()).toBeFalsy(CheckboxV1PageObject.ERRORMESSAGE_ASSERT);

--- a/apps/E2E/src/RadioGroupV1/specs/RadioGroupV1.spec.win.ts
+++ b/apps/E2E/src/RadioGroupV1/specs/RadioGroupV1.spec.win.ts
@@ -99,6 +99,22 @@ describe('RadioGroupV1/RadioV1 Accessibility Testing', () => {
 
     expect(await RadioGroupV1PageObject.didAssertPopup()).toBeFalsy(RadioGroupV1PageObject.ERRORMESSAGE_ASSERT);
   });
+
+  it('Set "required" prop on RadioGroup. Validate "IsRequiredForForm" element attribute is true.', async () => {
+    await expect(
+      await RadioGroupV1PageObject.compareAttribute(RadioGroupV1PageObject._secondaryComponent, Attribute.IsRequiredForForm, 'True'),
+    ).toBeTruthy();
+
+    await expect(await RadioGroupV1PageObject.didAssertPopup()).toBeFalsy(RadioGroupV1PageObject.ERRORMESSAGE_ASSERT);
+  });
+
+  it('Do NOT set "required" prop on RadioGroup. Validate "IsRequiredForForm" element attribute is false.', async () => {
+    await expect(
+      await RadioGroupV1PageObject.compareAttribute(RadioGroupV1PageObject._primaryComponent, Attribute.IsRequiredForForm, 'False'),
+    ).toBeTruthy();
+
+    await expect(await RadioGroupV1PageObject.didAssertPopup()).toBeFalsy(RadioGroupV1PageObject.ERRORMESSAGE_ASSERT);
+  });
 });
 
 describe('RadioGroupV1 Functional Testing', () => {

--- a/apps/E2E/src/RadioGroupV1/specs/RadioGroupV1.spec.win.ts
+++ b/apps/E2E/src/RadioGroupV1/specs/RadioGroupV1.spec.win.ts
@@ -1,4 +1,4 @@
-import { Attribute, Keys, RADIOBUTTON_A11Y_ROLE, RADIOGROUP_A11Y_ROLE } from '../../common/consts';
+import { Attribute, AttributeValue, Keys, RADIOBUTTON_A11Y_ROLE, RADIOGROUP_A11Y_ROLE } from '../../common/consts';
 import {
   FIRST_RADIO_ACCESSIBILITY_LABEL,
   RADIOGROUPV1_ACCESSIBILITY_LABEL,
@@ -102,7 +102,11 @@ describe('RadioGroupV1/RadioV1 Accessibility Testing', () => {
 
   it('Set "required" prop on RadioGroup. Validate "IsRequiredForForm" element attribute is true.', async () => {
     await expect(
-      await RadioGroupV1PageObject.compareAttribute(RadioGroupV1PageObject._secondaryComponent, Attribute.IsRequiredForForm, 'True'),
+      await RadioGroupV1PageObject.compareAttribute(
+        RadioGroupV1PageObject._secondaryComponent,
+        Attribute.IsRequiredForForm,
+        AttributeValue.true,
+      ),
     ).toBeTruthy();
 
     await expect(await RadioGroupV1PageObject.didAssertPopup()).toBeFalsy(RadioGroupV1PageObject.ERRORMESSAGE_ASSERT);
@@ -110,7 +114,11 @@ describe('RadioGroupV1/RadioV1 Accessibility Testing', () => {
 
   it('Do NOT set "required" prop on RadioGroup. Validate "IsRequiredForForm" element attribute is false.', async () => {
     await expect(
-      await RadioGroupV1PageObject.compareAttribute(RadioGroupV1PageObject._primaryComponent, Attribute.IsRequiredForForm, 'False'),
+      await RadioGroupV1PageObject.compareAttribute(
+        RadioGroupV1PageObject._primaryComponent,
+        Attribute.IsRequiredForForm,
+        AttributeValue.false,
+      ),
     ).toBeTruthy();
 
     await expect(await RadioGroupV1PageObject.didAssertPopup()).toBeFalsy(RadioGroupV1PageObject.ERRORMESSAGE_ASSERT);

--- a/apps/fluent-tester/src/TestComponents/CheckboxV1/E2ECheckboxV1Test.tsx
+++ b/apps/fluent-tester/src/TestComponents/CheckboxV1/E2ECheckboxV1Test.tsx
@@ -38,6 +38,7 @@ export const E2ECheckboxV1Test: React.FunctionComponent = () => {
         />
         <Checkbox
           label={CHECKBOXV1_TEST_COMPONENT_LABEL}
+          required
           /* For Android E2E testing purposes, testProps must be passed in after accessibilityLabel. */
           {...testProps(CHECKBOXV1_NO_A11Y_LABEL_COMPONENT)}
         />

--- a/apps/fluent-tester/src/TestComponents/RadioGroupV1/RadioGroupV1E2ETest.tsx
+++ b/apps/fluent-tester/src/TestComponents/RadioGroupV1/RadioGroupV1E2ETest.tsx
@@ -59,6 +59,7 @@ export const RadioGroupV1E2ETest: React.FunctionComponent = () => {
         </RadioGroup>
         <RadioGroup
           label={RADIOGROUPV1_TEST_COMPONENT_LABEL}
+          required
           /* For Android E2E testing purposes, testProps must be passed in after accessibilityLabel. */
           {...testProps(RADIOGROUPV1_NO_A11Y_LABEL_COMPONENT)}
         >

--- a/change/@fluentui-react-native-adapters-c942dc54-4362-4457-9d03-4852faa7f428.json
+++ b/change/@fluentui-react-native-adapters-c942dc54-4362-4457-9d03-4852faa7f428.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add aria-multiselectable and aria-reaquired",
+  "packageName": "@fluentui-react-native/adapters",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-e2e-testing-1083ddee-1517-43ce-b2d0-2f0b3ae5582f.json
+++ b/change/@fluentui-react-native-e2e-testing-1083ddee-1517-43ce-b2d0-2f0b3ae5582f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add e2e tests for required property",
+  "packageName": "@fluentui-react-native/e2e-testing",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-menu-button-cee10a0d-f15c-4aeb-826d-f9e3b341ce66.json
+++ b/change/@fluentui-react-native-experimental-menu-button-cee10a0d-f15c-4aeb-826d-f9e3b341ce66.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "update snapshots",
+  "packageName": "@fluentui-react-native/experimental-menu-button",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-tabs-9ba2f8d7-ecbd-42af-8567-a57af83b4854.json
+++ b/change/@fluentui-react-native-experimental-tabs-9ba2f8d7-ecbd-42af-8567-a57af83b4854.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "update snapshots",
+  "packageName": "@fluentui-react-native/experimental-tabs",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-interactive-hooks-218549a6-0c07-425d-9e4b-b4f897a07ee0.json
+++ b/change/@fluentui-react-native-interactive-hooks-218549a6-0c07-425d-9e4b-b4f897a07ee0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "update useKeyProps snapshots",
+  "packageName": "@fluentui-react-native/interactive-hooks",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-menu-0abaaa00-4bde-4012-b8c7-048a99cd7b5e.json
+++ b/change/@fluentui-react-native-menu-0abaaa00-4bde-4012-b8c7-048a99cd7b5e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "update snapshots",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-menu-button-41e3373c-8a96-45a9-b28b-bd09d89ad54b.json
+++ b/change/@fluentui-react-native-menu-button-41e3373c-8a96-45a9-b28b-bd09d89ad54b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "update snapshots",
+  "packageName": "@fluentui-react-native/menu-button",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tablist-07bbf2b4-46ce-4aff-96dc-55ad42ca6db5.json
+++ b/change/@fluentui-react-native-tablist-07bbf2b4-46ce-4aff-96dc-55ad42ca6db5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "update snapshots",
+  "packageName": "@fluentui-react-native/tablist",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tabs-2eaf12ef-3e67-455f-ba16-4d4ccbbfbecf.json
+++ b/change/@fluentui-react-native-tabs-2eaf12ef-3e67-455f-ba16-4d4ccbbfbecf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "update snapshots",
+  "packageName": "@fluentui-react-native/tabs",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-0f0b25ee-b3bb-484c-95af-bf14f6ce8be1.json
+++ b/change/@fluentui-react-native-tester-0f0b25ee-b3bb-484c-95af-bf14f6ce8be1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add e2e tests for required property",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/__tests__/__snapshots__/Menu.test.tsx.snap
+++ b/packages/components/Menu/src/__tests__/__snapshots__/Menu.test.tsx.snap
@@ -20,6 +20,8 @@ exports[`Menu component tests Menu default 1`] = `
       "checked": undefined,
       "disabled": false,
       "expanded": false,
+      "multiselectable": undefined,
+      "required": undefined,
       "selected": undefined,
     }
   }
@@ -123,6 +125,8 @@ exports[`Menu component tests Menu defaultOpen 1`] = `
       "checked": undefined,
       "disabled": false,
       "expanded": true,
+      "multiselectable": undefined,
+      "required": undefined,
       "selected": undefined,
     }
   }
@@ -226,6 +230,8 @@ exports[`Menu component tests Menu open 1`] = `
       "checked": undefined,
       "disabled": false,
       "expanded": true,
+      "multiselectable": undefined,
+      "required": undefined,
       "selected": undefined,
     }
   }
@@ -329,6 +335,8 @@ exports[`Menu component tests Menu open checkbox and divider 1`] = `
       "checked": undefined,
       "disabled": false,
       "expanded": true,
+      "multiselectable": undefined,
+      "required": undefined,
       "selected": undefined,
     }
   }
@@ -432,6 +440,8 @@ exports[`Menu component tests Menu open checkbox checked 1`] = `
       "checked": undefined,
       "disabled": false,
       "expanded": true,
+      "multiselectable": undefined,
+      "required": undefined,
       "selected": undefined,
     }
   }
@@ -535,6 +545,8 @@ exports[`Menu component tests Menu open checkbox defaultChecked 1`] = `
       "checked": undefined,
       "disabled": false,
       "expanded": true,
+      "multiselectable": undefined,
+      "required": undefined,
       "selected": undefined,
     }
   }
@@ -638,6 +650,8 @@ exports[`Menu component tests Menu open radio 1`] = `
       "checked": undefined,
       "disabled": false,
       "expanded": true,
+      "multiselectable": undefined,
+      "required": undefined,
       "selected": undefined,
     }
   }
@@ -741,6 +755,8 @@ exports[`Menu component tests Menu submenu 1`] = `
       "checked": undefined,
       "disabled": false,
       "expanded": true,
+      "multiselectable": undefined,
+      "required": undefined,
       "selected": undefined,
     }
   }
@@ -844,6 +860,8 @@ exports[`Menu open menu group and menu header 1`] = `
       "checked": undefined,
       "disabled": false,
       "expanded": true,
+      "multiselectable": undefined,
+      "required": undefined,
       "selected": undefined,
     }
   }

--- a/packages/components/MenuButton/src/__tests__/__snapshots__/MenuButton.test.tsx.snap
+++ b/packages/components/MenuButton/src/__tests__/__snapshots__/MenuButton.test.tsx.snap
@@ -10,6 +10,8 @@ exports[`ContextualMenu default 1`] = `
       "checked": undefined,
       "disabled": false,
       "expanded": undefined,
+      "multiselectable": undefined,
+      "required": undefined,
       "selected": undefined,
     }
   }

--- a/packages/components/Tabs/src/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/components/Tabs/src/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -9,6 +9,8 @@ exports[`Tabs FocusZone props 1`] = `
       "checked": undefined,
       "disabled": undefined,
       "expanded": undefined,
+      "multiselectable": undefined,
+      "required": undefined,
       "selected": undefined,
     }
   }
@@ -64,6 +66,8 @@ exports[`Tabs FocusZone props 1`] = `
             "checked": undefined,
             "disabled": undefined,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": false,
           }
         }
@@ -149,6 +153,8 @@ exports[`Tabs FocusZone props 1`] = `
             "checked": undefined,
             "disabled": undefined,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": true,
           }
         }
@@ -234,6 +240,8 @@ exports[`Tabs FocusZone props 1`] = `
             "checked": undefined,
             "disabled": undefined,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": false,
           }
         }
@@ -316,6 +324,8 @@ exports[`Tabs default props 1`] = `
       "checked": undefined,
       "disabled": undefined,
       "expanded": undefined,
+      "multiselectable": undefined,
+      "required": undefined,
       "selected": undefined,
     }
   }
@@ -371,6 +381,8 @@ exports[`Tabs default props 1`] = `
             "checked": undefined,
             "disabled": undefined,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": true,
           }
         }
@@ -456,6 +468,8 @@ exports[`Tabs default props 1`] = `
             "checked": undefined,
             "disabled": undefined,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": false,
           }
         }
@@ -541,6 +555,8 @@ exports[`Tabs default props 1`] = `
             "checked": undefined,
             "disabled": undefined,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": false,
           }
         }
@@ -623,6 +639,8 @@ exports[`Tabs disabled 1`] = `
       "checked": undefined,
       "disabled": undefined,
       "expanded": undefined,
+      "multiselectable": undefined,
+      "required": undefined,
       "selected": undefined,
     }
   }
@@ -678,6 +696,8 @@ exports[`Tabs disabled 1`] = `
             "checked": undefined,
             "disabled": true,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": false,
           }
         }
@@ -763,6 +783,8 @@ exports[`Tabs disabled 1`] = `
             "checked": undefined,
             "disabled": true,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": false,
           }
         }
@@ -848,6 +870,8 @@ exports[`Tabs disabled 1`] = `
             "checked": undefined,
             "disabled": undefined,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": true,
           }
         }
@@ -930,6 +954,8 @@ exports[`Tabs header text and count 1`] = `
       "checked": undefined,
       "disabled": undefined,
       "expanded": undefined,
+      "multiselectable": undefined,
+      "required": undefined,
       "selected": undefined,
     }
   }
@@ -986,6 +1012,8 @@ exports[`Tabs header text and count 1`] = `
             "checked": undefined,
             "disabled": undefined,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": true,
           }
         }
@@ -1086,6 +1114,8 @@ exports[`Tabs header text and count 1`] = `
             "checked": undefined,
             "disabled": undefined,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": false,
           }
         }
@@ -1186,6 +1216,8 @@ exports[`Tabs header text and count 1`] = `
             "checked": undefined,
             "disabled": undefined,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": false,
           }
         }
@@ -1282,6 +1314,8 @@ exports[`Tabs headers only 1`] = `
       "checked": undefined,
       "disabled": undefined,
       "expanded": undefined,
+      "multiselectable": undefined,
+      "required": undefined,
       "selected": undefined,
     }
   }
@@ -1337,6 +1371,8 @@ exports[`Tabs headers only 1`] = `
             "checked": undefined,
             "disabled": undefined,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": true,
           }
         }
@@ -1422,6 +1458,8 @@ exports[`Tabs headers only 1`] = `
             "checked": undefined,
             "disabled": undefined,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": false,
           }
         }
@@ -1507,6 +1545,8 @@ exports[`Tabs headers only 1`] = `
             "checked": undefined,
             "disabled": undefined,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": false,
           }
         }
@@ -1590,6 +1630,8 @@ exports[`Tabs props 1`] = `
       "checked": undefined,
       "disabled": undefined,
       "expanded": undefined,
+      "multiselectable": undefined,
+      "required": undefined,
       "selected": undefined,
     }
   }
@@ -1659,6 +1701,8 @@ exports[`Tabs props 1`] = `
             "checked": undefined,
             "disabled": true,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": false,
           }
         }
@@ -1759,6 +1803,8 @@ exports[`Tabs props 1`] = `
             "checked": undefined,
             "disabled": undefined,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": true,
           }
         }
@@ -1859,6 +1905,8 @@ exports[`Tabs props 1`] = `
             "checked": undefined,
             "disabled": undefined,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": false,
           }
         }

--- a/packages/experimental/MenuButton/src/__tests__/__snapshots__/MenuButton.test.tsx.snap
+++ b/packages/experimental/MenuButton/src/__tests__/__snapshots__/MenuButton.test.tsx.snap
@@ -10,6 +10,8 @@ exports[`ContextualMenu default 1`] = `
       "checked": undefined,
       "disabled": false,
       "expanded": undefined,
+      "multiselectable": undefined,
+      "required": undefined,
       "selected": undefined,
     }
   }

--- a/packages/experimental/TabList/src/Tab/__tests__/__snapshots__/Tab.test.tsx.snap
+++ b/packages/experimental/TabList/src/Tab/__tests__/__snapshots__/Tab.test.tsx.snap
@@ -18,6 +18,8 @@ exports[`Tab component tests Customized Tab 1`] = `
       "checked": undefined,
       "disabled": undefined,
       "expanded": undefined,
+      "multiselectable": undefined,
+      "required": undefined,
       "selected": false,
     }
   }
@@ -155,6 +157,8 @@ exports[`Tab component tests Tab default props 1`] = `
       "checked": undefined,
       "disabled": undefined,
       "expanded": undefined,
+      "multiselectable": undefined,
+      "required": undefined,
       "selected": false,
     }
   }
@@ -292,6 +296,8 @@ exports[`Tab component tests Tab disabled 1`] = `
       "checked": undefined,
       "disabled": true,
       "expanded": undefined,
+      "multiselectable": undefined,
+      "required": undefined,
       "selected": false,
     }
   }
@@ -429,6 +435,8 @@ exports[`Tab component tests Tab render icon + text 1`] = `
       "checked": undefined,
       "disabled": undefined,
       "expanded": undefined,
+      "multiselectable": undefined,
+      "required": undefined,
       "selected": false,
     }
   }
@@ -578,6 +586,8 @@ exports[`Tab component tests Tab render icon only 1`] = `
       "checked": undefined,
       "disabled": undefined,
       "expanded": undefined,
+      "multiselectable": undefined,
+      "required": undefined,
       "selected": false,
     }
   }

--- a/packages/experimental/TabList/src/TabList/__tests__/__snapshots__/TabList.test.tsx.snap
+++ b/packages/experimental/TabList/src/TabList/__tests__/__snapshots__/TabList.test.tsx.snap
@@ -44,6 +44,8 @@ exports[`TabList component tests TabList appearance 1`] = `
           "checked": undefined,
           "disabled": false,
           "expanded": undefined,
+          "multiselectable": undefined,
+          "required": undefined,
           "selected": false,
         }
       }
@@ -180,6 +182,8 @@ exports[`TabList component tests TabList appearance 1`] = `
           "checked": undefined,
           "disabled": false,
           "expanded": undefined,
+          "multiselectable": undefined,
+          "required": undefined,
           "selected": false,
         }
       }
@@ -316,6 +320,8 @@ exports[`TabList component tests TabList appearance 1`] = `
           "checked": undefined,
           "disabled": false,
           "expanded": undefined,
+          "multiselectable": undefined,
+          "required": undefined,
           "selected": false,
         }
       }
@@ -482,6 +488,8 @@ exports[`TabList component tests TabList default props 1`] = `
           "checked": undefined,
           "disabled": false,
           "expanded": undefined,
+          "multiselectable": undefined,
+          "required": undefined,
           "selected": false,
         }
       }
@@ -618,6 +626,8 @@ exports[`TabList component tests TabList default props 1`] = `
           "checked": undefined,
           "disabled": false,
           "expanded": undefined,
+          "multiselectable": undefined,
+          "required": undefined,
           "selected": false,
         }
       }
@@ -754,6 +764,8 @@ exports[`TabList component tests TabList default props 1`] = `
           "checked": undefined,
           "disabled": false,
           "expanded": undefined,
+          "multiselectable": undefined,
+          "required": undefined,
           "selected": false,
         }
       }
@@ -921,6 +933,8 @@ exports[`TabList component tests TabList disabled list 1`] = `
           "checked": undefined,
           "disabled": true,
           "expanded": undefined,
+          "multiselectable": undefined,
+          "required": undefined,
           "selected": false,
         }
       }
@@ -1057,6 +1071,8 @@ exports[`TabList component tests TabList disabled list 1`] = `
           "checked": undefined,
           "disabled": true,
           "expanded": undefined,
+          "multiselectable": undefined,
+          "required": undefined,
           "selected": false,
         }
       }
@@ -1193,6 +1209,8 @@ exports[`TabList component tests TabList disabled list 1`] = `
           "checked": undefined,
           "disabled": true,
           "expanded": undefined,
+          "multiselectable": undefined,
+          "required": undefined,
           "selected": false,
         }
       }
@@ -1359,6 +1377,8 @@ exports[`TabList component tests TabList orientation 1`] = `
           "checked": undefined,
           "disabled": false,
           "expanded": undefined,
+          "multiselectable": undefined,
+          "required": undefined,
           "selected": false,
         }
       }
@@ -1495,6 +1515,8 @@ exports[`TabList component tests TabList orientation 1`] = `
           "checked": undefined,
           "disabled": false,
           "expanded": undefined,
+          "multiselectable": undefined,
+          "required": undefined,
           "selected": false,
         }
       }
@@ -1631,6 +1653,8 @@ exports[`TabList component tests TabList orientation 1`] = `
           "checked": undefined,
           "disabled": false,
           "expanded": undefined,
+          "multiselectable": undefined,
+          "required": undefined,
           "selected": false,
         }
       }
@@ -1798,6 +1822,8 @@ exports[`TabList component tests TabList selected key 1`] = `
           "checked": undefined,
           "disabled": false,
           "expanded": undefined,
+          "multiselectable": undefined,
+          "required": undefined,
           "selected": true,
         }
       }
@@ -1934,6 +1960,8 @@ exports[`TabList component tests TabList selected key 1`] = `
           "checked": undefined,
           "disabled": false,
           "expanded": undefined,
+          "multiselectable": undefined,
+          "required": undefined,
           "selected": false,
         }
       }
@@ -2070,6 +2098,8 @@ exports[`TabList component tests TabList selected key 1`] = `
           "checked": undefined,
           "disabled": false,
           "expanded": undefined,
+          "multiselectable": undefined,
+          "required": undefined,
           "selected": false,
         }
       }
@@ -2236,6 +2266,8 @@ exports[`TabList component tests TabList size 1`] = `
           "checked": undefined,
           "disabled": false,
           "expanded": undefined,
+          "multiselectable": undefined,
+          "required": undefined,
           "selected": false,
         }
       }
@@ -2372,6 +2404,8 @@ exports[`TabList component tests TabList size 1`] = `
           "checked": undefined,
           "disabled": false,
           "expanded": undefined,
+          "multiselectable": undefined,
+          "required": undefined,
           "selected": false,
         }
       }
@@ -2508,6 +2542,8 @@ exports[`TabList component tests TabList size 1`] = `
           "checked": undefined,
           "disabled": false,
           "expanded": undefined,
+          "multiselectable": undefined,
+          "required": undefined,
           "selected": false,
         }
       }

--- a/packages/experimental/Tabs/src/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/experimental/Tabs/src/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -9,6 +9,8 @@ exports[`Tabs FocusZone props 1`] = `
       "checked": undefined,
       "disabled": undefined,
       "expanded": undefined,
+      "multiselectable": undefined,
+      "required": undefined,
       "selected": undefined,
     }
   }
@@ -75,6 +77,8 @@ exports[`Tabs FocusZone props 1`] = `
             "checked": undefined,
             "disabled": undefined,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": false,
           }
         }
@@ -168,6 +172,8 @@ exports[`Tabs FocusZone props 1`] = `
             "checked": undefined,
             "disabled": undefined,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": true,
           }
         }
@@ -261,6 +267,8 @@ exports[`Tabs FocusZone props 1`] = `
             "checked": undefined,
             "disabled": undefined,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": false,
           }
         }
@@ -356,6 +364,8 @@ exports[`Tabs default props 1`] = `
       "checked": undefined,
       "disabled": undefined,
       "expanded": undefined,
+      "multiselectable": undefined,
+      "required": undefined,
       "selected": undefined,
     }
   }
@@ -421,6 +431,8 @@ exports[`Tabs default props 1`] = `
             "checked": undefined,
             "disabled": undefined,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": true,
           }
         }
@@ -514,6 +526,8 @@ exports[`Tabs default props 1`] = `
             "checked": undefined,
             "disabled": undefined,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": false,
           }
         }
@@ -607,6 +621,8 @@ exports[`Tabs default props 1`] = `
             "checked": undefined,
             "disabled": undefined,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": false,
           }
         }
@@ -702,6 +718,8 @@ exports[`Tabs disabled 1`] = `
       "checked": undefined,
       "disabled": undefined,
       "expanded": undefined,
+      "multiselectable": undefined,
+      "required": undefined,
       "selected": undefined,
     }
   }
@@ -767,6 +785,8 @@ exports[`Tabs disabled 1`] = `
             "checked": undefined,
             "disabled": true,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": false,
           }
         }
@@ -860,6 +880,8 @@ exports[`Tabs disabled 1`] = `
             "checked": undefined,
             "disabled": true,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": false,
           }
         }
@@ -953,6 +975,8 @@ exports[`Tabs disabled 1`] = `
             "checked": undefined,
             "disabled": undefined,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": true,
           }
         }
@@ -1048,6 +1072,8 @@ exports[`Tabs header text and count 1`] = `
       "checked": undefined,
       "disabled": undefined,
       "expanded": undefined,
+      "multiselectable": undefined,
+      "required": undefined,
       "selected": undefined,
     }
   }
@@ -1114,6 +1140,8 @@ exports[`Tabs header text and count 1`] = `
             "checked": undefined,
             "disabled": undefined,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": true,
           }
         }
@@ -1225,6 +1253,8 @@ exports[`Tabs header text and count 1`] = `
             "checked": undefined,
             "disabled": undefined,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": false,
           }
         }
@@ -1336,6 +1366,8 @@ exports[`Tabs header text and count 1`] = `
             "checked": undefined,
             "disabled": undefined,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": false,
           }
         }
@@ -1448,6 +1480,8 @@ exports[`Tabs headers only 1`] = `
       "checked": undefined,
       "disabled": undefined,
       "expanded": undefined,
+      "multiselectable": undefined,
+      "required": undefined,
       "selected": undefined,
     }
   }
@@ -1514,6 +1548,8 @@ exports[`Tabs headers only 1`] = `
             "checked": undefined,
             "disabled": undefined,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": true,
           }
         }
@@ -1607,6 +1643,8 @@ exports[`Tabs headers only 1`] = `
             "checked": undefined,
             "disabled": undefined,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": false,
           }
         }
@@ -1700,6 +1738,8 @@ exports[`Tabs headers only 1`] = `
             "checked": undefined,
             "disabled": undefined,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": false,
           }
         }
@@ -1793,6 +1833,8 @@ exports[`Tabs props 1`] = `
       "checked": undefined,
       "disabled": undefined,
       "expanded": undefined,
+      "multiselectable": undefined,
+      "required": undefined,
       "selected": undefined,
     }
   }
@@ -1877,6 +1919,8 @@ exports[`Tabs props 1`] = `
             "checked": undefined,
             "disabled": true,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": false,
           }
         }
@@ -1988,6 +2032,8 @@ exports[`Tabs props 1`] = `
             "checked": undefined,
             "disabled": undefined,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": true,
           }
         }
@@ -2099,6 +2145,8 @@ exports[`Tabs props 1`] = `
             "checked": undefined,
             "disabled": undefined,
             "expanded": undefined,
+            "multiselectable": undefined,
+            "required": undefined,
             "selected": false,
           }
         }

--- a/packages/utils/adapters/src/adapters.ts
+++ b/packages/utils/adapters/src/adapters.ts
@@ -114,6 +114,8 @@ const _viewMask: IFilterMask<IViewProps> = {
   'aria-labelledby': true,
   'aria-live': true,
   'aria-modal': true,
+  'aria-multiselectable': true,
+  'aria-required': true,
   'aria-selected': true,
   'aria-valuemax': true,
   'aria-valuemin': true,

--- a/packages/utils/adapters/src/adapters.win32.ts
+++ b/packages/utils/adapters/src/adapters.win32.ts
@@ -114,6 +114,8 @@ const _viewMask: IFilterMask<IViewProps> = {
   'aria-labelledby': true,
   'aria-live': true,
   'aria-modal': true,
+  'aria-multiselectable': true,
+  'aria-required': true,
   'aria-selected': true,
   'aria-valuemax': true,
   'aria-valuemin': true,

--- a/packages/utils/interactive-hooks/src/__tests__/__snapshots__/useKeyProps.test.tsx.snap
+++ b/packages/utils/interactive-hooks/src/__tests__/__snapshots__/useKeyProps.test.tsx.snap
@@ -8,6 +8,8 @@ exports[`Pressable with useKeyProps 1`] = `
       "checked": undefined,
       "disabled": undefined,
       "expanded": undefined,
+      "multiselectable": undefined,
+      "required": undefined,
       "selected": undefined,
     }
   }
@@ -55,6 +57,8 @@ exports[`useKeyProps called twice 1`] = `
       "checked": undefined,
       "disabled": undefined,
       "expanded": undefined,
+      "multiselectable": undefined,
+      "required": undefined,
       "selected": undefined,
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5138,8 +5138,8 @@ __metadata:
   linkType: hard
 
 "@office-iss/react-native-win32@npm:^0.71.0":
-  version: 0.71.14
-  resolution: "@office-iss/react-native-win32@npm:0.71.14"
+  version: 0.71.15
+  resolution: "@office-iss/react-native-win32@npm:0.71.15"
   dependencies:
     "@babel/runtime": ^7.0.0
     "@jest/create-cache-key-function": ^29.2.1
@@ -5179,7 +5179,7 @@ __metadata:
   peerDependencies:
     react: 18.2.0
     react-native: ^0.71.0
-  checksum: dfc494a6f89e60b837738132a2a78a472301e1e4d669a561dd777be0ef8cd70bfd68411bc3664f02fd7fc6b4dbe0210f7fed37b83551c70a899c40704bd500a4
+  checksum: 79c183beca4d36cc4c805cf17a6563f106cd8b42524c59c5f3a874669564e9339600d1aa7ac08222d5a75eca403d513fff48afcdfc51160b01a94f0ff4965f1c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Adds E2E tests for the required property on CheckboxV1 and RadioGroupV1

### Verification

Ran `yarn e2etest` locally

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
