### PR TITLE
Fix bug where macOS CalloutView renders offscreen in RTL edge case

### DIFF
--- a/apps/fluent-tester/macos/Podfile.lock
+++ b/apps/fluent-tester/macos/Podfile.lock
@@ -1,25 +1,25 @@
 PODS:
   - boost (1.76.0)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.72.12)
-  - FBReactNativeSpec (0.72.12):
+  - FBLazyVector (0.72.15)
+  - FBReactNativeSpec (0.72.15):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTRequired (= 0.72.12)
-    - RCTTypeSafety (= 0.72.12)
-    - React-Core (= 0.72.12)
-    - React-jsi (= 0.72.12)
-    - ReactCommon/turbomodule/core (= 0.72.12)
+    - RCTRequired (= 0.72.15)
+    - RCTTypeSafety (= 0.72.15)
+    - React-Core (= 0.72.15)
+    - React-jsi (= 0.72.15)
+    - ReactCommon/turbomodule/core (= 0.72.15)
   - fmt (6.2.1)
-  - FRNAvatar (0.20.6):
+  - FRNAvatar (0.20.7):
     - MicrosoftFluentUI (= 0.13.1)
     - React
-  - FRNCallout (0.25.6):
+  - FRNCallout (0.25.7):
     - React
-  - FRNCheckbox (0.16.6):
+  - FRNCheckbox (0.16.7):
     - React
-  - FRNMenuButton (0.12.11):
+  - FRNMenuButton (0.12.12):
     - React
-  - FRNRadioButton (0.20.7):
+  - FRNRadioButton (0.20.9):
     - React
   - FRNVibrancyView (0.1.0):
     - React
@@ -104,28 +104,28 @@ PODS:
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
-  - RCTFocusZone (0.16.6):
+  - RCTFocusZone (0.16.7):
     - React
-  - RCTRequired (0.72.12)
-  - RCTTypeSafety (0.72.12):
-    - FBLazyVector (= 0.72.12)
-    - RCTRequired (= 0.72.12)
-    - React-Core (= 0.72.12)
-  - React (0.72.12):
-    - React-Core (= 0.72.12)
-    - React-Core/DevSupport (= 0.72.12)
-    - React-Core/RCTWebSocket (= 0.72.12)
-    - React-RCTActionSheet (= 0.72.12)
-    - React-RCTAnimation (= 0.72.12)
-    - React-RCTBlob (= 0.72.12)
-    - React-RCTImage (= 0.72.12)
-    - React-RCTLinking (= 0.72.12)
-    - React-RCTNetwork (= 0.72.12)
-    - React-RCTSettings (= 0.72.12)
-    - React-RCTText (= 0.72.12)
-    - React-RCTVibration (= 0.72.12)
-  - React-callinvoker (0.72.12)
-  - React-Codegen (0.72.12):
+  - RCTRequired (0.72.15)
+  - RCTTypeSafety (0.72.15):
+    - FBLazyVector (= 0.72.15)
+    - RCTRequired (= 0.72.15)
+    - React-Core (= 0.72.15)
+  - React (0.72.15):
+    - React-Core (= 0.72.15)
+    - React-Core/DevSupport (= 0.72.15)
+    - React-Core/RCTWebSocket (= 0.72.15)
+    - React-RCTActionSheet (= 0.72.15)
+    - React-RCTAnimation (= 0.72.15)
+    - React-RCTBlob (= 0.72.15)
+    - React-RCTImage (= 0.72.15)
+    - React-RCTLinking (= 0.72.15)
+    - React-RCTNetwork (= 0.72.15)
+    - React-RCTSettings (= 0.72.15)
+    - React-RCTText (= 0.72.15)
+    - React-RCTVibration (= 0.72.15)
+  - React-callinvoker (0.72.15)
+  - React-Codegen (0.72.15):
     - DoubleConversion
     - FBReactNativeSpec
     - glog
@@ -140,10 +140,10 @@ PODS:
     - React-rncore
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-Core (0.72.12):
+  - React-Core (0.72.15):
     - glog
     - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default (= 0.72.12)
+    - React-Core/Default (= 0.72.15)
     - React-cxxreact
     - React-jsc
     - React-jsi
