### PR TITLE
Fix some FURN Menu Item color and font tokens

### DIFF
--- a/change/@fluentui-react-native-menu-27e20700-f51e-42b2-93f6-36f30e1607c3.json
+++ b/change/@fluentui-react-native-menu-27e20700-f51e-42b2-93f6-36f30e1607c3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix some MenuItem font and color tokens",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "adgleitm@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/MenuItem/MenuItemTokens.macos.ts
+++ b/packages/components/Menu/src/MenuItem/MenuItemTokens.macos.ts
@@ -24,15 +24,18 @@ export const defaultMenuItemTokens: TokenSettings<MenuItemTokens, Theme> = (t: T
     backgroundColor: t.colors.menuItemBackgroundHovered,
     color: t.colors.menuItemTextHovered,
     iconColor: t.colors.menuItemTextHovered,
+    submenuIndicatorColor: t.colors.menuItemTextHovered,
   },
   pressed: {
     backgroundColor: t.colors.menuItemBackgroundPressed,
     color: t.colors.menuItemTextHovered,
     iconColor: t.colors.menuItemTextHovered,
+    submenuIndicatorColor: t.colors.menuItemTextHovered,
   },
   disabled: {
     backgroundColor: t.colors.menuBackground,
     color: t.colors.disabledText,
     iconColor: t.colors.disabledText,
+    submenuIndicatorColor: t.colors.disabledText,
   },
 });

--- a/packages/components/Menu/src/MenuItemCheckbox/MenuItemCheckboxTokens.macos.ts
+++ b/packages/components/Menu/src/MenuItemCheckbox/MenuItemCheckboxTokens.macos.ts
@@ -24,7 +24,7 @@ export const defaultMenuItemCheckboxTokens: TokenSettings<MenuItemCheckboxTokens
     color: t.colors.neutralForegroundOnBrand,
     iconColor: t.colors.neutralForegroundOnBrand,
     checked: {
-      checkmarkColor: t.colors.neutralForeground2Hover,
+      checkmarkColor: t.colors.neutralForegroundOnBrand,
       checkmarkVisibility: 1,
     },
   },

--- a/packages/components/Menu/src/MenuItemCheckbox/MenuItemCheckboxTokens.macos.ts
+++ b/packages/components/Menu/src/MenuItemCheckbox/MenuItemCheckboxTokens.macos.ts
@@ -12,7 +12,7 @@ export const defaultMenuItemCheckboxTokens: TokenSettings<MenuItemCheckboxTokens
   checkmarkVisibility: 0,
   color: t.colors.neutralForeground2,
   fontFamily: t.typography.families.primary,
-  fontSize: globalTokens.font.size300,
+  fontSize: 13, // aligning with NSMenu font size
   fontWeight: globalTokens.font.weight.regular as FontWeightValue,
   gap: globalTokens.size40,
   iconColor: t.colors.neutralForeground2,


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

While working through some menu bugs, I noticed that some of the color and font tokens were inconsistent.

This includes the following fixes:
* The checkbox and submenu chevron should match the menu text color when highlighted.
* The font size of a checkbox item should match other menu items.

### Verification

(how the change was tested, including both manual and automated tests)

| Before | w/o checkbox color fix | w/o checkbox font fix | After |
|-|-|-|-|
| <img width="749" alt="Screenshot 2024-02-16 at 3 06 01 PM" src="https://github.com/microsoft/fluentui-react-native/assets/717674/820c9fe6-782d-48af-a62f-95b6aef6c795"> | <img width="749" alt="Screenshot 2024-02-16 at 3 05 34 PM" src="https://github.com/microsoft/fluentui-react-native/assets/717674/bc92801f-721a-4bd9-9d33-e6b738759baa"> | <img width="749" alt="Screenshot 2024-02-20 at 1 01 14 PM" src="https://github.com/microsoft/fluentui-react-native/assets/717674/18e39e65-45e3-459b-99ca-3e9040b9fb8c"> | <img width="749" alt="Screenshot 2024-02-16 at 4 42 12 PM" src="https://github.com/microsoft/fluentui-react-native/assets/717674/a56d8907-1219-4a10-a70a-55ca688397e2"> |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
