### PR TITLE
Remove four unused size tokens from test page

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Spacing/SpacingTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Spacing/SpacingTest.tsx
@@ -43,10 +43,6 @@ const BasicUsage: React.FunctionComponent = () => {
         {spacingExample('size400', globalTokens.size400)}
         {spacingExample('size480', globalTokens.size480)}
         {spacingExample('size560', globalTokens.size560)}
-        {spacingExample('size640', globalTokens.size640)}
-        {spacingExample('size720', globalTokens.size720)}
-        {spacingExample('size800', globalTokens.size800)}
-        {spacingExample('size1200', globalTokens.size1200)}
       </Stack>
     </View>
   );

--- a/change/@fluentui-react-native-tester-cdba9309-e8fa-47ef-9118-2bfdafd812f2.json
+++ b/change/@fluentui-react-native-tester-cdba9309-e8fa-47ef-9118-2bfdafd812f2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove four unused size tokens from test page",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "16262858+TravisSpomer@users.noreply.github.com",
+  "dependentChangeType": "none"
+}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

FURN was the first to implement the Fluent design tokens for size. Since then, the largest four have been removed from Fluent. Since they aren't used anywhere except for this page, it seems acceptable to remove them from FURN even though it's *technically* a breaking change. This just updates the test page so that it doesn't expect `globalTokens.size640` to exist so I don't break your build; an upcoming change to the source token data will then actually remove `size640` from what eventually gets turned into `globalTokens`.