@@ -153,47 +153,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.72.12):
-    - glog
-    - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default
-    - React-cxxreact
-    - React-jsc
-    - React-jsi
-    - React-jsiexecutor
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-utils
-    - SocketRocket (= 0.7.0)
-    - Yoga
-  - React-Core/Default (0.72.12):
-    - glog
-    - RCT-Folly (= 2021.07.22.00)
-    - React-cxxreact
-    - React-jsc
-    - React-jsi
-    - React-jsiexecutor
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-utils
-    - SocketRocket (= 0.7.0)
-    - Yoga
-  - React-Core/DevSupport (0.72.12):
-    - glog
-    - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default (= 0.72.12)
-    - React-Core/RCTWebSocket (= 0.72.12)
-    - React-cxxreact
-    - React-jsc
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector (= 0.72.12)
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-utils
-    - SocketRocket (= 0.7.0)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.72.12):
+  - React-Core/CoreModulesHeaders (0.72.15):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
@@ -206,7 +166,34 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.72.12):
+  - React-Core/Default (0.72.15):
+    - glog
+    - RCT-Folly (= 2021.07.22.00)
+    - React-cxxreact
+    - React-jsc
+    - React-jsi
+    - React-jsiexecutor
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-utils
+    - SocketRocket (= 0.7.0)
+    - Yoga
+  - React-Core/DevSupport (0.72.15):
+    - glog
+    - RCT-Folly (= 2021.07.22.00)
+    - React-Core/Default (= 0.72.15)
+    - React-Core/RCTWebSocket (= 0.72.15)
+    - React-cxxreact
+    - React-jsc
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector (= 0.72.15)
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-utils
+    - SocketRocket (= 0.7.0)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.72.15):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
@@ -219,7 +206,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.72.12):
+  - React-Core/RCTAnimationHeaders (0.72.15):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
@@ -232,7 +219,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTImageHeaders (0.72.12):
+  - React-Core/RCTBlobHeaders (0.72.15):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
@@ -245,7 +232,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.72.12):
+  - React-Core/RCTImageHeaders (0.72.15):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
@@ -258,7 +245,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.72.12):
+  - React-Core/RCTLinkingHeaders (0.72.15):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
@@ -271,7 +258,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.72.12):
+  - React-Core/RCTNetworkHeaders (0.72.15):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
@@ -284,7 +271,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTTextHeaders (0.72.12):
+  - React-Core/RCTSettingsHeaders (0.72.15):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
@@ -297,7 +284,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.72.12):
+  - React-Core/RCTTextHeaders (0.72.15):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
@@ -310,10 +297,10 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTWebSocket (0.72.12):
+  - React-Core/RCTVibrationHeaders (0.72.15):
     - glog
     - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default (= 0.72.12)
+    - React-Core/Default
     - React-cxxreact
     - React-jsc
     - React-jsi
@@ -323,50 +310,63 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-CoreModules (0.72.12):
+  - React-Core/RCTWebSocket (0.72.15):
+    - glog
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.72.12)
-    - React-Codegen (= 0.72.12)
-    - React-Core/CoreModulesHeaders (= 0.72.12)
-    - React-jsi (= 0.72.12)
+    - React-Core/Default (= 0.72.15)
+    - React-cxxreact
+    - React-jsc
+    - React-jsi
+    - React-jsiexecutor
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-utils
+    - SocketRocket (= 0.7.0)
+    - Yoga
+  - React-CoreModules (0.72.15):
+    - RCT-Folly (= 2021.07.22.00)
+    - RCTTypeSafety (= 0.72.15)
+    - React-Codegen (= 0.72.15)
+    - React-Core/CoreModulesHeaders (= 0.72.15)
+    - React-jsi (= 0.72.15)
     - React-RCTBlob
-    - React-RCTImage (= 0.72.12)
-    - ReactCommon/turbomodule/core (= 0.72.12)
+    - React-RCTImage (= 0.72.15)
+    - ReactCommon/turbomodule/core (= 0.72.15)
     - SocketRocket (= 0.7.0)
