### PR TITLE
Fix win32 high contrast appearance of TabList

### DIFF
--- a/change/@fluentui-react-native-tablist-0db269b9-89dd-43a1-8e69-60dda8782c85.json
+++ b/change/@fluentui-react-native-tablist-0db269b9-89dd-43a1-8e69-60dda8782c85.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix win32 high contrast theming for TabList",
+  "packageName": "@fluentui-react-native/tablist",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/TabList/package.json
+++ b/packages/experimental/TabList/package.json
@@ -31,8 +31,8 @@
     "@fluentui-react-native/framework": "0.12.0",
     "@fluentui-react-native/icon": "0.20.1",
     "@fluentui-react-native/interactive-hooks": ">=0.25.0 <1.0.0",
-    "@fluentui-react-native/theming-utils": ">=0.25.0 <1.0.0",
     "@fluentui-react-native/text": ">=0.22.0 <1.0.0",
+    "@fluentui-react-native/theming-utils": ">=0.25.0 <1.0.0",
     "@fluentui-react-native/tokens": ">=0.22.0 <1.0.0",
     "@fluentui-react-native/use-styling": ">=0.12.0 <1.0.0",
     "tslib": "^2.3.1"

--- a/packages/experimental/TabList/package.json
+++ b/packages/experimental/TabList/package.json
@@ -31,6 +31,7 @@
     "@fluentui-react-native/framework": "0.12.0",
     "@fluentui-react-native/icon": "0.20.1",
     "@fluentui-react-native/interactive-hooks": ">=0.25.0 <1.0.0",
+    "@fluentui-react-native/theming-utils": ">=0.25.0 <1.0.0",
     "@fluentui-react-native/text": ">=0.22.0 <1.0.0",
     "@fluentui-react-native/tokens": ">=0.22.0 <1.0.0",
     "@fluentui-react-native/use-styling": ">=0.12.0 <1.0.0",

--- a/packages/experimental/TabList/src/Tab/Tab.styling.ts
+++ b/packages/experimental/TabList/src/Tab/Tab.styling.ts
@@ -107,7 +107,7 @@ export const useTabSlotProps = (props: TabProps, tokens: TabTokens, theme: Theme
         style: {
           flex: 1,
           borderRadius: tokens.indicatorRadius,
-          backgroundColor: hideStaticIndicator ? theme.colors.transparentStroke : tokens.indicatorColor,
+          backgroundColor: hideStaticIndicator ? theme.colors.transparentBackground : tokens.indicatorColor,
         },
       };
     },

--- a/packages/experimental/TabList/src/Tab/TabColorTokens.ts
+++ b/packages/experimental/TabList/src/Tab/TabColorTokens.ts
@@ -1,0 +1,86 @@
+import type { Theme } from '@fluentui-react-native/framework';
+import type { TokenSettings } from '@fluentui-react-native/use-styling';
+
+import type { TabTokens } from '..';
+
+export const tabStates: (keyof TabTokens)[] = [
+  'small',
+  'medium',
+  'large',
+  'vertical',
+  'hovered',
+  'disabled',
+  'selected',
+  'focused',
+  'pressed',
+  'transparent',
+  'subtle',
+  'hasIcon',
+];
+
+export const defaultTabColorTokens: TokenSettings<TabTokens, Theme> = (t: Theme) =>
+  ({
+    borderColor: t.colors.transparentBackground,
+    color: t.colors.neutralForeground2,
+    iconColor: t.colors.neutralForeground2,
+    indicatorColor: t.colors.transparentBackground,
+    transparent: {
+      backgroundColor: t.colors.transparentBackground,
+    },
+    subtle: {
+      backgroundColor: t.colors.subtleBackground,
+    },
+    selected: {
+      color: t.colors.neutralForeground1,
+      iconColor: t.colors.compoundBrandForeground1,
+      indicatorColor: t.colors.compoundBrandStroke1,
+      pressed: {
+        color: t.colors.neutralForeground1Pressed,
+        iconColor: t.colors.compoundBrandForeground1Pressed,
+        indicatorColor: t.colors.compoundBrandStroke1Pressed,
+      },
+    },
+    disabled: {
+      color: t.colors.neutralForegroundDisabled,
+      iconColor: t.colors.neutralForegroundDisabled,
+      selected: {
+        color: t.colors.neutralForegroundDisabled,
+        iconColor: t.colors.neutralForegroundDisabled,
+        indicatorColor: t.colors.neutralForegroundDisabled,
+      },
+    },
+    hovered: {
+      color: t.colors.neutralForeground2Hover,
+      iconColor: t.colors.neutralForeground2Hover,
+      indicatorColor: t.colors.neutralStroke1Hover,
+      selected: {
+        color: t.colors.neutralForeground1Hover,
+        iconColor: t.colors.compoundBrandForeground1Hover,
+        indicatorColor: t.colors.compoundBrandStroke1Hover,
+      },
+      disabled: {
+        indicatorColor: t.colors.transparentBackground,
+      },
+      transparent: {
+        backgroundColor: t.colors.transparentBackgroundHover,
+      },
+      subtle: {
+        backgroundColor: t.colors.subtleBackgroundHover,
+        indicatorColor: t.colors.neutralStroke1Hover,
+      },
+    },
+    pressed: {
+      color: t.colors.neutralForeground2Pressed,
+      iconColor: t.colors.neutralForeground2Pressed,
+      indicatorColor: t.colors.neutralStroke1Pressed,
+      transparent: {
+        backgroundColor: t.colors.transparentBackgroundPressed,
+      },
+      subtle: {
+        backgroundColor: t.colors.subtleBackgroundPressed,
+      },
+    },
+    focused: {
+      borderColor: t.colors.neutralForeground1,
+    },
+  } as TabTokens);

