### PR TITLE
Selected disabled Radio in RadioGroup no longer impedes keyboard navigation

### DIFF
--- a/change/@fluentui-react-native-radio-group-7ddd4330-ac34-44d1-a571-15152858ce07.json
+++ b/change/@fluentui-react-native-radio-group-7ddd4330-ac34-44d1-a571-15152858ce07.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix disabled, selected radio stopping keyboard navigation",
+  "packageName": "@fluentui-react-native/radio-group",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/RadioGroup/src/Radio/useRadio.win32.ts
+++ b/packages/components/RadioGroup/src/Radio/useRadio.win32.ts
@@ -66,15 +66,18 @@ export const useRadio = (props: RadioProps): RadioInfo => {
   React.useEffect(() => {
     radioGroupContext.addRadioValue(value);
 
-    if (!isDisabled) {
-      radioGroupContext.addRadioEnabledValue(value);
-    }
-
     return () => {
       radioGroupContext.removeRadioValue(value);
-      radioGroupContext.removeRadioEnabledValue(value);
     };
   }, []);
+
+  React.useEffect(() => {
+    if (isDisabled) {
+      radioGroupContext.removeRadioEnabledValue(value);
+    } else {
+      radioGroupContext.addRadioEnabledValue(value);
+    }
+  }, [isDisabled]);
 
   const isRTL = I18nManager.isRTL;
 

--- a/packages/components/RadioGroup/src/RadioGroup/RadioGroup.tsx
+++ b/packages/components/RadioGroup/src/RadioGroup/RadioGroup.tsx
@@ -67,7 +67,11 @@ export const RadioGroup = compose<RadioGroupType>({
 
       const radioGroupContent = <Slots.options>{children}</Slots.options>;
       const radioGroupContentWithFocusZone = (
-        <Slots.container isCircularNavigation defaultTabbableElement={defaultTabbableElement}>
+        <Slots.container
+          disabled={radioGroup.state.selectedButtonDisabled}
+          isCircularNavigation
+          defaultTabbableElement={defaultTabbableElement}
+        >
           {radioGroupContent}
         </Slots.container>
       );

--- a/packages/components/RadioGroup/src/RadioGroup/RadioGroup.types.ts
+++ b/packages/components/RadioGroup/src/RadioGroup/RadioGroup.types.ts
@@ -63,6 +63,12 @@ export interface RadioGroupState extends RadioGroupProps {
    * @platform win32
    */
   invoked?: boolean;
+
+  /**
+   * Signals whether the currently selected radio is disabled. If this is the case, the FocusZone state is set to 'disabled'.
+   * @platform win32
+   */
+  selectedButtonDisabled?: boolean;
 }
 
 export interface RadioGroupTokens extends IForegroundColorTokens, FontTokens {

--- a/packages/components/RadioGroup/src/RadioGroup/useRadioGroup.ts
+++ b/packages/components/RadioGroup/src/RadioGroup/useRadioGroup.ts
@@ -47,16 +47,14 @@ export const useRadioGroup = (props: RadioGroupProps): RadioGroupInfo => {
 
   const onAddRadioValue = React.useCallback(
     (value: string) => {
-      values.push(value);
-      setValues(values);
+      setValues((values) => [...values, value]);
     },
     [setValues],
   );
 
   const onRemoveRadioValue = React.useCallback(
     (value: string) => {
-      values.filter((item) => item !== value);
-      setValues(values);
+      setValues((values) => values.filter((item) => item !== value));
     },
     [setValues],
   );
@@ -65,16 +63,14 @@ export const useRadioGroup = (props: RadioGroupProps): RadioGroupInfo => {
 
   const onAddRadioEnabledValue = React.useCallback(
     (value: string) => {
-      enabledValues.push(value);
-      setEnabledValues(enabledValues);
+      setEnabledValues((enabledValues) => [...enabledValues, value]);
     },
     [setEnabledValues],
   );
 
   const onRemoveRadioEnabledValue = React.useCallback(
     (value: string) => {
-      enabledValues.filter((item) => item !== value);
-      setEnabledValues(enabledValues);
+      setEnabledValues((enabledValues) => enabledValues.filter((item) => item !== value));
     },
     [setEnabledValues],
   );
@@ -94,6 +90,7 @@ export const useRadioGroup = (props: RadioGroupProps): RadioGroupInfo => {
     removeRadioValue: onRemoveRadioValue,
     addRadioEnabledValue: onAddRadioEnabledValue,
     removeRadioEnabledValue: onRemoveRadioEnabledValue,
+    selectedButtonDisabled: values.includes(data.selectedKey) && !enabledValues.includes(data.selectedKey),
   };
 
   return {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Currently, the RadioGroup has a niche bug where keyboard navigation is impeded by a selected, disabled radio. Trying to set focus over the RadioGroup is impossible in this case.

This PR fixes this edge case by skipping focus of the RadioGroup when trying to switch focus onto a selected, disabled radio. This mirrors current behavior on the web RadioGroup.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| https://github.com/microsoft/fluentui-react-native/assets/15683103/b8574d05-ee5b-4f10-99a5-09c23537259e| https://github.com/microsoft/fluentui-react-native/assets/15683103/0d1ff6c9-bf88-42ed-a3cf-698f658113e0 |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [x] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
