### PR TITLE
Minimal Android build.gradle for NativeDatePicker

### DIFF
--- a/change/@fluentui-react-native-experimental-native-date-picker-03d39bbb-f462-42d9-a81b-e1fe8d212877.json
+++ b/change/@fluentui-react-native-experimental-native-date-picker-03d39bbb-f462-42d9-a81b-e1fe8d212877.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Android build.gradle file for NativeDatePicker",
+  "packageName": "@fluentui-react-native/experimental-native-date-picker",
+  "email": "ankarm@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/NativeDatePicker/android/build.gradle
+++ b/packages/experimental/NativeDatePicker/android/build.gradle
@@ -1,35 +1,50 @@
 buildscript {
-  ext.safeExtGet = { prop, fallback ->
-    return rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
-  }
-
-  repositories {
-    mavenCentral()
-    google()
-  }
-
-  dependencies {
-    classpath "com.android.tools.build:gradle"
-    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${safeExtGet('kotlinVersion', '1.6.10')}"
-    classpath "com.facebook.react:react-native-gradle-plugin"
-  }
+    repositories {
+        google()
+        mavenCentral()
+    }
 }
 
-def safeExtGet(prop, fallback) {
-  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+def getExtOrIntegerDefault(name) {
+    return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties['ReactNativeDateTimePicker_' + name]).toInteger()
+}
+
+def isNewArchitectureEnabled() {
+    // To opt-in for the New Architecture, you can either:
+    // - Set `newArchEnabled` to true inside the `gradle.properties` file
+    // - Invoke gradle with `-newArchEnabled=true`
+    // - Set an environment variable `ORG_GRADLE_PROJECT_newArchEnabled=true`
+    return project.hasProperty("newArchEnabled") && project.newArchEnabled == "true"
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+if (isNewArchitectureEnabled()) {
+  apply plugin: "com.facebook.react"
+}
+
 
 android {
-  compileSdkVersion safeExtGet('compileSdkVersion', 31)
-  buildToolsVersion safeExtGet('buildToolsVersion', '31.0.0')
+    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+    if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+      namespace "com.reactcommunity.rndatetimepicker"
+    }
 
-  defaultConfig {
-    minSdkVersion safeExtGet('minSdkVersion', 21)
-    targetSdkVersion safeExtGet('targetSdkVersion', 31)
-  }
+    compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
+
+    // Used to override the NDK path/version on internal CI or by allowing
+    // users to customize the NDK path/version from their root project (e.g. for M1 support)
+    if (rootProject.hasProperty("ndkPath")) {
+        ndkPath rootProject.ext.ndkPath
+    }
+    if (rootProject.hasProperty("ndkVersion")) {
+        ndkVersion rootProject.ext.ndkVersion
+    }
+
+    defaultConfig {
+        minSdkVersion getExtOrIntegerDefault('minSdkVersion')
+        targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
+        buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
+    }
 }
 
 repositories {
@@ -43,6 +58,6 @@ repositories {
 dependencies {
   implementation "com.facebook.react:react-android:+"
   implementation "com.microsoft.device:dualscreen-layout:1.0.0-alpha01"
-  implementation "com.microsoft.fluentui:fluentui_calendar:${safeExtGet('fluentUICalendarVersion', '0.0.27')}"
+  implementation "com.microsoft.fluentui:fluentui_calendar:0.0.27"
   implementation "com.jakewharton.threetenabp:threetenabp:1.1.0"
 }

--- a/packages/experimental/NativeDatePicker/android/build.gradle
+++ b/packages/experimental/NativeDatePicker/android/build.gradle
@@ -9,20 +9,41 @@ buildscript {
   }
 }
 
-def safeExtGet(prop, fallback) {
-  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+def getExtOrIntegerDefault(name, fallback) {
+    return rootProject.ext.has(name) ? rootProject.ext.get(name) : fallback;
+}
+
+def isNewArchitectureEnabled() {
+    // To opt-in for the New Architecture, you can either:
+    // - Set `newArchEnabled` to true inside the `gradle.properties` file
+    // - Invoke gradle with `-newArchEnabled=true`
+    // - Set an environment variable `ORG_GRADLE_PROJECT_newArchEnabled=true`
+    return project.hasProperty("newArchEnabled") && project.newArchEnabled == "true"
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-  compileSdkVersion safeExtGet('compileSdkVersion', 31)
-  buildToolsVersion safeExtGet('buildToolsVersion', '31.0.0')
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+  if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+    namespace "com.microsoft.fnandroid.frndatepicker"
+  }
+  compileSdkVersion getExtOrIntegerDefault('compileSdkVersion', 34)
+
+  // Used to override the NDK path/version on internal CI or by allowing
+  // users to customize the NDK path/version from their root project (e.g. for M1 support)
+  if (rootProject.hasProperty("ndkPath")) {
+      ndkPath rootProject.ext.ndkPath
+  }
+  if (rootProject.hasProperty("ndkVersion")) {
+      ndkVersion rootProject.ext.ndkVersion
+  }
 
   defaultConfig {
-    minSdkVersion safeExtGet('minSdkVersion', 21)
-    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+      minSdkVersion getExtOrIntegerDefault('minSdkVersion', 21)
+      targetSdkVersion getExtOrIntegerDefault('targetSdkVersion', 34)
+      //buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
   }
 }
 
@@ -37,6 +58,6 @@ repositories {
 dependencies {
   implementation "com.facebook.react:react-android:+"
   implementation "com.microsoft.device:dualscreen-layout:1.0.0-alpha01"
-  implementation "com.microsoft.fluentui:fluentui_calendar:${safeExtGet('fluentUICalendarVersion', '0.0.27')}"
+  implementation "com.microsoft.fluentui:fluentui_calendar:0.0.27"
   implementation "com.jakewharton.threetenabp:threetenabp:1.1.0"
 }

--- a/packages/experimental/NativeDatePicker/android/build.gradle
+++ b/packages/experimental/NativeDatePicker/android/build.gradle
@@ -7,12 +7,6 @@ buildscript {
     mavenCentral()
     google()
   }
-
-  // dependencies {
-  //   classpath "com.android.tools.build:gradle"
-  //   classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${safeExtGet('kotlinVersion', '1.6.10')}"
-  //   classpath "com.facebook.react:react-native-gradle-plugin"
-  // }
 }
 
 def safeExtGet(prop, fallback) {

--- a/packages/experimental/NativeDatePicker/android/build.gradle
+++ b/packages/experimental/NativeDatePicker/android/build.gradle
@@ -1,50 +1,35 @@
 buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
+  ext.safeExtGet = { prop, fallback ->
+    return rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+  }
+
+  repositories {
+    mavenCentral()
+    google()
+  }
+
+  // dependencies {
+  //   classpath "com.android.tools.build:gradle"
+  //   classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${safeExtGet('kotlinVersion', '1.6.10')}"
+  //   classpath "com.facebook.react:react-native-gradle-plugin"
+  // }
 }
 
-def getExtOrIntegerDefault(name) {
-    return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties['ReactNativeDateTimePicker_' + name]).toInteger()
-}
-
-def isNewArchitectureEnabled() {
-    // To opt-in for the New Architecture, you can either:
-    // - Set `newArchEnabled` to true inside the `gradle.properties` file
-    // - Invoke gradle with `-newArchEnabled=true`
-    // - Set an environment variable `ORG_GRADLE_PROJECT_newArchEnabled=true`
-    return project.hasProperty("newArchEnabled") && project.newArchEnabled == "true"
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
 apply plugin: 'com.android.library'
-if (isNewArchitectureEnabled()) {
-  apply plugin: "com.facebook.react"
-}
-
+apply plugin: 'kotlin-android'
 
 android {
-    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
-    if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
-      namespace "com.reactcommunity.rndatetimepicker"
-    }
+  compileSdkVersion safeExtGet('compileSdkVersion', 31)
+  buildToolsVersion safeExtGet('buildToolsVersion', '31.0.0')
 
-    compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
-
-    // Used to override the NDK path/version on internal CI or by allowing
-    // users to customize the NDK path/version from their root project (e.g. for M1 support)
-    if (rootProject.hasProperty("ndkPath")) {
-        ndkPath rootProject.ext.ndkPath
-    }
-    if (rootProject.hasProperty("ndkVersion")) {
-        ndkVersion rootProject.ext.ndkVersion
-    }
-
-    defaultConfig {
-        minSdkVersion getExtOrIntegerDefault('minSdkVersion')
-        targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
-        buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
-    }
+  defaultConfig {
+    minSdkVersion safeExtGet('minSdkVersion', 21)
+    targetSdkVersion safeExtGet('targetSdkVersion', 31)
+  }
 }
 
 repositories {
@@ -58,6 +43,6 @@ repositories {
 dependencies {
   implementation "com.facebook.react:react-android:+"
   implementation "com.microsoft.device:dualscreen-layout:1.0.0-alpha01"
-  implementation "com.microsoft.fluentui:fluentui_calendar:0.0.27"
+  implementation "com.microsoft.fluentui:fluentui_calendar:${safeExtGet('fluentUICalendarVersion', '0.0.27')}"
   implementation "com.jakewharton.threetenabp:threetenabp:1.1.0"
 }

--- a/packages/experimental/NativeDatePicker/android/build.gradle
+++ b/packages/experimental/NativeDatePicker/android/build.gradle
@@ -43,7 +43,7 @@ android {
   defaultConfig {
       minSdkVersion getExtOrIntegerDefault('minSdkVersion', 21)
       targetSdkVersion getExtOrIntegerDefault('targetSdkVersion', 34)
-      //buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
+      buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
   }
 }
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [x] android

### Description of changes

(a summary of the changes made, often organized by file)
This PR updates the build.gradle file in the Android project for NativeDatePicker to remove tight dependencies on specific gradle version and target SDK versions. The changed portions have been copied from the build.gradle of the `react-native-datetimepicker/datetimepicker` community project [here](https://github.com/react-native-datetimepicker/datetimepicker/blob/master/android/build.gradle).

### Verification

Running the Fluent-Tester app after making this build.gradle change still works.


| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
