### PR TITLE
Fix Tab styling bugs

### DIFF
--- a/change/@fluentui-react-native-tablist-1c442971-3b52-40dd-9207-d64c6a402ce6.json
+++ b/change/@fluentui-react-native-tablist-1c442971-3b52-40dd-9207-d64c6a402ce6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Correct indicatorColor token used for selected+pressed tab",
+  "packageName": "@fluentui-react-native/tablist",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tablist-1c442971-3b52-40dd-9207-d64c6a402ce6.json
+++ b/change/@fluentui-react-native-tablist-1c442971-3b52-40dd-9207-d64c6a402ce6.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Correct indicatorColor token used for selected+pressed tab",
+  "comment": "Fix small tab styling bugs regarding indicator color and tab sizing",
   "packageName": "@fluentui-react-native/tablist",
   "email": "winlarry@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/experimental/TabList/src/Tab/Tab.styling.ts
+++ b/packages/experimental/TabList/src/Tab/Tab.styling.ts
@@ -27,10 +27,11 @@ export const useTabSlotProps = (props: TabProps, tokens: TabTokens, theme: Theme
         justifyContent: 'center',
         padding: 1,
         backgroundColor: tokens.backgroundColor,
+        ...(!context.vertical ? { height: '100%' } : {}),
         ...borderStyles.from(tokens, theme),
       },
     }),
-    [tokens, theme],
+    [tokens, theme, context.vertical],
   );
 
   const contentContainer = React.useMemo<IViewProps>(

--- a/packages/experimental/TabList/src/Tab/Tab.styling.ts
+++ b/packages/experimental/TabList/src/Tab/Tab.styling.ts
@@ -27,11 +27,11 @@ export const useTabSlotProps = (props: TabProps, tokens: TabTokens, theme: Theme
         justifyContent: 'center',
         padding: 1,
         backgroundColor: tokens.backgroundColor,
-        ...(!context.vertical ? { height: '100%' } : {}),
+        ...(!vertical ? { height: '100%' } : {}),
         ...borderStyles.from(tokens, theme),
       },
     }),
-    [tokens, theme, context.vertical],
+    [tokens, theme, vertical],
   );
 
   const contentContainer = React.useMemo<IViewProps>(

--- a/packages/experimental/TabList/src/Tab/TabTokens.ts
+++ b/packages/experimental/TabList/src/Tab/TabTokens.ts
@@ -94,6 +94,11 @@ export const defaultTabTokens: TokensFromTheme<TabTokens, Theme> = (t: Theme) =>
       color: t.colors.neutralForeground1,
       iconColor: t.colors.compoundBrandForeground1,
       indicatorColor: t.colors.compoundBrandStroke1,
+      pressed: {
+        color: t.colors.neutralForeground1Pressed,
+        iconColor: t.colors.compoundBrandForeground1Pressed,
+        indicatorColor: t.colors.compoundBrandStroke1Pressed,
+      },
     },
     disabled: {
       color: t.colors.neutralForegroundDisabled,
@@ -126,11 +131,6 @@ export const defaultTabTokens: TokensFromTheme<TabTokens, Theme> = (t: Theme) =>
       color: t.colors.neutralForeground2Pressed,
       iconColor: t.colors.neutralForeground2Pressed,
       indicatorColor: t.colors.neutralStroke1Pressed,
-      selected: {
-        color: t.colors.neutralForeground1Pressed,
-        iconColor: t.colors.compoundBrandForeground1Pressed,
-        indicatorColor: t.colors.compoundBrandStroke1Pressed,
-      },
       transparent: {
         backgroundColor: t.colors.transparentBackgroundPressed,
       },

--- a/packages/experimental/TabList/src/Tab/__tests__/__snapshots__/Tab.test.tsx.snap
+++ b/packages/experimental/TabList/src/Tab/__tests__/__snapshots__/Tab.test.tsx.snap
@@ -69,6 +69,7 @@ exports[`Tab component tests Customized Tab 1`] = `
       "borderWidth": 2,
       "display": "flex",
       "flexDirection": "column",
+      "height": "100%",
       "justifyContent": "center",
       "padding": 1,
     }
@@ -204,6 +205,7 @@ exports[`Tab component tests Tab default props 1`] = `
       "borderWidth": 2,
       "display": "flex",
       "flexDirection": "column",
+      "height": "100%",
       "justifyContent": "center",
       "padding": 1,
     }
@@ -339,6 +341,7 @@ exports[`Tab component tests Tab disabled 1`] = `
       "borderWidth": 2,
       "display": "flex",
       "flexDirection": "column",
+      "height": "100%",
       "justifyContent": "center",
       "padding": 1,
     }
@@ -474,6 +477,7 @@ exports[`Tab component tests Tab render icon + text 1`] = `
       "borderWidth": 2,
       "display": "flex",
       "flexDirection": "column",
+      "height": "100%",
       "justifyContent": "center",
       "padding": 1,
     }