--- a/packages/experimental/TabList/src/Tab/TabColorTokens.win32.ts
+++ b/packages/experimental/TabList/src/Tab/TabColorTokens.win32.ts
@@ -1,7 +1,6 @@
-import { buildUseTokens } from '@fluentui-react-native/framework';
 import type { Theme } from '@fluentui-react-native/framework';
 import { isHighContrast } from '@fluentui-react-native/theming-utils';
-import type { TokensFromTheme } from '@fluentui-react-native/use-styling';
+import type { TokenSettings } from '@fluentui-react-native/use-styling';
 
 import type { TabTokens } from '..';
 
@@ -20,72 +19,12 @@ export const tabStates: (keyof TabTokens)[] = [
   'hasIcon',
 ];
 
-export const defaultTabTokens: TokensFromTheme<TabTokens, Theme> = (t: Theme) =>
+export const defaultTabColorTokens: TokenSettings<TabTokens, Theme> = (t: Theme) =>
   ({
-    indicatorOrientation: 'horizontal',
-    indicatorThickness: 2,
-    borderWidth: 2,
-    borderRadius: 4,
-    contentMarginStart: 2,
-    contentMarginEnd: 2,
-    flexDirection: 'column',
     borderColor: t.colors.transparentBackground,
     color: t.colors.neutralForeground2,
     iconColor: t.colors.neutralForeground2,
     indicatorColor: t.colors.transparentBackground,
-    indicatorRadius: 99,
-    small: {
-      iconSize: 20,
-      iconMargin: 2,
-      indicatorMargin: 8,
-      stackMarginHorizontal: 6,
-      stackMarginVertical: 8,
-      variant: 'body1',
-      selected: {
-        variant: 'body1Strong',
-      },
-    },
-    medium: {
-      iconSize: 20,
-      iconMargin: 6,
-      indicatorMargin: 12,
-      stackMarginHorizontal: 10,
-      stackMarginVertical: 12,
-      variant: 'body1',
-      selected: {
-        variant: 'body1Strong',
-      },
-    },
-    large: {
-      iconSize: 24,
-      iconMargin: 6,
-      indicatorMargin: 12,
-      stackMarginHorizontal: 10,
-      stackMarginVertical: 16,
-      variant: 'body2',
-      selected: {
-        variant: 'subtitle2',
-      },
-    },
-    vertical: {
-      flexDirection: 'row-reverse',
-      indicatorOrientation: 'vertical',
-      small: {
-        indicatorMargin: 4,
-        stackMarginHorizontal: 6,
-        stackMarginVertical: 2,
-      },
-      medium: {
-        indicatorMargin: 8,
-        stackMarginHorizontal: 10,
-        stackMarginVertical: 6,
-      },
-      large: {
-        indicatorMargin: 10,
-        stackMarginHorizontal: 10,
-        stackMarginVertical: 8,
-      },
-    },
     transparent: {
       backgroundColor: t.colors.transparentBackground,
     },
@@ -145,9 +84,4 @@ export const defaultTabTokens: TokensFromTheme<TabTokens, Theme> = (t: Theme) =>
     focused: {
       borderColor: isHighContrast(t) ? t.colors.compoundBrandStroke1 : t.colors.neutralForeground1,
     },
-    hasIcon: {
-      contentMarginStart: 8,
-    },
   } as TabTokens);
