### PR TITLE
Fix various Tab styling bugs

### DIFF
--- a/change/@fluentui-react-native-tablist-edca46cd-d2c1-4d31-b585-55edd4e283ea.json
+++ b/change/@fluentui-react-native-tablist-edca46cd-d2c1-4d31-b585-55edd4e283ea.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix various tab styling bugs",
+  "packageName": "@fluentui-react-native/tablist",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/TabList/src/Tab/Tab.styling.ts
+++ b/packages/experimental/TabList/src/Tab/Tab.styling.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Platform } from 'react-native';
 
 import type { IViewProps } from '@fluentui-react-native/adapters';
 import { borderStyles, fontStyles } from '@fluentui-react-native/framework';
@@ -27,7 +28,7 @@ export const useTabSlotProps = (props: TabProps, tokens: TabTokens, theme: Theme
         justifyContent: 'center',
         padding: 1,
         backgroundColor: tokens.backgroundColor,
-        ...(!vertical ? { height: '100%' } : {}),
+        ...(!vertical ? Platform.select({ macos: {}, default: { height: '100%' } }) : {}),
         ...borderStyles.from(tokens, theme),
       },
     }),

--- a/packages/experimental/TabList/src/Tab/TabTokens.ts
+++ b/packages/experimental/TabList/src/Tab/TabTokens.ts
@@ -106,6 +106,7 @@ export const defaultTabTokens: TokensFromTheme<TabTokens, Theme> = (t: Theme) =>
       iconColor: t.colors.neutralForegroundDisabled,
       selected: {
         color: t.colors.neutralForegroundDisabled,
+        iconColor: t.colors.neutralForegroundDisabled,
         indicatorColor: t.colors.neutralForegroundDisabled,
       },
     },

--- a/packages/experimental/TabList/src/TabListAnimatedIndicator/useAnimatedIndicatorStyles.ts
+++ b/packages/experimental/TabList/src/TabListAnimatedIndicator/useAnimatedIndicatorStyles.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Animated } from 'react-native';
+import { Animated, Easing } from 'react-native';
 import type { ViewStyle } from 'react-native';
 
 import type { AnimatedIndicatorProps, AnimatedIndicatorStyles } from './TabListAnimatedIndicator.types';
@@ -40,12 +40,14 @@ export function useAnimatedIndicatorStyles(props: AnimatedIndicatorProps): Anima
       Animated.parallel([
         Animated.timing(indicatorScale, {
           toValue: scaleValue,
-          duration: 200,
+          duration: 300,
+          easing: Easing.bezier(0, 0, 0, 1),
           useNativeDriver: true,
         }),
         Animated.timing(indicatorTranslate, {
           toValue: translateValue + translateOffset,
-          duration: 200,
+          duration: 300,
+          easing: Easing.bezier(0, 0, 0, 1),
           useNativeDriver: true,
         }),
       ]).start();


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This PR fixes various Tab styling bugs found in a bug bash:
- Fix disabled selected icon color using wrong token
- Fix macOS tab height being 100% of page
- Make animation duration and easing up to spec for non-win32 platforms

### Verification

Locally tested. 

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
