### PR TITLE
Fix more discovered typos in Overflow spec doc

### DIFF
--- a/change/@fluentui-react-native-overflow-e7e01c98-84d4-49b8-bd1f-0779130babae.json
+++ b/change/@fluentui-react-native-overflow-e7e01c98-84d4-49b8-bd1f-0779130babae.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix more typos in Overflow doc",
+  "packageName": "@fluentui-react-native/overflow",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Overflow/SPEC.md
+++ b/packages/experimental/Overflow/SPEC.md
@@ -152,12 +152,13 @@ import { Overflow, OverflowItem } from '@fluentui-react-native/overflow';
 
 import { OverflowMenu } from '.';
 
-const items = ['a', 'b', 'c', 'd'];
+const items = ['a', 'b', 'c', 'd', 'e'];
 const itemLabels = {
   a: 'Item A',
   b: 'Item B',
   c: 'Item C',
   d: 'Item D',
+  e: 'Item E',
 };
 
 function OverflowExperience() {
@@ -189,12 +190,13 @@ import { TabList, Tab } from '@fluentui-react-native/tablist';
 
 import { OverflowMenu } from '.';
 
-const items = ['a', 'b', 'c', 'd'];
+const items = ['a', 'b', 'c', 'd', 'e'];
 const itemLabels = {
   a: 'Item A',
   b: 'Item B',
   c: 'Item C',
   d: 'Item D',
+  e: 'Item E',
 };
 
 function OverflowTabListExperience() {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This PR is purely for fixing more discovered typos in the Overflow's spec file, involving the code examples not matching with the shown images (thanks EJ!). 

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
