### PR TITLE
[Button][macOS] Don't call onClick with onKeyDown

### DIFF
--- a/change/@fluentui-react-native-button-5bc15d5f-9987-4820-8fe0-aac297c0eb9d.json
+++ b/change/@fluentui-react-native-button-5bc15d5f-9987-4820-8fe0-aac297c0eb9d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[Button][macOS] Don't call onClick with onKeyDown",
+  "packageName": "@fluentui-react-native/button",
+  "email": "saadnajmi2@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Button/src/useButton.ts
+++ b/packages/components/Button/src/useButton.ts
@@ -56,14 +56,22 @@ export const useButton = (props: ButtonProps): ButtonInfo => {
   );
   const onKeyPress = React.useCallback(
     (e) => {
-      if (isProcessingKeyboardInvocation) {
-        onClick?.(e);
-        isProcessingKeyboardInvocation = false;
+      if (shouldOnlyFireIfPressed) {
+        if (isProcessingKeyboardInvocation) {
+          onClick?.(e);
+          isProcessingKeyboardInvocation = false;
+        }
+      } else {
+        if (Platform.OS === 'macos') {
+          // Do nothing as macOS's pressable already calls onPress with onKeyDown
+        } else {
+          onClick?.(e);
+        }
       }
     },
     [onClick],
   );
-  const onKeyProps = useKeyProps(shouldOnlyFireIfPressed ? onKeyPress : onClick, ' ', 'Enter');
+  const onKeyProps = useKeyProps(onKeyPress, ' ', 'Enter');
 
   const hasTogglePattern = props.accessibilityActions && !!props.accessibilityActions.find((action) => action.name === 'Toggle');
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Button on macOS would fire its `onPress` callback twice if the user invoked it via the keyboard (Space or Enter). This is because:

1) The [default behavior of macOS Pressable](https://github.com/microsoft/react-native-macos/blob/0fae3ab3adaab115282f5d0134bf4ca49dded59c/packages/react-native/Libraries/Pressability/Pressability.js#L599-L609C10) is to invoke `onPress` with `onKeyDown`
2) FURN overrode `onKeyDown` to also call `onClick` (which we map to onPress).

An option was to call `e.preventDefault()` in FURN's override, but then Pressable would stop giving us press styling (that is the default behavior after all..). So it seems we should just stop doing (2). To be honest, I have no idea why this isn't an issue for win32, as their [Pressable does the same with onKeyUp](https://github.com/microsoft/react-native-windows/blob/a038850bd3fcd53764fde5041e3915c488755f52/packages/%40office-iss/react-native-win32/src/Libraries/Pressability/Pressability.win32.js#L624C12-L624C12). But one problem at a time 🤷‍♂️

### Verification

Tested the button test page with a simple `console.log('click')` passed into the first buttons' `onClick`, and then invoked it with Spacebar. Before the change, I would get two console logs. After the change, I only get one console.log.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [x] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
