### PR TITLE
Add cred scan suppressions for issues from upstream libraries

### DIFF
--- a/.ado/config/CredScanSuppressions.json
+++ b/.ado/config/CredScanSuppressions.json
@@ -1,0 +1,17 @@
+{
+  "tool": "Credential Scanner",
+  "suppressions": [
+    {
+      "file": "\\node_modules\\react-native\\template\\android\\app\\debug.keystore",
+      "_justification": "Debug secret created and consumed by third-party library"
+    },
+    {
+      "file": "\\node_modules\\react-native-macos\\template\\android\\app\\debug.keystore",
+      "_justification": "Debug secret created and consumed by third-party library"
+    },
+    {
+      "file": "\\apps\\E2E\\node_modules\\react-native\\template\\android\\app\\debug.keystore",
+      "_justification": "Debug secret created and consumed by third-party library"
+    }
+  ]
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Add json file to configure some suppressions of findings from the cred scan tool which are from upstream libraries. This is to prevent the pipeline from being blocked in the future
