### PR TITLE
Specify disabled=false explicitly in accessibility state for Contextual Menu items and subitems

### DIFF
--- a/change/@fluentui-react-native-contextual-menu-0e8e7823-58b6-4621-b98a-1241fe072b8a.json
+++ b/change/@fluentui-react-native-contextual-menu-0e8e7823-58b6-4621-b98a-1241fe072b8a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Specify disabled=false explicitly for contextual menu items and subitems",
+  "packageName": "@fluentui-react-native/contextual-menu",
+  "email": "adgleitm@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/ContextualMenu/src/ContextualMenuItem.tsx
+++ b/packages/components/ContextualMenu/src/ContextualMenuItem.tsx
@@ -115,7 +115,7 @@ export const ContextualMenuItem = compose<ContextualMenuItemType>({
         accessible: true,
         accessibilityLabel: accessibilityLabel,
         accessibilityRole: 'menuitem',
-        accessibilityState: { disabled: state.disabled, selected: state.selected },
+        accessibilityState: { disabled: state.disabled ?? false, selected: state.selected },
         accessibilityValue: { text: itemKey },
         onAccessibilityTap: onAccTap,
         disabled,

--- a/packages/components/ContextualMenu/src/SubmenuItem.tsx
+++ b/packages/components/ContextualMenu/src/SubmenuItem.tsx
@@ -158,7 +158,7 @@ export const SubmenuItem = compose<SubmenuItemType>({
         accessible: true,
         accessibilityLabel: accessibilityLabel,
         accessibilityRole: 'menuitem',
-        accessibilityState: { disabled: state.disabled, selected: state.selected },
+        accessibilityState: { disabled: state.disabled ?? false, selected: state.selected },
         accessibilityValue: { text: itemKey },
         disabled,
         focusable: !disabled,


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

We've seen a bug where Voice Control doesn't label items that come out of a Menu Button V1.

Some basic experimentation shows that the bug ultimately lies in React Native macOS where specifying an accessibility state without explicitly saying we're not disabled causes the OS to not recognize an item as interactable. We can fix this by loosening [this check](https://github.com/microsoft/react-native-macos/blob/50e1a4e040649f05136814ea799b4cdc3f6e6b2c/packages/react-native/React/Views/RCTView.m#L514-L518) in React Native macOS, but this change limited to FURN is a valid workaround too.

### Verification

Validated that Voice Control will show numbers next to enabled items.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
