### PR TITLE
Fix Legacy SVG Icon `viewBox` prop being explicitly set as undefined

### DIFF
--- a/change/@fluentui-react-native-icon-eb55fe1f-1e42-4813-b78c-f86435788c72.json
+++ b/change/@fluentui-react-native-icon-eb55fe1f-1e42-4813-b78c-f86435788c72.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix viewBox prop being explicitly set as undefined on legacy icon",
+  "packageName": "@fluentui-react-native/icon",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Icon/src/legacy/Icon.tsx
+++ b/packages/components/Icon/src/legacy/Icon.tsx
@@ -5,7 +5,7 @@ import type { ImageStyle, TextStyle } from 'react-native';
 import { mergeStyles, useFluentTheme } from '@fluentui-react-native/framework';
 import { stagedComponent, mergeProps, getMemoCache } from '@fluentui-react-native/framework';
 import { Text } from '@fluentui-react-native/text';
-import type { SvgProps, UriProps } from 'react-native-svg';
+import type { SvgProps } from 'react-native-svg';
 import { SvgUri } from 'react-native-svg';
 
 import type { IconProps, SvgIconProps, FontIconProps } from './Icon.types';
@@ -71,7 +71,7 @@ function renderSvg(iconProps: IconProps) {
   const { accessible, accessibilityLabel, width, height, color } = iconProps;
   const style = mergeStyles(iconProps.style, rasterImageStyleCache({ width, height }, [width, height])[0]);
 
-  let svgProps: SvgProps | UriProps = { width, height, color };
+  const svgProps: SvgProps = { width, height, color };
   if (svgIconProps.viewBox) {
     svgProps.viewBox = svgIconProps.viewBox;
   }
@@ -83,10 +83,9 @@ function renderSvg(iconProps: IconProps) {
       </View>
     );
   } else if (svgIconProps.uri) {
-    svgProps = { ...svgProps, uri: svgIconProps.uri };
     return (
       <View style={style} accessible={accessible} accessibilityRole="image" accessibilityLabel={accessibilityLabel}>
-        <SvgUri {...svgProps} />
+        <SvgUri uri={svgIconProps.uri} {...svgProps} />
       </View>
     );
   } else {

--- a/packages/components/Icon/src/legacy/Icon.tsx
+++ b/packages/components/Icon/src/legacy/Icon.tsx
@@ -5,7 +5,7 @@ import type { ImageStyle, TextStyle } from 'react-native';
 import { mergeStyles, useFluentTheme } from '@fluentui-react-native/framework';
 import { stagedComponent, mergeProps, getMemoCache } from '@fluentui-react-native/framework';
 import { Text } from '@fluentui-react-native/text';
-import { SvgUri } from 'react-native-svg';
+import { SvgProps, SvgUri } from 'react-native-svg';
 
 import type { IconProps, SvgIconProps, FontIconProps } from './Icon.types';
 
@@ -68,19 +68,23 @@ function renderFontIcon(iconProps: IconProps) {
 function renderSvg(iconProps: IconProps) {
   const svgIconProps: SvgIconProps = iconProps.svgSource;
   const { accessible, accessibilityLabel, width, height, color } = iconProps;
-  const viewBox = iconProps.svgSource.viewBox;
   const style = mergeStyles(iconProps.style, rasterImageStyleCache({ width, height }, [width, height])[0]);
+
+  const svgProps: SvgProps = { width, height, color };
+  if (svgIconProps.viewBox) {
+    svgProps.viewBox = svgIconProps.viewBox;
+  }
 
   if (svgIconProps.src) {
     return (
       <View style={style} accessible={accessible} accessibilityRole="image" accessibilityLabel={accessibilityLabel}>
-        <svgIconProps.src viewBox={viewBox} width={width} height={height} color={color} />
+        <svgIconProps.src {...svgProps} />
       </View>
     );
   } else if (svgIconProps.uri) {
     return (
       <View style={style} accessible={accessible} accessibilityRole="image" accessibilityLabel={accessibilityLabel}>
-        <SvgUri uri={svgIconProps.uri} viewBox={viewBox} width={width} height={height} color={color} />
+        <SvgUri uri={svgIconProps.uri} {...svgProps} />
       </View>
     );
   } else {

--- a/packages/components/Icon/src/legacy/Icon.tsx
+++ b/packages/components/Icon/src/legacy/Icon.tsx
@@ -5,7 +5,8 @@ import type { ImageStyle, TextStyle } from 'react-native';
 import { mergeStyles, useFluentTheme } from '@fluentui-react-native/framework';
 import { stagedComponent, mergeProps, getMemoCache } from '@fluentui-react-native/framework';
 import { Text } from '@fluentui-react-native/text';
-import { SvgProps, SvgUri } from 'react-native-svg';
+import type { SvgProps, UriProps } from 'react-native-svg';
+import { SvgUri } from 'react-native-svg';
 
 import type { IconProps, SvgIconProps, FontIconProps } from './Icon.types';
 
@@ -70,7 +71,7 @@ function renderSvg(iconProps: IconProps) {
   const { accessible, accessibilityLabel, width, height, color } = iconProps;
   const style = mergeStyles(iconProps.style, rasterImageStyleCache({ width, height }, [width, height])[0]);
 
-  const svgProps: SvgProps = { width, height, color };
+  let svgProps: SvgProps | UriProps = { width, height, color };
   if (svgIconProps.viewBox) {
     svgProps.viewBox = svgIconProps.viewBox;
   }
@@ -82,9 +83,10 @@ function renderSvg(iconProps: IconProps) {
       </View>
     );
   } else if (svgIconProps.uri) {
+    svgProps = { ...svgProps, uri: svgIconProps.uri };
     return (
       <View style={style} accessible={accessible} accessibilityRole="image" accessibilityLabel={accessibilityLabel}>
-        <SvgUri uri={svgIconProps.uri} {...svgProps} />
+        <SvgUri {...svgProps} />
       </View>
     );
   } else {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

For rendering SVGs, the legacy Icon is mistakenly written to set the `viewBox` prop as undefined if no viewbox is passed. This is problematic because an un-set viewbox causes issues scaling across DPIs. ButtonV1 also consumes the legacy Icon which makes this even more of an issue.

This PR fixes this by not setting the prop if nothing is passed.

### Verification

Local testing and verification.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
