### PR TITLE
Have dependabot group @babel and @rnx-kit PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,19 @@ version: 2
 updates:
   - package-ecosystem: npm
     directory: '/'
+    groups:
+      babel:
+        patterns:
+          - '@babel*'
+        update-types:
+          - 'minor'
+          - 'patch'
+      rnx-kit:
+        patterns:
+          - '@rnx-kit*'
+        update-types:
+          - 'minor'
+          - 'patch'
     schedule:
       interval: daily
       time: '13:00'


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Based on [documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) this change should result in dependabot grouping @babel and @rnx-kit changes into one PR.
