### PR TITLE
Add workaround for CocoaPods 1.15.0 issues

### DIFF
--- a/.ado/azure-pipelines.yml
+++ b/.ado/azure-pipelines.yml
@@ -79,6 +79,8 @@ jobs:
 
       - template: templates/setup-repo-min-build.yml
 
+      - template: templates/apple-ensure-valid-cocoapods.yml
+
       - script: |
           yarn bundle:macos
         workingDirectory: apps/fluent-tester
@@ -121,6 +123,8 @@ jobs:
         persistCredentials: true
 
       - template: templates/setup-repo-min-build.yml
+
+      - template: templates/apple-ensure-valid-cocoapods.yml
 
       - script: |
           yarn bundle:ios

--- a/.ado/templates/apple-ensure-valid-cocoapods.yml
+++ b/.ado/templates/apple-ensure-valid-cocoapods.yml
@@ -1,0 +1,10 @@
+# Cocoapods 1.15.0 doesn't work with React Native
+steps:
+  - task: CmdLine@2
+    displayName: Install Cocoapods 1.15.2 if needed
+    inputs:
+      script: |
+        POD_VERSION=$(pod --version)
+        if [ $POD_VERSION = 1.15.0 ]; then
+          gem install cocoapods -v 1.15.2
+        fi

--- a/.ado/templates/setup-repo.yml
+++ b/.ado/templates/setup-repo.yml
@@ -13,5 +13,3 @@ steps:
   - script: |
       yarn
     displayName: 'yarn install'
-
-  - template: .ado/templates/apple-ensure-valid-cocoapods.yml@self

--- a/.ado/templates/setup-repo.yml
+++ b/.ado/templates/setup-repo.yml
@@ -13,3 +13,5 @@ steps:
   - script: |
       yarn
     displayName: 'yarn install'
+
+  - template: .ado/templates/apple-ensure-valid-cocoapods.yml@self


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

CocoaPods 1.15.0 is incompatible with React Native, which has been causing some CI failures. The fix is to upgrade to a later version. Since it might take some time before the relevant ADO images get this fixed, this is a good enough workaround for now.

### Verification

If the CIs pass, we should be good.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
