### PR TITLE
[Menu win32] Add focus zone around menu groups

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Menu/MenuTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Menu/MenuTest.tsx
@@ -377,9 +377,11 @@ const MenuWithGroups: React.FunctionComponent = () => {
             <MenuGroup>
               <MenuGroupHeader>Section 1</MenuGroupHeader>
               <MenuItem>A plain MenuItem</MenuItem>
+              <MenuItem>A plain MenuItem</MenuItem>
             </MenuGroup>
             <MenuGroup>
               <MenuGroupHeader>Section 2</MenuGroupHeader>
+              <MenuItem>A plain MenuItem</MenuItem>
               <MenuItem>A plain MenuItem</MenuItem>
             </MenuGroup>
           </MenuList>

--- a/change/@fluentui-react-native-menu-6b381700-15a9-4b87-b74e-2d379ce3fff7.json
+++ b/change/@fluentui-react-native-menu-6b381700-15a9-4b87-b74e-2d379ce3fff7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add focus zone around menu groups",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-0e6368a2-d3b4-4f2f-a8ce-c3450b389a64.json
+++ b/change/@fluentui-react-native-tester-0e6368a2-d3b4-4f2f-a8ce-c3450b389a64.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add focus zone around menu groups",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/MenuGroup/MenuGroup.tsx
+++ b/packages/components/Menu/src/MenuGroup/MenuGroup.tsx
@@ -10,10 +10,8 @@ import type { UseSlots } from '@fluentui-react-native/framework';
 import type { MenuGroupProps, MenuGroupType } from './MenuGroup.types';
 import { menuGroupName } from './MenuGroup.types';
 
-// macOS has focus zone around entire list, including it for groups may
-// cause bad keyboard behavior. Will review in the future.
+// Intentionally not enabled on macOS to match system context menus
 const hasFocusZone = ['win32'].includes(Platform.OS as string);
-const useCircularNav = Platform.OS !== 'macos';
 
 export const MenuGroup = compose<MenuGroupType>({
   displayName: menuGroupName,
@@ -54,7 +52,7 @@ export const MenuGroup = compose<MenuGroupType>({
             {...(hasFocusZone && {
               focusZoneDirection: 'vertical',
               enableFocusRing: false,
-              isCircularNavigation: useCircularNav,
+              isCircularNavigation: true,
             })}
           >
             {childrenWithSet}

--- a/packages/components/Menu/src/MenuGroup/MenuGroup.tsx
+++ b/packages/components/Menu/src/MenuGroup/MenuGroup.tsx
@@ -1,18 +1,25 @@
 /** @jsxRuntime classic */
 /** @jsx withSlots */
 import React from 'react';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 
+import { FocusZone } from '@fluentui-react-native/focus-zone';
 import { compose, mergeProps, withSlots } from '@fluentui-react-native/framework';
 import type { UseSlots } from '@fluentui-react-native/framework';
 
 import type { MenuGroupProps, MenuGroupType } from './MenuGroup.types';
 import { menuGroupName } from './MenuGroup.types';
 
+// macOS has focus zone around entire list, including it for groups may
+// cause bad keyboard behavior. Will review in the future.
+const hasFocusZone = ['win32'].includes(Platform.OS as string);
+const useCircularNav = Platform.OS !== 'macos';
+
 export const MenuGroup = compose<MenuGroupType>({
   displayName: menuGroupName,
   slots: {
     root: View,
+    focusZone: hasFocusZone ? FocusZone : React.Fragment,
   },
   useRender: (userProps: MenuGroupProps, useSlots: UseSlots<MenuGroupType>) => {
     const Slots = useSlots(userProps);
@@ -39,7 +46,21 @@ export const MenuGroup = compose<MenuGroupType>({
         }
         return child;
       });
-      return <Slots.root {...mergedProps}>{childrenWithSet}</Slots.root>;
+
+      return (
+        <Slots.root {...mergedProps}>
+          <Slots.focusZone
+            // avoid error that fires when props are passed into React.fragment
+            {...(hasFocusZone && {
+              focusZoneDirection: 'vertical',
+              enableFocusRing: false,
+              isCircularNavigation: useCircularNav,
+            })}
+          >
+            {childrenWithSet}
+          </Slots.focusZone>
+        </Slots.root>
+      );
     };
   },
 });

--- a/packages/components/Menu/src/MenuGroup/MenuGroup.types.ts
+++ b/packages/components/Menu/src/MenuGroup/MenuGroup.types.ts
@@ -1,6 +1,7 @@
 import type { ViewProps } from 'react-native';
 
 import type { IViewProps } from '@fluentui-react-native/adapters';
+import type { FocusZoneProps } from '@fluentui-react-native/focus-zone';
 import type { LayoutTokens } from '@fluentui-react-native/tokens';
 
 export const menuGroupName = 'MenuGroup';
@@ -11,6 +12,7 @@ export type MenuGroupProps = IViewProps;
 
 export interface MenuGroupSlotProps {
   root: ViewProps;
+  focusZone: FocusZoneProps;
 }
 
 export interface MenuGroupType {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

In win32, menu groups should be keyboard arrow-able while you use tab to move between groups. Wrapping a focus zone around the Menu Group should align the keyboard behavior to be closer to the ideal spec.

### Verification

Added more items to the menu group test to test keyboarding behavior

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
