### PR TITLE
Remove a usage of findNodeHandle in fluent-tester

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Common/Slider.tsx
+++ b/apps/fluent-tester/src/TestComponents/Common/Slider.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { ViewProps, StyleProp, ViewStyle } from 'react-native';
-import { StyleSheet, UIManager, Text, findNodeHandle, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 
 import { Separator, Pressable } from '@fluentui/react-native';
 import type { IPressableState } from '@fluentui-react-native/interactive-hooks';
@@ -109,9 +109,8 @@ export const Slider: React.FunctionComponent<ISliderProps> = (props: ISliderProp
   const ref = React.useRef<View>(null);
 
   React.useEffect(() => {
-    const parent = findNodeHandle(ref.current);
-    if (parent) {
-      UIManager.measure(parent, (_x, _y, width) => {
+    if (ref.current) {
+      ref.current.measure((_x, _y, width) => {
         if (width <= 0) {
           return;
         }

--- a/change/@fluentui-react-native-tester-f9ec04aa-4aed-4bb0-93ba-a98828b95cd0.json
+++ b/change/@fluentui-react-native-tester-f9ec04aa-4aed-4bb0-93ba-a98828b95cd0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove use of findNodeHandle",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
Removing a usage of `findNodeHandle` in `fluent-tester`.  This call was being used to call `UIManager.measure`, which is itself deprecated.

Replacing the call to `UIManager.measure` with `ref.measure`, also eliminates the call to `findNodeHandle`.