### PR TITLE
Add missing react-native peerDependencies

### DIFF
--- a/change/@uifabricshared-foundation-composable-0d8bcadb-8f46-4ca7-98da-c4d07db9ad19.json
+++ b/change/@uifabricshared-foundation-composable-0d8bcadb-8f46-4ca7-98da-c4d07db9ad19.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add missing react-native peerDependencies",
+  "packageName": "@uifabricshared/foundation-composable",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabricshared-foundation-compose-79a53e18-1ad5-4644-b88e-ee9a3da13ffe.json
+++ b/change/@uifabricshared-foundation-compose-79a53e18-1ad5-4644-b88e-ee9a3da13ffe.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add missing react-native peerDependencies",
+  "packageName": "@uifabricshared/foundation-compose",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabricshared-theming-ramp-83af1301-1860-4dfa-b4c7-7465d65a8465.json
+++ b/change/@uifabricshared-theming-ramp-83af1301-1860-4dfa-b4c7-7465d65a8465.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add missing react-native peerDependencies",
+  "packageName": "@uifabricshared/theming-ramp",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/deprecated/foundation-composable/package.json
+++ b/packages/deprecated/foundation-composable/package.json
@@ -40,5 +40,9 @@
     "@types/jest": "^29.0.0",
     "@types/react": "^18.2.0",
     "react": "18.2.0"
+  },
+  "peerDependencies": {
+    "react": "18.2.0",
+    "react-native": "^0.72.0"
   }
 }

--- a/packages/deprecated/foundation-compose/package.json
+++ b/packages/deprecated/foundation-compose/package.json
@@ -47,7 +47,8 @@
     "react": "18.2.0"
   },
   "peerDependencies": {
-    "react": ">=17.0.2"
+    "react": "18.2.0",
+    "react-native": "^0.72.0"
   },
   "depcheck": {
     "ignoreMatches": [

--- a/packages/deprecated/theming-ramp/package.json
+++ b/packages/deprecated/theming-ramp/package.json
@@ -44,6 +44,7 @@
     "react": "18.2.0"
   },
   "peerDependencies": {
-    "react": ">=17.0.2"
+    "react": "18.2.0",
+    "react-native": "^0.72.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7094,6 +7094,9 @@ __metadata:
     "@types/react": ^18.2.0
     "@uifabricshared/foundation-settings": "workspace:*"
     react: 18.2.0
+  peerDependencies:
+    react: 18.2.0
+    react-native: ^0.72.0
   languageName: unknown
   linkType: soft
 
@@ -7114,7 +7117,8 @@ __metadata:
     "@uifabricshared/theming-ramp": "workspace:*"
     react: 18.2.0
   peerDependencies:
-    react: ">=17.0.2"
+    react: 18.2.0
+    react-native: ^0.72.0
   languageName: unknown
   linkType: soft
 
@@ -7206,7 +7210,8 @@ __metadata:
     "@uifabricshared/foundation-settings": "workspace:*"
     react: 18.2.0
   peerDependencies:
-    react: ">=17.0.2"
+    react: 18.2.0
+    react-native: ^0.72.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### Description of changes
These 3 packages all use @uifabricshared/foundation-settings, which has a peer dependency of react-native and react. 
This currently requires extraDependency overrides when using FURN with MYS in OMR.