### PR TITLE
Create metro group for dependabot so that they all update together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,12 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
+      metro:
+        patterns:
+          - 'metro*'
+        update-types:
+          - 'minor'
+          - 'patch'
       rnx-kit:
         patterns:
           - '@rnx-kit*'


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Seems like several metro packages should update together, creating a dependabot group for them
