### PR TITLE
[mac/ios] Add a few more missing module includes

### DIFF
--- a/change/@fluentui-react-native-experimental-avatar-b8e39e20-cd59-4861-a4ee-18a4fbbe7c76.json
+++ b/change/@fluentui-react-native-experimental-avatar-b8e39e20-cd59-4861-a4ee-18a4fbbe7c76.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add more module includes",
+  "packageName": "@fluentui-react-native/experimental-avatar",
+  "email": "araje@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-native-date-picker-6fe4a5ca-247f-4035-9db1-668d48ca2d00.json
+++ b/change/@fluentui-react-native-experimental-native-date-picker-6fe4a5ca-247f-4035-9db1-668d48ca2d00.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add more module includes",
+  "packageName": "@fluentui-react-native/experimental-native-date-picker",
+  "email": "araje@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/experimental/Avatar/macos/AvatarViewManager.swift
+++ b/packages/experimental/Avatar/macos/AvatarViewManager.swift
@@ -1,5 +1,9 @@
+import AppKit
 import Foundation
 import FluentUI
+#if USE_REACT_AS_MODULE
+import React
+#endif
 
 @objc(FRNAvatarViewManager)
 class AvatarViewManager: RCTViewManager {

--- a/packages/experimental/NativeDatePicker/ios/DatePickerDelegate.swift
+++ b/packages/experimental/NativeDatePicker/ios/DatePickerDelegate.swift
@@ -1,4 +1,6 @@
 import FluentUI
+import Foundation
+import React
 
 class DatePickerDelegate: DateTimePickerDelegate {
     weak var manager: DatePickerManager?

--- a/packages/experimental/NativeDatePicker/ios/DatePickerManager.swift
+++ b/packages/experimental/NativeDatePicker/ios/DatePickerManager.swift
@@ -1,4 +1,6 @@
 import FluentUI
+import Foundation
+import React
 
 @objc(FRNDatePickerManager)
 public class DatePickerManager: NSObject {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
See #3382 for details. I...missed a few spots. Add the necessary module includes here, perpetuating the usage of a non-defined macro USE_REACT_AS_MODULE while the React module isn't yet importable on macOS (it is importable on iOS). This keeps the repo here building while other builds systems where it is importable can define that macro in SWIFT_ACTIVE_COMPILATION_CONDITIONS and get the necessary import.

### Verification
Local build

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
