### PR TITLE
Edit port for direct debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -66,7 +66,7 @@
       "type": "node",
       "request": "attach",
       "protocol": "inspector",
-      "port": 9223,
+      "port": 9222,
       "sourceMaps": true
     }
   ]


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Port needs to be changed to 9222 to allow direct debugging

### Verification

Confirmed that port aligns with port that Edge needs to direct debugging