### PR TITLE
[Menu] Add left and right arrow to stop propagation list

### DIFF
--- a/change/@fluentui-react-native-menu-a96c1b53-cb9d-458c-b095-985d51025bc1.json
+++ b/change/@fluentui-react-native-menu-a96c1b53-cb9d-458c-b095-985d51025bc1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Stop propagation of left right arrow keys for menu",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
+++ b/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
@@ -7,7 +7,7 @@ import type { MenuPopoverProps, MenuPopoverState } from './MenuPopover.types';
 import { useMenuContext } from '../context/menuContext';
 
 const controlledDismissBehaviors = ['preventDismissOnKeyDown', 'preventDismissOnClickOutside'] as DismissBehaviors[];
-const stopPropagationKeys = ['ArrowUp', 'ArrowDown', 'Tab', 'Home', 'End', 'Escape'] as const;
+const stopPropagationKeys = ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Tab', 'Home', 'End', 'Escape'] as const;
 
 export const useMenuPopover = (props: MenuPopoverProps): MenuPopoverState => {
   const context = useMenuContext();


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Add left/right arrows to the stop propagation list for Menu. Partner ask to make sure that arrow keys don't get handled up the stack, since the menu natively handles them.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
