### PR TITLE
Adding useControllableValue hook

### DIFF
--- a/change/@fluentui-react-native-input-7ea9a381-efa3-4ac5-ae66-8d49151bee81.json
+++ b/change/@fluentui-react-native-input-7ea9a381-efa3-4ac5-ae66-8d49151bee81.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Adopting useControllableValue in Input component.",
+  "packageName": "@fluentui-react-native/input",
+  "email": "nerios@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-interactive-hooks-33678739-eaf4-4445-ad7f-1e6d90c551b7.json
+++ b/change/@fluentui-react-native-interactive-hooks-33678739-eaf4-4445-ad7f-1e6d90c551b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Adding useControllableValue hook.",
+  "packageName": "@fluentui-react-native/interactive-hooks",
+  "email": "nerios@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Input/src/__tests__/__snapshots__/Input.test.tsx.snap
+++ b/packages/components/Input/src/__tests__/__snapshots__/Input.test.tsx.snap
@@ -67,7 +67,6 @@ exports[`Input component tests Input default 1`] = `
             "textDecorationLine": undefined,
           }
         }
-        value=""
       />
     </View>
   </View>
@@ -142,7 +141,6 @@ exports[`Input component tests Input in error state 1`] = `
             "textDecorationLine": undefined,
           }
         }
-        value=""
       />
     </View>
     <Text
@@ -246,7 +244,6 @@ exports[`Input component tests Input with all optional text 1`] = `
             "textDecorationLine": undefined,
           }
         }
-        value=""
       />
     </View>
     <Text
@@ -370,7 +367,6 @@ exports[`Input component tests Input with icon 1`] = `
               "textDecorationLine": undefined,
             }
           }
-          value=""
         />
       </View>
     </View>
@@ -446,7 +442,6 @@ exports[`Input component tests Input with placeholder 1`] = `
             "textDecorationLine": undefined,
           }
         }
-        value=""
       />
     </View>
   </View>
@@ -521,7 +516,6 @@ exports[`Input component tests Input without accessoryIcon 1`] = `
             "textDecorationLine": undefined,
           }
         }
-        value=""
       />
     </View>
   </View>

--- a/packages/components/Input/src/useInput.ts
+++ b/packages/components/Input/src/useInput.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { createIconProps } from '@fluentui-react-native/icon';
 import type { IconProps } from '@fluentui-react-native/icon';
-import { usePressableState } from '@fluentui-react-native/interactive-hooks';
+import { usePressableState, useControllableValue } from '@fluentui-react-native/interactive-hooks';
 
 import { DismissSvg } from './assets/dismissSvg';
 import type { InputProps, InputInfo } from './Input.types';
@@ -31,10 +31,10 @@ export const useInput = (props: InputProps): InputInfo => {
     ...rest
   } = props;
   const pressable = usePressableState({ onBlur, onFocus });
-  const [text, setText] = React.useState<string>(defaultValue ? defaultValue : '');
   const defaultIconProps = createIconProps(defaultIcon);
   const focusedIconProps = createIconProps(focusedStateIcon);
   const [iconProps, setIconProps] = React.useState<IconProps>(defaultIconProps);
