### PR TITLE
Make @fortawesome a group when updating dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,12 +9,19 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
+      fortawesome:
+        patterns:
+          - '@fortawesome*'
+        update-types:
+          - 'minor'
+          - 'patch'
       rnx-kit:
         patterns:
           - '@rnx-kit*'
         update-types:
           - 'minor'
           - 'patch'
+
     schedule:
       interval: daily
       time: '13:00'


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Seems like some fortawesome updates will depend on the core package being updated so it makes sense to group the updates together