-  - React-cxxreact (0.72.12):
+  - React-cxxreact (0.72.15):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.07.22.00)
-    - React-callinvoker (= 0.72.12)
-    - React-debug (= 0.72.12)
-    - React-jsi (= 0.72.12)
-    - React-jsinspector (= 0.72.12)
-    - React-logger (= 0.72.12)
-    - React-perflogger (= 0.72.12)
-    - React-runtimeexecutor (= 0.72.12)
-  - React-debug (0.72.12)
-  - React-jsc (0.72.12):
-    - React-jsc/Fabric (= 0.72.12)
-    - React-jsi (= 0.72.12)
-  - React-jsc/Fabric (0.72.12):
-    - React-jsi (= 0.72.12)
-  - React-jsi (0.72.12):
+    - React-callinvoker (= 0.72.15)
+    - React-debug (= 0.72.15)
+    - React-jsi (= 0.72.15)
+    - React-jsinspector (= 0.72.15)
+    - React-logger (= 0.72.15)
+    - React-perflogger (= 0.72.15)
+    - React-runtimeexecutor (= 0.72.15)
+  - React-debug (0.72.15)
+  - React-jsc (0.72.15):
+    - React-jsc/Fabric (= 0.72.15)
+    - React-jsi (= 0.72.15)
+  - React-jsc/Fabric (0.72.15):
+    - React-jsi (= 0.72.15)
+  - React-jsi (0.72.15):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.07.22.00)
-  - React-jsiexecutor (0.72.12):
+  - React-jsiexecutor (0.72.15):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.07.22.00)
-    - React-cxxreact (= 0.72.12)
-    - React-jsi (= 0.72.12)
-    - React-perflogger (= 0.72.12)
-  - React-jsinspector (0.72.12)
-  - React-logger (0.72.12):
+    - React-cxxreact (= 0.72.15)
+    - React-jsi (= 0.72.15)
+    - React-perflogger (= 0.72.15)
+  - React-jsinspector (0.72.15)
+  - React-logger (0.72.15):
     - glog
-  - React-NativeModulesApple (0.72.12):
+  - React-NativeModulesApple (0.72.15):
     - React-callinvoker
     - React-Core
     - React-cxxreact
@@ -374,17 +374,17 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-perflogger (0.72.12)
-  - React-RCTActionSheet (0.72.12):
-    - React-Core/RCTActionSheetHeaders (= 0.72.12)
-  - React-RCTAnimation (0.72.12):
+  - React-perflogger (0.72.15)
+  - React-RCTActionSheet (0.72.15):
+    - React-Core/RCTActionSheetHeaders (= 0.72.15)
+  - React-RCTAnimation (0.72.15):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.72.12)
-    - React-Codegen (= 0.72.12)
-    - React-Core/RCTAnimationHeaders (= 0.72.12)
-    - React-jsi (= 0.72.12)
-    - ReactCommon/turbomodule/core (= 0.72.12)
-  - React-RCTAppDelegate (0.72.12):
+    - RCTTypeSafety (= 0.72.15)
+    - React-Codegen (= 0.72.15)
+    - React-Core/RCTAnimationHeaders (= 0.72.15)
+    - React-jsi (= 0.72.15)
+    - ReactCommon/turbomodule/core (= 0.72.15)
+  - React-RCTAppDelegate (0.72.15):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -396,81 +396,81 @@ PODS:
     - React-RCTNetwork
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
-  - React-RCTBlob (0.72.12):
+  - React-RCTBlob (0.72.15):
     - RCT-Folly (= 2021.07.22.00)
