### PR TITLE
Add missing dependencies/devDependencies

### DIFF
--- a/apps/fluent-tester/package.json
+++ b/apps/fluent-tester/package.json
@@ -82,6 +82,7 @@
     "@fortawesome/fontawesome-svg-core": "^6.2.0",
     "@fortawesome/free-solid-svg-icons": "^6.2.0",
     "@fortawesome/react-native-fontawesome": "^0.3.0",
+    "@office-iss/react-native-win32": "^0.72.0",
     "@react-native-community/slider": "^4.2.0",
     "@react-native-menu/menu": "^0.7.3",
     "@react-native-picker/picker": "^2.2.1",
@@ -103,6 +104,7 @@
     "@rnx-kit/cli": "^0.16.2",
     "@rnx-kit/metro-config": "^1.3.1",
     "@types/jasmine": "3.10.3",
+    "@wdio/cli": "7.30.1",
     "@wdio/jasmine-framework": "7.26.0",
     "flow-bin": "^0.113.0",
     "metro-config": "^0.76.5",
@@ -111,9 +113,6 @@
     "react-native-test-app": "^3.1.1",
     "react-test-renderer": "18.2.0",
     "webdriverio": "7.30.1"
-  },
-  "peerDependencies": {
-    "@office-iss/react-native-win32": "^0.72.0"
   },
   "jest": {
     "preset": "react-native"

--- a/change/@fluentui-react-native-adapters-56c42725-e468-40db-a824-a05a96026575.json
+++ b/change/@fluentui-react-native-adapters-56c42725-e468-40db-a824-a05a96026575.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add missing dependencies",
+  "packageName": "@fluentui-react-native/adapters",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-codemods-f9975ee1-fb4d-4b53-8ecf-ec663ba285c2.json
+++ b/change/@fluentui-react-native-codemods-f9975ee1-fb4d-4b53-8ecf-ec663ba285c2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add missing dependencies",
+  "packageName": "@fluentui-react-native/codemods",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-dependency-profiles-a8b24201-630e-476e-a43c-ef14a1958e6c.json
+++ b/change/@fluentui-react-native-dependency-profiles-a8b24201-630e-476e-a43c-ef14a1958e6c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add missing dependencies",
+  "packageName": "@fluentui-react-native/dependency-profiles",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-8cd01ed4-5199-4570-823a-58f502b9f135.json
+++ b/change/@fluentui-react-native-tester-8cd01ed4-5199-4570-823a-58f502b9f135.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add missing dependencies",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   ],
   "resolutions": {
     "es5-ext": "0.10.63",
-    "react-native-svg": "^13.7.0",
+    "react-native-svg": "^13.14.0",
     "@types/react": "^18.2.0",
     "micromatch": "^4.0.0",
     "semver": "^7.5.2",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   ],
   "resolutions": {
     "es5-ext": "0.10.63",
+    "react-native-svg": "^13.7.0",
     "@types/react": "^18.2.0",
     "micromatch": "^4.0.0",
     "semver": "^7.5.2",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@rnx-kit/align-deps": "^2.2.5",
     "babel-jest": "^24.9.0",
     "beachball": "^2.20.0",
+    "eslint": "^8.0.0",
     "eslint-plugin-import": "^2.27.5",
     "lage": "^2.0.0",
     "markdown-link-check": "^3.8.7",
@@ -65,7 +66,6 @@
     "es5-ext": "0.10.63",
     "@types/react": "^18.2.0",
     "micromatch": "^4.0.0",
-    "react-native-svg": "^13.7.0",
     "semver": "^7.5.2",
     "xml2js": "^0.5.0",
     "yaml": "^2.2.2"

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -31,6 +31,8 @@
     "yargs": "^17.0.0"
   },
   "devDependencies": {
+    "@babel/core": "^7.8.0",
+    "@babel/preset-env": "^7.8.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",

--- a/packages/dependency-profiles/package.json
+++ b/packages/dependency-profiles/package.json
@@ -84,6 +84,7 @@
     "@uifabricshared/themed-settings": "*",
     "@uifabricshared/theming-ramp": "*",
     "@uifabricshared/theming-react-native": "*",
+    "react": "18.2.0",
     "react-native": "^0.72.0",
     "semver": "^7.3.5",
     "workspace-tools": "^0.26.3"

--- a/packages/utils/adapters/package.json
+++ b/packages/utils/adapters/package.json
@@ -25,19 +25,17 @@
     "url": "https://github.com/microsoft/fluentui-react-native.git",
     "directory": "packages/utils/adapters"
   },
-  "dependencies": {
+  "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "workspace:*",
+    "@fluentui-react-native/scripts": "workspace:*",
     "@office-iss/react-native-win32": "^0.72.0",
+    "@react-native/metro-config": "^0.72.0",
+    "@types/jest": "^29.0.0",
+    "@types/react": "^18.2.0",
     "react": "18.2.0",
     "react-native": "^0.72.0",
     "react-native-macos": "^0.72.0",
     "react-native-windows": "^0.72.0"
-  },
-  "devDependencies": {
-    "@fluentui-react-native/eslint-config-rules": "workspace:*",
-    "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/metro-config": "^0.72.0",
-    "@types/jest": "^29.0.0",
-    "@types/react": "^18.2.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.72.0",

--- a/packages/utils/adapters/package.json
+++ b/packages/utils/adapters/package.json
@@ -25,15 +25,19 @@
     "url": "https://github.com/microsoft/fluentui-react-native.git",
     "directory": "packages/utils/adapters"
   },
+  "dependencies": {
+    "@office-iss/react-native-win32": "^0.72.0",
+    "react": "18.2.0",
+    "react-native": "^0.72.0",
+    "react-native-macos": "^0.72.0",
+    "react-native-windows": "^0.72.0"
+  },
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native/metro-config": "^0.72.0",
     "@types/jest": "^29.0.0",
-    "react": "18.2.0",
-    "react-native": "^0.72.0",
-    "react-native-macos": "^0.72.0",
-    "react-native-windows": "^0.72.0"
+    "@types/react": "^18.2.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.72.0",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -20,7 +20,8 @@
   },
   "peerDependencies": {
     "just-scripts": "^1.8.0",
-    "react": "18.2.0"
+    "react": "18.2.0",
+    "react-native": "^0.72.0"
   },
   "devDependencies": {
     "@react-native-community/cli": "^11.3.2",
@@ -49,6 +50,8 @@
     "metro-react-native-babel-transformer": "^0.76.5",
     "prettier": "^2.4.1",
     "react": "18.2.0",
+    "react-native": "^0.72.0",
+    "react-native-svg": "^13.14.0",
     "react-native-svg-transformer": "^1.0.0",
     "react-test-renderer": "18.2.0",
     "rimraf": "^5.0.1",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -50,6 +50,7 @@
     "metro-react-native-babel-transformer": "^0.76.5",
     "prettier": "^2.4.1",
     "react": "18.2.0",
+    "react-dom": "^18.2.0",
     "react-native": "^0.72.0",
     "react-native-svg": "^13.14.0",
     "react-native-svg-transformer": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18331,19 +18331,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-svg@npm:^12.5.0":
-  version: 12.5.1
-  resolution: "react-native-svg@npm:12.5.1"
-  dependencies:
-    css-select: ^5.1.0
-    css-tree: ^1.1.3
-  peerDependencies:
-    react: "*"
-    react-native: ">=0.50.0"
-  checksum: e51a4eccb205c433c088087500b9da6a2956b2f5937ca18211243d033c2f57c9e720167222c394aa660fa070c417ea120ba9542cc3a6b178d0017895b7d35d2e
-  languageName: node
-  linkType: hard
-
 "react-native-svg@npm:^13.14.0":
   version: 13.14.0
   resolution: "react-native-svg@npm:13.14.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3478,6 +3478,7 @@ __metadata:
     metro-react-native-babel-transformer: ^0.76.5
     prettier: ^2.4.1
     react: 18.2.0
+    react-dom: ^18.2.0
     react-native: ^0.72.0
     react-native-svg: ^13.14.0
     react-native-svg-transformer: ^1.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -2223,8 +2223,10 @@ __metadata:
   dependencies:
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
+    "@office-iss/react-native-win32": ^0.72.0
     "@react-native/metro-config": ^0.72.0
     "@types/jest": ^29.0.0
+    "@types/react": ^18.2.0
     react: 18.2.0
     react-native: ^0.72.0
     react-native-macos: ^0.72.0
@@ -2463,6 +2465,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/codemods@workspace:packages/codemods"
   dependencies:
+    "@babel/core": ^7.8.0
+    "@babel/preset-env": ^7.8.0
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
     "@fluentui-react-native/test-tools": "workspace:*"
@@ -2633,6 +2637,7 @@ __metadata:
     "@uifabricshared/themed-settings": "*"
     "@uifabricshared/theming-ramp": "*"
     "@uifabricshared/theming-react-native": "*"
+    react: 18.2.0
     react-native: ^0.72.0
     semver: ^7.3.5
     workspace-tools: ^0.26.3
@@ -3428,6 +3433,7 @@ __metadata:
     "@rnx-kit/align-deps": ^2.2.5
     babel-jest: ^24.9.0
     beachball: ^2.20.0
+    eslint: ^8.0.0
     eslint-plugin-import: ^2.27.5
     lage: ^2.0.0
     markdown-link-check: ^3.8.7
@@ -3472,6 +3478,8 @@ __metadata:
     metro-react-native-babel-transformer: ^0.76.5
     prettier: ^2.4.1
     react: 18.2.0
+    react-native: ^0.72.0
+    react-native-svg: ^13.14.0
     react-native-svg-transformer: ^1.0.0
     react-test-renderer: 18.2.0
     rimraf: ^5.0.1
@@ -3480,6 +3488,7 @@ __metadata:
   peerDependencies:
     just-scripts: ^1.8.0
     react: 18.2.0
+    react-native: ^0.72.0
   bin:
     fluentui-scripts: ./just-scripts.js
   languageName: unknown
@@ -3713,6 +3722,7 @@ __metadata:
     "@fortawesome/fontawesome-svg-core": ^6.2.0
     "@fortawesome/free-solid-svg-icons": ^6.2.0
     "@fortawesome/react-native-fontawesome": ^0.3.0
+    "@office-iss/react-native-win32": ^0.72.0
     "@react-native-community/slider": ^4.2.0
     "@react-native-menu/menu": ^0.7.3
     "@react-native-picker/picker": ^2.2.1
@@ -3721,6 +3731,7 @@ __metadata:
     "@rnx-kit/metro-config": ^1.3.1
     "@types/jasmine": 3.10.3
     "@warren-ms/react-native-icons": ^0.0.13
+    "@wdio/cli": 7.30.1
     "@wdio/jasmine-framework": 7.26.0
     flow-bin: ^0.113.0
     metro-config: ^0.76.5
@@ -3735,8 +3746,6 @@ __metadata:
     react-test-renderer: 18.2.0
     tslib: ^2.3.1
     webdriverio: 7.30.1
-  peerDependencies:
-    "@office-iss/react-native-win32": ^0.72.0
   languageName: unknown
   linkType: soft
 
@@ -18322,7 +18331,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-svg@npm:^13.7.0":
+"react-native-svg@npm:^12.5.0":
+  version: 12.5.1
+  resolution: "react-native-svg@npm:12.5.1"
+  dependencies:
+    css-select: ^5.1.0
+    css-tree: ^1.1.3
+  peerDependencies:
+    react: "*"
+    react-native: ">=0.50.0"
+  checksum: e51a4eccb205c433c088087500b9da6a2956b2f5937ca18211243d033c2f57c9e720167222c394aa660fa070c417ea120ba9542cc3a6b178d0017895b7d35d2e
+  languageName: node
+  linkType: hard
+
+"react-native-svg@npm:^13.14.0":
   version: 13.14.0
   resolution: "react-native-svg@npm:13.14.0"
   dependencies:


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Fixing up a few yarn-related warnings w.r.t peer deps missing. Should help with some downstream clients.

If I'm honest I still don't quite know when it makes sense to declare something as a peerDep, so please let me know if an entry seems to be missing.

Notably the adapter package wasn't declaring the various RN packages as direct dependencies even though the code is using them directly. This should fix a few issues downstream.

### Verification

Most yarn warnings have disappeared. The main ones remaining relate to the fact that we're using an enzyme adapter package for React 17 while we're on react 18.