### PR TITLE
Add E2E testing to Overflow / Minor OverflowItem Bug Fix

### DIFF
--- a/apps/E2E/src/Overflow/consts.ts
+++ b/apps/E2E/src/Overflow/consts.ts
@@ -1,0 +1,32 @@
+export const HOMEPAGE_OVERFLOW_BUTTON = 'Homepage_Overflow_Button';
+export const OVERFLOW_TESTPAGE = 'Overflow_TestPage';
+
+export const OVERFLOW_TEST_COMPONENT = 'Overflow_Test_Component';
+export const OVERFLOW_ACCESSIBILITY_LABEL = 'E2E testing Overflow accessibility label';
+
+/* E2E Testing Overflow_Item (1 of 3) */
+export const FIRST_OVERFLOW_ITEM = 'First_Overflow_Item';
+export const FIRST_OVERFLOW_ITEM_ID = 'A';
+
+/* E2E Testing Overflow_Item (2 of 3) No accessibilityLabel */
+export const SECOND_OVERFLOW_ITEM = 'Second_Overflow_Item';
+export const SECOND_OVERFLOW_ITEM_ID = 'B';
+
+/* E2E Testing Overflow_Item (3 of 3) */
+export const THIRD_OVERFLOW_ITEM = 'Third_Overflow_Item';
+export const THIRD_OVERFLOW_ITEM_ID = 'C';
+
+/** Misc Testing Elements */
+export const OVERFLOW_MENU = 'Overflow_Menu';
+
+export const READY_LABEL = 'Ready_Label';
+export const READY_VALUE_TRUE = 'Ready';
+export const READY_VALUE_FALSE = 'Not Ready';
+
+export const UPDATED_LABEL = 'Updated_Label';
+export const UPDATED_VALUE_TRUE = 'Updated';
+export const UPDATED_VALUE_FALSE = 'Not Updated';
+
+export const RADIO_175 = 'Radio_175';
+export const RADIO_275 = 'Radio_275';
+export const RADIO_375 = 'Radio_375';

--- a/apps/E2E/src/Overflow/pages/OverflowPageObject.ts
+++ b/apps/E2E/src/Overflow/pages/OverflowPageObject.ts
@@ -1,0 +1,106 @@
+import { BasePage, By } from '../../common/BasePage';
+import {
+  HOMEPAGE_OVERFLOW_BUTTON,
+  OVERFLOW_TESTPAGE,
+  OVERFLOW_TEST_COMPONENT,
+  FIRST_OVERFLOW_ITEM,
+  SECOND_OVERFLOW_ITEM,
+  THIRD_OVERFLOW_ITEM,
+  OVERFLOW_MENU,
+  READY_LABEL,
+  READY_VALUE_TRUE,
+  UPDATED_LABEL,
+  UPDATED_VALUE_TRUE,
+  RADIO_175,
+  RADIO_275,
+  RADIO_375,
+} from '../consts';
+
+type OverflowItem = 'First' | 'Second' | 'Third';
+type OverflowWidth = 175 | 275 | 375;
+
+class OverflowPageObject extends BasePage {
+  async waitForOverflowToBeReady() {
+    const readyLabel = await By(READY_LABEL);
+    await this.waitForCondition(async () => (await readyLabel.getText()) === READY_VALUE_TRUE);
+  }
+
+  async waitForOverflowToBeUpdated() {
+    const updatedLabel = await By(UPDATED_LABEL);
+    await this.waitForCondition(async () => (await updatedLabel.getText()) === UPDATED_VALUE_TRUE);
+  }
+
+  async getOverflowItem(selector: OverflowItem) {
+    switch (selector) {
+      case 'First':
+        return By(FIRST_OVERFLOW_ITEM);
+      case 'Second':
+        return By(SECOND_OVERFLOW_ITEM);
+      case 'Third':
+        return By(THIRD_OVERFLOW_ITEM);
+    }
+  }
+
+  async itemIsVisible(selector: OverflowItem, errorMsg?: string) {
+    const item = await this.getOverflowItem(selector);
+    return this.waitForCondition(async () => await item.isDisplayed(), errorMsg);
+  }
+
+  async menuIsDisplayed(errorMsg?: string) {
+    return this.waitForCondition(async () => (await this._overflowMenu).isDisplayed(), errorMsg);
+  }
+
+  async setOverflowWidth(width: OverflowWidth) {
+    let selector: string;
+    switch (width) {
+      case 175:
+        selector = RADIO_175;
+        break;
+      case 275:
+        selector = RADIO_275;
+        break;
+      case 375:
+        selector = RADIO_375;
+        break;
+    }
+    const radio = await By(selector);
+    await radio.click();
+    await this.waitForOverflowToBeUpdated();
+  }
+
+  async menuHasNHidden(n: number) {
+    const menu = await this._overflowMenu;
+    const text = await menu.getText();
+    console.log('TEXT:', text);
+    return text.includes(n.toString());
+  }
+
+  /*****************************************/
+  /**************** Getters ****************/
+  /*****************************************/
+  get _overflowMenu() {
+    return By(OVERFLOW_MENU);
+  }
+
+  get _readyLabel() {
+    return By(READY_LABEL);
+  }
+
+  get _updatedLabel() {
+    return By(UPDATED_LABEL);
+  }
+
+  get _pageButtonName() {
+    return HOMEPAGE_OVERFLOW_BUTTON;
+  }
+
+  get _pageName() {
+    return OVERFLOW_TESTPAGE;
+  }
+
+  get _primaryComponentName() {
+    return OVERFLOW_TEST_COMPONENT;
+  }
+}
+
+export default new OverflowPageObject();