-    - React-Codegen (= 0.72.12)
-    - React-Core/RCTBlobHeaders (= 0.72.12)
-    - React-Core/RCTWebSocket (= 0.72.12)
-    - React-jsi (= 0.72.12)
-    - React-RCTNetwork (= 0.72.12)
-    - ReactCommon/turbomodule/core (= 0.72.12)
-  - React-RCTImage (0.72.12):
+    - React-Codegen (= 0.72.15)
+    - React-Core/RCTBlobHeaders (= 0.72.15)
+    - React-Core/RCTWebSocket (= 0.72.15)
+    - React-jsi (= 0.72.15)
+    - React-RCTNetwork (= 0.72.15)
+    - ReactCommon/turbomodule/core (= 0.72.15)
+  - React-RCTImage (0.72.15):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.72.12)
-    - React-Codegen (= 0.72.12)
-    - React-Core/RCTImageHeaders (= 0.72.12)
-    - React-jsi (= 0.72.12)
-    - React-RCTNetwork (= 0.72.12)
-    - ReactCommon/turbomodule/core (= 0.72.12)
-  - React-RCTLinking (0.72.12):
-    - React-Codegen (= 0.72.12)
-    - React-Core/RCTLinkingHeaders (= 0.72.12)
-    - React-jsi (= 0.72.12)
-    - ReactCommon/turbomodule/core (= 0.72.12)
-  - React-RCTNetwork (0.72.12):
+    - RCTTypeSafety (= 0.72.15)
+    - React-Codegen (= 0.72.15)
+    - React-Core/RCTImageHeaders (= 0.72.15)
+    - React-jsi (= 0.72.15)
+    - React-RCTNetwork (= 0.72.15)
+    - ReactCommon/turbomodule/core (= 0.72.15)
+  - React-RCTLinking (0.72.15):
+    - React-Codegen (= 0.72.15)
+    - React-Core/RCTLinkingHeaders (= 0.72.15)
+    - React-jsi (= 0.72.15)
+    - ReactCommon/turbomodule/core (= 0.72.15)
+  - React-RCTNetwork (0.72.15):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.72.12)
-    - React-Codegen (= 0.72.12)
-    - React-Core/RCTNetworkHeaders (= 0.72.12)
-    - React-jsi (= 0.72.12)
-    - ReactCommon/turbomodule/core (= 0.72.12)
-  - React-RCTSettings (0.72.12):
+    - RCTTypeSafety (= 0.72.15)
+    - React-Codegen (= 0.72.15)
+    - React-Core/RCTNetworkHeaders (= 0.72.15)
+    - React-jsi (= 0.72.15)
+    - ReactCommon/turbomodule/core (= 0.72.15)
+  - React-RCTSettings (0.72.15):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.72.12)
-    - React-Codegen (= 0.72.12)
-    - React-Core/RCTSettingsHeaders (= 0.72.12)
-    - React-jsi (= 0.72.12)
-    - ReactCommon/turbomodule/core (= 0.72.12)
-  - React-RCTText (0.72.12):
-    - React-Core/RCTTextHeaders (= 0.72.12)
-  - React-RCTVibration (0.72.12):
+    - RCTTypeSafety (= 0.72.15)
+    - React-Codegen (= 0.72.15)
+    - React-Core/RCTSettingsHeaders (= 0.72.15)
+    - React-jsi (= 0.72.15)
+    - ReactCommon/turbomodule/core (= 0.72.15)
+  - React-RCTText (0.72.15):
+    - React-Core/RCTTextHeaders (= 0.72.15)
+  - React-RCTVibration (0.72.15):
     - RCT-Folly (= 2021.07.22.00)
-    - React-Codegen (= 0.72.12)
-    - React-Core/RCTVibrationHeaders (= 0.72.12)
-    - React-jsi (= 0.72.12)
-    - ReactCommon/turbomodule/core (= 0.72.12)
-  - React-rncore (0.72.12)
-  - React-runtimeexecutor (0.72.12):
-    - React-jsi (= 0.72.12)
-  - React-runtimescheduler (0.72.12):
+    - React-Codegen (= 0.72.15)
+    - React-Core/RCTVibrationHeaders (= 0.72.15)
+    - React-jsi (= 0.72.15)
+    - ReactCommon/turbomodule/core (= 0.72.15)
+  - React-rncore (0.72.15)
+  - React-runtimeexecutor (0.72.15):
+    - React-jsi (= 0.72.15)
+  - React-runtimescheduler (0.72.15):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-callinvoker
     - React-debug
     - React-jsi
     - React-runtimeexecutor
-  - React-utils (0.72.12):
+  - React-utils (0.72.15):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-debug
-  - ReactCommon/turbomodule/bridging (0.72.12):
+  - ReactCommon/turbomodule/bridging (0.72.15):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.07.22.00)
-    - React-callinvoker (= 0.72.12)
-    - React-cxxreact (= 0.72.12)
-    - React-jsi (= 0.72.12)
-    - React-logger (= 0.72.12)
-    - React-perflogger (= 0.72.12)
-  - ReactCommon/turbomodule/core (0.72.12):
+    - React-callinvoker (= 0.72.15)
+    - React-cxxreact (= 0.72.15)
+    - React-jsi (= 0.72.15)
+    - React-logger (= 0.72.15)
+    - React-perflogger (= 0.72.15)
+  - ReactCommon/turbomodule/core (0.72.15):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.07.22.00)
-    - React-callinvoker (= 0.72.12)
-    - React-cxxreact (= 0.72.12)
-    - React-jsi (= 0.72.12)
-    - React-logger (= 0.72.12)
-    - React-perflogger (= 0.72.12)
+    - React-callinvoker (= 0.72.15)
+    - React-cxxreact (= 0.72.15)
+    - React-jsi (= 0.72.15)
+    - React-logger (= 0.72.15)
+    - React-perflogger (= 0.72.15)
   - ReactNativeHost (0.3.1):
     - React-Core
     - React-cxxreact