+
   React.useEffect(() => {
     if (pressable.state.focused && !error && focusedIconProps) {
       setIconProps(focusedIconProps);
@@ -42,6 +42,15 @@ export const useInput = (props: InputProps): InputInfo => {
       setIconProps(defaultIconProps);
     }
   }, [error, pressable.state.focused, defaultIconProps, focusedIconProps]);
+
+  const onChangeText = React.useCallback(
+    (_ev: unknown, text: string) => {
+      onChange?.(text);
+    },
+    [onChange],
+  );
+
+  const [text, setText] = useControllableValue(value, defaultValue, onChangeText);
 
   return {
     props: {
@@ -53,17 +62,15 @@ export const useInput = (props: InputProps): InputInfo => {
       onChange,
       accessoryIcon,
       accessoryButtonOnPress,
-      value,
+      value: text,
       // Directly applied onto the TextInput
       textInputProps: {
         ...textInputProps,
         keyboardType: type,
         placeholder,
-        defaultValue,
-        value: value ? value : text,
+        value: text,
         onChangeText: (text) => {
-          !value && setText(text);
-          onChange && onChange(text);
+          setText(text);
         },
         ref: componentRef,
         accessibilityLabel,
@@ -78,6 +85,6 @@ export const useInput = (props: InputProps): InputInfo => {
       componentRef,
       ...rest,
     },
-    state: { ...pressable.state, text: value ? value : text },
+    state: { ...pressable.state, text },
   };
 };

--- a/packages/components/Input/src/useInput.ts
+++ b/packages/components/Input/src/useInput.ts
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { createIconProps } from '@fluentui-react-native/icon';
 import type { IconProps } from '@fluentui-react-native/icon';
 import { usePressableState, useControllableValue } from '@fluentui-react-native/interactive-hooks';
+import type { ValueChangeCallback } from '@fluentui-react-native/interactive-hooks';
 
 import { DismissSvg } from './assets/dismissSvg';
 import type { InputProps, InputInfo } from './Input.types';
@@ -43,8 +44,8 @@ export const useInput = (props: InputProps): InputInfo => {
     }
   }, [error, pressable.state.focused, defaultIconProps, focusedIconProps]);
 
-  const onChangeText = React.useCallback(
-    (_ev: unknown, text: string) => {
+  const onChangeText: ValueChangeCallback<Element, string, React.SyntheticEvent<Element, Event>> = React.useCallback(
+    (_ev, text) => {
       onChange?.(text);
     },
     [onChange],

--- a/packages/utils/interactive-hooks/src/__tests__/useConst.test.tsx
+++ b/packages/utils/interactive-hooks/src/__tests__/useConst.test.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+
+import { validateHookValueNotChanged } from '@fluentui-react-native/test-tools';
+import { mount } from 'enzyme';
+
+import { useConst } from '../useConst';
+
+describe('useConst', () => {
+  validateHookValueNotChanged('returns the same value with value initializer', () => [useConst(Math.random())]);
+
+  validateHookValueNotChanged('returns the same value with function initializer', () => [useConst(() => Math.random())]);
+
+  it('calls the function initializer only once', () => {
+    const initializer = jest.fn(() => Math.random());
+    const TestComponent: React.FunctionComponent = () => {
+      const value = useConst(initializer);
+      return <div>{value}</div>;
+    };
+    const wrapper = mount(<TestComponent />);
+    const firstValue = wrapper.text();
+    // Re-render the component
+    wrapper.update();
+    // Text should be the same
+    expect(wrapper.text()).toBe(firstValue);
+    // Function shouldn't have been called again
+    expect(initializer).toHaveBeenCalledTimes(1);
+  });
+
+  it('works with a function initializer which returns undefined', () => {
+    const initializer = jest.fn(() => undefined);
+    const TestComponent: React.FunctionComponent = () => {
+      const value = useConst(initializer);
+      return <div>{value}</div>;
+    };
+    const wrapper = mount(<TestComponent />);
+    // Re-render the component
+    wrapper.update();
+    // Function shouldn't have been called again
+    expect(initializer).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/utils/interactive-hooks/src/__tests__/useConst.test.tsx
+++ b/packages/utils/interactive-hooks/src/__tests__/useConst.test.tsx
@@ -14,8 +14,10 @@ describe('useConst', () => {
     const initializer = jest.fn(() => Math.random());
     const TestComponent: React.FunctionComponent = () => {
       const value = useConst(initializer);
-      return <div>{value}</div>;
+
+      return <React.Fragment>{value}</React.Fragment>;
     };
+
     const wrapper = mount(<TestComponent />);
     const firstValue = wrapper.text();
     // Re-render the component
@@ -30,8 +32,10 @@ describe('useConst', () => {
     const initializer = jest.fn(() => undefined);
     const TestComponent: React.FunctionComponent = () => {
       const value = useConst(initializer);
-      return <div>{value}</div>;
+
+      return <React.Fragment>{value}</React.Fragment>;
     };
+
     const wrapper = mount(<TestComponent />);
     // Re-render the component
     wrapper.update();

--- a/packages/utils/interactive-hooks/src/__tests__/useControllableValue.test.tsx
+++ b/packages/utils/interactive-hooks/src/__tests__/useControllableValue.test.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+
+import { validateHookValueNotChanged } from '@fluentui-react-native/test-tools';
+import { mount } from 'enzyme';
+
+import { useControllableValue } from '../useControllableValue';
+
+describe('useControllableValue', () => {
+  it('respects controlled value', () => {
+    let resultValue: boolean | undefined;
+    const TestComponent: React.FunctionComponent<{ value?: boolean; defaultValue?: boolean }> = ({ value, defaultValue }) => {
+      [resultValue] = useControllableValue(value, defaultValue);
+      return <div />;
+    };
+
+    const wrapper1 = mount(<TestComponent value={true} />);
+    expect(resultValue!).toBe(true);
+
+    wrapper1.setProps({ value: false });
+    expect(resultValue!).toBe(false);
+
+    const wrapper2 = mount(<TestComponent value={false} defaultValue={true} />);
+    expect(resultValue!).toBe(false);
+
+    wrapper2.setProps({ value: true });
+    expect(resultValue!).toBe(true);
+  });
+
+  it('uses the default value if no controlled value is provided', () => {
+    let resultValue: boolean | undefined;
+    const TestComponent: React.FunctionComponent<{ value?: boolean; defaultValue?: boolean }> = ({ value, defaultValue }) => {
+      [resultValue] = useControllableValue(value, defaultValue);
+      return <div />;
+    };
+
+    mount(<TestComponent defaultValue={true} />);
+    expect(resultValue!).toBe(true);
+  });
+
+  it('does not change value when the default value changes', () => {
+    let resultValue: boolean | undefined;
+    const TestComponent: React.FunctionComponent<{ value?: boolean; defaultValue?: boolean }> = ({ value, defaultValue }) => {
+      [resultValue] = useControllableValue(value, defaultValue);
+      return <div />;
+    };
+
+    const wrapper = mount(<TestComponent defaultValue={true} />);
+    expect(resultValue!).toBe(true);
+
+    wrapper.setProps({ defaultValue: false });
+    expect(resultValue!).toBe(true);
+  });
+
+  validateHookValueNotChanged('returns the same setter callback', () => {
+    const [, setValue] = useControllableValue('hello', 'world');
+    return [setValue];
+  });
+
+  validateHookValueNotChanged(
+    'returns same setter callback even if param values change',
+    () => {
+      const [, setValue] = useControllableValue('a', 'b', () => undefined);
+      return [setValue];
+    },
+    () => {
+      const [, setValue] = useControllableValue('c', 'd', () => undefined);
+      return [setValue];
+    },
+  );
+});

--- a/packages/utils/interactive-hooks/src/__tests__/useControllableValue.test.tsx
+++ b/packages/utils/interactive-hooks/src/__tests__/useControllableValue.test.tsx
@@ -10,7 +10,7 @@ describe('useControllableValue', () => {
     let resultValue: boolean | undefined;
     const TestComponent: React.FunctionComponent<{ value?: boolean; defaultValue?: boolean }> = ({ value, defaultValue }) => {
       [resultValue] = useControllableValue(value, defaultValue);
-      return <div />;
+      return <React.Fragment />;
     };
 
     const wrapper1 = mount(<TestComponent value={true} />);
@@ -30,7 +30,7 @@ describe('useControllableValue', () => {
     let resultValue: boolean | undefined;
     const TestComponent: React.FunctionComponent<{ value?: boolean; defaultValue?: boolean }> = ({ value, defaultValue }) => {
       [resultValue] = useControllableValue(value, defaultValue);
-      return <div />;
+      return <React.Fragment />;
     };
 
     mount(<TestComponent defaultValue={true} />);
@@ -41,7 +41,7 @@ describe('useControllableValue', () => {
     let resultValue: boolean | undefined;
     const TestComponent: React.FunctionComponent<{ value?: boolean; defaultValue?: boolean }> = ({ value, defaultValue }) => {
       [resultValue] = useControllableValue(value, defaultValue);
-      return <div />;
+      return <React.Fragment />;
     };
 
     const wrapper = mount(<TestComponent defaultValue={true} />);

--- a/packages/utils/interactive-hooks/src/index.ts
+++ b/packages/utils/interactive-hooks/src/index.ts
@@ -21,6 +21,8 @@ export type { onKeySelectCallback } from './useSelectedKey.hooks';
 export { useAsToggle } from './useAsToggle';
 export type { OnChangeCallback, OnToggleCallback } from './useAsToggle';
 export { useAsToggleWithEvent } from './useAsToggleWithEvent';
+export type { ValueChangeCallback } from './useControllableValue';
+export { useControllableValue } from './useControllableValue';
 export type { OnChangeWithEventCallback, OnToggleWithEventCallback } from './useAsToggleWithEvent';
 export type {
   PressabilityConfig,

--- a/packages/utils/interactive-hooks/src/useConst.ts
+++ b/packages/utils/interactive-hooks/src/useConst.ts
@@ -1,0 +1,28 @@
+import * as React from 'react';
+
+/**
+ * Hook to initialize and return a constant value. Unlike `React.useMemo`, this is guaranteed to
+ * always return the same value (and if the initializer is a function, only call it once).
+ * This is similar to setting a private member in a class constructor.
+ *
+ * If the value should ever change based on dependencies, use `React.useMemo` instead.
+ *
+ * @param initialValue - Initial value, or function to get the initial value. Similar to `useState`,
+ * only the value/function passed in the first time this is called is respected.
+ * @returns The value. The identity of this value will always be the same.
+ */
+export function useConst<T>(initialValue: T | (() => T)): T {
+  // Use useRef to store the value because it's the least expensive built-in hook that works here
+  // (we could also use `const [value] = React.useState(initialValue)` but that's more expensive
+  // internally due to reducer handling which we don't need)
+  const ref = React.useRef<{ value: T }>();
+  if (ref.current === undefined) {
+    // Box the value in an object so we can tell if it's initialized even if the initializer
+    // returns/is undefined
+    ref.current = {
+      // eslint-disable-next-line @typescript-eslint/ban-types
+      value: typeof initialValue === 'function' ? (initialValue as Function)() : initialValue,
+    };
+  }
+  return ref.current.value;
+}

--- a/packages/utils/interactive-hooks/src/useControllableValue.ts
+++ b/packages/utils/interactive-hooks/src/useControllableValue.ts
@@ -1,0 +1,69 @@
+import * as React from 'react';
+
+import { useConst } from './useConst';
+
+export type ChangeCallback<TElement, TValue, TEvent extends React.SyntheticEvent<TElement> | undefined> = (
+  ev: TEvent,
+  newValue: TValue | undefined,
+) => void;
+
+/**
+ * Hook to manage a value that could be either controlled or uncontrolled, such as a checked state or
+ * text box string.
+ * @param controlledValue - The controlled value passed in the props. This value will always be used if provided,
+ * and the internal state will be updated to reflect it.
+ * @param defaultUncontrolledValue - Initial value for the internal state in the uncontrolled case.
+ * @returns An array of the current value and an updater callback. Like `React.useState`, the updater
+ * callback always has the same identity, and it can take either a new value, or a function which
+ * is passed the previous value and returns the new value.
+ * @see https://reactjs.org/docs/uncontrolled-components.html
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function useControllableValue<TValue, TElement>(
+  controlledValue: TValue | undefined,
+  defaultUncontrolledValue: TValue | undefined,
+): Readonly<[TValue | undefined, (update: React.SetStateAction<TValue | undefined>) => void]>;
+
+export function useControllableValue<TValue, TElement, TEvent extends React.SyntheticEvent<TElement> | undefined>(
+  controlledValue: TValue | undefined,
+  defaultUncontrolledValue: TValue | undefined,
+  onChange: ChangeCallback<TElement, TValue, TEvent> | undefined,
+): Readonly<[TValue | undefined, (update: React.SetStateAction<TValue | undefined>, ev?: React.FormEvent<TElement>) => void]>;
+
+export function useControllableValue<TValue, TElement extends HTMLElement, TEvent extends React.SyntheticEvent<TElement> | undefined>(
+  controlledValue: TValue | undefined,
+  defaultUncontrolledValue: TValue | undefined,
+  onChange?: ChangeCallback<TElement, TValue, TEvent>,
+) {
+  const [value, setValue] = React.useState<TValue | undefined>(defaultUncontrolledValue);
+  const isControlled = useConst<boolean>(controlledValue !== undefined);
+  const currentValue = isControlled ? controlledValue : value;
+
+  // Duplicate the current value and onChange in refs so they're accessible from
+  // setValueOrCallOnChange without creating a new callback every time
+  const valueRef = React.useRef(currentValue);
+  const onChangeRef = React.useRef(onChange);
+  React.useEffect(() => {
+    valueRef.current = currentValue;
+    onChangeRef.current = onChange;
+  });
+
+  // To match the behavior of the setter returned by React.useState, this callback's identity
+  // should never change. This means it MUST NOT directly reference variables that can change.
+  const setValueOrCallOnChange = useConst(() => (update: React.SetStateAction<TValue | undefined>, ev?: TEvent) => {
+    // Assuming here that TValue is not a function, because a controllable value will typically
+    // be something a user can enter as input
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    const newValue = typeof update === 'function' ? (update as Function)(valueRef.current) : update;
+
+    if (onChangeRef.current) {
+      onChangeRef.current(ev!, newValue);
+    }
+
+    if (!isControlled) {
+      setValue(newValue);
+    }
+  });
+
+  return [currentValue, setValueOrCallOnChange] as const;
+}

--- a/packages/utils/interactive-hooks/src/useControllableValue.ts
+++ b/packages/utils/interactive-hooks/src/useControllableValue.ts
@@ -30,7 +30,7 @@ export function useControllableValue<TValue, TElement, TEvent extends React.Synt
   onChange: ValueChangeCallback<TElement, TValue, TEvent> | undefined,
 ): Readonly<[TValue | undefined, (update: React.SetStateAction<TValue | undefined>, ev?: React.FormEvent<TElement>) => void]>;
 
-export function useControllableValue<TValue, TElement extends HTMLElement, TEvent extends React.SyntheticEvent<TElement> | undefined>(
+export function useControllableValue<TValue, TElement, TEvent extends React.SyntheticEvent<TElement> | undefined>(
   controlledValue: TValue | undefined,
   defaultUncontrolledValue: TValue | undefined,
   onChange?: ValueChangeCallback<TElement, TValue, TEvent>,

--- a/packages/utils/interactive-hooks/src/useControllableValue.ts
+++ b/packages/utils/interactive-hooks/src/useControllableValue.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { useConst } from './useConst';
 
-export type ChangeCallback<TElement, TValue, TEvent extends React.SyntheticEvent<TElement> | undefined> = (
+export type ValueChangeCallback<TElement, TValue, TEvent extends React.SyntheticEvent<TElement> | undefined> = (
   ev: TEvent,
   newValue: TValue | undefined,
 ) => void;
@@ -27,13 +27,13 @@ export function useControllableValue<TValue, TElement>(
 export function useControllableValue<TValue, TElement, TEvent extends React.SyntheticEvent<TElement> | undefined>(
   controlledValue: TValue | undefined,
   defaultUncontrolledValue: TValue | undefined,
-  onChange: ChangeCallback<TElement, TValue, TEvent> | undefined,
+  onChange: ValueChangeCallback<TElement, TValue, TEvent> | undefined,
 ): Readonly<[TValue | undefined, (update: React.SetStateAction<TValue | undefined>, ev?: React.FormEvent<TElement>) => void]>;
 
 export function useControllableValue<TValue, TElement extends HTMLElement, TEvent extends React.SyntheticEvent<TElement> | undefined>(
   controlledValue: TValue | undefined,
   defaultUncontrolledValue: TValue | undefined,
-  onChange?: ChangeCallback<TElement, TValue, TEvent>,
+  onChange?: ValueChangeCallback<TElement, TValue, TEvent>,
 ) {
   const [value, setValue] = React.useState<TValue | undefined>(defaultUncontrolledValue);
   const isControlled = useConst<boolean>(controlledValue !== undefined);

--- a/packages/utils/test-tools/src/enzymeTests.tsx
+++ b/packages/utils/test-tools/src/enzymeTests.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { View } from 'react-native';
 
 import type { ReactWrapper } from 'enzyme';
 import { mount } from 'enzyme';
@@ -112,7 +111,7 @@ export function validateHookValueNotChanged<TValues extends NonNullable<any>[]>(
       callCount++;
       // eslint-disable-next-line react-hooks/rules-of-hooks
       latestValues = callCount === 1 ? useHook() : (useHookAgain || useHook)();
-      return <View />;
+      return <React.Fragment />;
     };
 
     const wrapper = mount(<TestComponent />);

--- a/packages/utils/test-tools/src/enzymeTests.tsx
+++ b/packages/utils/test-tools/src/enzymeTests.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 import type { ReactWrapper } from 'enzyme';
 import { mount } from 'enzyme';
 
@@ -85,4 +87,52 @@ export function checkReRender(render: JSXProducer, depth: number = 1) {
   const w2 = w1.update();
   const t2 = snapshotPropTree(w2, depth, filter);
   compareTrees(t1, t2, []);
+}
+
+/**
+ * Validate that value(s) returned by a hook do not change in identity.
+ * @param testDescription - Custom test description
+ * @param useHook - Function to invoke the hook and return an array of return values which
+ * should not change
+ * @param useHookAgain - If you want to verify that the return value doesn't change when hook
+ * parameters change, you can pass this second callback which calls the hook differently.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function validateHookValueNotChanged<TValues extends NonNullable<any>[]>(
+  testDescription: string,
+  useHook: () => TValues,
+  useHookAgain?: () => TValues,
+) {
+  it(testDescription || 'returns the same value(s) each time', () => {
+    let latestValues: TValues | undefined;
+    let callCount = 0;
+
+    const TestComponent: React.FunctionComponent = () => {
+      callCount++;
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      latestValues = callCount === 1 ? useHook() : (useHookAgain || useHook)();
+      return <div />;
+    };
+
+    const wrapper = mount(<TestComponent />);
+    expect(callCount).toBe(1);
+    const firstValues = latestValues;
+    expect(firstValues).toBeDefined();
+    latestValues = undefined;
+
+    wrapper.setProps({});
+    expect(callCount).toBe(2);
+    expect(latestValues).toBeDefined();
+    expect(latestValues.length).toEqual(firstValues!.length);
+
+    for (let i = 0; i < latestValues!.length; i++) {
+      try {
+        expect(latestValues![i]).toBe(firstValues![i]);
+      } catch (err) {
+        // Make a more informative error message
+        const valueText = latestValues![i].toString();
+        expect('').toBe(`Identity of value at index ${i} has changed. This might help identify it:\n${valueText}`);
+      }
+    }
+  });
 }

--- a/packages/utils/test-tools/src/enzymeTests.tsx
+++ b/packages/utils/test-tools/src/enzymeTests.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { View } from 'react-native';
 
 import type { ReactWrapper } from 'enzyme';
 import { mount } from 'enzyme';
@@ -111,7 +112,7 @@ export function validateHookValueNotChanged<TValues extends NonNullable<any>[]>(
       callCount++;
       // eslint-disable-next-line react-hooks/rules-of-hooks
       latestValues = callCount === 1 ? useHook() : (useHookAgain || useHook)();
-      return <div />;
+      return <View />;
     };
 
     const wrapper = mount(<TestComponent />);

--- a/packages/utils/test-tools/src/index.ts
+++ b/packages/utils/test-tools/src/index.ts
@@ -1,3 +1,3 @@
-export { checkReRender, checkRenderConsistency, compareTrees, snapshotPropTree } from './enzymeTests';
+export { checkReRender, checkRenderConsistency, compareTrees, snapshotPropTree, validateHookValueNotChanged } from './enzymeTests';
 export type { JSXProducer, PropTreeFilter, PropTreeSnapshot } from './enzymeTests';
 export { mockTheme } from './mockTheme';


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

This PR adds a new hook used to manage state in components that can be controlled or uncontrolled based on which props the consumer provides (such as the Input component's value vs. defaultValue).

The implementation and tests are direct copies from:

https://github.com/microsoft/fluentui/blob/master/packages/react-hooks/src/useControllableValue.ts

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