-
-export const useTabTokens = buildUseTokens(defaultTabTokens);

--- a/packages/experimental/TabList/src/Tab/TabTokens.ts
+++ b/packages/experimental/TabList/src/Tab/TabTokens.ts
@@ -1,8 +1,10 @@
 import { buildUseTokens } from '@fluentui-react-native/framework';
 import type { Theme } from '@fluentui-react-native/framework';
-import type { TokensFromTheme } from '@fluentui-react-native/use-styling';
+import type { TokenSettings } from '@fluentui-react-native/use-styling';
 
-import type { TabTokens } from '..';
+import type { TabTokens } from './Tab.types';
+import { tabName } from './Tab.types';
+import { defaultTabColorTokens } from './TabColorTokens';
 
 export const tabStates: (keyof TabTokens)[] = [
   'small',
@@ -19,133 +21,70 @@ export const tabStates: (keyof TabTokens)[] = [
   'hasIcon',
 ];
 
-export const defaultTabTokens: TokensFromTheme<TabTokens, Theme> = (t: Theme) =>
-  ({
-    indicatorOrientation: 'horizontal',
-    indicatorThickness: 2,
-    borderWidth: 2,
-    borderRadius: 4,
-    contentMarginStart: 2,
-    contentMarginEnd: 2,
-    flexDirection: 'column',
-    borderColor: t.colors.transparentStroke,
-    color: t.colors.neutralForeground2,
-    iconColor: t.colors.neutralForeground2,
-    indicatorColor: t.colors.transparentStroke,
-    indicatorRadius: 99,
+export const defaultTabTokens: TokenSettings<TabTokens, Theme> = {
+  indicatorOrientation: 'horizontal',
+  indicatorThickness: 2,
+  borderWidth: 2,
+  borderRadius: 4,
+  contentMarginStart: 2,
+  contentMarginEnd: 2,
+  flexDirection: 'column',
+  indicatorRadius: 99,
+  small: {
+    iconSize: 20,
+    iconMargin: 2,
+    indicatorMargin: 8,
+    stackMarginHorizontal: 6,
+    stackMarginVertical: 8,
+    variant: 'body1',
+    selected: {
+      variant: 'body1Strong',
+    },
+  },
+  medium: {
+    iconSize: 20,
+    iconMargin: 6,
+    indicatorMargin: 12,
+    stackMarginHorizontal: 10,
+    stackMarginVertical: 12,
+    variant: 'body1',
+    selected: {
+      variant: 'body1Strong',
+    },
+  },
+  large: {
+    iconSize: 24,
+    iconMargin: 6,
+    indicatorMargin: 12,
+    stackMarginHorizontal: 10,
+    stackMarginVertical: 16,
+    variant: 'body2',
+    selected: {
+      variant: 'subtitle2',
+    },
+  },
+  vertical: {
+    flexDirection: 'row-reverse',
+    indicatorOrientation: 'vertical',
     small: {
-      iconSize: 20,
-      iconMargin: 2,
-      indicatorMargin: 8,
+      indicatorMargin: 4,
       stackMarginHorizontal: 6,
-      stackMarginVertical: 8,
-      variant: 'body1',
-      selected: {
-        variant: 'body1Strong',
-      },
+      stackMarginVertical: 2,
     },
     medium: {
-      iconSize: 20,
-      iconMargin: 6,
-      indicatorMargin: 12,
+      indicatorMargin: 8,
       stackMarginHorizontal: 10,
-      stackMarginVertical: 12,
-      variant: 'body1',
-      selected: {
-        variant: 'body1Strong',
-      },
+      stackMarginVertical: 6,
     },
     large: {
-      iconSize: 24,
-      iconMargin: 6,
-      indicatorMargin: 12,
+      indicatorMargin: 10,
       stackMarginHorizontal: 10,
-      stackMarginVertical: 16,
-      variant: 'body2',
-      selected: {
-        variant: 'subtitle2',
-      },
+      stackMarginVertical: 8,
     },
-    vertical: {
-      flexDirection: 'row-reverse',
-      indicatorOrientation: 'vertical',
-      small: {
-        indicatorMargin: 4,
-        stackMarginHorizontal: 6,
-        stackMarginVertical: 2,
-      },
-      medium: {
-        indicatorMargin: 8,
-        stackMarginHorizontal: 10,
-        stackMarginVertical: 6,
-      },
-      large: {
-        indicatorMargin: 10,
-        stackMarginHorizontal: 10,
-        stackMarginVertical: 8,
-      },
-    },
-    transparent: {
-      backgroundColor: t.colors.transparentBackground,
-    },
-    subtle: {
-      backgroundColor: t.colors.subtleBackground,
-    },
-    selected: {
-      color: t.colors.neutralForeground1,
-      iconColor: t.colors.compoundBrandForeground1,
-      indicatorColor: t.colors.compoundBrandStroke1,
-      pressed: {
-        color: t.colors.neutralForeground1Pressed,
-        iconColor: t.colors.compoundBrandForeground1Pressed,
-        indicatorColor: t.colors.compoundBrandStroke1Pressed,
-      },
-    },
-    disabled: {
-      color: t.colors.neutralForegroundDisabled,
-      iconColor: t.colors.neutralForegroundDisabled,
-      selected: {
-        color: t.colors.neutralForegroundDisabled,
-        iconColor: t.colors.neutralForegroundDisabled,
-        indicatorColor: t.colors.neutralForegroundDisabled,
-      },
-    },
-    hovered: {
-      color: t.colors.neutralForeground2Hover,
-      iconColor: t.colors.neutralForeground2Hover,
-      indicatorColor: t.colors.neutralStroke1Hover,
-      selected: {
-        color: t.colors.neutralForeground1Hover,
-        iconColor: t.colors.compoundBrandForeground1Hover,
-        indicatorColor: t.colors.compoundBrandStroke1Hover,
-      },
-      disabled: {
-        indicatorColor: t.colors.transparentStroke,
-      },
-      transparent: {
-        backgroundColor: t.colors.transparentBackgroundHover,
-      },
-      subtle: {
-        backgroundColor: t.colors.subtleBackgroundHover,
-      },
-    },
-    pressed: {
-      color: t.colors.neutralForeground2Pressed,
-      iconColor: t.colors.neutralForeground2Pressed,
-      indicatorColor: t.colors.neutralStroke1Pressed,
-      transparent: {
-        backgroundColor: t.colors.transparentBackgroundPressed,
-      },
-      subtle: {
-        backgroundColor: t.colors.subtleBackgroundPressed,
-      },
-    },
-    focused: {
-      borderColor: t.colors.neutralForeground1,
-    },
-    hasIcon: {
-      contentMarginStart: 8,
-    },
-  } as TabTokens);
+  },
+  hasIcon: {
+    contentMarginStart: 8,
+  },
+} as TabTokens;
 
-export const useTabTokens = buildUseTokens(defaultTabTokens);
+export const useTabTokens = buildUseTokens(defaultTabTokens, defaultTabColorTokens, tabName);

--- a/packages/experimental/TabList/src/Tab/TabTokens.win32.ts
+++ b/packages/experimental/TabList/src/Tab/TabTokens.win32.ts
@@ -1,0 +1,153 @@
+import { buildUseTokens } from '@fluentui-react-native/framework';
+import type { Theme } from '@fluentui-react-native/framework';
+import { isHighContrast } from '@fluentui-react-native/theming-utils';
+import type { TokensFromTheme } from '@fluentui-react-native/use-styling';
+
+import type { TabTokens } from '..';
+
+export const tabStates: (keyof TabTokens)[] = [
+  'small',
+  'medium',
+  'large',
+  'vertical',
+  'hovered',
+  'disabled',
+  'selected',
+  'focused',
+  'pressed',
+  'transparent',
+  'subtle',
+  'hasIcon',
+];
+
+export const defaultTabTokens: TokensFromTheme<TabTokens, Theme> = (t: Theme) =>
+  ({
+    indicatorOrientation: 'horizontal',
+    indicatorThickness: 2,
+    borderWidth: 2,
+    borderRadius: 4,
+    contentMarginStart: 2,
+    contentMarginEnd: 2,
+    flexDirection: 'column',
+    borderColor: t.colors.transparentBackground,
+    color: t.colors.neutralForeground2,
+    iconColor: t.colors.neutralForeground2,
+    indicatorColor: t.colors.transparentBackground,
+    indicatorRadius: 99,
+    small: {
+      iconSize: 20,
+      iconMargin: 2,
+      indicatorMargin: 8,
+      stackMarginHorizontal: 6,
+      stackMarginVertical: 8,
+      variant: 'body1',
+      selected: {
+        variant: 'body1Strong',
+      },
+    },
+    medium: {
+      iconSize: 20,
+      iconMargin: 6,
+      indicatorMargin: 12,
+      stackMarginHorizontal: 10,
+      stackMarginVertical: 12,
+      variant: 'body1',
+      selected: {
+        variant: 'body1Strong',
+      },
+    },
+    large: {
+      iconSize: 24,
+      iconMargin: 6,
+      indicatorMargin: 12,
+      stackMarginHorizontal: 10,
+      stackMarginVertical: 16,
+      variant: 'body2',
+      selected: {
+        variant: 'subtitle2',
+      },
+    },
+    vertical: {
+      flexDirection: 'row-reverse',
+      indicatorOrientation: 'vertical',
+      small: {
+        indicatorMargin: 4,
+        stackMarginHorizontal: 6,
+        stackMarginVertical: 2,
+      },
+      medium: {
+        indicatorMargin: 8,
+        stackMarginHorizontal: 10,
+        stackMarginVertical: 6,
+      },
+      large: {
+        indicatorMargin: 10,
+        stackMarginHorizontal: 10,
+        stackMarginVertical: 8,
+      },
+    },
+    transparent: {
+      backgroundColor: t.colors.transparentBackground,
+    },
+    subtle: {
+      backgroundColor: t.colors.subtleBackground,
+    },
+    selected: {
+      color: t.colors.neutralForeground1,
+      iconColor: t.colors.compoundBrandForeground1,
+      indicatorColor: t.colors.compoundBrandStroke1,
+      pressed: {
+        color: isHighContrast(t) ? t.colors.neutralForeground2 : t.colors.neutralForeground1Pressed,
+        iconColor: isHighContrast(t) ? t.colors.neutralForeground2 : t.colors.compoundBrandForeground1Pressed,
+        indicatorColor: t.colors.compoundBrandStroke1Pressed,
+      },
+    },
+    disabled: {
+      color: isHighContrast(t) ? t.colors.neutralStrokeDisabled : t.colors.neutralForegroundDisabled,
+      iconColor: isHighContrast(t) ? t.colors.neutralStrokeDisabled : t.colors.neutralForegroundDisabled,
+      selected: {
+        color: isHighContrast(t) ? t.colors.neutralStrokeDisabled : t.colors.neutralForegroundDisabled,
+        iconColor: isHighContrast(t) ? t.colors.neutralStrokeDisabled : t.colors.neutralForegroundDisabled,
+        indicatorColor: isHighContrast(t) ? t.colors.neutralStrokeDisabled : t.colors.neutralForegroundDisabled,
+      },
+    },
+    hovered: {
+      color: isHighContrast(t) ? t.colors.neutralForeground2 : t.colors.neutralForeground2Hover,
+      iconColor: isHighContrast(t) ? t.colors.compoundBrandForeground1Hover : t.colors.neutralForeground2Hover,
+      indicatorColor: isHighContrast(t) ? t.colors.compoundBrandStroke1Hover : t.colors.neutralStroke1Hover,
+      selected: {
+        color: isHighContrast(t) ? t.colors.neutralForeground2 : t.colors.neutralForeground1Hover,
+        iconColor: isHighContrast(t) ? t.colors.neutralForeground2 : t.colors.compoundBrandForeground1Hover,
+        indicatorColor: t.colors.compoundBrandStroke1Hover,
+      },
+      disabled: {
+        indicatorColor: t.colors.transparentBackground,
+      },
+      transparent: {
+        backgroundColor: t.colors.transparentBackgroundHover,
+      },
+      subtle: {
+        backgroundColor: t.colors.subtleBackgroundHover,
+        indicatorColor: isHighContrast(t) ? t.colors.neutralStroke1 : t.colors.neutralStroke1Hover,
+      },
+    },
+    pressed: {
+      color: isHighContrast(t) ? t.colors.neutralForeground2 : t.colors.neutralForeground2Pressed,
+      iconColor: isHighContrast(t) ? t.colors.neutralForeground2 : t.colors.neutralForeground2Pressed,
+      indicatorColor: isHighContrast(t) ? t.colors.compoundBrandBackground1Pressed : t.colors.neutralStroke1Pressed,
+      transparent: {
+        backgroundColor: t.colors.transparentBackgroundPressed,
+      },
+      subtle: {
+        backgroundColor: t.colors.subtleBackgroundPressed,
+      },
+    },
+    focused: {
+      borderColor: isHighContrast(t) ? t.colors.compoundBrandStroke1 : t.colors.neutralForeground1,
+    },
+    hasIcon: {
+      contentMarginStart: 8,
+    },
+  } as TabTokens);
+
+export const useTabTokens = buildUseTokens(defaultTabTokens);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3910,6 +3910,7 @@ __metadata:
     "@fluentui-react-native/scripts": ^0.1.1
     "@fluentui-react-native/test-tools": ">=0.1.1 <1.0.0"
     "@fluentui-react-native/text": ">=0.22.0 <1.0.0"
+    "@fluentui-react-native/theming-utils": ">=0.25.0 <1.0.0"
     "@fluentui-react-native/tokens": ">=0.22.0 <1.0.0"
     "@fluentui-react-native/use-styling": ">=0.12.0 <1.0.0"
     "@office-iss/react-native-win32": ^0.72.0


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Current high contrast appearance of the TabList has multiple UI elements not visible / hard to see on high contrast themes. 

This PR fixes this by using hand-selected values vs redline values to make the HC TabList visible and pretty.

### Verification

| | Aquatic | Desert | Dusk | Night Sky |
|-|----------|---------|-------|-----------|
| Before | <img width="150" alt="image" src="https://github.com/microsoft/fluentui-react-native/assets/15683103/6960e944-1aed-45dc-9d2a-2f4838e26255"> | <img width="150" alt="image" src="https://github.com/microsoft/fluentui-react-native/assets/15683103/aaea1dbe-a4ce-4077-b8e3-796b7ebf14ea"> | <img width="150" alt="image" src="https://github.com/microsoft/fluentui-react-native/assets/15683103/e0b55deb-7cf9-464e-9d73-179dc58c08d0"> | <img width="150" alt="image" src="https://github.com/microsoft/fluentui-react-native/assets/15683103/bea35325-f4ac-4025-9eab-c849cb8d3cbd"> |
| After | <img width="150" alt="image" src="https://github.com/microsoft/fluentui-react-native/assets/15683103/4d8f0f0c-363c-49a9-81ea-132ba367f01d">| <img width="150" alt="image" src="https://github.com/microsoft/fluentui-react-native/assets/15683103/56d5b493-8fb6-49ea-8a6b-934007a75148"> | <img width="150" alt="image" src="https://github.com/microsoft/fluentui-react-native/assets/15683103/e84fcdbd-a7af-49bb-9ebc-2ecab50ae0de"> | <img width="150" alt="image" src="https://github.com/microsoft/fluentui-react-native/assets/15683103/8967282f-ce9b-4c5c-94f8-bea896c0901f"> |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