@@ -650,58 +650,58 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: 8fa3cd00fa17ef6c3221e5fd283fa93e81d23017
   DoubleConversion: acaf5db79676d2e9119015819153f0f99191de12
-  FBLazyVector: 1224851890c748f0ce3a418ef375a1236ed08529
-  FBReactNativeSpec: 29a51527453e2a26d7349dee5e8b672bfbd5ffae
+  FBLazyVector: f3a437617321a576905548c703193fc8e2dbd456
+  FBReactNativeSpec: 1deb0c0a38bb71781594c73b9fb5d527af25b927
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  FRNAvatar: 39060d96d85fd0d76d56892d08ebbf40900af208
-  FRNCallout: bb7baacea769595b04f0cd50b5cf51bc7607c5e5
-  FRNCheckbox: 89e548aa100158f5af0baef8d6a5ca2605b95b00
-  FRNMenuButton: fdd110d0117e921e4adea09e8856a2ab9006f11e
-  FRNRadioButton: 4a7a9a7648e94da1b7b74236468cbd055f67722d
+  FRNAvatar: 4800a3053ad300d0d6b269abe7bacfc6e4bf09b9
+  FRNCallout: c45b703918a5ea576d939ddc9d45f68d286d8412
+  FRNCheckbox: 8eb1bc84f46c6f71e5e22b58b55ce7b820ccbd8d
+  FRNMenuButton: 785c2b90435e1ae8de1aa4e3b8aa814662a9294e
+  FRNRadioButton: 49b2b099456df66d2d491a27c8178efa39b80a27
   FRNVibrancyView: 4362b4c882bbf18e752c847544b97beea195b544
   glog: 6df0a3d6e2750a50609471fd1a01fd2948d405b5
   MicrosoftFluentUI: dde98d8ed3fc306d9ddd0a6f0bc0c1f24fe5275e
   RCT-Folly: bf7b4921a91932051ebf1c5c2d297154b1fa3c8c
