### PR TITLE
chore: patch `@react-native-picker/picker` to support package refs

### DIFF
--- a/.yarn/patches/@react-native-picker-picker-npm-2.6.1-90663b0c0f.patch
+++ b/.yarn/patches/@react-native-picker-picker-npm-2.6.1-90663b0c0f.patch
@@ -1,0 +1,17 @@
+diff --git a/windows/ReactNativePicker/ReactNativePicker.vcxproj b/windows/ReactNativePicker/ReactNativePicker.vcxproj
+index 32480642e7d64bec875b832c481d9fb194c803cb..b03a144988e4c1919d75ae517c3db616ded39af5 100644
+--- a/windows/ReactNativePicker/ReactNativePicker.vcxproj
++++ b/windows/ReactNativePicker/ReactNativePicker.vcxproj
+@@ -164,12 +164,4 @@
+     <Import Project="$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets')" />
+     <Import Project="$(SolutionDir)\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets" Condition="Exists('$(SolutionDir)\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets')" />
+   </ImportGroup>
+-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+-    <PropertyGroup>
+-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+-    </PropertyGroup>
+-    <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props'))" />
+-    <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+-    <Error Condition="!Exists('$(SolutionDir)\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets'))" />
+-  </Target>
+ </Project>

--- a/package.json
+++ b/package.json
@@ -63,8 +63,9 @@
     "scripts"
   ],
   "resolutions": {
-    "es5-ext": "0.10.63",
+    "@react-native-picker/picker@^2.2.1": "patch:@react-native-picker/picker@npm%3A2.6.1#./.yarn/patches/@react-native-picker-picker-npm-2.6.1-90663b0c0f.patch",
     "@types/react": "^18.2.0",
+    "es5-ext": "0.10.63",
     "micromatch": "^4.0.0",
     "react-native-svg": "^13.14.0",
     "semver": "^7.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6413,13 +6413,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native-picker/picker@npm:^2.2.1":
+"@react-native-picker/picker@npm:2.6.1":
   version: 2.6.1
   resolution: "@react-native-picker/picker@npm:2.6.1"
   peerDependencies:
     react: ">=16"
     react-native: ">=0.57"
   checksum: a8c58d5d945350b70fd8b5d66dfe97dd04641277db7c702912d8c41ae4da94cfef8b0b73bfa493adfdee8f089af6e0316872c3ee61a4efc18528e6e25a5452bc
+  languageName: node
+  linkType: hard
+
+"@react-native-picker/picker@patch:@react-native-picker/picker@npm%3A2.6.1#./.yarn/patches/@react-native-picker-picker-npm-2.6.1-90663b0c0f.patch::locator=%40fluentui-react-native%2Frepo%40workspace%3A.":
+  version: 2.6.1
+  resolution: "@react-native-picker/picker@patch:@react-native-picker/picker@npm%3A2.6.1#./.yarn/patches/@react-native-picker-picker-npm-2.6.1-90663b0c0f.patch::version=2.6.1&hash=cbbc8c&locator=%40fluentui-react-native%2Frepo%40workspace%3A."
+  peerDependencies:
+    react: ">=16"
+    react-native: ">=0.57"
+  checksum: b65f990627241a460b063f2fcd01ef8db7ca25d31e8f0d216dc5bfa9ee04db0095d4697a9e35f1c9b32478b9406328692a051e7dbe1eae233aa295d70ad4cef9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Platforms Impacted

- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [x] windows
- [ ] android

### Description of changes

Remove the block that verifies that NuGet packages have been downloaded. Since RNW 0.68, this causes build failures because RNW manages dependencies using package references.

Upstream PR: https://github.com/react-native-picker/picker/pull/554

### Verification

Build should succeed.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
