### PR TITLE
Use themed styles for FocusTrapZone test page

### DIFF
--- a/apps/fluent-tester/src/TestComponents/FocusTrapZone/FocusTrapZoneTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/FocusTrapZone/FocusTrapZoneTest.tsx
@@ -20,12 +20,12 @@ const getThemedStyles = themedStyleSheet((t: Theme) => {
     trapZoneStyle: {
       padding: 10,
       borderWidth: 2,
-      borderColor: t.colors.defaultBorder,
+      borderColor: t.colors.neutralStroke1,
       borderStyle: 'dashed',
     },
     activeTrapZoneStyle: {
       padding: 10,
-      borderColor: t.colors.defaultBorder,
+      borderColor: t.colors.neutralStroke1,
       borderWidth: 2,
       borderStyle: 'solid',
     },
@@ -33,7 +33,7 @@ const getThemedStyles = themedStyleSheet((t: Theme) => {
       borderWidth: 1,
       padding: 8,
       margin: 4,
-      borderColor: t.colors.defaultBorder,
+      borderColor: t.colors.neutralStroke1,
       borderStyle: 'solid',
     },
     focusedComponentTwiddlerStyle: {
@@ -41,14 +41,14 @@ const getThemedStyles = themedStyleSheet((t: Theme) => {
       padding: 8,
       margin: 4,
       borderStyle: 'solid',
-      borderColor: t.colors.defaultFocusedBorder,
-      backgroundColor: t.colors.defaultFocusedBackground,
+      borderColor: t.colors.strokeFocus2,
+      backgroundColor: t.colors.neutralBackground1Hover,
     },
     componentTwiddlerText: {
-      color: t.colors.defaultContent,
+      color: t.colors.neutralForeground1,
     },
     focusedComponentTwiddlerText: {
-      color: t.colors.defaultFocusedContent,
+      color: t.colors.neutralForeground1Hover,
     },
   };
 });

--- a/apps/fluent-tester/src/TestComponents/FocusTrapZone/FocusTrapZoneTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/FocusTrapZone/FocusTrapZoneTest.tsx
@@ -1,45 +1,57 @@
 import * as React from 'react';
-import type { TouchableHighlightProps, ViewProps } from 'react-native';
+import type { TouchableHighlightProps } from 'react-native';
 import { TouchableHighlight, View } from 'react-native';
 
-import type { IFocusTrapZoneProps } from '@fluentui/react-native';
 import { FocusTrapZone, Text } from '@fluentui/react-native';
+import type { Theme } from '@fluentui-react-native/framework';
 import type { KeyPressEvent } from '@fluentui-react-native/interactive-hooks';
 import { useFocusState } from '@fluentui-react-native/interactive-hooks';
 import { Stack } from '@fluentui-react-native/stack';
+import { useTheme } from '@fluentui-react-native/theme-types';
+import { themedStyleSheet } from '@fluentui-react-native/themed-stylesheet';
 
 import { FOCUSTRAPZONE_TESTPAGE } from '../../../../E2E/src/FocusTrapZone/consts';
 import { stackStyle } from '../Common/styles';
 import type { TestSection, PlatformStatus } from '../Test';
 import { Test } from '../Test';
 
-const trapZoneStyle: IFocusTrapZoneProps['style'] = {
-  padding: 10,
-  borderWidth: 2,
-  borderColor: '#ababab',
-  borderStyle: 'dashed',
-};
-
-const activeTrapZoneStyle: IFocusTrapZoneProps['style'] = {
-  padding: 10,
-  borderColor: '#ababab',
-  borderWidth: 2,
-  borderStyle: 'solid',
-};
-
-const componentTwiddlerStyle: ViewProps['style'] = {
-  borderWidth: 1,
-  padding: 8,
-  margin: 4,
-  borderColor: '#ababab',
-  borderStyle: 'solid',
-};
-
-const focusedComponentTwiddlerStyle: ViewProps['style'] = {
-  ...componentTwiddlerStyle,
-  borderColor: 'black',
-  backgroundColor: 'lightblue',
-};
+const getThemedStyles = themedStyleSheet((t: Theme) => {
+  return {
+    trapZoneStyle: {
+      padding: 10,
+      borderWidth: 2,
+      borderColor: t.colors.defaultBorder,
+      borderStyle: 'dashed',
+    },
+    activeTrapZoneStyle: {
+      padding: 10,
+      borderColor: t.colors.defaultBorder,
+      borderWidth: 2,
+      borderStyle: 'solid',
+    },
+    componentTwiddlerStyle: {
+      borderWidth: 1,
+      padding: 8,
+      margin: 4,
+      borderColor: t.colors.defaultBorder,
+      borderStyle: 'solid',
+    },
+    focusedComponentTwiddlerStyle: {
+      borderWidth: 1,
+      padding: 8,
+      margin: 4,
+      borderStyle: 'solid',
+      borderColor: t.colors.defaultFocusedBorder,
+      backgroundColor: t.colors.defaultFocusedBackground,
+    },
+    componentTwiddlerText: {
+      color: t.colors.defaultContent,
+    },
+    focusedComponentTwiddlerText: {
+      color: t.colors.defaultFocusedContent,
+    },
+  };
+});
 
 interface IComponentTwiddlerProps {
   label?: string;
@@ -48,17 +60,28 @@ interface IComponentTwiddlerProps {
 
 export const ComponentTwiddler: React.FunctionComponent<IComponentTwiddlerProps> = (props: IComponentTwiddlerProps) => {
   const [focusProps, focusState] = useFocusState({});
+  const theme = useTheme();
+  const themedStyles = getThemedStyles(theme);
 
   return (
     <TouchableHighlight {...{ focusable: false }} onPress={props.onPress}>
-      <View focusable={true} {...(focusProps as any)} style={focusState.focused ? focusedComponentTwiddlerStyle : componentTwiddlerStyle}>
-        <Text>{props.label}</Text>
+      <View
+        focusable={true}
+        {...(focusProps as any)}
+        style={focusState.focused ? themedStyles.focusedComponentTwiddlerStyle : themedStyles.componentTwiddlerStyle}
+      >
+        <Text style={focusState.focused ? themedStyles.focusedComponentTwiddlerText : themedStyles.componentTwiddlerText}>
+          {props.label}
+        </Text>
       </View>
     </TouchableHighlight>
   );
 };
 
 const BasicFocusTrapZone: React.FunctionComponent = () => {
+  const theme = useTheme();
+  const themedStyles = getThemedStyles(theme);
+
   const [state, setState] = React.useState({
     useTrapZone: false,
     renderTrapZone: true,
@@ -121,7 +144,7 @@ const BasicFocusTrapZone: React.FunctionComponent = () => {
             ignoreExternalFocusing={state.ignoreExternalFocusing}
             focusPreviouslyFocusedInnerElement={state.focusPreviouslyFocusedInnerElement}
             disabled={!state.useTrapZone}
-            style={state.useTrapZone ? activeTrapZoneStyle : trapZoneStyle}
+            style={state.useTrapZone ? themedStyles.activeTrapZoneStyle : themedStyles.trapZoneStyle}
           >
             <Text>{state.useTrapZone ? 'Trap Active' : 'Trap Active'}</Text>
             <ComponentTwiddler label="trapped" />

--- a/change/@fluentui-react-native-tester-ab78831c-c9e4-4407-968a-fae3c21f7e44.json
+++ b/change/@fluentui-react-native-tester-ab78831c-c9e4-4407-968a-fae3c21f7e44.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "use themed colors for FocusTrapZone test",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

In high contrast mode, the texts present under the "Basic FocusTrapZone Usage" is not visible properly. This change uses themed styles instead of set color values for the FocusTrapZone test page components so high contrast requirements are met. 

### Verification

Ensured contrast requirements were met with Accessibility Insights for Windows.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://github.com/microsoft/fluentui-react-native/assets/22876140/ee1471da-2908-4ed4-80ca-a8deca8ea3d0) | ![image](https://github.com/microsoft/fluentui-react-native/assets/22876140/2448b7e0-9362-4286-85d1-94f0856d3dcb) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
