### PR TITLE
[FURN Menu] Exclude dividers from n of m in MenuGroup

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Menu/MenuTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Menu/MenuTest.tsx
@@ -384,6 +384,8 @@ const MenuWithGroups: React.FunctionComponent = () => {
               <MenuGroupHeader>Section 2</MenuGroupHeader>
               <MenuItem>A plain MenuItem</MenuItem>
               <MenuItem>A plain MenuItem</MenuItem>
+              <MenuDivider />
+              <MenuItem>A plain MenuItem</MenuItem>
             </MenuGroup>
           </MenuList>
         </MenuPopover>

--- a/change/@fluentui-react-native-menu-9b1ed6fc-801b-49b5-96de-14a5f4ebe553.json
+++ b/change/@fluentui-react-native-menu-9b1ed6fc-801b-49b5-96de-14a5f4ebe553.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "exclude dividers from n of m in MenuGroup",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-53d58209-bdbf-48a1-be03-355b25e50fc6.json
+++ b/change/@fluentui-react-native-tester-53d58209-bdbf-48a1-be03-355b25e50fc6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "exclude dividers from n of m in MenuGroup",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/MenuGroup/MenuGroup.tsx
+++ b/packages/components/Menu/src/MenuGroup/MenuGroup.tsx
@@ -28,10 +28,13 @@ export const MenuGroup = compose<MenuGroupType>({
       const childrenWithSet = React.Children.toArray(children).map((child) => {
         if (React.isValidElement(child)) {
           const itemCount = React.Children.toArray(children).filter(
-            (child) => React.isValidElement(child) && (child as any).type.displayName !== 'MenuGroupHeader',
+            (child) =>
+              React.isValidElement(child) &&
+              (child as any).type.displayName !== 'MenuGroupHeader' &&
+              (child as any).type.displayName !== 'MenuDivider',
           ).length;
 
-          if ((child as any).type.displayName !== 'MenuGroupHeader') {
+          if ((child as any).type.displayName !== 'MenuGroupHeader' && (child as any).type.displayName !== 'MenuDivider') {
             itemPosition++;
           }
           return React.cloneElement(


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Checks for MenuDivider under MenuGroup and excludes it from n of m calculations.

### Verification

Added a MenuDivider (under a MenuGroup) to the test case with MenuGroups and verified the MenuDivider did not contribute to the n of m count with AccessibilityInsights.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://github.com/microsoft/fluentui-react-native/assets/22876140/855582e9-dbbd-4845-aa95-4af6e4dbdaee) | ![image](https://github.com/microsoft/fluentui-react-native/assets/22876140/3eab546a-af96-40a2-82a3-3ed456d79e78) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [x] Voiceover
- [ ] Internationalization and Right-to-left Layouts