-  RCTFocusZone: 9c2e2cc4678271aab1006c1396c061573276514d
-  RCTRequired: bfacf9ecfae24ae67ff4a62929d49f2471f95fcc
-  RCTTypeSafety: dcaad8825a650ae7aadaf9300b781e07ab8614d3
-  React: cc4714942fd88f864e20e8ad3e6edbf4222c54d9
-  React-callinvoker: c96aba9bca657eb16707e997a6718a0903178e27
-  React-Codegen: 65ed8d9fffa64a8081ee35e6fae3ef029cd2c7c0
-  React-Core: 831200b62d8971463d17039327a0550d982aea91
-  React-CoreModules: f601235f579bf9449a941a29fbe224e01d44f9e1
-  React-cxxreact: 633d2677d3527ef75a040c5b99dee9cdc2bf9c52
-  React-debug: 5cccb088017cb4adf008b1f4f908c16970d99e9d
-  React-jsc: ce1a661ad9b8c21d0b68c6d36ae0343c67fe49d2
-  React-jsi: 37b821edd936ea97187d18c29945cfdd5358278e
-  React-jsiexecutor: 2cba74981485b7ffdfd50a00078c1693eecc43f4
-  React-jsinspector: a9c2e6a72f3758359c3ec5eebc936c79db9a2f0d
-  React-logger: 6ae6640b72ecb8b555e1c30d6e9d4916ea0f87b0
-  React-NativeModulesApple: 82b3afc5e24ed572cab703c9462c3269f8ab41c5
-  React-perflogger: 62d39324878a31defe4bef979b927c4499e349ee
-  React-RCTActionSheet: 37c154868b4a36006e0db1f0e96648066dac5a55
-  React-RCTAnimation: 025d2298d4bfb61f662e029a0b738967b536fd09
-  React-RCTAppDelegate: 853ae4f815d96bcd11c7677c13b6d0da6cac7ee3
-  React-RCTBlob: 103ee176c12166af95fc688886d3eb31a16da207
-  React-RCTImage: edacf710fb5c3c99e9731d2e5614ad216d9ac4fb
-  React-RCTLinking: 5157b301fb9696c650872ef48b68b53d78d0a359
-  React-RCTNetwork: 6362aee6925bbbe6bc1b5908659b768376eca9f3
-  React-RCTSettings: 45d0e321c6b1fddeadce314b611a21366d1ab777
-  React-RCTText: 22200832f3890a9cd561591457baa347813e92b1
-  React-RCTVibration: e77697f8a2f1f08f8ee07820e93847ffead6ea07
-  React-rncore: 8573d0db8dd345c07ac045d199e75ae65d1a0f3c
-  React-runtimeexecutor: f3f631473672673b0dedf32b6d0ce39f59fefd01
-  React-runtimescheduler: e26baec9132d9a85a257904e378d0a63b8b26d05
-  React-utils: f1241058a1fa08735e7af55dee37230f849ad27d
-  ReactCommon: 3cfbcac9c34b9779ae9ccc262122a78dfc607ddb
+  RCTFocusZone: d635359e79f444c4fa3a269769caed72e46bfafa
+  RCTRequired: 160507b13db57211cbcc421bfc30034170d25043
+  RCTTypeSafety: c18f79f887eb142430ccf896fd8c85b139d0195f
+  React: 4243e754c50f07ecfaf34a78d557024de401c4c7
+  React-callinvoker: da9b19f92a150a98d97e82a1c6b537f5ac427e49
+  React-Codegen: 62ebcc34c429e27f8565fd0366a26f95a6b1e50f
+  React-Core: ac7f5accf39e0f303f6a0207d395cd4331489492
+  React-CoreModules: a048649821fbc331b6e6d1402df1c3f9b777ed65
+  React-cxxreact: c73daa8fdd61008db827243d42b52258fa9ba7db
+  React-debug: 20e65b51cb3d9103caf1ad78068e4d7d638e4b88
+  React-jsc: c181ada8178321b695d81cce8e59dac96dad8969
+  React-jsi: d590e37939959a4d4bba8ebf657814e3fd81ad74
+  React-jsiexecutor: 0e661ee211aad91ce355f1dee853d9820b61536a
+  React-jsinspector: 1fdefa464d72276b486af8fe2bfc59d6bbb7091d
+  React-logger: 259ae0e04c51cdae5786b834b324988c14d24770
+  React-NativeModulesApple: 0058848369aa539615c922af5c3c5ca69e5c624d
+  React-perflogger: b3d8ab20e4cf835c9a767bb7d661cc58cc340daf
+  React-RCTActionSheet: 1093663382e6b71bd14267e260d37a4428b51276
+  React-RCTAnimation: 1bedaac9abf286e433f89a85e8e148cc50f3a878
+  React-RCTAppDelegate: c15d7a30a9bae6f751dc029071e7685eb93b9623
+  React-RCTBlob: d44913b65360f2faf4638b3941ebb248d6ca5bf8
+  React-RCTImage: 386aa19b0bcf0c62cd71e6445c33e8fc1277eb19
+  React-RCTLinking: ccaeeb6d17efbef8b970ae85bcbf3fb0ef9bf5fd
+  React-RCTNetwork: db29290b93bb650331c1dce067026cdc81d10186
+  React-RCTSettings: 870707e1251da4575cab59f18540747c8991c159
+  React-RCTText: 1bd393edf6950b2ba54adbbf65124751cf7d5741
+  React-RCTVibration: dd0b41437011b116d939a724a4aae0089af60a8f
+  React-rncore: 1e9b75d3438f852ac61175b25c00228570881243
+  React-runtimeexecutor: 8298555716bd1b55ed64a3b4c2cb18f50436b407
+  React-runtimescheduler: 18320bc1b361b96961af7e91e1eeee0e3d6b163f
+  React-utils: 9313e2d91348eb737ed5b5346f558c6e045dfdf0
+  ReactCommon: 6dd019f24617a24022f137c6b46f2b48655fa6d6
   ReactNativeHost: 60ee30b89d14716f0e10f7c09313f1cdef855a52
   ReactTestApp-DevSupport: 40919aada890289089d1f051c831734cd4d4a62c
   ReactTestApp-Resources: 8c0164a3cc5052418c92018e2af0e05d564aa307
   RNCPicker: b18aaf30df596e9b1738e7c1f9ee55402a229dca
   RNSVG: d00c8f91c3cbf6d476451313a18f04d220d4f396
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
-  Yoga: 5a5557fa1f32858eb391dfcc1afd0772966e6f5c
+  Yoga: e9e1659ae4108b4a4f9aa44c67b0c6635a5fd90c
 
 PODFILE CHECKSUM: 0e740f9fca1901b692b84c05390764ca72e2fb41
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.14.2

