### PR TITLE
[FURN Menu] Add Timestamp Per Instance

### DIFF
--- a/change/@fluentui-react-native-menu-3f6d4b03-ffff-45d0-9b72-8d668c0f8ab8.json
+++ b/change/@fluentui-react-native-menu-3f6d4b03-ffff-45d0-9b72-8d668c0f8ab8.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "timestamp per instance",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "gulnazsayed@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/Menu/useMenu.ts
+++ b/packages/components/Menu/src/Menu/useMenu.ts
@@ -12,7 +12,6 @@ import { useMenuContext } from '../context/menuContext';
 // a menu when we close it. Adding in a delay to prevent
 // this behavior.
 const delayOpen = 150;
-let lastCloseTimestamp = -1;
 
 export const useMenu = (props: MenuProps): MenuState => {
   const triggerRef = React.useRef();
@@ -61,10 +60,12 @@ const useMenuOpenState = (
 
   const state = isControlled ? open : openInternal;
 
+  const lastCloseTimestampRef = React.useRef<number>(-1);
+
   const setOpen = React.useCallback(
     (e: InteractionEvent, isOpen: boolean, bubble?: boolean) => {
       const openPrev = state;
-      if (!isControlled && (!isOpen || lastCloseTimestamp + delayOpen <= Date.now())) {
+      if (!isControlled && (!isOpen || lastCloseTimestampRef.current + delayOpen <= Date.now())) {
         setOpenInternal(isOpen);
       }
 
@@ -78,7 +79,7 @@ const useMenuOpenState = (
 
       if (!isOpen) {
         setShouldFocusOnContainer(undefined);
-        lastCloseTimestamp = Date.now();
+        lastCloseTimestampRef.current = Date.now();
       }
 
       if (onOpenChange && openPrev !== isOpen) {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Changing to use a new timestamp per instance to avoid disruptions in the opening behavior between two different menus. Previously, the global timestamp resulted in issues with opening a second menu when the time between clicks was very short.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![flyout before](https://github.com/microsoft/fluentui-react-native/assets/30990970/b9adcd4d-4d7e-46ca-9498-c282c8f36b08) | ![flyout after](https://github.com/microsoft/fluentui-react-native/assets/30990970/44771318-07b0-4655-9c65-6a19508f3bfa) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