--- a/apps/E2E/src/Overflow/specs/Overflow.spec.win.ts
+++ b/apps/E2E/src/Overflow/specs/Overflow.spec.win.ts
@@ -1,11 +1,11 @@
 import OverflowPageObject from '../pages/OverflowPageObject';
 
-describe('TabList Testing Initialization', () => {
+describe('Overflow Testing Initialization', () => {
   it('Wait for app load', async () => {
     expect(await OverflowPageObject.waitForInitialPageToDisplay()).toBeTrue();
   });
 
-  it('Click and navigate to TabList test page', async () => {
+  it('Click and navigate to Overflow test page', async () => {
     expect(await OverflowPageObject.navigateToPageAndLoadTests()).toBeTrue();
 
     /* Expand E2E section */

--- a/apps/E2E/src/Overflow/specs/Overflow.spec.win.ts
+++ b/apps/E2E/src/Overflow/specs/Overflow.spec.win.ts
@@ -1,0 +1,92 @@
+import OverflowPageObject from '../pages/OverflowPageObject';
+
+describe('TabList Testing Initialization', () => {
+  it('Wait for app load', async () => {
+    expect(await OverflowPageObject.waitForInitialPageToDisplay()).toBeTrue();
+  });
+
+  it('Click and navigate to TabList test page', async () => {
+    expect(await OverflowPageObject.navigateToPageAndLoadTests()).toBeTrue();
+
+    /* Expand E2E section */
+    expect(await OverflowPageObject.enableE2ETesterMode()).toBeTrue();
+
+    expect(await OverflowPageObject.didAssertPopup())
+      .withContext(OverflowPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
+  });
+});
+
+describe('Overflow Functional Testing', () => {
+  beforeEach(async () => {
+    await OverflowPageObject.scrollToTestElement(await OverflowPageObject._readyLabel);
+    await OverflowPageObject.waitForOverflowToBeReady();
+  });
+
+  it('Set Overflow width to 375. Overflow renders all three items.', async () => {
+    await OverflowPageObject.setOverflowWidth(375);
+    await OverflowPageObject.waitForOverflowToBeUpdated();
+
+    expect(
+      await OverflowPageObject.itemIsVisible('First', 'Expected the first Overflow Item to be visible, but the item remained hidden.'),
+    ).toBeTruthy();
+
+    expect(
+      await OverflowPageObject.itemIsVisible('Second', 'Expected the second Overflow Item to be visible, but the item remained hidden.'),
+    ).toBeTruthy();
+
+    expect(
+      await OverflowPageObject.itemIsVisible('Third', 'Expected the third Overflow Item to be visible, but the item remained hidden.'),
+    ).toBeTruthy();
+
+    expect(await OverflowPageObject.didAssertPopup())
+      .withContext(OverflowPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
+  });
+
+  it('Set Overflow width to 275. Overflow renders first and second items, and the third is hidden.', async () => {
+    await OverflowPageObject.setOverflowWidth(275);
+    await OverflowPageObject.waitForOverflowToBeUpdated();
+
+    expect(
+      await OverflowPageObject.itemIsVisible('First', 'Expected the first Overflow Item to be visible, but the item remained hidden.'),
+    ).toBeTruthy();
+
+    expect(
+      await OverflowPageObject.itemIsVisible('Second', 'Expected the second Overflow Item to be visible, but the item remained hidden.'),
+    ).toBeTruthy();
+
+    expect(
+      await OverflowPageObject.menuIsDisplayed('Expected the overflow menu to be visible, but the menu remained hidden.'),
+    ).toBeTruthy();
+
+    expect(await OverflowPageObject.menuHasNHidden(1))
+      .withContext('Expected the overflow menu to have one hidden item, but the menu has the incorrect number of items.')
+      .toBeTruthy();
+
+    expect(await OverflowPageObject.didAssertPopup())
+      .withContext(OverflowPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
+  });
+
+  it('Set Overflow width to 175. Overflow renders first item, and the second and third are hidden.', async () => {
+    await OverflowPageObject.setOverflowWidth(175);
+    await OverflowPageObject.waitForOverflowToBeUpdated();
+
+    expect(await OverflowPageObject.itemIsVisible('First'))
+      .withContext('Expected the first Overflow Item to be visible, but the item remained hidden.')
+      .toBeTruthy();
+
+    expect(
+      await OverflowPageObject.menuIsDisplayed('Expected the overflow menu to be visible, but the menu remained hidden.'),
+    ).toBeTruthy();
+
+    expect(await OverflowPageObject.menuHasNHidden(2))
+      .withContext('Expected the overflow menu to have two hidden items, but the menu has the incorrect number of items.')
+      .toBeTruthy();
+
+    expect(await OverflowPageObject.didAssertPopup())
+      .withContext(OverflowPageObject.ERRORMESSAGE_ASSERT)
+      .toBeFalsy();
+  });
+});

--- a/apps/E2E/src/index.consts.ts
+++ b/apps/E2E/src/index.consts.ts
@@ -21,6 +21,7 @@ export * from './LinkV1/consts';
 export * from './Menu/consts';
 export * from './MenuButtonLegacy/consts';
 export * from './MenuButtonV1/consts';
+export * from './Overflow/consts';
 export * from './Persona/consts';
 export * from './PersonaCoin/consts';
 export * from './Pressable/consts';

--- a/apps/fluent-tester/src/TestComponents/Overflow/OverflowE2ETest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Overflow/OverflowE2ETest.tsx
@@ -8,6 +8,25 @@ import { Overflow, OverflowItem, useOverflowMenu } from '@fluentui-react-native/
 import { RadioGroupV1 as RadioGroup, Radio } from '@fluentui-react-native/radio-group';
 import { TextV1 as Text } from '@fluentui-react-native/text';
 
+import {
+  FIRST_OVERFLOW_ITEM,
+  FIRST_OVERFLOW_ITEM_ID,
+  SECOND_OVERFLOW_ITEM,
+  SECOND_OVERFLOW_ITEM_ID,
+  THIRD_OVERFLOW_ITEM,
+  THIRD_OVERFLOW_ITEM_ID,
+  OVERFLOW_MENU,
+  READY_LABEL,
+  READY_VALUE_FALSE,
+  READY_VALUE_TRUE,
+  UPDATED_LABEL,
+  UPDATED_VALUE_FALSE,
+  UPDATED_VALUE_TRUE,
+  RADIO_175,
+  RADIO_275,
+  RADIO_375,
+} from '../../../../E2E/src/Overflow/consts';
+
 const styles = StyleSheet.create({
   menu: {
     width: 50,
@@ -23,8 +42,8 @@ function OverflowMenu() {
 
   if (showMenu) {
     return (
-      <Button onLayout={onMenuTriggerLayout} style={styles.menu}>
-        <Text>{`${overflowCount} hidden`}</Text>
+      <Button testID={OVERFLOW_MENU} onLayout={onMenuTriggerLayout} style={styles.menu}>
+        {`${overflowCount} hidden`}
       </Button>
     );
   } else {
@@ -32,7 +51,12 @@ function OverflowMenu() {
   }
 }
 
-const items = ['a', 'b', 'c'];
+const items = [FIRST_OVERFLOW_ITEM_ID, SECOND_OVERFLOW_ITEM_ID, THIRD_OVERFLOW_ITEM_ID];
+const itemsToTestIDs = {
+  [FIRST_OVERFLOW_ITEM_ID]: FIRST_OVERFLOW_ITEM,
+  [SECOND_OVERFLOW_ITEM_ID]: SECOND_OVERFLOW_ITEM,
+  [THIRD_OVERFLOW_ITEM_ID]: THIRD_OVERFLOW_ITEM,
+};
 
 export function E2EOverflowTest() {
   const [overflowStyles, setOverflowStyles] = React.useState<StyleProp<ViewStyle>>({});
@@ -50,18 +74,18 @@ export function E2EOverflowTest() {
 
   return (
     <View>
-      <Text>{ready ? 'Ready' : 'Not Ready'}</Text>
-      <Text>{updated ? 'Updated' : 'Not Updated'}</Text>
+      <Text testID={READY_LABEL}>{ready ? READY_VALUE_TRUE : READY_VALUE_FALSE}</Text>
+      <Text testID={UPDATED_LABEL}>{updated ? UPDATED_VALUE_TRUE : UPDATED_VALUE_FALSE}</Text>
       <Divider />
       <RadioGroup defaultValue="375" label="Width Options" onChange={handleRadioGroupChange}>
-        <Radio label="175" value="175" />
-        <Radio label="275" value="275" />
-        <Radio label="375" value="375" />
+        <Radio testID={RADIO_175} label="175" value="175" />
+        <Radio testID={RADIO_275} label="275" value="275" />
+        <Radio testID={RADIO_375} label="375" value="375" />
       </RadioGroup>
       <Divider />
       <Overflow onOverflowUpdate={handleOverflowUpdate} itemIDs={items} style={overflowStyles} onReady={handleReady}>
         {items.map((id, i) => (
-          <OverflowItem priority={items.length - i} overflowID={id} key={id}>
+          <OverflowItem testID={itemsToTestIDs[id]} priority={items.length - i} overflowID={id} key={id}>
             <Button style={styles.item}>{`Item '${id}'`}</Button>
           </OverflowItem>
         ))}

--- a/apps/fluent-tester/src/TestComponents/Overflow/OverflowE2ETest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Overflow/OverflowE2ETest.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react';
+import { View, StyleSheet } from 'react-native';
+import type { StyleProp, ViewStyle } from 'react-native';
+
+import { ButtonV1 as Button } from '@fluentui-react-native/button';
+import { Divider } from '@fluentui-react-native/divider';
+import { Overflow, OverflowItem, useOverflowMenu } from '@fluentui-react-native/overflow';
+import { RadioGroupV1 as RadioGroup, Radio } from '@fluentui-react-native/radio-group';
+import { TextV1 as Text } from '@fluentui-react-native/text';
+
+const styles = StyleSheet.create({
+  menu: {
+    width: 50,
+  },
+  item: {
+    width: 100,
+  },
+});
+
+function OverflowMenu() {
+  const { showMenu, visibleMenuItems, onMenuTriggerLayout } = useOverflowMenu();
+  const overflowCount = visibleMenuItems.length;
+
+  if (showMenu) {
+    return (
+      <Button onLayout={onMenuTriggerLayout} style={styles.menu}>
+        <Text>{`${overflowCount} hidden`}</Text>
+      </Button>
+    );
+  } else {
+    return null;
+  }
+}
+
+const items = ['a', 'b', 'c'];
+
+export function E2EOverflowTest() {
+  const [overflowStyles, setOverflowStyles] = React.useState<StyleProp<ViewStyle>>({});
+  const [ready, setReady] = React.useState(false);
+  const [updated, setUpdated] = React.useState(false);
+
+  const handleRadioGroupChange = React.useCallback((key) => {
+    setUpdated(false);
+    const keyAsInt = parseInt(key);
+    setOverflowStyles({ width: keyAsInt });
+  }, []);
+
+  const handleReady = React.useCallback(() => setReady(true), []);
+  const handleOverflowUpdate = React.useCallback(() => setUpdated(true), []);
+
+  return (
+    <View>
+      <Text>{ready ? 'Ready' : 'Not Ready'}</Text>
+      <Text>{updated ? 'Updated' : 'Not Updated'}</Text>
+      <Divider />
+      <RadioGroup defaultValue="375" label="Width Options" onChange={handleRadioGroupChange}>
+        <Radio label="175" value="175" />
+        <Radio label="275" value="275" />
+        <Radio label="375" value="375" />
+      </RadioGroup>
+      <Divider />
+      <Overflow onOverflowUpdate={handleOverflowUpdate} itemIDs={items} style={overflowStyles} onReady={handleReady}>
+        {items.map((id, i) => (
+          <OverflowItem priority={items.length - i} overflowID={id} key={id}>
+            <Button style={styles.item}>{`Item '${id}'`}</Button>
+          </OverflowItem>
+        ))}
+        <OverflowMenu />
+      </Overflow>
+    </View>
+  );
+}

--- a/apps/fluent-tester/src/TestComponents/Overflow/OverflowTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Overflow/OverflowTest.tsx
@@ -11,6 +11,7 @@ import { TextV1 as Text } from '@fluentui-react-native/text';
 
 import MoreHorizontalIcon from './MoreHorizontalFilled.svg';
 import { Test } from '../Test';
+import { E2EOverflowTest } from './OverflowE2ETest';
 
 const items = ['a', 'b', 'c', 'd', 'e'];
 const itemLabels = {
@@ -161,6 +162,12 @@ export const OverflowTest: React.FunctionComponent = () => {
         {
           name: 'Overflow Variable Width',
           component: OverflowDifferentWidthTest,
+        },
+      ]}
+      e2eSections={[
+        {
+          name: 'Overflow E2E Section',
+          component: E2EOverflowTest,
         },
       ]}
       spec="https://github.com/microsoft/fluentui-react-native/blob/main/packages/experimental/Overflow/SPEC.md"

--- a/apps/fluent-tester/src/TestComponents/Overflow/OverflowTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Overflow/OverflowTest.tsx
@@ -10,8 +10,9 @@ import { TabList, Tab } from '@fluentui-react-native/tablist';
 import { TextV1 as Text } from '@fluentui-react-native/text';
 
 import MoreHorizontalIcon from './MoreHorizontalFilled.svg';
-import { Test } from '../Test';
 import { E2EOverflowTest } from './OverflowE2ETest';
+import { OVERFLOW_TESTPAGE } from '../../../../E2E/src/index.consts';
+import { Test } from '../Test';
 
 const items = ['a', 'b', 'c', 'd', 'e'];
 const itemLabels = {
@@ -154,6 +155,7 @@ export const OverflowTest: React.FunctionComponent = () => {
         {
           name: 'Overflow',
           component: OverflowMainTest,
+          testID: OVERFLOW_TESTPAGE,
         },
         {
           name: 'Overflow TabList',

--- a/apps/fluent-tester/src/testPages.ts
+++ b/apps/fluent-tester/src/testPages.ts
@@ -214,7 +214,7 @@ export const tests: TestDescription[] = [
   {
     name: 'Overflow',
     component: OverflowTest,
-    testPageButton: '',
+    testPageButton: Constants.HOMEPAGE_OVERFLOW_BUTTON,
     platforms: ['win32', 'macos'],
   },
   {

--- a/change/@fluentui-react-native-e2e-testing-654713da-0d47-4824-b586-8124f066a492.json
+++ b/change/@fluentui-react-native-e2e-testing-654713da-0d47-4824-b586-8124f066a492.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add Overflow E2E test spec for win32.",
+  "packageName": "@fluentui-react-native/e2e-testing",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-overflow-37378cee-c17a-4c60-b88b-86ab39eccb0c.json
+++ b/change/@fluentui-react-native-overflow-37378cee-c17a-4c60-b88b-86ab39eccb0c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix OverflowItem incorrectly merging its props with its cloned child.",
+  "packageName": "@fluentui-react-native/overflow",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-4803c4f2-e14a-4ca5-a591-a450bf677789.json
+++ b/change/@fluentui-react-native-tester-4803c4f2-e14a-4ca5-a591-a450bf677789.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add Overflow E2E test section.",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Overflow/src/Overflow/Overflow.types.ts
+++ b/packages/experimental/Overflow/src/Overflow/Overflow.types.ts
@@ -26,6 +26,11 @@ export interface OverflowProps extends ViewProps {
    * Callback triggering whenever the visibility of one or more items changes
    */
   onOverflowUpdate?: (data: OverflowUpdatePayload) => void;
+
+  /**
+   * Callback that triggers when the container, menu, and every item is registered in the manager. If `dontHideBeforeReady` is false, this triggers once `Overflow` is visible.
+   */
+  onReady?: () => void;
 }
 
 type MenuSetLayoutStateParam = { type: 'menu'; layoutDone: boolean };

--- a/packages/experimental/Overflow/src/Overflow/useOverflow.ts
+++ b/packages/experimental/Overflow/src/Overflow/useOverflow.ts
@@ -32,7 +32,7 @@ interface LayoutState {
  *
  * Returns state to feed into context provider and props (with an important onLayout callback) to pass to Overflow's containing view. */
 export function useOverflow(props: OverflowProps): OverflowInfo {
-  const { itemIDs, onLayout, onOverflowUpdate: overflowUpdateCallback } = props;
+  const { itemIDs, onLayout, onOverflowUpdate: overflowUpdateCallback, onReady } = props;
 
   // The overflow manager records layout info of the container, menu, and items and calculates what is visible and what isn't.
   const overflowManager = React.useRef<OverflowManager>(createOverflowManager()).current;
@@ -157,6 +157,12 @@ export function useOverflow(props: OverflowProps): OverflowInfo {
 
   const initialLayoutDone =
     layoutState.container && layoutState.menu && itemIDs.map((id) => layoutState.items[id]).reduce((prev, curr) => prev && curr);
+
+  React.useEffect(() => {
+    if (initialLayoutDone) {
+      onReady && onReady();
+    }
+  }, [initialLayoutDone, onReady]);
 
   return {
     state: {

--- a/packages/experimental/Overflow/src/OverflowItem/OverflowItem.tsx
+++ b/packages/experimental/Overflow/src/OverflowItem/OverflowItem.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import type { LayoutChangeEvent, StyleProp, ViewProps, ViewStyle } from 'react-native';
 
-import { mergeProps, stagedComponent, memoize } from '@fluentui-react-native/framework';
+import { mergeProps, stagedComponent, memoize, mergeStyles } from '@fluentui-react-native/framework';
 
 import type { OverflowItemProps } from './OverflowItem.types';
 import { overflowItemName } from './OverflowItem.types';
@@ -36,7 +36,8 @@ export const OverflowItem = stagedComponent<OverflowItemProps>((userProps: Overf
     }
 
     // Assume that the child can accept ViewProps.
-    const viewProps = getOverflowItemProps(finalProps.style, finalProps.onLayout);
+    const viewStyles = mergeStyles(child.props.style, finalProps.style);
+    const viewProps = getOverflowItemProps(viewStyles, finalProps.onLayout);
 
     const clone = React.cloneElement(child, viewProps);
     return clone;

--- a/packages/experimental/Overflow/src/OverflowItem/OverflowItem.tsx
+++ b/packages/experimental/Overflow/src/OverflowItem/OverflowItem.tsx
@@ -1,6 +1,6 @@
 /** @jsxRuntime classic */
 import * as React from 'react';
-import type { LayoutChangeEvent, StyleProp, ViewProps, ViewStyle } from 'react-native';
+import type { StyleProp, ViewProps, ViewStyle } from 'react-native';
 
 import { mergeProps, stagedComponent, memoize, mergeStyles } from '@fluentui-react-native/framework';
 
@@ -9,8 +9,8 @@ import { overflowItemName } from './OverflowItem.types';
 import { useOverflowItem } from './useOverflowItem';
 
 const getOverflowItemProps = memoize(overflowItemPropWorker);
-function overflowItemPropWorker(style: StyleProp<ViewStyle>, onLayout: (e: LayoutChangeEvent) => void): ViewProps {
-  return { style, onLayout };
+function overflowItemPropWorker(props: ViewProps, style: StyleProp<ViewStyle>): ViewProps {
+  return { ...props, style };
 }
 
 export const OverflowItem = stagedComponent<OverflowItemProps>((userProps: OverflowItemProps) => {
@@ -20,7 +20,7 @@ export const OverflowItem = stagedComponent<OverflowItemProps>((userProps: Overf
       return null;
     }
 
-    finalProps = mergeProps(props, finalProps);
+    const mergedProps = mergeProps(props, finalProps);
     const childrenArray = React.Children.toArray(children);
     const child = childrenArray[0];
 
@@ -37,7 +37,7 @@ export const OverflowItem = stagedComponent<OverflowItemProps>((userProps: Overf
 
     // Assume that the child can accept ViewProps.
     const viewStyles = mergeStyles(child.props.style, finalProps.style);
-    const viewProps = getOverflowItemProps(viewStyles, finalProps.onLayout);
+    const viewProps = getOverflowItemProps(mergedProps, viewStyles);
 
     const clone = React.cloneElement(child, viewProps);
     return clone;

--- a/packages/experimental/Overflow/src/__tests__/__snapshots__/Overflow.test.tsx.snap
+++ b/packages/experimental/Overflow/src/__tests__/__snapshots__/Overflow.test.tsx.snap
@@ -62,6 +62,7 @@ exports[`Overflow component tests Overflow default 1`] = `
     onResponderTerminate={[Function]}
     onResponderTerminationRequest={[Function]}
     onStartShouldSetResponder={[Function]}
+    overflowID="a"
     style={
       {
         "alignItems": "center",
@@ -152,6 +153,7 @@ exports[`Overflow component tests Overflow default 1`] = `
     onResponderTerminate={[Function]}
     onResponderTerminationRequest={[Function]}
     onStartShouldSetResponder={[Function]}
+    overflowID="b"
     style={
       {
         "alignItems": "center",
@@ -242,6 +244,7 @@ exports[`Overflow component tests Overflow default 1`] = `
     onResponderTerminate={[Function]}
     onResponderTerminationRequest={[Function]}
     onStartShouldSetResponder={[Function]}
+    overflowID="c"
     style={
       {
         "alignItems": "center",


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This PR adds automation to Overflow, and it includes some minor bug fixes to the component.

- Add Overflow spec, page object, and constants within the E2E test package.
- Create Overflow E2E test section on test page.
- Fix `OverflowItem` bug where the item's `ViewProps` and styles were incorrectly merged with its cloned child. 

### Verification

Automated tests pass locally.

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
