### PR TITLE
[Button V1] [win32] Check for falsy dimensions before rendering focusInnerBorder

### DIFF
--- a/change/@fluentui-react-native-button-374802de-d193-4d90-a38b-a9bfce4d8103.json
+++ b/change/@fluentui-react-native-button-374802de-d193-4d90-a38b-a9bfce4d8103.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "check if measuredHeight/Width are falsy before using",
+  "packageName": "@fluentui-react-native/button",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Button/src/Button.tsx
+++ b/packages/components/Button/src/Button.tsx
@@ -113,8 +113,8 @@ export const Button = compose<ButtonType>({
           <Slots.root {...mergedProps} accessibilityLabel={label}>
             {buttonContent}
             {button.state.focused &&
-              button.state.measuredHeight &&
-              button.state.measuredWidth &&
+              !!button.state.measuredHeight &&
+              !!button.state.measuredWidth &&
               button.state.shouldUseTwoToneFocusBorder && (
                 <Slots.focusInnerBorder
                   style={getFocusBorderStyle(button.state.measuredHeight, button.state.measuredWidth)}

--- a/packages/components/Button/src/CompoundButton/CompoundButton.tsx
+++ b/packages/components/Button/src/CompoundButton/CompoundButton.tsx
@@ -84,13 +84,16 @@ export const CompoundButton = compose<CompoundButtonType>({
             )}
           </Slots.contentContainer>
           {shouldShowIcon && iconPosition === 'after' && <Slots.icon {...iconProps} accessible={false} />}
-          {button.state.focused && button.state.shouldUseTwoToneFocusBorder && (
-            <Slots.focusInnerBorder
-              style={getFocusBorderStyle(button.state.measuredHeight, button.state.measuredWidth)}
-              accessible={false}
-              focusable={false}
-            />
-          )}
+          {button.state.focused &&
+            !!button.state.measuredHeight &&
+            !!button.state.measuredWidth &&
+            button.state.shouldUseTwoToneFocusBorder && (
+              <Slots.focusInnerBorder
+                style={getFocusBorderStyle(button.state.measuredHeight, button.state.measuredWidth)}
+                accessible={false}
+                focusable={false}
+              />
+            )}
         </Slots.root>
       );
     };

--- a/packages/components/Button/src/ToggleButton/ToggleButton.tsx
+++ b/packages/components/Button/src/ToggleButton/ToggleButton.tsx
@@ -68,13 +68,16 @@ export const ToggleButton = compose<ToggleButtonType>({
             ),
           )}
           {shouldShowIcon && iconPosition === 'after' && <Slots.icon {...iconProps} accessible={false} />}
-          {toggleButton.state.focused && toggleButton.state.shouldUseTwoToneFocusBorder && (
-            <Slots.focusInnerBorder
-              style={getFocusBorderStyle(toggleButton.state.measuredHeight, toggleButton.state.measuredWidth)}
-              accessible={false}
-              focusable={false}
-            />
-          )}
+          {toggleButton.state.focused &&
+            !!toggleButton.state.measuredHeight &&
+            !!toggleButton.state.measuredWidth &&
+            toggleButton.state.shouldUseTwoToneFocusBorder && (
+              <Slots.focusInnerBorder
+                style={getFocusBorderStyle(toggleButton.state.measuredHeight, toggleButton.state.measuredWidth)}
+                accessible={false}
+                focusable={false}
+              />
+            )}
         </Slots.root>
       );
     };


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Ran into an issue where button.state.measuredHeight/measuredWidth = 0 and gets rendered as text outside of a <Text> component. This checks if the value of button.state.measuredHeight/measuredWidth is falsy instead (and also adds the checks for Compound and Toggle buttons).

### Verification

Manually tested this resolves the text rendering outside of a <Text> component issue.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
