### PR TITLE
Fix deprecated usage of `isFalsy()` / `isTruthy()` methods in E2E tests

### DIFF
--- a/apps/E2E/src/ActivityIndicator/specs/ActivityIndicator.spec.win.ts
+++ b/apps/E2E/src/ActivityIndicator/specs/ActivityIndicator.spec.win.ts
@@ -9,6 +9,8 @@ describe('Activity Indicator Testing Initialization', () => {
   it('Navigate to Activity Indicator test page', async () => {
     expect(await ActivityIndicatorPageObject.navigateToPageAndLoadTests()).toBeTrue();
 
-    expect(await ActivityIndicatorPageObject.didAssertPopup()).toBeFalsy(ActivityIndicatorPageObject.ERRORMESSAGE_ASSERT);
+    expect(await ActivityIndicatorPageObject.didAssertPopup())
+      .withContext(ActivityIndicatorPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 });

--- a/apps/E2E/src/Avatar/specs/Avatar.spec.android.ts
+++ b/apps/E2E/src/Avatar/specs/Avatar.spec.android.ts
@@ -9,6 +9,8 @@ describe('Avatar Testing Initialization', () => {
   it('Click and navigate to Avatar test page', async () => {
     expect(await AvatarPageObject.navigateToPageAndLoadTests()).toBeTrue();
 
-    await expect(await AvatarPageObject.didAssertPopup()).toBeFalsy(AvatarPageObject.ERRORMESSAGE_ASSERT);
+    await expect(await AvatarPageObject.didAssertPopup())
+      .withContext(AvatarPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 });

--- a/apps/E2E/src/Avatar/specs/Avatar.spec.win.ts
+++ b/apps/E2E/src/Avatar/specs/Avatar.spec.win.ts
@@ -15,7 +15,9 @@ describe('Avatar Testing Initialization', () => {
     /* Expand E2E section */
     expect(await AvatarPageObject.enableE2ETesterMode()).toBeTrue();
 
-    await expect(await AvatarPageObject.didAssertPopup()).toBeFalsy(AvatarPageObject.ERRORMESSAGE_ASSERT);
+    await expect(await AvatarPageObject.didAssertPopup())
+      .withContext(AvatarPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 });
 

--- a/apps/E2E/src/Badge/specs/Badge.spec.android.ts
+++ b/apps/E2E/src/Badge/specs/Badge.spec.android.ts
@@ -12,6 +12,8 @@ describe('Badge Testing Initialization', () => {
     /* Expand E2E section */
     expect(await BasicBadgePageObject.enableE2ETesterMode()).toBeTrue();
 
-    await expect(await BasicBadgePageObject.didAssertPopup()).toBeFalsy(BasicBadgePageObject.ERRORMESSAGE_ASSERT);
+    await expect(await BasicBadgePageObject.didAssertPopup())
+      .withContext(BasicBadgePageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 });

--- a/apps/E2E/src/Badge/specs/Badge.spec.win.ts
+++ b/apps/E2E/src/Badge/specs/Badge.spec.win.ts
@@ -9,6 +9,8 @@ describe('Badge Testing Initialization', () => {
   it('Click and navigate to Badge test page', async () => {
     expect(await BasicBadgePageObject.navigateToPageAndLoadTests()).toBeTrue();
 
-    await expect(await BasicBadgePageObject.didAssertPopup()).toBeFalsy(BasicBadgePageObject.ERRORMESSAGE_ASSERT);
+    await expect(await BasicBadgePageObject.didAssertPopup())
+      .withContext(BasicBadgePageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 });

--- a/apps/E2E/src/ButtonLegacy/specs/ButtonLegacy.spec.win.ts
+++ b/apps/E2E/src/ButtonLegacy/specs/ButtonLegacy.spec.win.ts
@@ -15,7 +15,9 @@ describe('Button Legacy Testing Initialization', () => {
     /* Expand E2E section */
     expect(await ButtonLegacyPageObject.enableE2ETesterMode()).toBeTrue();
 
-    await expect(await ButtonLegacyPageObject.didAssertPopup()).toBeFalsy(ButtonLegacyPageObject.ERRORMESSAGE_ASSERT);
+    await expect(await ButtonLegacyPageObject.didAssertPopup())
+      .withContext(ButtonLegacyPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 });
 
@@ -72,7 +74,9 @@ describe('Button Legacy Functional Testing', () => {
       await ButtonLegacyPageObject.didOnClickCallbackFire('Clicking on the primary button failed to fire the onClick() callback.'),
     ).toBeTruthy();
 
-    await expect(await ButtonLegacyPageObject.didAssertPopup()).toBeFalsy(ButtonLegacyPageObject.ERRORMESSAGE_ASSERT);
+    await expect(await ButtonLegacyPageObject.didAssertPopup())
+      .withContext(ButtonLegacyPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Type "Enter" on primary button. Validate onClick() callback was fired.', async () => {
@@ -82,7 +86,9 @@ describe('Button Legacy Functional Testing', () => {
         "Pressing the 'Enter' key on the primary button failed to fire the onClick() callback.",
       ),
     ).toBeTruthy();
-    await expect(await ButtonLegacyPageObject.didAssertPopup()).toBeFalsy(ButtonLegacyPageObject.ERRORMESSAGE_ASSERT);
+    await expect(await ButtonLegacyPageObject.didAssertPopup())
+      .withContext(ButtonLegacyPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Type "Space" on primary button. Validate onClick() callback was fired.', async () => {
@@ -93,6 +99,8 @@ describe('Button Legacy Functional Testing', () => {
       ),
     ).toBeTruthy();
 
-    await expect(await ButtonLegacyPageObject.didAssertPopup()).toBeFalsy(ButtonLegacyPageObject.ERRORMESSAGE_ASSERT);
+    await expect(await ButtonLegacyPageObject.didAssertPopup())
+      .withContext(ButtonLegacyPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 });

--- a/apps/E2E/src/ButtonV1/specs/ButtonV1.spec.android.ts
+++ b/apps/E2E/src/ButtonV1/specs/ButtonV1.spec.android.ts
@@ -5,7 +5,7 @@ import ButtonV1PageObject from '../pages/ButtonV1PageObject';
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Button Testing Initialization', () => {
   it('Wait for app load', async () => {
-     expect(await ButtonV1PageObject.waitForInitialPageToDisplay()).toBeTrue();
+    expect(await ButtonV1PageObject.waitForInitialPageToDisplay()).toBeTrue();
   });
 
   it('Click and navigate to Button test page', async () => {
@@ -14,7 +14,9 @@ describe('Button Testing Initialization', () => {
     /* Expand E2E section */
     expect(await ButtonV1PageObject.enableE2ETesterMode()).toBeTrue();
 
-    await expect(await ButtonV1PageObject.didAssertPopup()).toBeFalsy(ButtonV1PageObject.ERRORMESSAGE_ASSERT);
+    await expect(await ButtonV1PageObject.didAssertPopup())
+      .withContext(ButtonV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 });
 
@@ -32,7 +34,9 @@ describe('ButtonV1 Accessibility Testing', () => {
       ),
     ).toBeTruthy();
 
-    await expect(await ButtonV1PageObject.didAssertPopup()).toBeFalsy(ButtonV1PageObject.ERRORMESSAGE_ASSERT);
+    await expect(await ButtonV1PageObject.didAssertPopup())
+      .withContext(ButtonV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Validate Button Class on Android', async () => {
@@ -40,7 +44,9 @@ describe('ButtonV1 Accessibility Testing', () => {
       await ButtonV1PageObject.compareAttribute(ButtonV1PageObject._primaryComponent, AndroidAttribute.Class, ANDROID_BUTTON),
     ).toBeTruthy();
 
-    await expect(await ButtonV1PageObject.didAssertPopup()).toBeFalsy(ButtonV1PageObject.ERRORMESSAGE_ASSERT);
+    await expect(await ButtonV1PageObject.didAssertPopup())
+      .withContext(ButtonV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 });
 
@@ -55,7 +61,9 @@ describe('ButtonV1 Functional Testing', () => {
     await expect(
       await ButtonV1PageObject.waitForOnClickCallbackToFire(`The primary button failed to fire an onClick callback with a mouse click.`),
     ).toBeTruthy();
-    await expect(await ButtonV1PageObject.didAssertPopup()).toBeFalsy(ButtonV1PageObject.ERRORMESSAGE_ASSERT);
+    await expect(await ButtonV1PageObject.didAssertPopup())
+      .withContext(ButtonV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
 
     await ButtonV1PageObject.click(ButtonV1PageObject._primaryComponent); // Reset Button State
   });

--- a/apps/E2E/src/ButtonV1/specs/ButtonV1.spec.win.ts
+++ b/apps/E2E/src/ButtonV1/specs/ButtonV1.spec.win.ts
@@ -15,7 +15,9 @@ describe('ButtonV1 Testing Initialization', () => {
     /* Expand E2E section */
     expect(await ButtonV1PageObject.enableE2ETesterMode()).toBeTrue();
 
-    await expect(await ButtonV1PageObject.didAssertPopup()).toBeFalsy(ButtonV1PageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    await expect(await ButtonV1PageObject.didAssertPopup())
+      .withContext(ButtonV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 });
 
@@ -67,7 +69,9 @@ describe('ButtonV1 Functional Testing', () => {
       await ButtonV1PageObject.waitForOnClickCallbackToFire(`The primary button failed to fire an onClick callback with a mouse click.`),
     ).toBeTruthy();
 
-    await expect(await ButtonV1PageObject.didAssertPopup()).toBeFalsy(ButtonV1PageObject.ERRORMESSAGE_ASSERT);
+    await expect(await ButtonV1PageObject.didAssertPopup())
+      .withContext(ButtonV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Type "Enter" on primary button. Validate onClick() callback was fired.', async () => {
@@ -78,7 +82,9 @@ describe('ButtonV1 Functional Testing', () => {
       ),
     ).toBeTruthy();
 
-    await expect(await ButtonV1PageObject.didAssertPopup()).toBeFalsy(ButtonV1PageObject.ERRORMESSAGE_ASSERT);
+    await expect(await ButtonV1PageObject.didAssertPopup())
+      .withContext(ButtonV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Type "Space" on primary button. Validate onClick() callback was fired.', async () => {
@@ -88,6 +94,8 @@ describe('ButtonV1 Functional Testing', () => {
       await ButtonV1PageObject.waitForOnClickCallbackToFire(`The primary button failed to fire an onClick callback with a space keypress.`),
     ).toBeTruthy();
 
-    await expect(await ButtonV1PageObject.didAssertPopup()).toBeFalsy(ButtonV1PageObject.ERRORMESSAGE_ASSERT);
+    await expect(await ButtonV1PageObject.didAssertPopup())
+      .withContext(ButtonV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 });

--- a/apps/E2E/src/Callout/specs/Callout.spec.win.ts
+++ b/apps/E2E/src/Callout/specs/Callout.spec.win.ts
@@ -15,7 +15,9 @@ describe('Callout Testing Initialization', () => {
     /* Expand E2E section */
     expect(await CalloutPageObject.enableE2ETesterMode()).toBeTrue();
 
-    await expect(await CalloutPageObject.didAssertPopup()).toBeFalsy(CalloutPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    await expect(await CalloutPageObject.didAssertPopup())
+      .withContext(CalloutPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 });
 
@@ -53,7 +55,9 @@ describe('Callout Functional Testing', () => {
   });
 
   it('Open Callout by clicking a button. Validate that the Callout is displayed.', async () => {
-    await expect(await CalloutPageObject.isCalloutOpen()).toBeTruthy('The callout failed to visibly display.');
+    await expect(await CalloutPageObject.isCalloutOpen())
+      .withContext('The callout failed to visibly display.')
+      .toBeTruthy();
   });
 
   afterEach(async () => {

--- a/apps/E2E/src/CheckboxLegacy/specs/CheckboxLegacy.spec.win.ts
+++ b/apps/E2E/src/CheckboxLegacy/specs/CheckboxLegacy.spec.win.ts
@@ -13,7 +13,7 @@ describe('Checkbox Legacy Testing Initialization', () => {
     /* Expand E2E section */
     expect(await CheckboxLegacyPageObject.enableE2ETesterMode()).toBeTrue();
 
-    await expect(await CheckboxLegacyPageObject.didAssertPopup()).toBeFalsy(CheckboxLegacyPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    await expect(await CheckboxLegacyPageObject.didAssertPopup()).withContext(CheckboxLegacyPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped u.toBeFalsy()p
   });
 });
 
@@ -64,7 +64,9 @@ describe('Checkbox Legacy Functional Testing', () => {
 
   it("Click the primary checkbox. Validate that the Checkbox toggles correctly AND calls the user's onChange() callback.", async () => {
     /* Validate the Checkbox is initially toggled OFF */
-    await expect(await CheckboxLegacyPageObject.isCheckboxChecked()).toBeFalsy('The primary checkbox should initially be toggled off.');
+    await expect(await CheckboxLegacyPageObject.isCheckboxChecked())
+      .withContext('The primary checkbox should initially be toggled off.')
+      .toBeFalsy();
 
     /* Click on the Checkbox to toggle on */
     await CheckboxLegacyPageObject.click(CheckboxLegacyPageObject._primaryComponent);
@@ -85,12 +87,16 @@ describe('Checkbox Legacy Functional Testing', () => {
       await CheckboxLegacyPageObject.waitForCheckboxToggle(false, 'The primary checkbox should have been toggled off via click.'),
     ).toBeTruthy();
 
-    await expect(await CheckboxLegacyPageObject.didAssertPopup()).toBeFalsy(CheckboxLegacyPageObject.ERRORMESSAGE_ASSERT);
+    await expect(await CheckboxLegacyPageObject.didAssertPopup())
+      .withContext(CheckboxLegacyPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it("Press 'Space' on the primary checkbox. Validate that the Checkbox toggles correctly AND calls the user's onChange() callback.", async () => {
     /* Validate the Checkbox is initially toggled OFF */
-    await expect(await CheckboxLegacyPageObject.isCheckboxChecked()).toBeFalsy('The primary checkbox should initially be toggled off.');
+    await expect(await CheckboxLegacyPageObject.isCheckboxChecked())
+      .withContext('The primary checkbox should initially be toggled off.')
+      .toBeFalsy();
 
     /* Presses the "space bar" to select the Checkbox */
     await CheckboxLegacyPageObject.sendKeys(CheckboxLegacyPageObject._primaryComponent, [Keys.SPACE]);
@@ -110,6 +116,8 @@ describe('Checkbox Legacy Functional Testing', () => {
       await CheckboxLegacyPageObject.waitForCheckboxToggle(false, "The primary checkbox should have been toggled off via 'Space' press."),
     ).toBeTruthy();
 
-    await expect(await CheckboxLegacyPageObject.didAssertPopup()).toBeFalsy(CheckboxLegacyPageObject.ERRORMESSAGE_ASSERT);
+    await expect(await CheckboxLegacyPageObject.didAssertPopup())
+      .withContext(CheckboxLegacyPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 });

--- a/apps/E2E/src/CheckboxV1/specs/CheckboxV1.spec.android.ts
+++ b/apps/E2E/src/CheckboxV1/specs/CheckboxV1.spec.android.ts
@@ -13,7 +13,9 @@ describe('CheckboxV1 Testing Initialization', () => {
     /* Expand E2E section */
     expect(await CheckboxV1PageObject.enableE2ETesterMode()).toBeTrue();
 
-    await expect(await CheckboxV1PageObject.didAssertPopup()).toBeFalsy(CheckboxV1PageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    await expect(await CheckboxV1PageObject.didAssertPopup())
+      .withContext(CheckboxV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 });
 
@@ -54,7 +56,9 @@ describe('CheckboxV1 Functional Testing', () => {
     await CheckboxV1PageObject.click(CheckboxV1PageObject._primaryComponent);
 
     /* Validate the Checkbox is toggled ON */
-    expect(await CheckboxV1PageObject.didAssertPopup()).toBeFalsy(CheckboxV1PageObject.ERRORMESSAGE_ASSERT);
+    expect(await CheckboxV1PageObject.didAssertPopup())
+      .withContext(CheckboxV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
     await expect(await CheckboxV1PageObject.waitForCheckboxToggleAndroid(true, 'Checkbox should have toggled on.')).toBeTruthy();
     expect(await CheckboxV1PageObject.didOnChangeCallbackFire('Callback failed to fire via click.')).toBeTruthy();
     expect(await CheckboxV1PageObject.isCheckboxCheckedAndroid()).toBeTruthy();
@@ -63,7 +67,9 @@ describe('CheckboxV1 Functional Testing', () => {
     await CheckboxV1PageObject.click(CheckboxV1PageObject._primaryComponent);
 
     /* Validate the Checkbox is toggled OFF */
-    expect(await CheckboxV1PageObject.didAssertPopup()).toBeFalsy(CheckboxV1PageObject.ERRORMESSAGE_ASSERT);
+    expect(await CheckboxV1PageObject.didAssertPopup())
+      .withContext(CheckboxV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
     await expect(await CheckboxV1PageObject.waitForCheckboxToggleAndroid(false, 'Checkbox should have toggled off.')).toBeTruthy();
     expect(await CheckboxV1PageObject.isCheckboxCheckedAndroid()).toBeFalsy();
   });

--- a/apps/E2E/src/CheckboxV1/specs/CheckboxV1.spec.win.ts
+++ b/apps/E2E/src/CheckboxV1/specs/CheckboxV1.spec.win.ts
@@ -13,7 +13,7 @@ describe('CheckboxV1 Testing Initialization', () => {
     /* Expand E2E section */
     expect(await CheckboxV1PageObject.enableE2ETesterMode()).toBeTrue();
 
-    await expect(await CheckboxV1PageObject.didAssertPopup()).toBeFalsy(CheckboxV1PageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    await expect(await CheckboxV1PageObject.didAssertPopup()).withContext(CheckboxV1PageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped u.toBeFalsy()p
   });
 });
 
@@ -80,7 +80,9 @@ describe('CheckboxV1 Functional Testing', () => {
 
   it("Click the primary checkbox. Validate that the Checkbox toggles correctly AND calls the user's onChange() callback.", async () => {
     /* Validate the Checkbox is initially toggled OFF */
-    await expect(await CheckboxV1PageObject.isCheckboxChecked()).toBeFalsy('The primary checkbox should initially be toggled off.');
+    await expect(await CheckboxV1PageObject.isCheckboxChecked())
+      .withContext('The primary checkbox should initially be toggled off.')
+      .toBeFalsy();
 
     /* Click on the Checkbox to toggle on */
     await CheckboxV1PageObject.click(CheckboxV1PageObject._primaryComponent);
@@ -101,12 +103,16 @@ describe('CheckboxV1 Functional Testing', () => {
       await CheckboxV1PageObject.waitForCheckboxToggle(false, 'The primary checkbox should have been toggled off via click.'),
     ).toBeTruthy();
 
-    await expect(await CheckboxV1PageObject.didAssertPopup()).toBeFalsy(CheckboxV1PageObject.ERRORMESSAGE_ASSERT);
+    await expect(await CheckboxV1PageObject.didAssertPopup())
+      .withContext(CheckboxV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it("Press 'Space' on the primary checkbox. Validate that the Checkbox toggles correctly AND calls the user's onChange() callback.", async () => {
     /* Validate the Checkbox is initially toggled OFF */
-    await expect(await CheckboxV1PageObject.isCheckboxChecked()).toBeFalsy('The primary checkbox should initially be toggled off.');
+    await expect(await CheckboxV1PageObject.isCheckboxChecked())
+      .withContext('The primary checkbox should initially be toggled off.')
+      .toBeFalsy();
 
     /* Presses the "space bar" to select the Checkbox */
     await CheckboxV1PageObject.sendKeys(CheckboxV1PageObject._primaryComponent, [Keys.SPACE]);
@@ -126,6 +132,8 @@ describe('CheckboxV1 Functional Testing', () => {
       await CheckboxV1PageObject.waitForCheckboxToggle(false, "The primary checkbox should have been toggled off via 'Space' press."),
     ).toBeTruthy();
 
-    await expect(await CheckboxV1PageObject.didAssertPopup()).toBeFalsy(CheckboxV1PageObject.ERRORMESSAGE_ASSERT);
+    await expect(await CheckboxV1PageObject.didAssertPopup())
+      .withContext(CheckboxV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 });

--- a/apps/E2E/src/Chip/specs/Chip.spec.android.ts
+++ b/apps/E2E/src/Chip/specs/Chip.spec.android.ts
@@ -14,7 +14,9 @@ describe('Chip Testing Initialization', () => {
     /* Expand E2E section */
     expect(await ChipPageObject.enableE2ETesterMode()).toBeTrue();
 
-    await expect(await ChipPageObject.didAssertPopup()).toBeFalsy(ChipPageObject.ERRORMESSAGE_ASSERT);
+    await expect(await ChipPageObject.didAssertPopup())
+      .withContext(ChipPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 });
 
@@ -35,6 +37,8 @@ describe('Chip Functional Testing', () => {
       'OnPress callback failing.',
     );
     await expect(await ChipPageObject.verifyTextContent(CHIP_CALLBACK_TEXT_END_STATE)).toBeTruthy();
-    await expect(await ChipPageObject.didAssertPopup()).toBeFalsy(ChipPageObject.ERRORMESSAGE_ASSERT);
+    await expect(await ChipPageObject.didAssertPopup())
+      .withContext(ChipPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 });

--- a/apps/E2E/src/ColorTokens/specs/ColorTokens.spec.win.ts
+++ b/apps/E2E/src/ColorTokens/specs/ColorTokens.spec.win.ts
@@ -9,6 +9,8 @@ describe('Color Tokens Testing Initialization', () => {
   it('Click and navigate to Color Tokens test page', async () => {
     expect(await ColorTokenPageObject.navigateToPageAndLoadTests()).toBeTrue();
 
-    await expect(await ColorTokenPageObject.didAssertPopup()).toBeFalsy(ColorTokenPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    await expect(await ColorTokenPageObject.didAssertPopup())
+      .withContext(ColorTokenPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 });

--- a/apps/E2E/src/ContextualMenu/specs/ContextualMenu.spec.win.ts
+++ b/apps/E2E/src/ContextualMenu/specs/ContextualMenu.spec.win.ts
@@ -13,7 +13,9 @@ describe('ContextualMenu Testing Initialization', () => {
     /* Expand E2E section */
     expect(await ContextualMenuPageObject.enableE2ETesterMode()).toBeTrue();
 
-    await expect(await ContextualMenuPageObject.didAssertPopup()).toBeFalsy(ContextualMenuPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    await expect(await ContextualMenuPageObject.didAssertPopup())
+      .withContext(ContextualMenuPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 });
 
@@ -31,7 +33,9 @@ describe('ContextualMenu Functional Tests', () => {
 
     await expect(await ContextualMenuPageObject.waitForContextualMenuItemsToDisplay(PAGE_TIMEOUT)).toBeTruthy();
 
-    await expect(await ContextualMenuPageObject.didAssertPopup()).toBeFalsy(ContextualMenuPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    await expect(await ContextualMenuPageObject.didAssertPopup())
+      .withContext(ContextualMenuPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 
   it("Type 'SPACE' on ContextualMenu Button. Validate that the menu opens by checking if its items are displayed.", async () => {
@@ -40,7 +44,9 @@ describe('ContextualMenu Functional Tests', () => {
 
     await expect(await ContextualMenuPageObject.waitForContextualMenuItemsToDisplay(PAGE_TIMEOUT)).toBeTruthy();
 
-    await expect(await ContextualMenuPageObject.didAssertPopup()).toBeFalsy(ContextualMenuPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    await expect(await ContextualMenuPageObject.didAssertPopup())
+      .withContext(ContextualMenuPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 
   it("Type 'ENTER' on ContextualMenu Button. Validate that the menu opens by checking if its items are displayed.", async () => {
@@ -49,7 +55,9 @@ describe('ContextualMenu Functional Tests', () => {
 
     await expect(await ContextualMenuPageObject.waitForContextualMenuItemsToDisplay(PAGE_TIMEOUT)).toBeTruthy();
 
-    await expect(await ContextualMenuPageObject.didAssertPopup()).toBeFalsy(ContextualMenuPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    await expect(await ContextualMenuPageObject.didAssertPopup())
+      .withContext(ContextualMenuPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 
   /* Runs after all tests. This ensures the ContextualMenu closes. If it stays open, the test driver won't be able to close the test app */

--- a/apps/E2E/src/CornerRadiusTokens/specs/CornerRadiusTokens.spec.win.ts
+++ b/apps/E2E/src/CornerRadiusTokens/specs/CornerRadiusTokens.spec.win.ts
@@ -9,6 +9,8 @@ describe('CornerRadiusTokens Testing Initialization', () => {
   it('Click and navigate to CornerRadiusTokens test page', async () => {
     expect(await CornerRadiusTokensPageObject.navigateToPageAndLoadTests()).toBeTrue();
 
-    await expect(await CornerRadiusTokensPageObject.didAssertPopup()).toBeFalsy(CornerRadiusTokensPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    await expect(await CornerRadiusTokensPageObject.didAssertPopup())
+      .withContext(CornerRadiusTokensPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 });

--- a/apps/E2E/src/Divider/specs/Divider.spec.android.ts
+++ b/apps/E2E/src/Divider/specs/Divider.spec.android.ts
@@ -10,6 +10,8 @@ describe('Divider Testing Initialization', () => {
     /* Click on component button to navigate to test page */
     expect(await DividerPageObject.navigateToPageAndLoadTests()).toBeTrue();
 
-    expect(await DividerPageObject.didAssertPopup()).toBeFalsy(DividerPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    expect(await DividerPageObject.didAssertPopup())
+      .withContext(DividerPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 });

--- a/apps/E2E/src/Divider/specs/Divider.spec.win.ts
+++ b/apps/E2E/src/Divider/specs/Divider.spec.win.ts
@@ -10,6 +10,8 @@ describe('Divider Testing Initialization', () => {
     /* Click on component button to navigate to test page */
     expect(await DividerPageObject.navigateToPageAndLoadTests()).toBeTrue();
 
-    expect(await DividerPageObject.didAssertPopup()).toBeFalsy(DividerPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    expect(await DividerPageObject.didAssertPopup())
+      .withContext(DividerPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 });

--- a/apps/E2E/src/FocusTrapZone/specs/FocusTrapZone.spec.win.ts
+++ b/apps/E2E/src/FocusTrapZone/specs/FocusTrapZone.spec.win.ts
@@ -10,6 +10,8 @@ describe('FocusTrapZone Testing Initialization', () => {
     /* Click on component button to navigate to test page */
     expect(await FocusTrapZonePageObject.navigateToPageAndLoadTests()).toBeTrue();
 
-    await expect(await FocusTrapZonePageObject.didAssertPopup()).toBeFalsy(FocusTrapZonePageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    await expect(await FocusTrapZonePageObject.didAssertPopup())
+      .withContext(FocusTrapZonePageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 });

--- a/apps/E2E/src/FocusZone/specs/FocusZone.spec.win.ts
+++ b/apps/E2E/src/FocusZone/specs/FocusZone.spec.win.ts
@@ -11,10 +11,12 @@ describe('FocusZone Testing Initialization', () => {
     /* Click on component button to navigate to test page */
     expect(await FocusZonePageObject.navigateToPageAndLoadTests()).toBeTrue();
 
-   /* Expand E2E section */
-   expect(await FocusZonePageObject.enableE2ETesterMode()).toBeTrue();
+    /* Expand E2E section */
+    expect(await FocusZonePageObject.enableE2ETesterMode()).toBeTrue();
 
-    await expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    await expect(await FocusZonePageObject.didAssertPopup())
+      .withContext(FocusZonePageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 });
 
@@ -44,7 +46,9 @@ describe('FocusZone Functional Testing', () => {
       await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton(3), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
+    expect(await FocusZonePageObject.didAssertPopup())
+      .withContext(FocusZonePageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Navigate horizontal focuszone using arrow keys. Validate focus switches correctly.', async () => {
@@ -67,7 +71,9 @@ describe('FocusZone Functional Testing', () => {
       await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton(3), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
+    expect(await FocusZonePageObject.didAssertPopup())
+      .withContext(FocusZonePageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Navigates vertical focuszone using arrow keys. Validate focus switches correctly.', async () => {
@@ -91,7 +97,9 @@ describe('FocusZone Functional Testing', () => {
       await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton(3), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
+    expect(await FocusZonePageObject.didAssertPopup())
+      .withContext(FocusZonePageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Navigates none-direction focuszone using arrow keys. Validate focus does not switch.', async () => {
@@ -118,7 +126,9 @@ describe('FocusZone Functional Testing', () => {
       await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton(2), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
+    expect(await FocusZonePageObject.didAssertPopup())
+      .withContext(FocusZonePageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Navigates bi-directional focuszone with 2d navigation. Validate focus switches correctly.', async () => {
@@ -134,7 +144,9 @@ describe('FocusZone Functional Testing', () => {
       await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton(5), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
+    expect(await FocusZonePageObject.didAssertPopup())
+      .withContext(FocusZonePageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it("Navigates focuszone with circular navigation off. Validate focus between start and end doesn't switch.", async () => {
@@ -148,7 +160,9 @@ describe('FocusZone Functional Testing', () => {
       await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton(9), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
+    expect(await FocusZonePageObject.didAssertPopup())
+      .withContext(FocusZonePageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Navigates focuszone with circular navigation on. Validate focus between start and end switches.', async () => {
@@ -164,7 +178,9 @@ describe('FocusZone Functional Testing', () => {
       await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton(1), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
+    expect(await FocusZonePageObject.didAssertPopup())
+      .withContext(FocusZonePageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Navigates disabled focuszone by arrow keys. Validate focus switches correctly.', async () => {
@@ -191,7 +207,9 @@ describe('FocusZone Functional Testing', () => {
       await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton(2), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
+    expect(await FocusZonePageObject.didAssertPopup())
+      .withContext(FocusZonePageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Tabs in and out of the FocusZone. Validate focus switches correctly.', async () => {
@@ -215,7 +233,9 @@ describe('FocusZone Functional Testing', () => {
       await FocusZonePageObject.compareAttribute(FocusZonePageObject._beforeButton, Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
+    expect(await FocusZonePageObject.didAssertPopup())
+      .withContext(FocusZonePageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Tabs in and out of the FocusZone with a defaultTabbableElement set. Validate focus switches to the defaultTabbableElement.', async () => {
@@ -253,6 +273,8 @@ describe('FocusZone Functional Testing', () => {
       await FocusZonePageObject.compareAttribute(FocusZonePageObject.gridButton(4), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    expect(await FocusZonePageObject.didAssertPopup()).toBeFalsy(FocusZonePageObject.ERRORMESSAGE_ASSERT);
+    expect(await FocusZonePageObject.didAssertPopup())
+      .withContext(FocusZonePageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 });

--- a/apps/E2E/src/IconLegacy/specs/IconLegacy.spec.win.ts
+++ b/apps/E2E/src/IconLegacy/specs/IconLegacy.spec.win.ts
@@ -9,6 +9,8 @@ describe('Icon Legacy Testing Initialization', () => {
   it('Click and navigate to Icon Legacy test page', async () => {
     expect(await IconLegacyPageObject.navigateToPageAndLoadTests()).toBeTrue();
 
-    await expect(await IconLegacyPageObject.didAssertPopup()).toBeFalsy(IconLegacyPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    await expect(await IconLegacyPageObject.didAssertPopup())
+      .withContext(IconLegacyPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 });

--- a/apps/E2E/src/IconV1/specs/IconV1.spec.win.ts
+++ b/apps/E2E/src/IconV1/specs/IconV1.spec.win.ts
@@ -14,7 +14,9 @@ describe('IconV1 Testing Initialization', () => {
     /* Expand E2E section */
     expect(await IconV1PageObject.enableE2ETesterMode()).toBeTrue();
 
-    await expect(await IconV1PageObject.didAssertPopup()).toBeFalsy(IconV1PageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    await expect(await IconV1PageObject.didAssertPopup())
+      .withContext(IconV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 });
 
@@ -28,7 +30,9 @@ describe('IconV1 Accessibility Testing', () => {
       await IconV1PageObject.compareAttribute(IconV1PageObject._primaryComponent, Attribute.AccessibilityLabel, ICON_ACCESSIBILITY_LABEL),
     ).toBeTruthy();
 
-    await expect(await IconV1PageObject.didAssertPopup()).toBeFalsy(IconV1PageObject.ERRORMESSAGE_ASSERT);
+    await expect(await IconV1PageObject.didAssertPopup())
+      .withContext(IconV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Set Font Icon "accessibilityLabel" prop. Validate "accessibilityLabel" value propagates to "Name" element attribute.', async () => {
@@ -36,7 +40,9 @@ describe('IconV1 Accessibility Testing', () => {
       await IconV1PageObject.compareAttribute(IconV1PageObject._secondaryComponent, Attribute.AccessibilityLabel, ICON_ACCESSIBILITY_LABEL),
     ).toBeTruthy();
 
-    await expect(await IconV1PageObject.didAssertPopup()).toBeFalsy(IconV1PageObject.ERRORMESSAGE_ASSERT);
+    await expect(await IconV1PageObject.didAssertPopup())
+      .withContext(IconV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Validate IconV1\'s "accessibilityRole" defaults to "ControlType.Image".', async () => {
@@ -44,6 +50,8 @@ describe('IconV1 Accessibility Testing', () => {
       await IconV1PageObject.compareAttribute(IconV1PageObject._primaryComponent, Attribute.AccessibilityRole, IMAGE_A11Y_ROLE),
     ).toBeTruthy();
 
-    await expect(await IconV1PageObject.didAssertPopup()).toBeFalsy(IconV1PageObject.ERRORMESSAGE_ASSERT);
+    await expect(await IconV1PageObject.didAssertPopup())
+      .withContext(IconV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 });

--- a/apps/E2E/src/Input/specs/Input.spec.android.ts
+++ b/apps/E2E/src/Input/specs/Input.spec.android.ts
@@ -5,7 +5,7 @@ import InputPageObject from '../pages/InputPageObject';
 // Before testing begins, allow up to 60 seconds for app to open
 describe('Input Testing Initialization', () => {
   it('Wait for app load', async () => {
-      expect(await InputPageObject.waitForInitialPageToDisplay()).toBeTrue();
+    expect(await InputPageObject.waitForInitialPageToDisplay()).toBeTrue();
   });
 
   it('Click and navigate to Input test page', async () => {
@@ -14,7 +14,9 @@ describe('Input Testing Initialization', () => {
     /* Expand E2E section */
     expect(await InputPageObject.enableE2ETesterMode()).toBeTrue();
 
-    await expect(await InputPageObject.didAssertPopup()).toBeFalsy(InputPageObject.ERRORMESSAGE_ASSERT);
+    await expect(await InputPageObject.didAssertPopup())
+      .withContext(InputPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 });
 
@@ -53,25 +55,35 @@ describe('Input Functional Testing', () => {
     await InputPageObject.typeText(INPUT_TYPE_STRING);
     await expect(await InputPageObject.waitForStringUpdate(INPUT_START_STRING + INPUT_TYPE_STRING, 'Text typing failing.'));
     await expect(await InputPageObject.verifyTextContent(INPUT_START_STRING + INPUT_TYPE_STRING)).toBeTruthy();
-    await expect(await InputPageObject.didAssertPopup()).toBeFalsy(InputPageObject.ERRORMESSAGE_ASSERT);
+    await expect(await InputPageObject.didAssertPopup())
+      .withContext(InputPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Validate error state was achieved', async () => {
     await InputPageObject.click(InputPageObject._primaryComponent);
-    await expect(await InputPageObject.didAssertPopup()).toBeFalsy(InputPageObject.ERRORMESSAGE_ASSERT);
+    await expect(await InputPageObject.didAssertPopup())
+      .withContext(InputPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
 
     await InputPageObject.typeText(INPUT_TYPE_STRING);
     await expect(await InputPageObject.waitForStringUpdate(INPUT_ERROR_STRING, 'Error state not achieved.'));
     await expect(await InputPageObject.verifyTextContent(INPUT_ERROR_STRING)).toBeTruthy();
-    await expect(await InputPageObject.didAssertPopup()).toBeFalsy(InputPageObject.ERRORMESSAGE_ASSERT);
+    await expect(await InputPageObject.didAssertPopup())
+      .withContext(InputPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Validate accessory icon OnPress() callback was fired -> Click', async () => {
     await InputPageObject.click(InputPageObject._accessoryButton);
-    await expect(await InputPageObject.didAssertPopup()).toBeFalsy(InputPageObject.ERRORMESSAGE_ASSERT);
+    await expect(await InputPageObject.didAssertPopup())
+      .withContext(InputPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
 
     await expect(await InputPageObject.waitForStringUpdate(INPUT_ONCLICK_STRING, 'OnPress callback failing.'));
     await expect(await InputPageObject.verifyTextContent(INPUT_ONCLICK_STRING)).toBeTruthy();
-    await expect(await InputPageObject.didAssertPopup()).toBeFalsy(InputPageObject.ERRORMESSAGE_ASSERT);
+    await expect(await InputPageObject.didAssertPopup())
+      .withContext(InputPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 });

--- a/apps/E2E/src/LinkLegacy/specs/LinkLegacy.spec.win.ts
+++ b/apps/E2E/src/LinkLegacy/specs/LinkLegacy.spec.win.ts
@@ -14,7 +14,9 @@ describe('Link Testing Initialization', () => {
     /* Expand E2E section */
     expect(await LinkLegacyPageObject.enableE2ETesterMode()).toBeTrue();
 
-    await expect(await LinkLegacyPageObject.didAssertPopup()).toBeFalsy(LinkLegacyPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    await expect(await LinkLegacyPageObject.didAssertPopup())
+      .withContext(LinkLegacyPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 });
 

--- a/apps/E2E/src/LinkV1/specs/LinkV1.spec.win.ts
+++ b/apps/E2E/src/LinkV1/specs/LinkV1.spec.win.ts
@@ -14,7 +14,9 @@ describe('LinkV1 Testing Initialization', () => {
     /* Expand E2E section */
     expect(await LinkV1PageObject.enableE2ETesterMode()).toBeTrue();
 
-    await expect(await LinkV1PageObject.didAssertPopup()).toBeFalsy(LinkV1PageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    await expect(await LinkV1PageObject.didAssertPopup())
+      .withContext(LinkV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 });
 
@@ -50,7 +52,9 @@ describe('Link Testing Functionality', () => {
     await expect(
       await LinkV1PageObject.didOnPressCallbackFire(`The link failed to fire an onPress callback with a mouse click.`),
     ).toBeTruthy();
-    await expect(await LinkV1PageObject.didAssertPopup()).toBeFalsy(LinkV1PageObject.ERRORMESSAGE_ASSERT);
+    await expect(await LinkV1PageObject.didAssertPopup())
+      .withContext(LinkV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Validate OnPress() callback was fired after hitting "Enter"', async () => {
@@ -58,7 +62,9 @@ describe('Link Testing Functionality', () => {
     await expect(
       await LinkV1PageObject.didOnPressCallbackFire(`The link failed to fire an OnPress callback with an enter keypress.`),
     ).toBeTruthy();
-    await expect(await LinkV1PageObject.didAssertPopup()).toBeFalsy(LinkV1PageObject.ERRORMESSAGE_ASSERT);
+    await expect(await LinkV1PageObject.didAssertPopup())
+      .withContext(LinkV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Validate OnPress() callback was fired after hitting "SPACE"', async () => {
@@ -66,6 +72,8 @@ describe('Link Testing Functionality', () => {
     await expect(
       await LinkV1PageObject.didOnPressCallbackFire(`The link failed to fire an OnPress callback with a space keypress.`),
     ).toBeTruthy();
-    await expect(await LinkV1PageObject.didAssertPopup()).toBeFalsy(LinkV1PageObject.ERRORMESSAGE_ASSERT);
+    await expect(await LinkV1PageObject.didAssertPopup())
+      .withContext(LinkV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 });

--- a/apps/E2E/src/Menu/specs/Menu.spec.win.ts
+++ b/apps/E2E/src/Menu/specs/Menu.spec.win.ts
@@ -15,7 +15,9 @@ describe('Menu Testing Initialization', () => {
     /* Expand E2E section */
     expect(await MenuPageObject.enableE2ETesterMode()).toBeTrue();
 
-    expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    expect(await MenuPageObject.didAssertPopup())
+      .withContext(MenuPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 });
 
@@ -59,7 +61,9 @@ describe('Menu Accessibility Testing', () => {
       await MenuPageObject.compareAttribute(MenuPageObject._menuTrigger, Attribute.ExpandCollapseState, AttributeValue.collapsed),
     ).toBeTruthy();
 
-    expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
+    expect(await MenuPageObject.didAssertPopup())
+      .withContext(MenuPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 });
 
@@ -75,21 +79,27 @@ describe('Menu Functional Testing', () => {
     await MenuPageObject.click(MenuPageObject._menuTrigger);
     expect(await MenuPageObject.waitForMenuToOpen()).toBeTruthy();
 
-    expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
+    expect(await MenuPageObject.didAssertPopup())
+      .withContext(MenuPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Press "Enter" on MenuTrigger. Validate Menu is opened by checking if MenuItems are visible.', async () => {
     await MenuPageObject.sendKeys(MenuPageObject._menuTrigger, [Keys.ENTER]);
     expect(await MenuPageObject.waitForMenuToOpen()).toBeTruthy();
 
-    expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
+    expect(await MenuPageObject.didAssertPopup())
+      .withContext(MenuPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Press "Space" on MenuTrigger. Validate Menu is opened by checking if MenuItems are visible.', async () => {
     await MenuPageObject.sendKeys(MenuPageObject._menuTrigger, [Keys.SPACE]);
     expect(await MenuPageObject.waitForMenuToOpen()).toBeTruthy();
 
-    expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
+    expect(await MenuPageObject.didAssertPopup())
+      .withContext(MenuPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Press "Space", Press "Enter", and "Click" on MenuItem. Validate that onClick() callback fires correctly.', async () => {
@@ -104,7 +114,9 @@ describe('Menu Functional Testing', () => {
     await MenuPageObject.click(MenuPageObject.getMenuItem('First'));
     expect(await MenuPageObject.waitForItemCallbackToFire(3, 'Click input failed to fire MenuItem onClick callback')).toBeTrue();
 
-    expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
+    expect(await MenuPageObject.didAssertPopup())
+      .withContext(MenuPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Press "Space", Press "Enter", and "Click" on disabled MenuItem. Validate that onClick() callback does not fire.', async () => {
@@ -120,7 +132,9 @@ describe('Menu Functional Testing', () => {
     await MenuPageObject.click(MenuPageObject.getMenuItem('Second'));
     expect(await MenuPageObject.waitForItemCallbackToFire(0, 'Click input fired disabled MenuItem onClick callback')).toBeTrue();
 
-    expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
+    expect(await MenuPageObject.didAssertPopup())
+      .withContext(MenuPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Press "Up" + "Down" to navigate between MenuItems. Validate that focus switches correctly between MenuItems.', async () => {
@@ -141,7 +155,9 @@ describe('Menu Functional Testing', () => {
       await MenuPageObject.compareAttribute(MenuPageObject.getMenuItem('Fourth'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
+    expect(await MenuPageObject.didAssertPopup())
+      .withContext(MenuPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Press "Tab" to navigate between MenuItems. Validate that focus switches correctly between MenuItems.', async () => {
@@ -157,7 +173,9 @@ describe('Menu Functional Testing', () => {
       await MenuPageObject.compareAttribute(MenuPageObject.getMenuItem('First'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
+    expect(await MenuPageObject.didAssertPopup())
+      .withContext(MenuPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Press "Escape" on MenuItem. Validate that Menu closes by checking if MenuItems are not visible.', async () => {
@@ -168,6 +186,8 @@ describe('Menu Functional Testing', () => {
       'Expected the Menu to close, but its MenuItems are still displayed - the menu appears to still be open.',
     );
 
-    expect(await MenuPageObject.didAssertPopup()).toBeFalsy(MenuPageObject.ERRORMESSAGE_ASSERT);
+    expect(await MenuPageObject.didAssertPopup())
+      .withContext(MenuPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 });

--- a/apps/E2E/src/MenuButtonLegacy/specs/MenuButtonLegacy.spec.macos.ts
+++ b/apps/E2E/src/MenuButtonLegacy/specs/MenuButtonLegacy.spec.macos.ts
@@ -9,6 +9,8 @@ describe('MenuButton Legacy Testing Initialization', () => {
   it('Click and navigate to MenuButton Legacy test page', async () => {
     expect(await MenuButtonLegacyPageObject.navigateToPageAndLoadTests()).toBeTrue();
 
-    await expect(await MenuButtonLegacyPageObject.isPageLoaded()).toBeTruthy(MenuButtonLegacyPageObject.ERRORMESSAGE_PAGELOAD);
+    await expect(await MenuButtonLegacyPageObject.isPageLoaded())
+      .withContext(MenuButtonLegacyPageObject.ERRORMESSAGE_PAGELOAD)
+      .toBeTruthy();
   });
 });

--- a/apps/E2E/src/MenuButtonLegacy/specs/MenuButtonLegacy.spec.win.ts
+++ b/apps/E2E/src/MenuButtonLegacy/specs/MenuButtonLegacy.spec.win.ts
@@ -14,7 +14,9 @@ describe('MenuButton Legacy Testing Initialization', () => {
     /* Expand E2E section */
     expect(await MenuButtonLegacyPageObject.enableE2ETesterMode()).toBeTrue();
 
-    await expect(await MenuButtonLegacyPageObject.didAssertPopup()).toBeFalsy(MenuButtonLegacyPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    await expect(await MenuButtonLegacyPageObject.didAssertPopup())
+      .withContext(MenuButtonLegacyPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 });
 
@@ -71,7 +73,9 @@ describe('MenuButton Legacy Functional Testing', () => {
       await MenuButtonLegacyPageObject.waitForMenuItemToDisplay('Clicked MenuButton, but menu items failed to display before timeout.'),
     ).toBeTruthy();
 
-    await expect(await MenuButtonLegacyPageObject.didAssertPopup()).toBeFalsy(MenuButtonLegacyPageObject.ERRORMESSAGE_ASSERT);
+    await expect(await MenuButtonLegacyPageObject.didAssertPopup())
+      .withContext(MenuButtonLegacyPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Type "SPACE" on first MenuButton. Validate that its list of Menu Items display.', async () => {
@@ -84,7 +88,9 @@ describe('MenuButton Legacy Functional Testing', () => {
       ),
     ).toBeTruthy();
 
-    await expect(await MenuButtonLegacyPageObject.didAssertPopup()).toBeFalsy(MenuButtonLegacyPageObject.ERRORMESSAGE_ASSERT);
+    await expect(await MenuButtonLegacyPageObject.didAssertPopup())
+      .withContext(MenuButtonLegacyPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   /* Runs after all tests. This ensures the MenuButton closes. If it stays open, the test driver won't be able to close the test app */

--- a/apps/E2E/src/MenuButtonV1/specs/MenuButtonV1.spec.win.ts
+++ b/apps/E2E/src/MenuButtonV1/specs/MenuButtonV1.spec.win.ts
@@ -14,7 +14,9 @@ describe('MenuButtonV1 Testing Initialization', () => {
     /* Expand E2E section */
     expect(await MenuButtonV1PageObject.enableE2ETesterMode()).toBeTrue();
 
-    await expect(await MenuButtonV1PageObject.didAssertPopup()).toBeFalsy(MenuButtonV1PageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    await expect(await MenuButtonV1PageObject.didAssertPopup())
+      .withContext(MenuButtonV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 });
 

--- a/apps/E2E/src/Persona/specs/Persona.spec.win.ts
+++ b/apps/E2E/src/Persona/specs/Persona.spec.win.ts
@@ -9,6 +9,8 @@ describe('Persona Testing Initialization', () => {
   it('Click and navigate to Persona test page', async () => {
     expect(await PersonaPageObject.navigateToPageAndLoadTests()).toBeTrue();
 
-    await expect(await PersonaPageObject.didAssertPopup()).toBeFalsy(PersonaPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    await expect(await PersonaPageObject.didAssertPopup())
+      .withContext(PersonaPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 });

--- a/apps/E2E/src/PersonaCoin/specs/PersonaCoin.spec.win.ts
+++ b/apps/E2E/src/PersonaCoin/specs/PersonaCoin.spec.win.ts
@@ -9,6 +9,8 @@ describe('PersonaCoin Testing Initialization', () => {
   it('Click and navigate to PersonaCoin test page', async () => {
     expect(await PersonaCoinPageObject.navigateToPageAndLoadTests()).toBeTrue();
 
-    await expect(await PersonaCoinPageObject.didAssertPopup()).toBeFalsy(PersonaCoinPageObject.ERRORMESSAGE_ASSERT);
+    await expect(await PersonaCoinPageObject.didAssertPopup())
+      .withContext(PersonaCoinPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 });

--- a/apps/E2E/src/Pressable/specs/Pressable.spec.win.ts
+++ b/apps/E2E/src/Pressable/specs/Pressable.spec.win.ts
@@ -9,6 +9,8 @@ describe('Pressable Testing Initialization', () => {
   it('Click and navigate to Pressable test page', async () => {
     expect(await PressablePageObject.navigateToPageAndLoadTests()).toBeTrue();
 
-    await expect(await PressablePageObject.didAssertPopup()).toBeFalsy(PressablePageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    await expect(await PressablePageObject.didAssertPopup())
+      .withContext(PressablePageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 });

--- a/apps/E2E/src/RadioGroupLegacy/specs/RadioGroupLegacy.spec.win.ts
+++ b/apps/E2E/src/RadioGroupLegacy/specs/RadioGroupLegacy.spec.win.ts
@@ -19,7 +19,9 @@ describe('RadioGroup/RadioButton Legacy Testing Initialization', () => {
     /* Expand E2E section */
     expect(await RadioGroupPageObject.enableE2ETesterMode()).toBeTrue();
 
-    await expect(await RadioGroupPageObject.didAssertPopup()).toBeFalsy(RadioGroupPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    await expect(await RadioGroupPageObject.didAssertPopup())
+      .withContext(RadioGroupPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 });
 
@@ -108,7 +110,9 @@ describe('RadioGroup Legacy Functional Testing', () => {
       await RadioGroupPageObject.waitForRadioButtonSelected('Second', 'Clicked the second RadioButton, but it failed to be selected.'),
     ).toBeTruthy();
 
-    expect(await RadioGroupPageObject.didAssertPopup()).toBeFalsy(RadioGroupPageObject.ERRORMESSAGE_ASSERT);
+    expect(await RadioGroupPageObject.didAssertPopup())
+      .withContext(RadioGroupPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Press forward "Arrow Key" on a RadioButton. Validate adjacent RadioButton is newly selected.', async () => {
@@ -123,7 +127,9 @@ describe('RadioGroup Legacy Functional Testing', () => {
       ),
     ).toBeTruthy();
 
-    expect(await RadioGroupPageObject.didAssertPopup()).toBeFalsy(RadioGroupPageObject.ERRORMESSAGE_ASSERT);
+    expect(await RadioGroupPageObject.didAssertPopup())
+      .withContext(RadioGroupPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Press forward "Arrow Key" on a RadioButton adjacent to a disabled RadioButton. Validate disabled RadioButton is skipped.', async () => {
@@ -138,6 +144,8 @@ describe('RadioGroup Legacy Functional Testing', () => {
       ),
     ).toBeTruthy(); // It should skip RadioButton 3 since it is disabled
 
-    expect(await RadioGroupPageObject.didAssertPopup()).toBeFalsy(RadioGroupPageObject.ERRORMESSAGE_ASSERT);
+    expect(await RadioGroupPageObject.didAssertPopup())
+      .withContext(RadioGroupPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 });

--- a/apps/E2E/src/RadioGroupV1/specs/RadioGroupV1.spec.android.ts
+++ b/apps/E2E/src/RadioGroupV1/specs/RadioGroupV1.spec.android.ts
@@ -14,7 +14,9 @@ describe('RadioGroupV1/RadioV1 Testing Initialization', () => {
     /* Expand E2E section */
     expect(await RadioGroupV1PageObject.enableE2ETesterMode()).toBeTrue();
 
-    await expect(await RadioGroupV1PageObject.didAssertPopup()).toBeFalsy(RadioGroupV1PageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    await expect(await RadioGroupV1PageObject.didAssertPopup())
+      .withContext(RadioGroupV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 });
 
@@ -32,7 +34,9 @@ describe('RadioGroupV1/RadioV1 Accessibility Testing', () => {
         RADIOGROUPV1_TEST_COMPONENT,
       ),
     ).toBeTruthy();
-    expect(await RadioGroupV1PageObject.didAssertPopup()).toBeFalsy(RadioGroupV1PageObject.ERRORMESSAGE_ASSERT);
+    expect(await RadioGroupV1PageObject.didAssertPopup())
+      .withContext(RadioGroupV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Validate Radio Group Class on Android', async () => {
@@ -40,7 +44,9 @@ describe('RadioGroupV1/RadioV1 Accessibility Testing', () => {
       await RadioGroupV1PageObject.compareAttribute(RadioGroupV1PageObject.getRadio('First'), AndroidAttribute.Class, ANDROID_RADIOBUTTON),
     ).toBeTruthy();
 
-    expect(await RadioGroupV1PageObject.didAssertPopup()).toBeFalsy(RadioGroupV1PageObject.ERRORMESSAGE_ASSERT);
+    expect(await RadioGroupV1PageObject.didAssertPopup())
+      .withContext(RadioGroupV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 });
 
@@ -61,6 +67,8 @@ describe('RadioGroupV1 Functional Testing', async () => {
 
     /* Validate the Radio is selected */
     expect(await RadioGroupV1PageObject.waitForRadioSelected('Second', 'Expected radio #2 to be selected by click.')).toBeTruthy();
-    expect(await RadioGroupV1PageObject.didAssertPopup()).toBeFalsy(RadioGroupV1PageObject.ERRORMESSAGE_ASSERT);
+    expect(await RadioGroupV1PageObject.didAssertPopup())
+      .withContext(RadioGroupV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 });

--- a/apps/E2E/src/RadioGroupV1/specs/RadioGroupV1.spec.win.ts
+++ b/apps/E2E/src/RadioGroupV1/specs/RadioGroupV1.spec.win.ts
@@ -19,7 +19,9 @@ describe('RadioGroupV1/RadioV1 Testing Initialization', () => {
     /* Expand E2E section */
     expect(await RadioGroupV1PageObject.enableE2ETesterMode()).toBeTrue();
 
-    expect(await RadioGroupV1PageObject.didAssertPopup()).toBeFalsy(RadioGroupV1PageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    expect(await RadioGroupV1PageObject.didAssertPopup())
+      .withContext(RadioGroupV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 });
 
@@ -132,7 +134,9 @@ describe('RadioGroupV1 Functional Testing', () => {
       await RadioGroupV1PageObject.waitForRadioSelected('Second', 'Expected radio #2 to be selected by click, but #2 remained unselected.'),
     ).toBeTruthy();
 
-    expect(await RadioGroupV1PageObject.didAssertPopup()).toBeFalsy(RadioGroupV1PageObject.ERRORMESSAGE_ASSERT);
+    expect(await RadioGroupV1PageObject.didAssertPopup())
+      .withContext(RadioGroupV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Navigate to unselected radio using "DOWN ARROW" key. Validate state changes from unselected to selected.', async () => {
@@ -147,7 +151,9 @@ describe('RadioGroupV1 Functional Testing', () => {
       ),
     ).toBeTruthy();
 
-    expect(await RadioGroupV1PageObject.didAssertPopup()).toBeFalsy(RadioGroupV1PageObject.ERRORMESSAGE_ASSERT);
+    expect(await RadioGroupV1PageObject.didAssertPopup())
+      .withContext(RadioGroupV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Navigate to unselected radio using "DOWN ARROW" key. Validate disabled Radio is skipped.', async () => {
@@ -162,7 +168,9 @@ describe('RadioGroupV1 Functional Testing', () => {
       ),
     ).toBeTruthy();
 
-    expect(await RadioGroupV1PageObject.didAssertPopup()).toBeFalsy(RadioGroupV1PageObject.ERRORMESSAGE_ASSERT);
+    expect(await RadioGroupV1PageObject.didAssertPopup())
+      .withContext(RadioGroupV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Press "DOWN ARROW" on the last Radio of a RadioGroup. Validate circular navigation functions correctly.', async () => {
@@ -174,7 +182,9 @@ describe('RadioGroupV1 Functional Testing', () => {
       await RadioGroupV1PageObject.waitForRadioSelected('First', 'Expected radio #1 to be selected by a "DOWN ARROW" input from radio #4.'),
     ).toBeTruthy();
 
-    await expect(await RadioGroupV1PageObject.didAssertPopup()).toBeFalsy(RadioGroupV1PageObject.ERRORMESSAGE_ASSERT);
+    await expect(await RadioGroupV1PageObject.didAssertPopup())
+      .withContext(RadioGroupV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Press "TAB" on a Radio. Validate Radio in the next RadioGroup is focused.', async () => {
@@ -189,6 +199,8 @@ describe('RadioGroupV1 Functional Testing', () => {
       ),
     ).toBeTruthy();
 
-    await expect(await RadioGroupV1PageObject.didAssertPopup()).toBeFalsy(RadioGroupV1PageObject.ERRORMESSAGE_ASSERT);
+    await expect(await RadioGroupV1PageObject.didAssertPopup())
+      .withContext(RadioGroupV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 });

--- a/apps/E2E/src/Separator/specs/Separator.spec.win.ts
+++ b/apps/E2E/src/Separator/specs/Separator.spec.win.ts
@@ -9,6 +9,8 @@ describe('Separator Testing Initialization', () => {
   it('Click and navigate to Separator test page', async () => {
     expect(await SeparatorPageObject.navigateToPageAndLoadTests()).toBeTrue();
 
-    await expect(await SeparatorPageObject.didAssertPopup()).toBeFalsy(SeparatorPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    await expect(await SeparatorPageObject.didAssertPopup())
+      .withContext(SeparatorPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 });

--- a/apps/E2E/src/Shadow/specs/Shadow.spec.win.ts
+++ b/apps/E2E/src/Shadow/specs/Shadow.spec.win.ts
@@ -7,9 +7,10 @@ describe('Shadow Testing Initialization', () => {
   });
 
   it('Click and navigate to Shadow test page', async () => {
-
     expect(await ShadowPageObject.navigateToPageAndLoadTests()).toBeTrue();
 
-    await expect(await ShadowPageObject.didAssertPopup()).toBeFalsy(ShadowPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    await expect(await ShadowPageObject.didAssertPopup())
+      .withContext(ShadowPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 });

--- a/apps/E2E/src/Shimmer/specs/Shimmer.spec.android.ts
+++ b/apps/E2E/src/Shimmer/specs/Shimmer.spec.android.ts
@@ -9,6 +9,8 @@ describe('Shimmer Testing Initialization', () => {
   it('Click and navigate to Shimmer test page', async () => {
     expect(await ShimmerPageObject.navigateToPageAndLoadTests()).toBeTrue();
 
-    await expect(await ShimmerPageObject.didAssertPopup()).toBeFalsy(ShimmerPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    await expect(await ShimmerPageObject.didAssertPopup())
+      .withContext(ShimmerPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 });

--- a/apps/E2E/src/Shimmer/specs/Shimmer.spec.win.ts
+++ b/apps/E2E/src/Shimmer/specs/Shimmer.spec.win.ts
@@ -9,6 +9,8 @@ describe('Shimmer Testing Initialization', () => {
   it('Click and navigate to Shimmer test page', async () => {
     expect(await ShimmerPageObject.navigateToPageAndLoadTests()).toBeTrue();
 
-    await expect(await ShimmerPageObject.didAssertPopup()).toBeFalsy(ShimmerPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    await expect(await ShimmerPageObject.didAssertPopup())
+      .withContext(ShimmerPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 });

--- a/apps/E2E/src/Spacing/specs/SpacingTokens.spec.win.ts
+++ b/apps/E2E/src/Spacing/specs/SpacingTokens.spec.win.ts
@@ -9,6 +9,8 @@ describe('Spacing Token Testing Initialization', () => {
   it('Click and navigate to Spacing Tokens test page', async () => {
     expect(await SpacingTokensPageObject.navigateToPageAndLoadTests()).toBeTrue();
 
-    await expect(await SpacingTokensPageObject.didAssertPopup()).toBeFalsy(SpacingTokensPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    await expect(await SpacingTokensPageObject.didAssertPopup())
+      .withContext(SpacingTokensPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 });

--- a/apps/E2E/src/StrokeWidthTokens/specs/StrokeWidthTokens.spec.win.ts
+++ b/apps/E2E/src/StrokeWidthTokens/specs/StrokeWidthTokens.spec.win.ts
@@ -9,6 +9,8 @@ describe('Stroke Width Token Testing Initialization', () => {
   it('Click and navigate to Stroke Width Tokens test page', async () => {
     expect(await StrokeWidthTokensPageObject.navigateToPageAndLoadTests()).toBeTrue();
 
-    await expect(await StrokeWidthTokensPageObject.didAssertPopup()).toBeFalsy(StrokeWidthTokensPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    await expect(await StrokeWidthTokensPageObject.didAssertPopup())
+      .withContext(StrokeWidthTokensPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 });

--- a/apps/E2E/src/Svg/specs/Svg.spec.win.ts
+++ b/apps/E2E/src/Svg/specs/Svg.spec.win.ts
@@ -9,6 +9,8 @@ describe('Svg Testing Initialization', () => {
   it('Click and navigate to Svg test page', async () => {
     expect(await SvgPageObject.navigateToPageAndLoadTests()).toBeTrue();
 
-    await expect(await SvgPageObject.didAssertPopup()).toBeFalsy(SvgPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    await expect(await SvgPageObject.didAssertPopup())
+      .withContext(SvgPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 });

--- a/apps/E2E/src/Switch/specs/Switch.spec.win.ts
+++ b/apps/E2E/src/Switch/specs/Switch.spec.win.ts
@@ -14,7 +14,9 @@ describe('Switch Testing Initialization', () => {
     /* Expand E2E section */
     expect(await SwitchPageObject.enableE2ETesterMode()).toBeTrue();
 
-    await expect(await SwitchPageObject.didAssertPopup()).toBeFalsy(SwitchPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    await expect(await SwitchPageObject.didAssertPopup())
+      .withContext(SwitchPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 });
 
@@ -82,7 +84,9 @@ describe('Switch Functional Testing', () => {
       await SwitchPageObject.waitForSwitchStateChange(false, 'Clicked the primary switch to turn it off, but it remained on.'),
     ).toBeTruthy();
 
-    await expect(await SwitchPageObject.didAssertPopup()).toBeFalsy(SwitchPageObject.ERRORMESSAGE_ASSERT);
+    await expect(await SwitchPageObject.didAssertPopup())
+      .withContext(SwitchPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Press "ENTER" on primary Switch. Validate it toggles correctly AND calls the user\'s onChange() callback.', async () => {
@@ -112,7 +116,9 @@ describe('Switch Functional Testing', () => {
       await SwitchPageObject.waitForSwitchStateChange(false, 'Pressed "ENTER" on the primary switch to turn it off, but it remained on.'),
     ).toBeTruthy();
 
-    await expect(await SwitchPageObject.didAssertPopup()).toBeFalsy(SwitchPageObject.ERRORMESSAGE_ASSERT);
+    await expect(await SwitchPageObject.didAssertPopup())
+      .withContext(SwitchPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Press "SPACE" on primary Switch. Validate it toggles correctly AND calls the user\'s onChange() callback.', async () => {
@@ -142,6 +148,8 @@ describe('Switch Functional Testing', () => {
       await SwitchPageObject.waitForSwitchStateChange(false, 'Pressed "SPACE" on the primary switch to turn it off, but it remained on.'),
     ).toBeTruthy();
 
-    await expect(await SwitchPageObject.didAssertPopup()).toBeFalsy(SwitchPageObject.ERRORMESSAGE_ASSERT);
+    await expect(await SwitchPageObject.didAssertPopup())
+      .withContext(SwitchPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 });

--- a/apps/E2E/src/TabsLegacy/specs/TabsLegacy.spec.win.ts
+++ b/apps/E2E/src/TabsLegacy/specs/TabsLegacy.spec.win.ts
@@ -13,7 +13,9 @@ describe('Tabs Legacy Testing Initialization', () => {
     /* Expand E2E section */
     expect(await TabsLegacyPageObject.enableE2ETesterMode()).toBeTrue();
 
-    expect(await TabsLegacyPageObject.didAssertPopup()).toBeFalsy(TabsLegacyPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    expect(await TabsLegacyPageObject.didAssertPopup())
+      .withContext(TabsLegacyPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 });
 
@@ -54,7 +56,9 @@ describe('Tabs Legacy Functional Tests', () => {
         "Expected the second tab item's content to show by clicking the second tab item.",
       ),
     ).toBeTruthy();
-    expect(await TabsLegacyPageObject.didAssertPopup()).toBeFalsy(TabsLegacyPageObject.ERRORMESSAGE_ASSERT);
+    expect(await TabsLegacyPageObject.didAssertPopup())
+      .withContext(TabsLegacyPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Input the following arrow keys on the tabs: Right -> Down -> Left -> Up. Validate the correct TabItem content gets shown.', async () => {
@@ -97,6 +101,8 @@ describe('Tabs Legacy Functional Tests', () => {
         'Expected the first tab item\'s content to show by pressing "Up Arrow" on the first tab item.',
       ),
     ).toBeTruthy();
-    expect(await TabsLegacyPageObject.didAssertPopup()).toBeFalsy(TabsLegacyPageObject.ERRORMESSAGE_ASSERT);
+    expect(await TabsLegacyPageObject.didAssertPopup())
+      .withContext(TabsLegacyPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 });

--- a/apps/E2E/src/TabsLegacy/specs/TabsLegacy.spec.windows.ts
+++ b/apps/E2E/src/TabsLegacy/specs/TabsLegacy.spec.windows.ts
@@ -13,7 +13,9 @@ describe('Tabs Legacy Testing Initialization', () => {
     /* Expand E2E section */
     expect(await TabsLegacyPageObject.enableE2ETesterMode()).toBeTrue();
 
-    expect(await TabsLegacyPageObject.didAssertPopup()).toBeFalsy(TabsLegacyPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    expect(await TabsLegacyPageObject.didAssertPopup())
+      .withContext(TabsLegacyPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 });
 
@@ -54,7 +56,9 @@ describe('Tabs Legacy Functional Tests', () => {
         "Expected the second tab item's content to show by clicking the second tab item.",
       ),
     ).toBeTruthy();
-    expect(await TabsLegacyPageObject.didAssertPopup()).toBeFalsy(TabsLegacyPageObject.ERRORMESSAGE_ASSERT);
+    expect(await TabsLegacyPageObject.didAssertPopup())
+      .withContext(TabsLegacyPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   // Keyboarding is currently not integrated for UWP tabs - Task #5758598

--- a/apps/E2E/src/TabsV1/specs/TabsV1.spec.win.ts
+++ b/apps/E2E/src/TabsV1/specs/TabsV1.spec.win.ts
@@ -13,7 +13,9 @@ describe('TabsV1 Testing Initialization', () => {
     /* Expand E2E section */
     expect(await TabsV1PageObject.enableE2ETesterMode()).toBeTrue();
 
-    expect(await TabsV1PageObject.didAssertPopup()).toBeFalsy(TabsV1PageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    expect(await TabsV1PageObject.didAssertPopup())
+      .withContext(TabsV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 });
 
@@ -49,7 +51,9 @@ describe('TabsV1 Functional Tests', () => {
         "Expected the second tab item's content to show by clicking the second tab item.",
       ),
     ).toBeTruthy();
-    expect(await TabsV1PageObject.didAssertPopup()).toBeFalsy(TabsV1PageObject.ERRORMESSAGE_ASSERT);
+    expect(await TabsV1PageObject.didAssertPopup())
+      .withContext(TabsV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 
   it('Input the following arrow keys on the tabs: Right -> Down -> Left -> Up. Validate the correct TabItem content gets shown.', async () => {
@@ -93,6 +97,8 @@ describe('TabsV1 Functional Tests', () => {
       ),
     ).toBeTruthy();
 
-    expect(await TabsV1PageObject.didAssertPopup()).toBeFalsy(TabsV1PageObject.ERRORMESSAGE_ASSERT);
+    expect(await TabsV1PageObject.didAssertPopup())
+      .withContext(TabsV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 });

--- a/apps/E2E/src/TextLegacy/specs/TextLegacy.spec.win.ts
+++ b/apps/E2E/src/TextLegacy/specs/TextLegacy.spec.win.ts
@@ -14,7 +14,9 @@ describe('Text Legacy Testing Initialization', () => {
     /* Expand E2E section */
     expect(await TextLegacyPageObject.enableE2ETesterMode()).toBeTrue();
 
-    expect(await TextLegacyPageObject.didAssertPopup()).toBeFalsy(TextLegacyPageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    expect(await TextLegacyPageObject.didAssertPopup())
+      .withContext(TextLegacyPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 });
 

--- a/apps/E2E/src/TextV1/specs/TextV1.spec.win.ts
+++ b/apps/E2E/src/TextV1/specs/TextV1.spec.win.ts
@@ -14,7 +14,9 @@ describe('TextV1 Testing Initialization', () => {
     /* Expand E2E section */
     expect(await TextV1PageObject.enableE2ETesterMode()).toBeTrue();
 
-    expect(await TextV1PageObject.didAssertPopup()).toBeFalsy(TextV1PageObject.ERRORMESSAGE_ASSERT);
+    expect(await TextV1PageObject.didAssertPopup())
+      .withContext(TextV1PageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
   });
 });
 

--- a/apps/E2E/src/Theme/specs/Theme.spec.win.ts
+++ b/apps/E2E/src/Theme/specs/Theme.spec.win.ts
@@ -9,6 +9,8 @@ describe('Theme Testing Initialization', () => {
   it('Click and navigate to Theme test page', async () => {
     expect(await ThemePageObject.navigateToPageAndLoadTests()).toBeTrue();
 
-    await expect(await ThemePageObject.didAssertPopup()).toBeFalsy(ThemePageObject.ERRORMESSAGE_ASSERT); // Ensure no asserts popped up
+    await expect(await ThemePageObject.didAssertPopup())
+      .withContext(ThemePageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy(); // Ensure no asserts popped up
   });
 });

--- a/apps/E2E/src/common/NativeTesting/specs/NativeTesting.spec.win.ts
+++ b/apps/E2E/src/common/NativeTesting/specs/NativeTesting.spec.win.ts
@@ -14,9 +14,9 @@ describe('Native Safety Check Testing Initialization', () => {
   //    2) Keeps testID='SCROLLVIEW_TEST_ID'
   it('Validate the ScrollView containing all the navigational buttons exists', async () => {
     await NativeTestingPageObject.waitForScrollViewDisplayed(PAGE_TIMEOUT);
-    await expect(await NativeTestingPageObject.doesScrollViewParentExist()).toBeTruthy(
-      'The testing ScrollView containing navigation buttons to individual testPages was not displayed in time.',
-    );
+    await expect(await NativeTestingPageObject.doesScrollViewParentExist())
+      .withContext('The testing ScrollView containing navigation buttons to individual testPages was not displayed in time.')
+      .toBeTruthy();
   });
 
   // In addition to existing, we want to ensure the Children of the ScrollView stay intact. The children are the buttons that

--- a/change/@fluentui-react-native-e2e-testing-85451491-337a-4ea3-9e5f-e9370eebe10e.json
+++ b/change/@fluentui-react-native-e2e-testing-85451491-337a-4ea3-9e5f-e9370eebe10e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Replace deprecated usage of falsy/truthy methods in E2E tests",
+  "packageName": "@fluentui-react-native/e2e-testing",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

Currently, some E2E test cases spit out error messages by passing them in the `.isFalsy()` or `.isTruthy()` methods. Per webdriverio, this usage is deprecated. The correct usage is passing the error message into the `.withContext(msg)` method, before checking for falsiness/ truthiness. This PR removes all deprecated usages of `.isFalsy()` / `.isTruthy()`, replacing it with `.withContext()`. 

### Verification

Tests pass / builds locally. 

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
