### PR TITLE
[Test] Use `macos-12` instead of `internal-macos12

### DIFF
--- a/.ado/variables/vars.yml
+++ b/.ado/variables/vars.yml
@@ -1,6 +1,6 @@
 variables:
   - name: VmImageApple
-    value: internal-macos12
+    value: macos-12
   - name: xcode_version
     value: 'Xcode 14.2'
   - name: xcode_path

--- a/apps/E2E/wdio.conf.ios.js
+++ b/apps/E2E/wdio.conf.ios.js
@@ -1,8 +1,8 @@
 const fs = require('fs');
 
-const defaultWaitForTimeout = 20000;
-const defaultConnectionRetryTimeout = 60000;
-const jasmineDefaultTimeout = 60000; // 60 seconds for Jasmine test timeout
+const defaultWaitForTimeout = 200000;
+const defaultConnectionRetryTimeout = 600000;
+const jasmineDefaultTimeout = 600000; // 60 seconds for Jasmine test timeout
 
 exports.config = {
   runner: 'local', // Where should your test be launched


### PR DESCRIPTION
Don't merge.

Do the iOS E2E tests still break if we _just_ switch to the public image?