### PR TITLE
[ButtonV1] [Win32] Check for dimensions before rendering focusInnerBorder

### DIFF
--- a/change/@fluentui-react-native-button-f7b53bbe-a680-40e5-86a2-9ea1f705b77a.json
+++ b/change/@fluentui-react-native-button-f7b53bbe-a680-40e5-86a2-9ea1f705b77a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "check dimensions before rendering focusInnerBorder",
+  "packageName": "@fluentui-react-native/button",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Button/src/Button.tsx
+++ b/packages/components/Button/src/Button.tsx
@@ -112,13 +112,16 @@ export const Button = compose<ButtonType>({
         return (
           <Slots.root {...mergedProps} accessibilityLabel={label}>
             {buttonContent}
-            {button.state.focused && button.state.shouldUseTwoToneFocusBorder && (
-              <Slots.focusInnerBorder
-                style={getFocusBorderStyle(button.state.measuredHeight, button.state.measuredWidth)}
-                accessible={false}
-                focusable={false}
-              />
-            )}
+            {button.state.focused &&
+              button.state.measuredHeight &&
+              button.state.measuredWidth &&
+              button.state.shouldUseTwoToneFocusBorder && (
+                <Slots.focusInnerBorder
+                  style={getFocusBorderStyle(button.state.measuredHeight, button.state.measuredWidth)}
+                  accessible={false}
+                  focusable={false}
+                />
+              )}
           </Slots.root>
         );
       }


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

If we have a primary button that receives focus on initial render, the focusInnerBorder is rendered before we have the dimensions of the button. This PR checks for the dimensions first before rendering the focusInnerBorder.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
