### PR TITLE
Fix `fontSize` prop not being correctly applied on Font Icon Buttons. 

### DIFF
--- a/change/@fluentui-react-native-icon-30a5191d-a26f-4170-853f-e5bbabedd180.json
+++ b/change/@fluentui-react-native-icon-30a5191d-a26f-4170-853f-e5bbabedd180.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix fontSource props not being correctly applied",
+  "packageName": "@fluentui-react-native/icon",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Icon/src/legacy/Icon.tsx
+++ b/packages/components/Icon/src/legacy/Icon.tsx
@@ -54,7 +54,7 @@ function renderFontIcon(iconProps: IconProps) {
       fontSize: fontSource.fontSize,
       color: iconProps.color,
     },
-    [iconProps.color, fontSource.fontSrcFile, fontSource.fontFamily],
+    [iconProps.color, fontSource.fontSrcFile, fontSource.fontFamily, fontSource.fontSize],
   )[0];
 
   const char = String.fromCharCode(fontSource.codepoint);


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [ ] windows
- [x] android

### Description of changes

When passing in a font source for an Icon Button, the `fontSize` prop doesn't get applied to the icon styles. This is because `fontSize` isn't used as a dependency for fetching the correct icon styles from cache. 

This PR adds the fontSize as a dependency for the font icon style cache and fixes this issue. 

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![MicrosoftTeams-image (6)](https://github.com/microsoft/fluentui-react-native/assets/15683103/85e551f1-9b2e-462c-91bb-485cad224425) | <img width="929" alt="image" src="https://github.com/microsoft/fluentui-react-native/assets/15683103/66db0764-c9c2-4781-af7a-d7e00cc6229a"> |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
