### PR TITLE
Mark tests to satisfy compliance

### DIFF
--- a/.ado/azure-pipelines.publish.yml
+++ b/.ado/azure-pipelines.publish.yml
@@ -81,7 +81,7 @@ extends:
                 displayName: 'yarn install'
 
               - script: |
-                  yarn buildci
+                  yarn buildci [test]
                 displayName: 'yarn buildci'
 
               - script: |

--- a/.ado/azure-pipelines.publish.yml
+++ b/.ado/azure-pipelines.publish.yml
@@ -81,8 +81,8 @@ extends:
                 displayName: 'yarn install'
 
               - script: |
-                  yarn buildci [test]
-                displayName: 'yarn buildci'
+                  yarn buildci
+                displayName: 'yarn buildci [test]'
 
               - script: |
                   echo ##vso[task.setvariable variable=SkipNpmPublishArgs]--no-publish

--- a/.ado/azure-pipelines.yml
+++ b/.ado/azure-pipelines.yml
@@ -29,8 +29,8 @@ jobs:
         displayName: 'check prettier'
 
       - script: |
-          yarn buildci [test]
-        displayName: 'yarn buildci'
+          yarn buildci
+        displayName: 'yarn buildci [test]'
 
       - script: |
           yarn check-for-changed-files

--- a/.ado/azure-pipelines.yml
+++ b/.ado/azure-pipelines.yml
@@ -29,7 +29,7 @@ jobs:
         displayName: 'check prettier'
 
       - script: |
-          yarn buildci
+          yarn buildci [test]
         displayName: 'yarn buildci'
 
       - script: |

--- a/.ado/templates/e2e-testing-android.yml
+++ b/.ado/templates/e2e-testing-android.yml
@@ -36,7 +36,7 @@ steps:
   - script: |
       yarn e2etest:android
     workingDirectory: apps/E2E
-    displayName: 'run E2E Android tests'
+    displayName: 'run E2E Android tests [test]'
     condition: succeeded()
 
   - template: e2e-publish-artifacts.yml

--- a/.ado/templates/e2e-testing-ios.yml
+++ b/.ado/templates/e2e-testing-ios.yml
@@ -20,7 +20,7 @@ steps:
   - script: |
       yarn e2etest:ios
     workingDirectory: apps/E2E
-    displayName: 'run E2E iOS tests'
+    displayName: 'run E2E iOS tests [test]'
     condition: succeeded()
 
   - template: e2e-publish-artifacts.yml

--- a/.ado/templates/e2e-testing-macos.yml
+++ b/.ado/templates/e2e-testing-macos.yml
@@ -20,7 +20,7 @@ steps:
   - script: |
       yarn e2etest:macos
     workingDirectory: apps/E2E
-    displayName: 'run E2E macos tests'
+    displayName: 'run E2E macos tests [test]'
     condition: succeeded()
 
   - template: e2e-publish-artifacts.yml

--- a/.ado/templates/e2e-testing-uwp.yml
+++ b/.ado/templates/e2e-testing-uwp.yml
@@ -44,7 +44,7 @@ steps:
   - script: |
       yarn e2etest:windows
     workingDirectory: apps\E2E
-    displayName: 'run E2E UWP tests'
+    displayName: 'run E2E UWP tests [test]'
     condition: succeeded()
 
   # The following condition (using task.Build.status variable) make it so the reports generate even if the E2E tasks fails,

--- a/.ado/templates/e2e-testing-win32.yml
+++ b/.ado/templates/e2e-testing-win32.yml
@@ -34,7 +34,7 @@ steps:
   - script: |
       yarn e2etest:win32
     workingDirectory: apps/E2E
-    displayName: 'run E2E Win32 tests'
+    displayName: 'run E2E Win32 tests [test]'
     condition: succeeded()
 
   - template: e2e-publish-artifacts.yml

--- a/.ado/templates/win32-nuget-publish.yml
+++ b/.ado/templates/win32-nuget-publish.yml
@@ -25,8 +25,8 @@ jobs:
       - template: setup-repo-min-build.yml
 
       - script: |
-          yarn buildci [test]
-        displayName: 'Building the repo'
+          yarn buildci
+        displayName: 'Building the repo [test]'
 
       - script: |
           yarn bundle

--- a/.ado/templates/win32-nuget-publish.yml
+++ b/.ado/templates/win32-nuget-publish.yml
@@ -25,7 +25,7 @@ jobs:
       - template: setup-repo-min-build.yml
 
       - script: |
-          yarn buildci
+          yarn buildci [test]
         displayName: 'Building the repo'
 
       - script: |


### PR DESCRIPTION
### Description of changes

Compliance requires we run tests, we don't use build-in ADO test runners so we need to annotate which tasks run tests.

### Verification
N/A
