### PR TITLE
[FURN Tester] Fix HC ratio for button text

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Button/ButtonHOCTestSection.tsx
+++ b/apps/fluent-tester/src/TestComponents/Button/ButtonHOCTestSection.tsx
@@ -9,7 +9,7 @@ import { TextV1 as Text } from '@fluentui-react-native/text';
 import { svgProps } from '../Common/iconExamples';
 import { commonTestStyles, stackStyle } from '../Common/styles';
 
-const CustomText = Text.customize({ fontSize: 'header', color: 'hotpink' });
+const CustomText = Text.customize({ fontSize: 'header', color: '#ad0258' });
 const CustomButton = Button.customize({ backgroundColor: 'pink' });
 const CustomIconButton = Button.customize({ iconColor: 'yellow' });
 const ComposedButton = Button.compose({

--- a/change/@fluentui-react-native-tester-6caf0027-375c-4c1f-8353-35d2f54b95d6.json
+++ b/change/@fluentui-react-native-tester-6caf0027-375c-4c1f-8353-35d2f54b95d6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix HC on button text",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Adjusts the color of the text on a test button where the contrast ratio is less than 4.5:1

### Verification

Tested new contrast ratio meets 4.5:1 on standard, focused, and hovered button states.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://github.com/microsoft/fluentui-react-native/assets/22876140/f5a60515-a9af-415c-a8a0-ea3d60897b1b)| ![image](https://github.com/microsoft/fluentui-react-native/assets/22876140/b176fea3-fdbb-4682-93a4-29dff20f0a88) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
