### PR TITLE
Set disabled=false by default in MenuV1 item props

### DIFF
--- a/change/@fluentui-react-native-menu-7c1743ea-a952-413c-b6ed-35a4c1ada58e.json
+++ b/change/@fluentui-react-native-menu-7c1743ea-a952-413c-b6ed-35a4c1ada58e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Set disabled=false by default in menu item props",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "adgleitm@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/MenuItem/useMenuItem.ts
+++ b/packages/components/Menu/src/MenuItem/useMenuItem.ts
@@ -18,7 +18,7 @@ export const submenuTriggerKeys = ['ArrowLeft', 'ArrowRight', ...triggerKeys];
 export const useMenuItem = (props: MenuItemProps): MenuItemInfo => {
   // attach the pressable state handlers
   const defaultComponentRef = React.useRef(null);
-  const { accessible, onClick, accessibilityState, componentRef = defaultComponentRef, disabled, persistOnClick, ...rest } = props;
+  const { accessible, onClick, accessibilityState, componentRef = defaultComponentRef, disabled = false, persistOnClick, ...rest } = props;
   const { isSubmenu, persistOnItemClick, setOpen } = useMenuContext();
   const { hasCheckmarks, hasIcons, hasTooltips, onArrowClose } = useMenuListContext();
   const isTrigger = useMenuTriggerContext();

--- a/packages/components/Menu/src/MenuItemCheckbox/useMenuItemCheckbox.ts
+++ b/packages/components/Menu/src/MenuItemCheckbox/useMenuItemCheckbox.ts
@@ -15,7 +15,7 @@ import { useMenuItemTracking } from '../MenuList/useMenuList';
 const defaultAccessibilityActions = [{ name: 'Toggle' }];
 
 export const useMenuItemCheckbox = (props: MenuItemCheckboxProps): MenuItemCheckboxInfo => {
-  const { disabled, name } = props;
+  const { disabled = false, name } = props;
   const context = useMenuListContext();
   const checked = context.checked?.[name];
   const onCheckedChange = context.onCheckedChange;
@@ -59,7 +59,7 @@ export const useMenuCheckboxInteraction = (
     accessibilityState,
     accessible,
     componentRef = defaultComponentRef,
-    disabled,
+    disabled = false,
     name,
     onAccessibilityAction,
     ...rest

--- a/packages/components/Menu/src/MenuItemRadio/useMenuItemRadio.ts
+++ b/packages/components/Menu/src/MenuItemRadio/useMenuItemRadio.ts
@@ -8,7 +8,7 @@ import { useMenuCheckboxInteraction } from '../MenuItemCheckbox/useMenuItemCheck
 import type { MenuItemRadioProps, MenuItemRadioInfo } from '../MenuItemRadio/MenuItemRadio.types';
 
 export const useMenuItemRadio = (props: MenuItemRadioProps): MenuItemRadioInfo => {
-  const { disabled, name, persistOnClick } = props;
+  const { disabled = false, name, persistOnClick } = props;
   const context = useMenuContext();
   const listContext = useMenuListContext();
   const selectRadio = listContext.selectRadio;


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Similar to #3333, this ensures that `disabled` is always defined for `MenuItem` props.

### Verification

Validated via Voice Control that numbers show up in all the different menu types in FURN Tester's MenuV1 test page.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