--- a/change/@fluentui-react-native-callout-95c46780-56c8-4e0f-b4de-0a9452fa75b3.json
+++ b/change/@fluentui-react-native-callout-95c46780-56c8-4e0f-b4de-0a9452fa75b3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix rtl bug in macos callout/menu controls going offscreen",
+  "packageName": "@fluentui-react-native/callout",
+  "email": "7664112+FalseLobster@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-fc4d61b0-9dec-4831-8d85-9b1adfdea902.json
+++ b/change/@fluentui-react-native-tester-fc4d61b0-9dec-4831-8d85-9b1adfdea902.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix rtl bug in macos callout/menu controls going offscreen",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "7664112+FalseLobster@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Callout/macos/CalloutView.swift
+++ b/packages/components/Callout/macos/CalloutView.swift
@@ -337,6 +337,10 @@ class CalloutView: RCTView, CalloutWindowLifeCycleDelegate {
 				if (NSMaxX(calloutScreenRect) > NSMaxX(screenFrame)) {
 					calloutScreenRect.origin.x = NSMaxX(screenFrame) - NSWidth(calloutScreenRect)
 				}
+				// If we go off the left edge in RTL, just slide to the right so we're fully onscreen
+				if (NSMinX(calloutScreenRect) < NSMinX(screenFrame)) {
+					calloutScreenRect.origin.x = 0;
+				}
 			@unknown default:
 				preconditionFailure("Unknown directional hint")
 			}

--- a/packages/components/Callout/macos/CalloutView.swift
+++ b/packages/components/Callout/macos/CalloutView.swift
@@ -264,7 +264,7 @@ class CalloutView: RCTView, CalloutWindowLifeCycleDelegate {
 				origin.y = NSMaxY(anchorScreenRect) - calloutFrame.size.height
 			case .maxY:
 				// When in RTL mode, align the right edges of the menu and flyout anchor
-				if (NSApp.userInterfaceLayoutDirection == .rightToLeft) {
+				if (NSApp.userInterfaceLayoutDirection == .rightToLeft || RCTI18nUtil.sharedInstance().isRTL()) {
 					origin.x = NSMaxX(anchorScreenRect) - calloutFrame.size.width
 				} else {
 					origin.x = NSMinX(anchorScreenRect);

--- a/packages/components/Callout/macos/FRNCalloutManager.h
+++ b/packages/components/Callout/macos/FRNCalloutManager.h
@@ -1,3 +1,4 @@
+#import <React/RCTI18nUtil.h>
 #import <React/RCTTouchHandler.h>
 #import <React/RCTUIManager.h>
 #import <React/RCTView.h>


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

In LTR layouts, we do work to make sure that our callouts, when anchored, are fully rendered on screen when snapping to the edge would make part of the control render off screen.  However, while we do make sure this works if we render off screen past the extents of the far right X dimension, we do not take into account RTL situations when we render off screen in the negative X dimension relative to the screen.

This simply adds a check when such a situation happens and pushes the origin on the new callout to 0 to ensure the contents are fully visible, as other macOS menus behave.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|![Screenshot 2024-01-30 at 3 51 29 PM](https://github.com/microsoft/fluentui-react-native/assets/7664112/e4748406-c79c-4ed4-9028-aa49dd57ae98) |![Screenshot 2024-01-30 at 3 52 07 PM](https://github.com/microsoft/fluentui-react-native/assets/7664112/a8f21b24-1e7e-4dfb-950c-05bceb0871b5)|
![Screenshot 2024-01-30 at 3 50 45 PM](https://github.com/microsoft/fluentui-react-native/assets/7664112/289fb95c-83d1-4571-88a6-d111895f571b)|![Screenshot 2024-01-30 at 3 47 34 PM](https://github.com/microsoft/fluentui-react-native/assets/7664112/34483f64-1d4f-4d38-86b9-de132dd15d8b)|

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [x] Internationalization and Right-to-left Layouts
