### PR TITLE
Change to the UseFontIcon to actually use the computed prop

### DIFF
--- a/change/@fluentui-react-native-icon-517887c1-a42b-40e8-a414-c7a7c593051e.json
+++ b/change/@fluentui-react-native-icon-517887c1-a42b-40e8-a414-c7a7c593051e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "small change to use output of function",
+  "packageName": "@fluentui-react-native/icon",
+  "email": "56889386+gremlin529@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Icon/src/FontIcon/useFontIcon.ts
+++ b/packages/components/Icon/src/FontIcon/useFontIcon.ts
@@ -13,11 +13,11 @@ export const useFontIcon = (props: FontIconProps): FontIconProps => {
     [color, fontSize, fontFamily],
   )[0];
 
-  mergeStyles(style, styleOrig);
+  const mergedStyle = mergeStyles(style, styleOrig);
 
   return {
     accessible: accessible ?? true,
-    style,
+    style: mergedStyle,
     ...rest,
   };
 };


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

Change that makes use of the property that was computed, this change was suggested by Ruriko

### Verification

(how the change was tested, including both manual and automated tests)

Checked through test app

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
