### PR TITLE
[mac/ios] Ensure explicit module imports and fix a few warnings

### DIFF
--- a/change/@fluentui-react-native-callout-89164caa-7029-4e46-805b-1432e941d3da.json
+++ b/change/@fluentui-react-native-callout-89164caa-7029-4e46-805b-1432e941d3da.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add explicit module imports",
+  "packageName": "@fluentui-react-native/callout",
+  "email": "araje@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-avatar-5c1e69ce-39f2-49ad-88e8-706389c68f0a.json
+++ b/change/@fluentui-react-native-experimental-avatar-5c1e69ce-39f2-49ad-88e8-706389c68f0a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add explicit module imports",
+  "packageName": "@fluentui-react-native/experimental-avatar",
+  "email": "araje@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-checkbox-f9f49143-3e69-483c-b810-f72827f03902.json
+++ b/change/@fluentui-react-native-experimental-checkbox-f9f49143-3e69-483c-b810-f72827f03902.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add explicit module imports",
+  "packageName": "@fluentui-react-native/experimental-checkbox",
+  "email": "araje@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-native-font-metrics-cdabb87a-b3f6-41fe-b312-f243685c3fcb.json
+++ b/change/@fluentui-react-native-experimental-native-font-metrics-cdabb87a-b3f6-41fe-b312-f243685c3fcb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add explicit module imports",
+  "packageName": "@fluentui-react-native/experimental-native-font-metrics",
+  "email": "araje@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-focus-zone-e8512d6c-5864-4f1f-83cb-5a4baf6be5a7.json
+++ b/change/@fluentui-react-native-focus-zone-e8512d6c-5864-4f1f-83cb-5a4baf6be5a7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add explicit module ",
+  "packageName": "@fluentui-react-native/focus-zone",
+  "email": "araje@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-menu-button-30568767-78d2-4f52-9f86-76b9dc7738a4.json
+++ b/change/@fluentui-react-native-menu-button-30568767-78d2-4f52-9f86-76b9dc7738a4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add explicit module imports",
+  "packageName": "@fluentui-react-native/menu-button",
+  "email": "araje@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-radio-group-4e310bbb-300b-4275-a8af-7752cac880de.json
+++ b/change/@fluentui-react-native-radio-group-4e310bbb-300b-4275-a8af-7752cac880de.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add explicit module imports",
+  "packageName": "@fluentui-react-native/radio-group",
+  "email": "araje@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-vibrancy-view-fbc807a8-94a0-4813-948f-290b06393174.json
+++ b/change/@fluentui-react-native-vibrancy-view-fbc807a8-94a0-4813-948f-290b06393174.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add explicit module imports",
+  "packageName": "@fluentui-react-native/vibrancy-view",
+  "email": "araje@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/components/Callout/macos/CalloutManager.swift
+++ b/packages/components/Callout/macos/CalloutManager.swift
@@ -1,4 +1,6 @@
+import AppKit
 import Foundation
