### PR TITLE
Fix shimmer test

### DIFF
--- a/change/@fluentui-react-native-experimental-shimmer-5fa7f9cc-ba53-413f-8254-2725e0427147.json
+++ b/change/@fluentui-react-native-experimental-shimmer-5fa7f9cc-ba53-413f-8254-2725e0427147.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix shimmer test",
+  "packageName": "@fluentui-react-native/experimental-shimmer",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Shimmer/src/Shimmer.test.tsx
+++ b/packages/experimental/Shimmer/src/Shimmer.test.tsx
@@ -5,9 +5,6 @@ import * as renderer from 'react-test-renderer';
 import { Shimmer } from './Shimmer';
 import type { ShimmerCircleElement, ShimmerRectElement } from './Shimmer.types';
 
-// mocks out setTimeout and other timer functions with mock functions, test will fail without this as we're using Animated API
-jest.useFakeTimers();
-
 function shimmerRects(): Array<ShimmerRectElement | ShimmerCircleElement> {
   return [
     {
@@ -43,6 +40,12 @@ function shimmerRects(): Array<ShimmerRectElement | ShimmerCircleElement> {
 const style = { width: 300, height: 100 };
 
 describe('Shimmer component tests', () => {
+  beforeAll(() => {
+    // mocks out setTimeout and other timer functions with mock functions, test will fail without this as we're using Animated API
+    jest.useFakeTimers();
+    jest.mock('react-native/Libraries/Animated/NativeAnimatedHelper');
+  });
+
   it('Shimmer default', async () => {
     const tree = renderer.create(<Shimmer elements={shimmerRects()} />).toJSON();
     expect(tree).toMatchSnapshot();


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Shimmer test fails locally making running local tests fail. Mocked out the animated driver-related stuff, which doesn't run in jest.

### Verification

Ran `yarn test` locally

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