@@ -621,6 +625,7 @@ exports[`Tab component tests Tab render icon only 1`] = `
       "borderWidth": 2,
       "display": "flex",
       "flexDirection": "column",
+      "height": "100%",
       "justifyContent": "center",
       "padding": 1,
     }

--- a/packages/experimental/TabList/src/TabList/__tests__/__snapshots__/TabList.test.tsx.snap
+++ b/packages/experimental/TabList/src/TabList/__tests__/__snapshots__/TabList.test.tsx.snap
@@ -95,6 +95,7 @@ exports[`TabList component tests TabList appearance 1`] = `
           "borderWidth": 2,
           "display": "flex",
           "flexDirection": "column",
+          "height": "100%",
           "justifyContent": "center",
           "padding": 1,
         }
@@ -227,6 +228,7 @@ exports[`TabList component tests TabList appearance 1`] = `
           "borderWidth": 2,
           "display": "flex",
           "flexDirection": "column",
+          "height": "100%",
           "justifyContent": "center",
           "padding": 1,
         }
@@ -359,6 +361,7 @@ exports[`TabList component tests TabList appearance 1`] = `
           "borderWidth": 2,
           "display": "flex",
           "flexDirection": "column",
+          "height": "100%",
           "justifyContent": "center",
           "padding": 1,
         }
@@ -522,6 +525,7 @@ exports[`TabList component tests TabList default props 1`] = `
           "borderWidth": 2,
           "display": "flex",
           "flexDirection": "column",
+          "height": "100%",
           "justifyContent": "center",
           "padding": 1,
         }
@@ -654,6 +658,7 @@ exports[`TabList component tests TabList default props 1`] = `
           "borderWidth": 2,
           "display": "flex",
           "flexDirection": "column",
+          "height": "100%",
           "justifyContent": "center",
           "padding": 1,
         }
@@ -786,6 +791,7 @@ exports[`TabList component tests TabList default props 1`] = `
           "borderWidth": 2,
           "display": "flex",
           "flexDirection": "column",
+          "height": "100%",
           "justifyContent": "center",
           "padding": 1,
         }
@@ -950,6 +956,7 @@ exports[`TabList component tests TabList disabled list 1`] = `
           "borderWidth": 2,
           "display": "flex",
           "flexDirection": "column",
+          "height": "100%",
           "justifyContent": "center",
           "padding": 1,
         }
@@ -1082,6 +1089,7 @@ exports[`TabList component tests TabList disabled list 1`] = `
           "borderWidth": 2,
           "display": "flex",
           "flexDirection": "column",
+          "height": "100%",
           "justifyContent": "center",
           "padding": 1,
         }
@@ -1214,6 +1222,7 @@ exports[`TabList component tests TabList disabled list 1`] = `
           "borderWidth": 2,
           "display": "flex",
           "flexDirection": "column",
+          "height": "100%",
           "justifyContent": "center",
           "padding": 1,
         }
@@ -1805,6 +1814,7 @@ exports[`TabList component tests TabList selected key 1`] = `
           "borderWidth": 2,
           "display": "flex",
           "flexDirection": "column",
+          "height": "100%",
           "justifyContent": "center",
           "padding": 1,
         }
@@ -1937,6 +1947,7 @@ exports[`TabList component tests TabList selected key 1`] = `
           "borderWidth": 2,
           "display": "flex",
           "flexDirection": "column",
+          "height": "100%",
           "justifyContent": "center",
           "padding": 1,
         }
@@ -2069,6 +2080,7 @@ exports[`TabList component tests TabList selected key 1`] = `
           "borderWidth": 2,
           "display": "flex",
           "flexDirection": "column",
+          "height": "100%",
           "justifyContent": "center",
           "padding": 1,
         }
@@ -2232,6 +2244,7 @@ exports[`TabList component tests TabList size 1`] = `
           "borderWidth": 2,
           "display": "flex",
           "flexDirection": "column",
+          "height": "100%",
           "justifyContent": "center",
           "padding": 1,
         }
@@ -2364,6 +2377,7 @@ exports[`TabList component tests TabList size 1`] = `
           "borderWidth": 2,
           "display": "flex",
           "flexDirection": "column",
+          "height": "100%",
           "justifyContent": "center",
           "padding": 1,
         }
@@ -2496,6 +2510,7 @@ exports[`TabList component tests TabList size 1`] = `
           "borderWidth": 2,
           "display": "flex",
           "flexDirection": "column",
+          "height": "100%",
           "justifyContent": "center",
           "padding": 1,
         }


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This PR fixes two bugs related to tab styling.

- Within the token logic, there's a minor Tab bug where a selected and pressed Tab applies the wrong indicator color token. This PR fixes this by re-ordering the tokens applied in Tab.tokens.ts.
- Within the styling logic, there's a bug where tabs with smaller heights than the rest of a horizontal tablist have the animated indicator appear outside the focus border. This PR fixes this by making the heights of tabs in a horizontal tablist uniform. 

### Verification

Local testing

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://github.com/microsoft/fluentui-react-native/assets/15683103/c33840a2-86c4-40d4-89f2-f0822dea56ae) | ![image](https://github.com/microsoft/fluentui-react-native/assets/15683103/e347bef0-418b-404a-88af-32624b26f654) |
| ![image](https://github.com/microsoft/fluentui-react-native/assets/15683103/54f159b7-d831-4734-be70-45725e1df1aa) | ![image](https://github.com/microsoft/fluentui-react-native/assets/15683103/0328da4b-36f7-41ba-ba71-f7f74ab2c7d7) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
