### PR TITLE
[FURN Menu] Set directionalHint on MenuPopover from user props

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Menu/MenuTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Menu/MenuTest.tsx
@@ -295,7 +295,7 @@ const MenuCustomized: React.FunctionComponent = () => {
         <MenuTrigger>
           <Button>Test</Button>
         </MenuTrigger>
-        <CustomMenuPopover>
+        <CustomMenuPopover directionalHint="rightCenter">
           <CustomMenuList>
             <CustomMenuItem>A MenuItem</CustomMenuItem>
             <CustomMenuItem>A MenuItem</CustomMenuItem>

--- a/change/@fluentui-react-native-menu-40f8f154-07b7-4668-8f65-f71f5a7f5253.json
+++ b/change/@fluentui-react-native-menu-40f8f154-07b7-4668-8f65-f71f5a7f5253.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "set directionalHint on MenuPopover from user props",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-7c0c6fcc-f0e1-4e65-aacd-4c66e7be4642.json
+++ b/change/@fluentui-react-native-tester-7c0c6fcc-f0e1-4e65-aacd-4c66e7be4642.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "set directionalHint on MenuPopover from user props",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
+++ b/packages/components/Menu/src/MenuPopover/useMenuPopover.ts
@@ -31,7 +31,7 @@ export const useMenuPopover = (props: MenuPopoverProps): MenuPopoverState => {
     setOpen(undefined, false /* isOpen */), [setOpen];
   }, [props.onDismiss, setOpen]);
   const dismissBehaviors = isControlled ? controlledDismissBehaviors : undefined;
-  const directionalHint = getDirectionalHint(isSubmenu, I18nManager.isRTL);
+  const directionalHint = props.directionalHint ?? getDirectionalHint(isSubmenu, I18nManager.isRTL);
 
   const setInitialFocus = true;
   const doNotTakePointerCapture = props.doNotTakePointerCapture ?? openOnHover;


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Allow the `directionalHint` property to set the position of the MenuPopover.

### Verification

Added a test example to the Menu Test page (where `directionalHint={'rightCenter'}`) and verified manually.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://github.com/microsoft/fluentui-react-native/assets/22876140/cc3b3a0d-7a6f-4b8e-9c59-86ee9bbc264d) | ![image](https://github.com/microsoft/fluentui-react-native/assets/22876140/bb2f2f8d-3ac8-40f6-8bf5-9cff055a28f9) |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
