### PR TITLE
Fix selected, hovered, subtle Tab token selection

### DIFF
--- a/change/@fluentui-react-native-tablist-fc1d03fd-92f4-4bfd-a383-aca8a1961b52.json
+++ b/change/@fluentui-react-native-tablist-fc1d03fd-92f4-4bfd-a383-aca8a1961b52.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix color token for selected, hovered, subtle tab",
+  "packageName": "@fluentui-react-native/tablist",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/TabList/src/Tab/TabColorTokens.ts
+++ b/packages/experimental/TabList/src/Tab/TabColorTokens.ts
@@ -57,6 +57,9 @@ export const defaultTabColorTokens: TokenSettings<TabTokens, Theme> = (t: Theme)
         color: t.colors.neutralForeground1Hover,
         iconColor: t.colors.compoundBrandForeground1Hover,
         indicatorColor: t.colors.compoundBrandStroke1Hover,
+        subtle: {
+          indicatorColor: t.colors.compoundBrandStroke1Hover,
+        },
       },
       disabled: {
         indicatorColor: t.colors.transparentBackground,

--- a/packages/experimental/TabList/src/Tab/TabColorTokens.win32.ts
+++ b/packages/experimental/TabList/src/Tab/TabColorTokens.win32.ts
@@ -58,6 +58,9 @@ export const defaultTabColorTokens: TokenSettings<TabTokens, Theme> = (t: Theme)
         color: isHighContrast(t) ? t.colors.neutralForeground2 : t.colors.neutralForeground1Hover,
         iconColor: isHighContrast(t) ? t.colors.neutralForeground2 : t.colors.compoundBrandForeground1Hover,
         indicatorColor: t.colors.compoundBrandStroke1Hover,
+        subtle: {
+          indicatorColor: isHighContrast(t) ? t.colors.neutralStroke1 : t.colors.compoundBrandStroke1Hover,
+        },
       },
       disabled: {
         indicatorColor: t.colors.transparentBackground,


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

The indicator uses the wrong color token for a selected, hovered, subtle Tab. This is a problem because it is hard to see on non-HC themes and invisible on HC themes. 

This PR fixes this by getting the correct token value for `indicatorColor` in both color token files for a subtle, hovered, selected tab.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="45" alt="image" src="https://github.com/microsoft/fluentui-react-native/assets/15683103/ac91a801-c9bc-41b5-baac-ed264e40a09d"> | <img width="47" alt="image" src="https://github.com/microsoft/fluentui-react-native/assets/15683103/4253aad2-504e-41d3-89ea-f0a4a7d4e0cb"> |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
