### PR TITLE
FURN Text in Circular Compound Button no longer cuts into button's margins

### DIFF
--- a/change/@fluentui-react-native-button-b0243d2d-749d-4a39-9b87-c2e7d2e50d2b.json
+++ b/change/@fluentui-react-native-button-b0243d2d-749d-4a39-9b87-c2e7d2e50d2b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Text in circular compound button no longer cuts into button padding",
+  "packageName": "@fluentui-react-native/button",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Button/src/CompoundButton/CompoundButtonTokens.ts
+++ b/packages/components/Button/src/CompoundButton/CompoundButtonTokens.ts
@@ -22,6 +22,12 @@ export const defaultCompoundButtonTokens: TokenSettings<CompoundButtonTokens, Th
       hasIconBefore: {
         spacingIconContentBefore: globalTokens.size120,
       },
+      circular: {
+        paddingHorizontal: globalTokens.size160 - globalTokens.stroke.width10,
+        focused: {
+          paddingHorizontal: globalTokens.size160,
+        },
+      },
     },
   },
   small: {
@@ -41,6 +47,12 @@ export const defaultCompoundButtonTokens: TokenSettings<CompoundButtonTokens, Th
       hasIconBefore: {
         spacingIconContentBefore: globalTokens.size80,
       },
+      circular: {
+        paddingHorizontal: globalTokens.size120 - globalTokens.stroke.width10,
+        focused: {
+          paddingHorizontal: globalTokens.size120,
+        },
+      },
     },
   },
   large: {
@@ -59,6 +71,12 @@ export const defaultCompoundButtonTokens: TokenSettings<CompoundButtonTokens, Th
       },
       hasIconBefore: {
         spacingIconContentBefore: globalTokens.size160,
+      },
+      circular: {
+        paddingHorizontal: globalTokens.size200 - globalTokens.stroke.width10,
+        focused: {
+          paddingHorizontal: globalTokens.size200,
+        },
       },
     },
   },

--- a/packages/components/Button/src/CompoundButton/CompoundButtonTokens.win32.ts
+++ b/packages/components/Button/src/CompoundButton/CompoundButtonTokens.win32.ts
@@ -33,6 +33,11 @@ export const defaultCompoundButtonTokens: TokenSettings<CompoundButtonTokens, Th
         focused: {
           paddingHorizontal: globalTokens.size120 - globalTokens.stroke.width20,
         },
+        circular: {
+          focused: {
+            paddingHorizontal: globalTokens.size160 - globalTokens.stroke.width20,
+          },
+        },
         square: {
           focused: {
             paddingHorizontal: globalTokens.size120 - globalTokens.stroke.width10,
@@ -44,6 +49,12 @@ export const defaultCompoundButtonTokens: TokenSettings<CompoundButtonTokens, Th
       },
       hasIconBefore: {
         spacingIconContentBefore: globalTokens.size120,
+      },
+      circular: {
+        paddingHorizontal: globalTokens.size160 - globalTokens.stroke.width10,
+        focused: {
+          paddingHorizontal: globalTokens.size160,
+        },
       },
     },
   },
@@ -75,6 +86,11 @@ export const defaultCompoundButtonTokens: TokenSettings<CompoundButtonTokens, Th
         focused: {
           paddingHorizontal: globalTokens.size80 - globalTokens.stroke.width20,
         },
+        circular: {
+          focused: {
+            paddingHorizontal: globalTokens.size120 - globalTokens.stroke.width20,
+          },
+        },
         square: {
           focused: {
             paddingHorizontal: globalTokens.size80 - globalTokens.stroke.width10,
@@ -86,6 +102,12 @@ export const defaultCompoundButtonTokens: TokenSettings<CompoundButtonTokens, Th
       },
       hasIconBefore: {
         spacingIconContentBefore: globalTokens.size80,
+      },
+      circular: {
+        paddingHorizontal: globalTokens.size120 - globalTokens.stroke.width10,
+        focused: {
+          paddingHorizontal: globalTokens.size120,
+        },
       },
     },
   },
@@ -116,6 +138,11 @@ export const defaultCompoundButtonTokens: TokenSettings<CompoundButtonTokens, Th
         focused: {
           paddingHorizontal: globalTokens.size160 - globalTokens.stroke.width20,
         },
+        circular: {
+          focused: {
+            paddingHorizontal: globalTokens.size200 - globalTokens.stroke.width20,
+          },
+        },
         square: {
           focused: {
             paddingHorizontal: globalTokens.size160 - globalTokens.stroke.width10,
@@ -127,6 +154,12 @@ export const defaultCompoundButtonTokens: TokenSettings<CompoundButtonTokens, Th
       },
       hasIconBefore: {
         spacingIconContentBefore: globalTokens.size160,
+      },
+      circular: {
+        paddingHorizontal: globalTokens.size200 - globalTokens.stroke.width10,
+        focused: {
+          paddingHorizontal: globalTokens.size200,
+        },
       },
     },
   },


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [ ] android

### Description of changes

Currently, when a compound button is circular and renders secondary text, the secondary text appears to be closer to its button's edge versus the rounded and square buttons. This is due to the fully circular edge cutting into the button's margins.

This PR adds some extra horizontal padding to circular compound buttons of each size to distance the text from the button's edge. 

### Verification

|   | Before                                       | After                                      |
|--|--------------------------------------------|--------------------------------------------|
| Unmarked |<img width="110" alt="compound button before" src="https://github.com/microsoft/fluentui-react-native/assets/15683103/d7161ad3-7e40-41af-80a4-a412e115505d"> | <img width="110" alt="compound button after" src="https://github.com/microsoft/fluentui-react-native/assets/15683103/e2e0ac14-8868-43ef-8127-dac23fead4f8"> |
| Marked     | <img width="107" alt="compound button before (marked)" src="https://github.com/microsoft/fluentui-react-native/assets/15683103/53352a1f-572a-475d-a492-c4788d24636d"> | <img width="110" alt="compound button after (marked)" src="https://github.com/microsoft/fluentui-react-native/assets/15683103/bd428750-6fc4-44cc-987f-09bd70c80af0"> |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
