### PR TITLE
Fix dynamic addition / removal of OverflowItems not propagating updates + other styling issues. 

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Overflow/OverflowTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Overflow/OverflowTest.tsx
@@ -47,6 +47,7 @@ interface OverflowMenuProps {
 
 function OverflowMenu(props: OverflowMenuProps) {
   const { showMenu, visibleMenuItems, menuTriggerRef, onMenuTriggerLayout } = useOverflowMenu();
+
   if (showMenu) {
     return (
       <Menu>
@@ -65,7 +66,7 @@ function OverflowMenu(props: OverflowMenuProps) {
           <MenuList>
             {visibleMenuItems.map((id) => (
               <MenuItem onClick={() => props.onItemPress(id)} key={id}>
-                {itemLabels[id]}
+                {itemLabels[id] ?? 'Item ' + id}
               </MenuItem>
             ))}
           </MenuList>
@@ -143,6 +144,36 @@ function OverflowDifferentWidthTest() {
   );
 }
 
+function OverflowDynamicAddRemovalTest() {
+  const [ids, setIDs] = React.useState(['1', '2', '3']);
+  const addItem = React.useCallback(
+    () =>
+      setIDs((prev) => {
+        const newItem = (parseInt(prev[prev.length - 1]) + 1).toString();
+        return [...prev, newItem];
+      }),
+    [],
+  );
+  const removeItem = React.useCallback((item: string) => setIDs((prev) => prev.filter((x) => x !== item)), []);
+  return (
+    <View style={overflowTestPageStyles.containerStyle}>
+      <Text>{ids.reduce((prev, curr) => prev + ', ' + curr)}</Text>
+      <Button onClick={addItem}>Add item</Button>
+      <Divider />
+      <Overflow style={{ width: 400, borderWidth: 1, borderStyle: 'solid', borderColor: 'black' }} itemIDs={ids}>
+        {ids.map((id) => {
+          return (
+            <OverflowItem key={id} overflowID={id}>
+              <Button onClick={() => removeItem(id)}>{'Item ' + id}</Button>
+            </OverflowItem>
+          );
+        })}
+        <OverflowMenu onItemPress={removeItem} />
+      </Overflow>
+    </View>
+  );
+}
+
 export const OverflowTest: React.FunctionComponent = () => {
   const description =
     'The `Overflow` and `OverflowItem` components, based off the same Fluent web v9 components of the same name, are low level utilities that enable users to create overflow experiences with any component. These components will detect and hide overflowing elements on screen and manage the overflow state.';
@@ -160,6 +191,10 @@ export const OverflowTest: React.FunctionComponent = () => {
         {
           name: 'Overflow TabList',
           component: OverflowTabTest,
+        },
+        {
+          name: 'Overflow Dynamic Add/Removal of Items',
+          component: OverflowDynamicAddRemovalTest,
         },
         {
           name: 'Overflow Variable Width',

--- a/apps/fluent-tester/src/TestComponents/Overflow/OverflowTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Overflow/OverflowTest.tsx
@@ -39,6 +39,12 @@ const overflowTestPageStyles = StyleSheet.create({
   menuTrigger: {
     alignSelf: 'center',
   },
+  dynamicAddRemoval: {
+    width: 400,
+    borderWidth: 1,
+    borderStyle: 'solid',
+    borderColor: 'black',
+  },
 });
 
 interface OverflowMenuProps {
@@ -157,10 +163,11 @@ function OverflowDynamicAddRemovalTest() {
   const removeItem = React.useCallback((item: string) => setIDs((prev) => prev.filter((x) => x !== item)), []);
   return (
     <View style={overflowTestPageStyles.containerStyle}>
-      <Text>{ids.reduce((prev, curr) => prev + ', ' + curr)}</Text>
+      <Text>Add buttons using the button below. Remove by clicking on individual items in the Overflow container.</Text>
       <Button onClick={addItem}>Add item</Button>
+      <Text>Overflow Items (raw): {ids.reduce((prev, curr) => prev + ', ' + curr)}</Text>
       <Divider />
-      <Overflow style={{ width: 400, borderWidth: 1, borderStyle: 'solid', borderColor: 'black' }} itemIDs={ids}>
+      <Overflow padding={4} style={overflowTestPageStyles.dynamicAddRemoval} itemIDs={ids}>
         {ids.map((id) => {
           return (
             <OverflowItem key={id} overflowID={id}>

--- a/change/@fluentui-react-native-overflow-c9160def-58d6-495d-9fe5-704b67107ddd.json
+++ b/change/@fluentui-react-native-overflow-c9160def-58d6-495d-9fe5-704b67107ddd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix dynamic removal and addition of OverflowItems not causing overflow updates.",
+  "packageName": "@fluentui-react-native/overflow",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-c37b36a9-f01b-4ffb-9312-cef526855a0f.json
+++ b/change/@fluentui-react-native-tester-c37b36a9-f01b-4ffb-9312-cef526855a0f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add new Overflow example for dynamic addition / removal of items.",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Overflow/src/Overflow/Overflow.tsx
+++ b/packages/experimental/Overflow/src/Overflow/Overflow.tsx
@@ -1,6 +1,7 @@
 /** @jsxRuntime classic */
 import * as React from 'react';
 import { View } from 'react-native';
+
 import { mergeProps, stagedComponent } from '@fluentui-react-native/framework';
 
 import type { OverflowProps } from './Overflow.types';

--- a/packages/experimental/Overflow/src/Overflow/Overflow.tsx
+++ b/packages/experimental/Overflow/src/Overflow/Overflow.tsx
@@ -1,6 +1,7 @@
 /** @jsxRuntime classic */
 import * as React from 'react';
 import { View } from 'react-native';
+import type { StyleProp, ViewStyle } from 'react-native';
 
 import { mergeProps, mergeStyles, stagedComponent, memoize } from '@fluentui-react-native/framework';
 
@@ -9,17 +10,20 @@ import { overflowName } from './Overflow.types';
 import { useOverflow } from './useOverflow';
 import { OverflowContext } from '../OverflowContext';
 
+const defaultStyles: StyleProp<ViewStyle> = {
+  display: 'flex',
+  flexDirection: 'row',
+  flexWrap: 'nowrap',
+};
+
 export const getOverflowStyleProps = memoize(overflowStylePropsWorker);
 function overflowStylePropsWorker(props: OverflowProps, initialOverflowLayoutDone: boolean): Partial<OverflowProps> {
   const { dontHideBeforeReady, style, padding } = props;
   return {
-    style: mergeStyles(style, {
+    style: mergeStyles(defaultStyles, style, {
       opacity: dontHideBeforeReady || initialOverflowLayoutDone ? 1 : 0,
-      display: 'flex',
-      flexDirection: 'row',
-      flexWrap: 'wrap',
       padding: padding,
-    }),
+    } as StyleProp<ViewStyle>),
   };
 }
 

--- a/packages/experimental/Overflow/src/Overflow/Overflow.tsx
+++ b/packages/experimental/Overflow/src/Overflow/Overflow.tsx
@@ -1,36 +1,17 @@
 /** @jsxRuntime classic */
 import * as React from 'react';
 import { View } from 'react-native';
-import type { StyleProp, ViewStyle } from 'react-native';
-
-import { mergeProps, mergeStyles, stagedComponent, memoize } from '@fluentui-react-native/framework';
+import { mergeProps, stagedComponent } from '@fluentui-react-native/framework';
 
 import type { OverflowProps } from './Overflow.types';
 import { overflowName } from './Overflow.types';
 import { useOverflow } from './useOverflow';
 import { OverflowContext } from '../OverflowContext';
 
-const defaultStyles: StyleProp<ViewStyle> = {
-  display: 'flex',
-  flexDirection: 'row',
-  flexWrap: 'nowrap',
-};
-
-export const getOverflowStyleProps = memoize(overflowStylePropsWorker);
-function overflowStylePropsWorker(props: OverflowProps, initialOverflowLayoutDone: boolean): Partial<OverflowProps> {
-  const { dontHideBeforeReady, style, padding } = props;
-  return {
-    style: mergeStyles(defaultStyles, style, {
-      opacity: dontHideBeforeReady || initialOverflowLayoutDone ? 1 : 0,
-      padding: padding,
-    } as StyleProp<ViewStyle>),
-  };
-}
-
 export const Overflow = stagedComponent<OverflowProps>((initial: OverflowProps) => {
   const { props, state } = useOverflow(initial);
   return (final: OverflowProps, ...children: React.ReactNode[]) => {
-    const { itemIDs: _, ...mergedProps } = mergeProps(props, final, getOverflowStyleProps(props, state.initialOverflowLayoutDone));
+    const mergedProps = mergeProps(props, final);
     return (
       <OverflowContext.Provider value={state}>
         <View {...mergedProps}>{children}</View>

--- a/packages/experimental/Overflow/src/Overflow/Overflow.tsx
+++ b/packages/experimental/Overflow/src/Overflow/Overflow.tsx
@@ -1,9 +1,8 @@
 /** @jsxRuntime classic */
 import * as React from 'react';
 import { View } from 'react-native';
-import type { DimensionValue } from 'react-native';
 
-import { mergeProps, stagedComponent, memoize } from '@fluentui-react-native/framework';
+import { mergeProps, mergeStyles, stagedComponent, memoize } from '@fluentui-react-native/framework';
 
 import type { OverflowProps } from './Overflow.types';
 import { overflowName } from './Overflow.types';
@@ -11,30 +10,23 @@ import { useOverflow } from './useOverflow';
 import { OverflowContext } from '../OverflowContext';
 
 export const getOverflowStyleProps = memoize(overflowStylePropsWorker);
-function overflowStylePropsWorker(
-  dontHideBeforeReady: boolean,
-  initialOverflowLayoutDone: boolean,
-  padding?: DimensionValue,
-): Partial<OverflowProps> {
+function overflowStylePropsWorker(props: OverflowProps, initialOverflowLayoutDone: boolean): Partial<OverflowProps> {
+  const { dontHideBeforeReady, style, padding } = props;
   return {
-    style: {
+    style: mergeStyles(style, {
       opacity: dontHideBeforeReady || initialOverflowLayoutDone ? 1 : 0,
       display: 'flex',
       flexDirection: 'row',
       flexWrap: 'wrap',
-      paddingHorizontal: padding,
-    },
+      padding: padding,
+    }),
   };
 }
 
 export const Overflow = stagedComponent<OverflowProps>((initial: OverflowProps) => {
   const { props, state } = useOverflow(initial);
   return (final: OverflowProps, ...children: React.ReactNode[]) => {
-    const { itemIDs: _, ...mergedProps } = mergeProps(
-      props,
-      final,
-      getOverflowStyleProps(props.dontHideBeforeReady, state.initialOverflowLayoutDone, props.padding),
-    );
+    const { itemIDs: _, ...mergedProps } = mergeProps(props, final, getOverflowStyleProps(props, state.initialOverflowLayoutDone));
     return (
       <OverflowContext.Provider value={state}>
         <View {...mergedProps}>{children}</View>

--- a/packages/experimental/Overflow/src/Overflow/Overflow.types.ts
+++ b/packages/experimental/Overflow/src/Overflow/Overflow.types.ts
@@ -54,6 +54,8 @@ export type OverflowItemChangeHandler = (data: OverflowItemChangePayload) => voi
 export interface OverflowState {
   /** Size of the Overflow Container */
   containerSize?: LayoutSize;
+  /** `dontHideBeforeReady` prop propagated to the child items */
+  dontHideBeforeReady?: boolean;
   /**  Flag set to true when one or more items are hidden by the manager */
   hasOverflow: boolean;
   /**  Flag set to true once the overflow manager runs its first calculation to see which items should initially be visible / hidden */

--- a/packages/experimental/Overflow/src/Overflow/useOverflow.ts
+++ b/packages/experimental/Overflow/src/Overflow/useOverflow.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type { View, LayoutChangeEvent } from 'react-native';
+import type { View, LayoutChangeEvent, StyleProp, ViewStyle } from 'react-native';
 
 import type {
   LayoutSize,
@@ -32,7 +32,7 @@ interface LayoutState {
  *
  * Returns state to feed into context provider and props (with an important onLayout callback) to pass to Overflow's containing view. */
 export function useOverflow(props: OverflowProps): OverflowInfo {
-  const { itemIDs, onLayout, onOverflowUpdate: overflowUpdateCallback, onReady, padding } = props;
+  const { dontHideBeforeReady, itemIDs, onLayout, onOverflowUpdate: overflowUpdateCallback, onReady, padding, style } = props;
 
   // The overflow manager records layout info of the container, menu, and items and calculates what is visible and what isn't.
   const overflowManager = React.useRef<OverflowManager>(createOverflowManager()).current;
@@ -181,11 +181,21 @@ export function useOverflow(props: OverflowProps): OverflowInfo {
     }
   }, [initialLayoutDone, onReady]);
 
+  const overflowStyles = React.useMemo<StyleProp<ViewStyle>>(() => [
+    style,
+    {
+      display: 'flex',
+      flexDirection: 'row',
+      opacity: dontHideBeforeReady || initialLayoutDone ? 1 : 0,
+      padding: padding,
+    }
+  ], [dontHideBeforeReady, initialLayoutDone, padding, style]);
+
   return {
     state: {
       ...overflowState,
       containerSize,
-      dontHideBeforeReady: props.dontHideBeforeReady,
+      dontHideBeforeReady: dontHideBeforeReady,
       initialOverflowLayoutDone: initialLayoutDone,
       overflowMenuRef: overflowMenuRef,
       register: register,
@@ -197,6 +207,7 @@ export function useOverflow(props: OverflowProps): OverflowInfo {
     },
     props: {
       ...props,
+      style: overflowStyles,
       onLayout: onContainerLayout,
     },
   };

--- a/packages/experimental/Overflow/src/Overflow/useOverflow.ts
+++ b/packages/experimental/Overflow/src/Overflow/useOverflow.ts
@@ -181,15 +181,18 @@ export function useOverflow(props: OverflowProps): OverflowInfo {
     }
   }, [initialLayoutDone, onReady]);
 
-  const overflowStyles = React.useMemo<StyleProp<ViewStyle>>(() => [
-    style,
-    {
-      display: 'flex',
-      flexDirection: 'row',
-      opacity: dontHideBeforeReady || initialLayoutDone ? 1 : 0,
-      padding: padding,
-    }
-  ], [dontHideBeforeReady, initialLayoutDone, padding, style]);
+  const overflowStyles = React.useMemo<StyleProp<ViewStyle>>(
+    () => [
+      style,
+      {
+        display: 'flex',
+        flexDirection: 'row',
+        opacity: dontHideBeforeReady || initialLayoutDone ? 1 : 0,
+        padding: padding,
+      },
+    ],
+    [dontHideBeforeReady, initialLayoutDone, padding, style],
+  );
 
   return {
     state: {

--- a/packages/experimental/Overflow/src/Overflow/useOverflow.ts
+++ b/packages/experimental/Overflow/src/Overflow/useOverflow.ts
@@ -32,7 +32,7 @@ interface LayoutState {
  *
  * Returns state to feed into context provider and props (with an important onLayout callback) to pass to Overflow's containing view. */
 export function useOverflow(props: OverflowProps): OverflowInfo {
-  const { itemIDs, onLayout, onOverflowUpdate: overflowUpdateCallback, onReady } = props;
+  const { itemIDs, onLayout, onOverflowUpdate: overflowUpdateCallback, onReady, padding } = props;
 
   // The overflow manager records layout info of the container, menu, and items and calculates what is visible and what isn't.
   const overflowManager = React.useRef<OverflowManager>(createOverflowManager()).current;
@@ -151,6 +151,7 @@ export function useOverflow(props: OverflowProps): OverflowInfo {
     if (!layoutState.container) {
       overflowManager.initialize({
         initialContainerSize: containerSize,
+        padding: typeof padding === 'number' ? padding : typeof padding === 'string' ? parseInt(padding) : 0,
         onOverflowUpdate,
         onUpdateItemDimension,
         onUpdateItemVisibility,

--- a/packages/experimental/Overflow/src/OverflowItem/OverflowItem.tsx
+++ b/packages/experimental/Overflow/src/OverflowItem/OverflowItem.tsx
@@ -16,7 +16,7 @@ function overflowItemPropWorker(props: ViewProps, style: StyleProp<ViewStyle>): 
 export const OverflowItem = stagedComponent<OverflowItemProps>((userProps: OverflowItemProps) => {
   const { props, state } = useOverflowItem(userProps);
   return (finalProps: OverflowItemProps, children: React.ReactNode) => {
-    if (!state.visible) {
+    if (state.layoutDone && !state.visible) {
       return null;
     }
 
@@ -36,7 +36,7 @@ export const OverflowItem = stagedComponent<OverflowItemProps>((userProps: Overf
     }
 
     // Assume that the child can accept ViewProps.
-    const viewStyles = mergeStyles(child.props.style, finalProps.style);
+    const viewStyles = mergeStyles(child.props.style, mergedProps.style);
     const viewProps = getOverflowItemProps(mergedProps, viewStyles);
 
     const clone = React.cloneElement(child, viewProps);

--- a/packages/experimental/Overflow/src/OverflowItem/OverflowItem.types.ts
+++ b/packages/experimental/Overflow/src/OverflowItem/OverflowItem.types.ts
@@ -15,6 +15,7 @@ export interface OverflowItemProps extends ViewProps {
 
 export interface OverflowItemState {
   visible: boolean;
+  layoutDone: boolean;
 }
 
 export interface OverflowItemInfo {

--- a/packages/experimental/Overflow/src/__tests__/Overflow.test.tsx
+++ b/packages/experimental/Overflow/src/__tests__/Overflow.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { ButtonV1 } from '@fluentui-react-native/button';
 import { Menu, MenuPopover, MenuTrigger, MenuItem } from '@fluentui-react-native/menu';
-import { checkRenderConsistency, checkReRender } from '@fluentui-react-native/test-tools';
+import { checkReRender } from '@fluentui-react-native/test-tools';
 import * as renderer from 'react-test-renderer';
 
 import { Overflow, OverflowItem, useOverflowMenu } from '../';
@@ -44,22 +44,6 @@ describe('Overflow component tests', () => {
       )
       .toJSON();
     expect(tree).toMatchSnapshot();
-  });
-
-  it('Overflow simple rendering does not invalidate styling', () => {
-    checkRenderConsistency(
-      () => (
-        <Overflow itemIDs={items}>
-          {items.map((item) => (
-            <OverflowItem key={item} overflowID={item}>
-              <ButtonV1>{item}</ButtonV1>
-            </OverflowItem>
-          ))}
-          <OverflowMenu />
-        </Overflow>
-      ),
-      2,
-    );
   });
 
   it('Overflow re-renders correctly', () => {

--- a/packages/experimental/Overflow/src/__tests__/__snapshots__/Overflow.test.tsx.snap
+++ b/packages/experimental/Overflow/src/__tests__/__snapshots__/Overflow.test.tsx.snap
@@ -2,15 +2,24 @@
 
 exports[`Overflow component tests Overflow default 1`] = `
 <View
+  itemIDs={
+    [
+      "a",
+      "b",
+      "c",
+    ]
+  }
   onLayout={[Function]}
   style={
-    {
-      "display": "flex",
-      "flexDirection": "row",
-      "flexWrap": "wrap",
-      "opacity": 0,
-      "paddingHorizontal": undefined,
-    }
+    [
+      undefined,
+      {
+        "display": "flex",
+        "flexDirection": "row",
+        "opacity": 0,
+        "padding": undefined,
+      },
+    ]
   }
 >
   <View
@@ -76,9 +85,9 @@ exports[`Overflow component tests Overflow default 1`] = `
         "justifyContent": "center",
         "minHeight": 24,
         "minWidth": 64,
+        "opacity": 0,
         "padding": 3,
         "paddingHorizontal": 7,
-        "width": undefined,
       }
     }
   >
@@ -167,9 +176,9 @@ exports[`Overflow component tests Overflow default 1`] = `
         "justifyContent": "center",
         "minHeight": 24,
         "minWidth": 64,
+        "opacity": 0,
         "padding": 3,
         "paddingHorizontal": 7,
-        "width": undefined,
       }
     }
   >
@@ -258,9 +267,9 @@ exports[`Overflow component tests Overflow default 1`] = `
         "justifyContent": "center",
         "minHeight": 24,
         "minWidth": 64,
+        "opacity": 0,
         "padding": 3,
         "paddingHorizontal": 7,
-        "width": undefined,
       }
     }
   >


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Currently, the Overflow has a bug where dynamically removing items from an Overflow container does not trigger an update to the items rendered in the container and in the overflow menu. There is also another issue where adding items with an ID that was previously removed also does not trigger an overflow update.

This PR fixes both bugs, and it also makes changes to the styling of the Overflow container, to reduce visible shifting of items + flicker, and how they are applied. 

### Verification

Local testing: 

https://github.com/microsoft/fluentui-react-native/assets/15683103/f4cd7d43-34fa-4582-b3f3-5445593d6e9d

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
