### PR TITLE
[FURN Menu] Add Timestamp Per Instance

### DIFF
--- a/change/@fluentui-react-native-menu-325c1e4b-3690-4cdb-9aa4-f786e307225a.json
+++ b/change/@fluentui-react-native-menu-325c1e4b-3690-4cdb-9aa4-f786e307225a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "adding timestamp per instance",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "gulnazsayed@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/Menu/useMenu.ts
+++ b/packages/components/Menu/src/Menu/useMenu.ts
@@ -7,13 +7,6 @@ import { isMouseEvent } from '@fluentui-react-native/interactive-hooks';
 import type { MenuProps, MenuState } from './Menu.types';
 import { useMenuContext } from '../context/menuContext';
 
-// Due to how events get fired we get double notifications
-// for the same event causing us to immediately reopen
-// a menu when we close it. Adding in a delay to prevent
-// this behavior.
-const delayOpen = 150;
-let lastCloseTimestamp = -1;
-
 export const useMenu = (props: MenuProps): MenuState => {
   const triggerRef = React.useRef();
   const context = useMenuContext();
@@ -61,6 +54,13 @@ const useMenuOpenState = (
 
   const state = isControlled ? open : openInternal;
 
+  // Due to how events get fired we get double notifications
+  // for the same event causing us to immediately reopen
+  // a menu when we close it. Adding in a delay to prevent
+  // this behavior.
+  const delayOpen = 150;
+  const [lastCloseTimestamp, setLastCloseTimestamp] = React.useState<number>(-1);
+
   const setOpen = React.useCallback(
     (e: InteractionEvent, isOpen: boolean, bubble?: boolean) => {
       const openPrev = state;
@@ -78,7 +78,7 @@ const useMenuOpenState = (
 
       if (!isOpen) {
         setShouldFocusOnContainer(undefined);
-        lastCloseTimestamp = Date.now();
+        setLastCloseTimestamp(Date.now());
       }
 
       if (onOpenChange && openPrev !== isOpen) {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Changing to use a new timestamp per instance to avoid disruptions in the opening behavior between two different menus. Previously, the global timestamp resulted in issues with opening a second menu when the time between clicks was very short. 

### Verification

Ran automation tests and manually checked that menu open behavior appeared correct.

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
