### PR TITLE
Allow turbomodule for avatar constants

### DIFF
--- a/change/@fluentui-react-native-experimental-avatar-3ea05b5c-2c94-4279-a9d4-dd74cd45feda.json
+++ b/change/@fluentui-react-native-experimental-avatar-3ea05b5c-2c94-4279-a9d4-dd74cd45feda.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Allow turbomodule for avatar constants",
+  "packageName": "@fluentui-react-native/experimental-avatar",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/Avatar/src/NativeAvatar.tsx
+++ b/packages/experimental/Avatar/src/NativeAvatar.tsx
@@ -6,7 +6,7 @@
 /** @jsxRuntime classic */
 /** @jsx withSlots */
 import type { ImageURISource, ViewProps, ColorValue } from 'react-native';
-import { NativeModules } from 'react-native';
+import { NativeModules, TurboModuleRegistry } from 'react-native';
 
 import type { UseSlots } from '@fluentui-react-native/framework';
 import { compose, buildProps, mergeProps, withSlots } from '@fluentui-react-native/framework';
@@ -26,7 +26,7 @@ interface ExportedConstants {
   sizes: { [key in Size]: number };
 }
 
-const ExportedNativeConstants: ExportedConstants = NativeModules.FRNAvatarViewManager;
+const ExportedNativeConstants: ExportedConstants = TurboModuleRegistry.get('FRNAvatarConstants') || NativeModules.FRNAvatarViewManager;
 
 export type NativeAvatarTokens = {
   /**


### PR DESCRIPTION
This change will enable platforms to provide a turbomodule that provides the size constants for Avatar.
We need this since in bridgeless mode the viewmanager may not exist.