### PR TITLE
ThemeProvider now correctly updates state when the passed ThemeReference changes

### DIFF
--- a/change/@fluentui-react-native-theme-1952a3b4-d475-4205-9f6a-b2961b1209c0.json
+++ b/change/@fluentui-react-native-theme-1952a3b4-d475-4205-9f6a-b2961b1209c0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix theme state not changing when themeRef passed into provider is changed",
+  "packageName": "@fluentui-react-native/theme",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/framework/theme/src/ThemeProvider.tsx
+++ b/packages/framework/theme/src/ThemeProvider.tsx
@@ -16,6 +16,9 @@ export const ThemeProvider: React.FunctionComponent<ThemeProviderProps> = (props
   const [theme, setThemeState] = React.useState(() => themeRef.theme);
 
   React.useEffect(() => {
+    // Result of https://github.com/microsoft/fluentui-react-native/issues/3163
+    setThemeState(themeRef.theme);
+
     const onInvalidate = () => {
       setThemeState(themeRef.theme);
     };

--- a/packages/framework/theme/src/ThemeProvider.tsx
+++ b/packages/framework/theme/src/ThemeProvider.tsx
@@ -16,7 +16,7 @@ export const ThemeProvider: React.FunctionComponent<ThemeProviderProps> = (props
   const [theme, setThemeState] = React.useState(() => themeRef.theme);
 
   React.useEffect(() => {
-    // Result of https://github.com/microsoft/fluentui-react-native/issues/3163
+    // If the theme passed by prop is different, we directly update state. We also add a listener to update state if there's a change within the passed theme.
     setThemeState(themeRef.theme);
 
     const onInvalidate = () => {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Bug: #3163 

Currently, a ThemeProvider updates its stored theme whenever its ThemeReference prop listens to a change in its theme. However, when the ThemeReference prop itself changes, the ThemeProvider does not update its stored theme. 

This PR fixes this by setting the theme state variable first whenever the ThemeReference prop updates in a useEffect hook.

### Verification

Locally tested and verified. 

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
