### PR TITLE
VoiceOver should ignore contextual menu item children

### DIFF
--- a/change/@fluentui-react-native-contextual-menu-1307ae9b-0f45-4a60-a5ff-386e47fbdc0a.json
+++ b/change/@fluentui-react-native-contextual-menu-1307ae9b-0f45-4a60-a5ff-386e47fbdc0a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "VoiceOver should ignore contextual menu item children",
+  "packageName": "@fluentui-react-native/contextual-menu",
+  "email": "adgleitm@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/ContextualMenu/src/ContextualMenuItem.tsx
+++ b/packages/components/ContextualMenu/src/ContextualMenuItem.tsx
@@ -128,8 +128,8 @@ export const ContextualMenuItem = compose<ContextualMenuItemType>({
         children: text,
       },
       icon: {
-        accessible: false,
         ...createIconProps(icon),
+        accessible: false,
       },
     });
 

--- a/packages/components/ContextualMenu/src/ContextualMenuItem.tsx
+++ b/packages/components/ContextualMenu/src/ContextualMenuItem.tsx
@@ -123,8 +123,14 @@ export const ContextualMenuItem = compose<ContextualMenuItemType>({
         testID,
         ...rest,
       },
-      content: { children: text },
-      icon: createIconProps(icon),
+      content: {
+        accessible: false,
+        children: text,
+      },
+      icon: {
+        accessible: false,
+        ...createIconProps(icon),
+      },
     });
 
     return { slotProps, state };

--- a/packages/components/ContextualMenu/src/SubmenuItem.tsx
+++ b/packages/components/ContextualMenu/src/SubmenuItem.tsx
@@ -165,9 +165,18 @@ export const SubmenuItem = compose<SubmenuItemType>({
         onAccessibilityTap: onAccTap,
         ...rest,
       },
-      content: { children: text },
-      icon: createIconProps(icon),
-      chevron: createIconProps({ svgSource: svgProps, width: 12, height: 12 }),
+      content: {
+        accessible: false,
+        children: text,
+      },
+      icon: {
+        accessible: false,
+        ...createIconProps(icon),
+      },
+      chevron: {
+        accessible: false,
+        ...createIconProps({ svgSource: svgProps, width: 12, height: 12 }),
+      },
     });
 
     return { slotProps, state };

--- a/packages/components/ContextualMenu/src/SubmenuItem.tsx
+++ b/packages/components/ContextualMenu/src/SubmenuItem.tsx
@@ -170,12 +170,12 @@ export const SubmenuItem = compose<SubmenuItemType>({
         children: text,
       },
       icon: {
-        accessible: false,
         ...createIconProps(icon),
+        accessible: false,
       },
       chevron: {
-        accessible: false,
         ...createIconProps({ svgSource: svgProps, width: 12, height: 12 }),
+        accessible: false,
       },
     });
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

On macOS, VoiceOver reads "interactive" when looking at `ContextualMenuItem`s and `SubmenuItem`s, which is not on par with what a native `NSMenu` does. The reason for this appears to be that we were previously able to navigate to the FURN contextual menu item child views (such as the icon, the text, or the chevron indicating a submenu). `NSMenu` doesn't allow for this, so we can replicate this by setting `accessible: false` on all the subcomponents that make up a `ContextualMenuItem` or `SubmenuItem`.

### Verification

Validated that VoiceOver treats native `NSMenu`s and FURN contextual menus more similarly as per the specs above.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [x] Keyboard Accessibility
- [x] Voiceover
- [ ] Internationalization and Right-to-left Layouts