+import React
 
 @objc(FRNCalloutManager)
 class CalloutManager: RCTViewManager {

--- a/packages/components/Callout/macos/CalloutManager.swift
+++ b/packages/components/Callout/macos/CalloutManager.swift
@@ -1,6 +1,8 @@
 import AppKit
 import Foundation
+#if USE_REACT_AS_MODULE
 import React
+#endif // USE_REACT_AS_MODULE
 
 @objc(FRNCalloutManager)
 class CalloutManager: RCTViewManager {

--- a/packages/components/Callout/macos/CalloutView.swift
+++ b/packages/components/Callout/macos/CalloutView.swift
@@ -1,5 +1,6 @@
-import Foundation
 import AppKit
+import Foundation
+import React
 
 @objc(FRNCalloutView)
 class CalloutView: RCTView, CalloutWindowLifeCycleDelegate {

--- a/packages/components/Callout/macos/CalloutView.swift
+++ b/packages/components/Callout/macos/CalloutView.swift
@@ -1,6 +1,8 @@
 import AppKit
 import Foundation
+#if USE_REACT_AS_MODULE
 import React
+#endif // USE_REACT_AS_MODULE
 
 @objc(FRNCalloutView)
 class CalloutView: RCTView, CalloutWindowLifeCycleDelegate {

--- a/packages/components/Callout/macos/FRNCalloutManager.m
+++ b/packages/components/Callout/macos/FRNCalloutManager.m
@@ -1,4 +1,4 @@
-#import <FRNCalloutManager.h>
+#import "FRNCalloutManager.h"
 
 @implementation RCTConvert (FRNCalloutAdditions)
 

--- a/packages/components/Callout/macos/FlippedVisualEffectView.swift
+++ b/packages/components/Callout/macos/FlippedVisualEffectView.swift
@@ -1,3 +1,5 @@
+import AppKit
+
 /// React Native macOS uses a flipped coordinate space by default. Let's stay consistent and
 /// ensure any views hosting React Native views are also flipped. This helps RCTTouchHandler
 /// register clicks in the right location.

--- a/packages/components/Callout/macos/GuardedEventMonitor.swift
+++ b/packages/components/Callout/macos/GuardedEventMonitor.swift
@@ -1,4 +1,4 @@
-
+import AppKit
 
 /// NSEvent localMonitors are an _old_ API that requires you to do some  memory management yourself.
 /// You _must_ call `removeMonitor`exactly once per monitor created from. This helper class enforces

--- a/packages/components/FocusZone/macos/RCTFocusZone.m
+++ b/packages/components/FocusZone/macos/RCTFocusZone.m
@@ -421,7 +421,7 @@ static BOOL ShouldSkipFocusZone(NSView *view)
 
 		// If the previous view is in a FocusZone, focus on its defaultKeyView
 		// (For FocusZoneActionTab, this is handled by becomeFirstResponder).
-		RCTFocusZone *focusZoneAncestor = GetFocusZoneAncestor(nextViewToFocus);
+		focusZoneAncestor = GetFocusZoneAncestor(nextViewToFocus);
 		NSView *ancestorKeyView = [focusZoneAncestor defaultResponder];
 		if (ancestorKeyView != nil) {
 			nextViewToFocus = [focusZoneAncestor defaultResponder];

--- a/packages/components/MenuButton/macos/MenuButton.swift
+++ b/packages/components/MenuButton/macos/MenuButton.swift
@@ -4,7 +4,9 @@
 //
 
 import AppKit
+#if USE_REACT_AS_MODULE
 import React
+#endif // USE_REACT_AS_MODULE
 
 @objc(FRNMenuButton)
 class MenuButton: NSPopUpButton {

--- a/packages/components/MenuButton/macos/MenuButton.swift
+++ b/packages/components/MenuButton/macos/MenuButton.swift
@@ -4,6 +4,7 @@
 //
 
 import AppKit
+import React
 
 @objc(FRNMenuButton)
 class MenuButton: NSPopUpButton {

--- a/packages/components/MenuButton/macos/MenuButtonManager.swift
+++ b/packages/components/MenuButton/macos/MenuButtonManager.swift
@@ -1,6 +1,8 @@
 import AppKit
 import Foundation
+#if USE_REACT_AS_MODULE
 import React
+#endif // USE_REACT_AS_MODULE
 
 @objc(FRNMenuButtonManager)
 class MenuButtonManager: RCTViewManager {

--- a/packages/components/MenuButton/macos/MenuButtonManager.swift
+++ b/packages/components/MenuButton/macos/MenuButtonManager.swift
@@ -1,4 +1,6 @@
+import AppKit
 import Foundation
+import React
 
 @objc(FRNMenuButtonManager)
 class MenuButtonManager: RCTViewManager {

--- a/packages/components/RadioGroup/macos/RadioButton.swift
+++ b/packages/components/RadioGroup/macos/RadioButton.swift
@@ -1,5 +1,7 @@
 import AppKit
+#if USE_REACT_AS_MODULE
 import React
+#endif // USE_REACT_AS_MODULE
 
 class RadioButton: NSButton {
 

--- a/packages/components/RadioGroup/macos/RadioButton.swift
+++ b/packages/components/RadioGroup/macos/RadioButton.swift
@@ -1,3 +1,6 @@
+import AppKit
+import React
+
 class RadioButton: NSButton {
 
 	@objc public var onPress: RCTBubblingEventBlock?
@@ -5,11 +8,11 @@ class RadioButton: NSButton {
 	public override init(frame:NSRect) {
 		super.init(frame: frame)
 	}
-	
+
 	required init?(coder: NSCoder) {
 		preconditionFailure("init(coder:) has not been implemented")
 	}
-	
+
 	@objc public func sendCallback() {
 		self.window?.makeFirstResponder(self)
 		if (onPress != nil) {

--- a/packages/components/RadioGroup/macos/RadioButtonViewManager.swift
+++ b/packages/components/RadioGroup/macos/RadioButtonViewManager.swift
@@ -1,6 +1,8 @@
 import AppKit
 import Foundation
+#if USE_REACT_AS_MODULE
 import React
+#endif // USE_REACT_AS_MODULE
 
 @objc(FRNRadioButtonViewManager)
 class RadioButtonViewManager: RCTViewManager {

--- a/packages/components/RadioGroup/macos/RadioButtonViewManager.swift
+++ b/packages/components/RadioGroup/macos/RadioButtonViewManager.swift
@@ -1,4 +1,6 @@
+import AppKit
 import Foundation
+import React
 
 @objc(FRNRadioButtonViewManager)
 class RadioButtonViewManager: RCTViewManager {

--- a/packages/experimental/Avatar/ios/AvatarViewManager.swift
+++ b/packages/experimental/Avatar/ios/AvatarViewManager.swift
@@ -1,5 +1,7 @@
+import AppKit
 import Foundation
 import FluentUI
+import React
 
 @objc(FRNAvatarViewManager)
 class AvatarViewManager: RCTViewManager {

--- a/packages/experimental/Avatar/ios/AvatarViewManager.swift
+++ b/packages/experimental/Avatar/ios/AvatarViewManager.swift
@@ -1,7 +1,7 @@
-import AppKit
 import Foundation
 import FluentUI
 import React
+import UIKit
 
 @objc(FRNAvatarViewManager)
 class AvatarViewManager: RCTViewManager {

--- a/packages/experimental/Checkbox/macos/Checkbox.swift
+++ b/packages/experimental/Checkbox/macos/Checkbox.swift
@@ -1,5 +1,7 @@
 import AppKit
+#if USE_REACT_AS_MODULE
 import React
+#endif // USE_REACT_AS_MODULE
 
 class Checkbox: NSButton {
 

--- a/packages/experimental/Checkbox/macos/Checkbox.swift
+++ b/packages/experimental/Checkbox/macos/Checkbox.swift
@@ -1,3 +1,6 @@
+import AppKit
+import React
+
 class Checkbox: NSButton {
 
 	@objc public var onPress: RCTBubblingEventBlock?

--- a/packages/experimental/Checkbox/macos/CheckboxViewManager.swift
+++ b/packages/experimental/Checkbox/macos/CheckboxViewManager.swift
@@ -1,4 +1,6 @@
+import AppKit
 import Foundation
+import React
 
 @objc(FRNCheckboxViewManager)
 class CheckboxViewManager: RCTViewManager {

--- a/packages/experimental/Checkbox/macos/CheckboxViewManager.swift
+++ b/packages/experimental/Checkbox/macos/CheckboxViewManager.swift
@@ -1,6 +1,8 @@
 import AppKit
 import Foundation
+#if USE_REACT_AS_MODULE
 import React
+#endif // USE_REACT_AS_MODULE
 
 @objc(FRNCheckboxViewManager)
 class CheckboxViewManager: RCTViewManager {

--- a/packages/experimental/NativeFontMetrics/ios/FRNFontMetrics.m
+++ b/packages/experimental/NativeFontMetrics/ios/FRNFontMetrics.m
@@ -105,7 +105,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(scaleFactorForStyle:(NSString *)styleStri
 
 #pragma mark - RCTEventEmitter
 
-- (NSArray<NSString *> *)supportedEvents
+- (NSArray<NSString *> *_Nullable)supportedEvents
 {
     return @[ @"onFontMetricsChanged" ];
 }

--- a/packages/experimental/VibrancyView/macos/FixedVisualEffectView.swift
+++ b/packages/experimental/VibrancyView/macos/FixedVisualEffectView.swift
@@ -1,5 +1,7 @@
 import AppKit
+#if USE_REACT_AS_MODULE
 import React
+#endif // USE_REACT_AS_MODULE
 
 /// React Native macOS inherits some assumptions from React Native on iOS / UIKit.
 /// This serves as an issue when we want to write our own native components derived from NSView, as we don't

--- a/packages/experimental/VibrancyView/macos/FixedVisualEffectView.swift
+++ b/packages/experimental/VibrancyView/macos/FixedVisualEffectView.swift
@@ -1,3 +1,6 @@
+import AppKit
+import React
+
 /// React Native macOS inherits some assumptions from React Native on iOS / UIKit.
 /// This serves as an issue when we want to write our own native components derived from NSView, as we don't
 /// inherit the "fixes" we need from RCTView to get views working properly.. This subclass "fixes" the minimal amount

--- a/packages/experimental/VibrancyView/macos/VibrancyView.swift
+++ b/packages/experimental/VibrancyView/macos/VibrancyView.swift
@@ -1,4 +1,5 @@
 import AppKit
+import React
 
 @objc(FRNVibrancyView)
 open class VibrancyView: RCTView {

--- a/packages/experimental/VibrancyView/macos/VibrancyView.swift
+++ b/packages/experimental/VibrancyView/macos/VibrancyView.swift
@@ -1,5 +1,7 @@
 import AppKit
+#if USE_REACT_AS_MODULE
 import React
+#endif // USE_REACT_AS_MODULE
 
 @objc(FRNVibrancyView)
 open class VibrancyView: RCTView {

--- a/packages/experimental/VibrancyView/macos/VibrancyViewManager.swift
+++ b/packages/experimental/VibrancyView/macos/VibrancyViewManager.swift
@@ -1,6 +1,8 @@
 import AppKit
 import Foundation
+#if USE_REACT_AS_MODULE
 import React
+#endif // USE_REACT_AS_MODULE
 
 @objc(FRNVibrancyViewManager)
 class VibrancyViewManager: RCTViewManager {

--- a/packages/experimental/VibrancyView/macos/VibrancyViewManager.swift
+++ b/packages/experimental/VibrancyView/macos/VibrancyViewManager.swift
@@ -1,4 +1,6 @@
+import AppKit
 import Foundation
+import React
 
 @objc(FRNVibrancyViewManager)
 class VibrancyViewManager: RCTViewManager {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

- fluentui-react-native has lots of usage of other modules but doesn't import them. This seems to work in cocoapods (likely through the unfortunate magic of the module cache), but doesn't work in other build systems and is likely to break in a future version of Xcode. Add explicit imports for things we use.
  - Wrap in USE_REACT_AS_MODULE, which is not defined in this repo and thus doesn't actually add the imports. This can be defined in other repos which don't get the free module usage magically afforded by cocoapods' setup), but we can we remove these wrappers when rn 0.73 is merged and React is importable.
- Warnings are not treated as errors, but may be so in other build systems and are good to fix anyway
  - Use "" for path-relative intra-project imports (FRNCalloutManager.m)
  - Don't have multiple declarations of the same symbol in the same scope (RCTFocusZone.m)
  - Match nullability specifications between function declaration and implementation (FRNFontMetrics.m)
  
### Verification
All build-time, not run-time impact, so just local build

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
