### PR TITLE
chore: Update react-native-svg to 15.1.0

### DIFF
--- a/apps/fluent-tester/package.json
+++ b/apps/fluent-tester/package.json
@@ -90,7 +90,7 @@
     "react": "18.2.0",
     "react-native": "^0.73.0",
     "react-native-macos": "^0.73.0",
-    "react-native-svg": "^14.0.0",
+    "react-native-svg": "^15.0.0",
     "react-native-windows": "^0.73.0",
     "tslib": "^2.3.1"
   },

--- a/apps/win32/package.json
+++ b/apps/win32/package.json
@@ -33,7 +33,7 @@
     "@fluentui-react-native/tester": "workspace:*",
     "react": "18.2.0",
     "react-native": "^0.73.0",
-    "react-native-svg": "^14.0.0",
+    "react-native-svg": "^15.0.0",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/change/@fluentui-react-native-887c5f01-3470-404e-8548-69d63b8ca2e9.json
+++ b/change/@fluentui-react-native-887c5f01-3470-404e-8548-69d63b8ca2e9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update react-native-svg to 15.1.0",
+  "packageName": "@fluentui/react-native",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-avatar-65c6134d-ab00-4275-a8c8-52d3b69f95f5.json
+++ b/change/@fluentui-react-native-avatar-65c6134d-ab00-4275-a8c8-52d3b69f95f5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update react-native-svg to 15.1.0",
+  "packageName": "@fluentui-react-native/avatar",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-badge-4fa828cc-28b9-47ed-bd1c-188602490996.json
+++ b/change/@fluentui-react-native-badge-4fa828cc-28b9-47ed-bd1c-188602490996.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update react-native-svg to 15.1.0",
+  "packageName": "@fluentui-react-native/badge",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-button-2f8156ac-c407-42fe-bc0a-2e306f7307b0.json
+++ b/change/@fluentui-react-native-button-2f8156ac-c407-42fe-bc0a-2e306f7307b0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update react-native-svg to 15.1.0",
+  "packageName": "@fluentui-react-native/button",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-checkbox-a67d353c-93e6-4029-9294-c5101ccb37d8.json
+++ b/change/@fluentui-react-native-checkbox-a67d353c-93e6-4029-9294-c5101ccb37d8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update react-native-svg to 15.1.0",
+  "packageName": "@fluentui-react-native/checkbox",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-chip-82844568-a230-444b-b876-794a523f3fb2.json
+++ b/change/@fluentui-react-native-chip-82844568-a230-444b-b876-794a523f3fb2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update react-native-svg to 15.1.0",
+  "packageName": "@fluentui-react-native/chip",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-contextual-menu-ef11d93d-a389-443e-809b-a308643a5b11.json
+++ b/change/@fluentui-react-native-contextual-menu-ef11d93d-a389-443e-809b-a308643a5b11.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update react-native-svg to 15.1.0",
+  "packageName": "@fluentui-react-native/contextual-menu",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-dependency-profiles-9094f4ef-665b-4f93-bd7a-1646ff2a1bc7.json
+++ b/change/@fluentui-react-native-dependency-profiles-9094f4ef-665b-4f93-bd7a-1646ff2a1bc7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update react-native-svg to 15.1.0",
+  "packageName": "@fluentui-react-native/dependency-profiles",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-divider-88862a04-1414-4d68-b569-eaf577a80ae3.json
+++ b/change/@fluentui-react-native-divider-88862a04-1414-4d68-b569-eaf577a80ae3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update react-native-svg to 15.1.0",
+  "packageName": "@fluentui-react-native/divider",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-dropdown-e3a7c840-720b-4789-8460-a752044d54d1.json
+++ b/change/@fluentui-react-native-dropdown-e3a7c840-720b-4789-8460-a752044d54d1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update react-native-svg to 15.1.0",
+  "packageName": "@fluentui-react-native/dropdown",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-activity-indicator-f03da45a-e65c-45c0-90f8-eff04129ec7a.json
+++ b/change/@fluentui-react-native-experimental-activity-indicator-f03da45a-e65c-45c0-90f8-eff04129ec7a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update react-native-svg to 15.1.0",
+  "packageName": "@fluentui-react-native/experimental-activity-indicator",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-checkbox-934d387c-dbdd-4b1f-858b-8cf1607ef451.json
+++ b/change/@fluentui-react-native-experimental-checkbox-934d387c-dbdd-4b1f-858b-8cf1607ef451.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update react-native-svg to 15.1.0",
+  "packageName": "@fluentui-react-native/experimental-checkbox",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-menu-button-a248baed-160f-4e9a-9611-fa679eae1e99.json
+++ b/change/@fluentui-react-native-experimental-menu-button-a248baed-160f-4e9a-9611-fa679eae1e99.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update react-native-svg to 15.1.0",
+  "packageName": "@fluentui-react-native/experimental-menu-button",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-shimmer-f8de6724-763b-49c4-a157-a1e9a1e747c6.json
+++ b/change/@fluentui-react-native-experimental-shimmer-f8de6724-763b-49c4-a157-a1e9a1e747c6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update react-native-svg to 15.1.0",
+  "packageName": "@fluentui-react-native/experimental-shimmer",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-icon-2038de5c-acba-4848-9612-e042805ee11b.json
+++ b/change/@fluentui-react-native-icon-2038de5c-acba-4848-9612-e042805ee11b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update react-native-svg to 15.1.0",
+  "packageName": "@fluentui-react-native/icon",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-input-db5fb92f-c66c-4711-bbfe-2d84daab0e07.json
+++ b/change/@fluentui-react-native-input-db5fb92f-c66c-4711-bbfe-2d84daab0e07.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update react-native-svg to 15.1.0",
+  "packageName": "@fluentui-react-native/input",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-menu-22ad5f08-6b77-45d7-b4fd-958e497cd5e5.json
+++ b/change/@fluentui-react-native-menu-22ad5f08-6b77-45d7-b4fd-958e497cd5e5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update react-native-svg to 15.1.0",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-menu-button-d0111db9-2c0a-4217-ab41-d80d50ddd4c1.json
+++ b/change/@fluentui-react-native-menu-button-d0111db9-2c0a-4217-ab41-d80d50ddd4c1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update react-native-svg to 15.1.0",
+  "packageName": "@fluentui-react-native/menu-button",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-notification-30b2ba24-ffac-4289-91f7-eb71fff5a6ca.json
+++ b/change/@fluentui-react-native-notification-30b2ba24-ffac-4289-91f7-eb71fff5a6ca.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update react-native-svg to 15.1.0",
+  "packageName": "@fluentui-react-native/notification",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-radio-group-2fb22c2d-a5e6-4832-a640-3013142cfd56.json
+++ b/change/@fluentui-react-native-radio-group-2fb22c2d-a5e6-4832-a640-3013142cfd56.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update react-native-svg to 15.1.0",
+  "packageName": "@fluentui-react-native/radio-group",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-spinner-69ac994a-8043-4014-98af-06f56ffa14b5.json
+++ b/change/@fluentui-react-native-spinner-69ac994a-8043-4014-98af-06f56ffa14b5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update react-native-svg to 15.1.0",
+  "packageName": "@fluentui-react-native/spinner",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tablist-f357abcf-54a2-4b58-8a00-d62fdd139d8f.json
+++ b/change/@fluentui-react-native-tablist-f357abcf-54a2-4b58-8a00-d62fdd139d8f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update react-native-svg to 15.1.0",
+  "packageName": "@fluentui-react-native/tablist",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-72ef2bf5-c30b-4e1a-b3b0-47a139d0dc2d.json
+++ b/change/@fluentui-react-native-tester-72ef2bf5-c30b-4e1a-b3b0-47a139d0dc2d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update react-native-svg to 15.1.0",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-win32-f6fd1258-44e8-457e-8e78-38bbb151ab9e.json
+++ b/change/@fluentui-react-native-tester-win32-f6fd1258-44e8-457e-8e78-38bbb151ab9e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update react-native-svg to 15.1.0",
+  "packageName": "@fluentui-react-native/tester-win32",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "express": "^4.19.2",
     "@types/react": "^18.2.0",
     "micromatch": "^4.0.0",
-    "react-native-svg": "^14.0.0",
+    "react-native-svg": "^15.0.0",
     "semver": "^7.5.2",
     "xml2js": "^0.5.0",
     "yaml": "^2.2.2"

--- a/packages/components/Avatar/package.json
+++ b/packages/components/Avatar/package.json
@@ -53,7 +53,7 @@
     "react": "18.2.0",
     "react-native": "^0.73.0",
     "react-native-macos": "^0.73.0",
-    "react-native-svg": "^14.0.0",
+    "react-native-svg": "^15.0.0",
     "react-native-windows": "^0.73.0"
   },
   "rnx-kit": {

--- a/packages/components/Avatar/src/__tests__/__snapshots__/Avatar.test.tsx.snap
+++ b/packages/components/Avatar/src/__tests__/__snapshots__/Avatar.test.tsx.snap
@@ -47,8 +47,8 @@ exports[`Avatar component tests Avatar badge 1`] = `
   >
     <RNSVGSvgView
       align="xMidYMid"
-      bbHeight="16"
-      bbWidth="16"
+      bbHeight={16}
+      bbWidth={16}
       color="#616161"
       focusable={false}
       height={16}
@@ -123,8 +123,8 @@ exports[`Avatar component tests Avatar badge 1`] = `
   >
     <RNSVGSvgView
       align="xMidYMid"
-      bbHeight="6"
-      bbWidth="6"
+      bbHeight={6}
+      bbWidth={6}
       fill="none"
       focusable={false}
       meetOrSlice={0}
@@ -225,8 +225,8 @@ exports[`Avatar component tests Avatar circular 1`] = `
   >
     <RNSVGSvgView
       align="xMidYMid"
-      bbHeight="16"
-      bbWidth="16"
+      bbHeight={16}
+      bbWidth={16}
       color="#616161"
       focusable={false}
       height={16}
@@ -323,8 +323,8 @@ exports[`Avatar component tests Avatar default 1`] = `
   >
     <RNSVGSvgView
       align="xMidYMid"
-      bbHeight="16"
-      bbWidth="16"
+      bbHeight={16}
+      bbWidth={16}
       color="#616161"
       focusable={false}
       height={16}
@@ -441,8 +441,8 @@ exports[`Avatar component tests Avatar ring 1`] = `
     >
       <RNSVGSvgView
         align="xMidYMid"
-        bbHeight="16"
-        bbWidth="16"
+        bbHeight={16}
+        bbWidth={16}
         color="#616161"
         focusable={false}
         height={16}
@@ -540,8 +540,8 @@ exports[`Avatar component tests Avatar square 1`] = `
   >
     <RNSVGSvgView
       align="xMidYMid"
-      bbHeight="16"
-      bbWidth="16"
+      bbHeight={16}
+      bbWidth={16}
       color="#616161"
       focusable={false}
       height={16}

--- a/packages/components/Badge/package.json
+++ b/packages/components/Badge/package.json
@@ -51,7 +51,7 @@
     "react": "18.2.0",
     "react-native": "^0.73.0",
     "react-native-macos": "^0.73.0",
-    "react-native-svg": "^14.0.0",
+    "react-native-svg": "^15.0.0",
     "react-native-windows": "^0.73.0"
   },
   "sideEffects": false,

--- a/packages/components/Badge/src/__tests__/__snapshots__/Badge.test.tsx.snap
+++ b/packages/components/Badge/src/__tests__/__snapshots__/Badge.test.tsx.snap
@@ -467,8 +467,8 @@ exports[`PresenceBadge component tests PresenceBadge props 1`] = `
 >
   <RNSVGSvgView
     align="xMidYMid"
-    bbHeight="20"
-    bbWidth="20"
+    bbHeight={20}
+    bbWidth={20}
     fill="none"
     focusable={false}
     meetOrSlice={0}

--- a/packages/components/Button/package.json
+++ b/packages/components/Button/package.json
@@ -60,7 +60,7 @@
     "react": "18.2.0",
     "react-native": "^0.73.0",
     "react-native-macos": "^0.73.0",
-    "react-native-svg": "^14.0.0",
+    "react-native-svg": "^15.0.0",
     "react-native-windows": "^0.73.0"
   },
   "author": "",

--- a/packages/components/Checkbox/package.json
+++ b/packages/components/Checkbox/package.json
@@ -57,7 +57,7 @@
     "react": "18.2.0",
     "react-native": "^0.73.0",
     "react-native-macos": "^0.73.0",
-    "react-native-svg": "^14.0.0",
+    "react-native-svg": "^15.0.0",
     "react-native-windows": "^0.73.0"
   },
   "author": "",

--- a/packages/components/Chip/package.json
+++ b/packages/components/Chip/package.json
@@ -49,7 +49,7 @@
     "react": "18.2.0",
     "react-native": "^0.73.0",
     "react-native-macos": "^0.73.0",
-    "react-native-svg": "^14.0.0",
+    "react-native-svg": "^15.0.0",
     "react-native-windows": "^0.73.0"
   },
   "rnx-kit": {

--- a/packages/components/ContextualMenu/package.json
+++ b/packages/components/ContextualMenu/package.json
@@ -49,7 +49,7 @@
     "@react-native/metro-config": "^0.73.0",
     "react": "18.2.0",
     "react-native": "^0.73.0",
-    "react-native-svg": "^14.0.0",
+    "react-native-svg": "^15.0.0",
     "react-native-svg-transformer": "^1.0.0"
   },
   "peerDependencies": {
@@ -57,7 +57,7 @@
     "react": "18.2.0",
     "react-native": "^0.73.0",
     "react-native-macos": "^0.73.0",
-    "react-native-svg": "^14.0.0",
+    "react-native-svg": "^15.0.0",
     "react-native-windows": "^0.73.0"
   },
   "rnx-kit": {

--- a/packages/components/Divider/package.json
+++ b/packages/components/Divider/package.json
@@ -47,7 +47,7 @@
     "react": "18.2.0",
     "react-native": "^0.73.0",
     "react-native-macos": "^0.73.0",
-    "react-native-svg": "^14.0.0",
+    "react-native-svg": "^15.0.0",
     "react-native-windows": "^0.73.0"
   },
   "author": "",

--- a/packages/components/Icon/package.json
+++ b/packages/components/Icon/package.json
@@ -46,7 +46,7 @@
     "react": "18.2.0",
     "react-native": "^0.73.0",
     "react-native-macos": "^0.73.0",
-    "react-native-svg": "^14.0.0",
+    "react-native-svg": "^15.0.0",
     "react-native-windows": "^0.73.0"
   },
   "author": "",

--- a/packages/components/Input/package.json
+++ b/packages/components/Input/package.json
@@ -50,7 +50,7 @@
     "react": "18.2.0",
     "react-native": "^0.73.0",
     "react-native-macos": "^0.73.0",
-    "react-native-svg": "^14.0.0",
+    "react-native-svg": "^15.0.0",
     "react-native-windows": "^0.73.0"
   },
   "author": "",

--- a/packages/components/Menu/package.json
+++ b/packages/components/Menu/package.json
@@ -55,7 +55,7 @@
     "react": "18.2.0",
     "react-native": "^0.73.0",
     "react-native-macos": "^0.73.0",
-    "react-native-svg": "^14.0.0",
+    "react-native-svg": "^15.0.0",
     "react-native-windows": "^0.73.0"
   },
   "author": "",

--- a/packages/components/MenuButton/package.json
+++ b/packages/components/MenuButton/package.json
@@ -52,7 +52,7 @@
     "react": "18.2.0",
     "react-native": "^0.73.0",
     "react-native-macos": "^0.73.0",
-    "react-native-svg": "^14.0.0",
+    "react-native-svg": "^15.0.0",
     "react-native-windows": "^0.73.0"
   },
   "rnx-kit": {

--- a/packages/components/MenuButton/src/__tests__/__snapshots__/MenuButton.test.tsx.snap
+++ b/packages/components/MenuButton/src/__tests__/__snapshots__/MenuButton.test.tsx.snap
@@ -69,8 +69,8 @@ exports[`ContextualMenu default 1`] = `
 >
   <RNSVGSvgView
     align="xMidYMid"
-    bbHeight="16"
-    bbWidth="12"
+    bbHeight={16}
+    bbWidth={12}
     color="#616161"
     focusable={false}
     height={16}

--- a/packages/components/Notification/package.json
+++ b/packages/components/Notification/package.json
@@ -56,7 +56,7 @@
     "react": "18.2.0",
     "react-native": "^0.73.0",
     "react-native-macos": "^0.73.0",
-    "react-native-svg": "^14.0.0",
+    "react-native-svg": "^15.0.0",
     "react-native-windows": "^0.73.0"
   },
   "author": "",

--- a/packages/components/RadioGroup/package.json
+++ b/packages/components/RadioGroup/package.json
@@ -56,7 +56,7 @@
     "react": "18.2.0",
     "react-native": "^0.73.0",
     "react-native-macos": "^0.73.0",
-    "react-native-svg": "^14.0.0",
+    "react-native-svg": "^15.0.0",
     "react-native-windows": "^0.73.0"
   },
   "author": "",

--- a/packages/components/TabList/package.json
+++ b/packages/components/TabList/package.json
@@ -52,7 +52,7 @@
     "react": "18.2.0",
     "react-native": "^0.73.0",
     "react-native-macos": "^0.73.0",
-    "react-native-svg": "^14.0.0",
+    "react-native-svg": "^15.0.0",
     "react-native-windows": "^0.73.0"
   },
   "author": "",

--- a/packages/dependency-profiles/package.json
+++ b/packages/dependency-profiles/package.json
@@ -93,7 +93,7 @@
     "react": "18.2.0",
     "react-native": "^0.73.0",
     "react-native-macos": "^0.73.0",
-    "react-native-svg": "^14.0.0",
+    "react-native-svg": "^15.0.0",
     "react-native-windows": "^0.73.0",
     "workspace-tools": "^0.26.3"
   }

--- a/packages/experimental/ActivityIndicator/package.json
+++ b/packages/experimental/ActivityIndicator/package.json
@@ -43,7 +43,7 @@
     "react": "18.2.0",
     "react-native": "^0.73.0",
     "react-native-macos": "^0.73.0",
-    "react-native-svg": "^14.0.0",
+    "react-native-svg": "^15.0.0",
     "react-native-windows": "^0.73.0"
   },
   "author": "",

--- a/packages/experimental/Checkbox/package.json
+++ b/packages/experimental/Checkbox/package.json
@@ -45,7 +45,7 @@
     "react": "18.2.0",
     "react-native": "^0.73.0",
     "react-native-macos": "^0.73.0",
-    "react-native-svg": "^14.0.0",
+    "react-native-svg": "^15.0.0",
     "react-native-windows": "^0.73.0"
   },
   "author": "",

--- a/packages/experimental/Dropdown/package.json
+++ b/packages/experimental/Dropdown/package.json
@@ -49,7 +49,7 @@
     "react": "18.2.0",
     "react-native": "^0.73.0",
     "react-native-macos": "^0.73.0",
-    "react-native-svg": "^14.0.0",
+    "react-native-svg": "^15.0.0",
     "react-native-windows": "^0.73.0"
   },
   "author": "",

--- a/packages/experimental/MenuButton/package.json
+++ b/packages/experimental/MenuButton/package.json
@@ -46,7 +46,7 @@
     "react": "18.2.0",
     "react-native": "^0.73.0",
     "react-native-macos": "^0.73.0",
-    "react-native-svg": "^14.0.0",
+    "react-native-svg": "^15.0.0",
     "react-native-windows": "^0.73.0"
   },
   "author": "",

--- a/packages/experimental/MenuButton/src/__tests__/__snapshots__/MenuButton.test.tsx.snap
+++ b/packages/experimental/MenuButton/src/__tests__/__snapshots__/MenuButton.test.tsx.snap
@@ -93,8 +93,8 @@ exports[`ContextualMenu default 1`] = `
   </Text>
   <RNSVGSvgView
     align="xMidYMid"
-    bbHeight="16"
-    bbWidth="12"
+    bbHeight={16}
+    bbWidth={12}
     color="#616161"
     focusable={false}
     height={16}

--- a/packages/experimental/Shimmer/package.json
+++ b/packages/experimental/Shimmer/package.json
@@ -46,7 +46,7 @@
     "react": "18.2.0",
     "react-native": "^0.73.0",
     "react-native-macos": "^0.73.0",
-    "react-native-svg": "^14.0.0",
+    "react-native-svg": "^15.0.0",
     "react-native-windows": "^0.73.0"
   },
   "author": "",

--- a/packages/experimental/Shimmer/src/__snapshots__/Shimmer.test.tsx.snap
+++ b/packages/experimental/Shimmer/src/__snapshots__/Shimmer.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`Shimmer component tests Shimmer default 1`] = `
         }
         gradientUnits={0}
         name="gradient"
-        x1="-2"
+        x1={-2}
         x2="-1"
         y1="0%"
         y2="0%"
@@ -84,12 +84,12 @@ exports[`Shimmer component tests Shimmer default 1`] = `
               "type": 0,
             }
           }
-          height="20"
-          rx="3"
-          ry="3"
-          width="100"
-          x="90"
-          y="70"
+          height={20}
+          rx={3}
+          ry={3}
+          width={100}
+          x={90}
+          y={70}
         />
         <RNSVGRect
           fill={
@@ -98,12 +98,12 @@ exports[`Shimmer component tests Shimmer default 1`] = `
               "type": 0,
             }
           }
-          height="20"
-          rx="3"
-          ry="3"
-          width="150"
-          x="90"
-          y="42"
+          height={20}
+          rx={3}
+          ry={3}
+          width={150}
+          x={90}
+          y={42}
         />
         <RNSVGRect
           fill={
@@ -112,12 +112,12 @@ exports[`Shimmer component tests Shimmer default 1`] = `
               "type": 0,
             }
           }
-          height="20"
-          rx="3"
-          ry="3"
-          width="200"
-          x="90"
-          y="15"
+          height={20}
+          rx={3}
+          ry={3}
+          width={200}
+          x={90}
+          y={15}
         />
       </RNSVGClipPath>
     </RNSVGDefs>
@@ -142,7 +142,7 @@ exports[`Shimmer component tests Shimmer default 1`] = `
             "fill",
           ]
         }
-        rx="0"
+        rx={0}
         width="100%"
         x="0"
         y="0"
@@ -161,7 +161,7 @@ exports[`Shimmer component tests Shimmer default 1`] = `
             "fill",
           ]
         }
-        rx="0"
+        rx={0}
         width="100%"
         x="0"
         y="0"
@@ -176,8 +176,8 @@ exports[`Shimmer component tests Shimmer with style prop 1`] = `
   accessibilityRole="progressbar"
   accessible={true}
   angle={45}
-  bbHeight="100"
-  bbWidth="300"
+  bbHeight={100}
+  bbWidth={300}
   delay={0}
   duration={1000}
   focusable={false}
@@ -236,7 +236,7 @@ exports[`Shimmer component tests Shimmer with style prop 1`] = `
         }
         gradientUnits={0}
         name="gradient"
-        x1="-2"
+        x1={-2}
         x2="-1"
         y1="0%"
         y2="0%"
@@ -257,12 +257,12 @@ exports[`Shimmer component tests Shimmer with style prop 1`] = `
               "type": 0,
             }
           }
-          height="20"
-          rx="3"
-          ry="3"
-          width="100"
-          x="90"
-          y="70"
+          height={20}
+          rx={3}
+          ry={3}
+          width={100}
+          x={90}
+          y={70}
         />
         <RNSVGRect
           fill={
@@ -271,12 +271,12 @@ exports[`Shimmer component tests Shimmer with style prop 1`] = `
               "type": 0,
             }
           }
-          height="20"
-          rx="3"
-          ry="3"
-          width="150"
-          x="90"
-          y="42"
+          height={20}
+          rx={3}
+          ry={3}
+          width={150}
+          x={90}
+          y={42}
         />
         <RNSVGRect
           fill={
@@ -285,12 +285,12 @@ exports[`Shimmer component tests Shimmer with style prop 1`] = `
               "type": 0,
             }
           }
-          height="20"
-          rx="3"
-          ry="3"
-          width="200"
-          x="90"
-          y="15"
+          height={20}
+          rx={3}
+          ry={3}
+          width={200}
+          x={90}
+          y={15}
         />
       </RNSVGClipPath>
     </RNSVGDefs>
@@ -309,14 +309,14 @@ exports[`Shimmer component tests Shimmer with style prop 1`] = `
             "type": 0,
           }
         }
-        height="100"
+        height={100}
         propList={
           [
             "fill",
           ]
         }
-        rx="0"
-        width="300"
+        rx={0}
+        width={300}
         x="0"
         y="0"
       />
@@ -328,14 +328,14 @@ exports[`Shimmer component tests Shimmer with style prop 1`] = `
             "type": 1,
           }
         }
-        height="100"
+        height={100}
         propList={
           [
             "fill",
           ]
         }
-        rx="0"
-        width="300"
+        rx={0}
+        width={300}
         x="0"
         y="0"
       />

--- a/packages/experimental/Spinner/package.json
+++ b/packages/experimental/Spinner/package.json
@@ -45,7 +45,7 @@
     "react": "18.2.0",
     "react-native": "^0.73.0",
     "react-native-macos": "^0.73.0",
-    "react-native-svg": "^14.0.0",
+    "react-native-svg": "^15.0.0",
     "react-native-windows": "^0.73.0"
   },
   "author": "",

--- a/packages/libraries/core/package.json
+++ b/packages/libraries/core/package.json
@@ -58,7 +58,7 @@
     "react": "18.2.0",
     "react-native": "^0.73.0",
     "react-native-macos": "^0.73.0",
-    "react-native-svg": "^14.0.0",
+    "react-native-svg": "^15.0.0",
     "react-native-windows": "^0.73.0"
   },
   "author": "",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -52,7 +52,7 @@
     "react": "18.2.0",
     "react-dom": "^18.2.0",
     "react-native": "^0.73.0",
-    "react-native-svg": "^14.0.0",
+    "react-native-svg": "^15.0.0",
     "react-native-svg-transformer": "^1.0.0",
     "react-test-renderer": "18.2.0",
     "rimraf": "^5.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2465,7 +2465,7 @@ __metadata:
     react: 18.2.0
     react-native: ^0.73.0
     react-native-macos: ^0.73.0
-    react-native-svg: ^14.0.0
+    react-native-svg: ^15.0.0
     react-native-windows: ^0.73.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
@@ -2505,7 +2505,7 @@ __metadata:
     react: 18.2.0
     react-native: ^0.73.0
     react-native-macos: ^0.73.0
-    react-native-svg: ^14.0.0
+    react-native-svg: ^15.0.0
     react-native-windows: ^0.73.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
@@ -2552,7 +2552,7 @@ __metadata:
     react: 18.2.0
     react-native: ^0.73.0
     react-native-macos: ^0.73.0
-    react-native-svg: ^14.0.0
+    react-native-svg: ^15.0.0
     react-native-windows: ^0.73.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
@@ -2629,7 +2629,7 @@ __metadata:
     react: 18.2.0
     react-native: ^0.73.0
     react-native-macos: ^0.73.0
-    react-native-svg: ^14.0.0
+    react-native-svg: ^15.0.0
     react-native-windows: ^0.73.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
@@ -2667,7 +2667,7 @@ __metadata:
     react: 18.2.0
     react-native: ^0.73.0
     react-native-macos: ^0.73.0
-    react-native-svg: ^14.0.0
+    react-native-svg: ^15.0.0
     react-native-windows: ^0.73.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
@@ -2737,14 +2737,14 @@ __metadata:
     "@uifabricshared/foundation-settings": "workspace:*"
     react: 18.2.0
     react-native: ^0.73.0
-    react-native-svg: ^14.0.0
+    react-native-svg: ^15.0.0
     react-native-svg-transformer: ^1.0.0
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
     react-native: ^0.73.0
     react-native-macos: ^0.73.0
-    react-native-svg: ^14.0.0
+    react-native-svg: ^15.0.0
     react-native-windows: ^0.73.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
@@ -2870,7 +2870,7 @@ __metadata:
     react: 18.2.0
     react-native: ^0.73.0
     react-native-macos: ^0.73.0
-    react-native-svg: ^14.0.0
+    react-native-svg: ^15.0.0
     react-native-windows: ^0.73.0
     workspace-tools: ^0.26.3
   languageName: unknown
@@ -2933,7 +2933,7 @@ __metadata:
     react: 18.2.0
     react-native: ^0.73.0
     react-native-macos: ^0.73.0
-    react-native-svg: ^14.0.0
+    react-native-svg: ^15.0.0
     react-native-windows: ^0.73.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
@@ -2999,7 +2999,7 @@ __metadata:
     react: 18.2.0
     react-native: ^0.73.0
     react-native-macos: ^0.73.0
-    react-native-svg: ^14.0.0
+    react-native-svg: ^15.0.0
     react-native-windows: ^0.73.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
@@ -3076,7 +3076,7 @@ __metadata:
     react: 18.2.0
     react-native: ^0.73.0
     react-native-macos: ^0.73.0
-    react-native-svg: ^14.0.0
+    react-native-svg: ^15.0.0
     react-native-windows: ^0.73.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
@@ -3164,7 +3164,7 @@ __metadata:
     react: 18.2.0
     react-native: ^0.73.0
     react-native-macos: ^0.73.0
-    react-native-svg: ^14.0.0
+    react-native-svg: ^15.0.0
     react-native-windows: ^0.73.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
@@ -3225,7 +3225,7 @@ __metadata:
     react: 18.2.0
     react-native: ^0.73.0
     react-native-macos: ^0.73.0
-    react-native-svg: ^14.0.0
+    react-native-svg: ^15.0.0
     react-native-windows: ^0.73.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
@@ -3322,7 +3322,7 @@ __metadata:
     react: 18.2.0
     react-native: ^0.73.0
     react-native-macos: ^0.73.0
-    react-native-svg: ^14.0.0
+    react-native-svg: ^15.0.0
     react-native-windows: ^0.73.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
@@ -3486,7 +3486,7 @@ __metadata:
     react: 18.2.0
     react-native: ^0.73.0
     react-native-macos: ^0.73.0
-    react-native-svg: ^14.0.0
+    react-native-svg: ^15.0.0
     react-native-windows: ^0.73.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
@@ -3535,7 +3535,7 @@ __metadata:
     react: 18.2.0
     react-native: ^0.73.0
     react-native-macos: ^0.73.0
-    react-native-svg: ^14.0.0
+    react-native-svg: ^15.0.0
     react-native-windows: ^0.73.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
@@ -3658,7 +3658,7 @@ __metadata:
     react: 18.2.0
     react-native: ^0.73.0
     react-native-macos: ^0.73.0
-    react-native-svg: ^14.0.0
+    react-native-svg: ^15.0.0
     react-native-windows: ^0.73.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
@@ -3700,7 +3700,7 @@ __metadata:
     react: 18.2.0
     react-native: ^0.73.0
     react-native-macos: ^0.73.0
-    react-native-svg: ^14.0.0
+    react-native-svg: ^15.0.0
     react-native-windows: ^0.73.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
@@ -3763,7 +3763,7 @@ __metadata:
     react: 18.2.0
     react-native: ^0.73.0
     react-native-macos: ^0.73.0
-    react-native-svg: ^14.0.0
+    react-native-svg: ^15.0.0
     react-native-windows: ^0.73.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
@@ -3967,7 +3967,7 @@ __metadata:
     react: 18.2.0
     react-native: ^0.73.0
     react-native-macos: ^0.73.0
-    react-native-svg: ^14.0.0
+    react-native-svg: ^15.0.0
     react-native-windows: ^0.73.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
@@ -4041,7 +4041,7 @@ __metadata:
     react: 18.2.0
     react-dom: ^18.2.0
     react-native: ^0.73.0
-    react-native-svg: ^14.0.0
+    react-native-svg: ^15.0.0
     react-native-svg-transformer: ^1.0.0
     react-test-renderer: 18.2.0
     rimraf: ^5.0.1
@@ -4105,7 +4105,7 @@ __metadata:
     react: 18.2.0
     react-native: ^0.73.0
     react-native-macos: ^0.73.0
-    react-native-svg: ^14.0.0
+    react-native-svg: ^15.0.0
     react-native-windows: ^0.73.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
@@ -4230,7 +4230,7 @@ __metadata:
     react: 18.2.0
     react-native: ^0.73.0
     react-native-macos: ^0.73.0
-    react-native-svg: ^14.0.0
+    react-native-svg: ^15.0.0
     react-native-windows: ^0.73.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
@@ -4276,7 +4276,7 @@ __metadata:
     metro-config: ^0.80.0
     react: 18.2.0
     react-native: ^0.73.0
-    react-native-svg: ^14.0.0
+    react-native-svg: ^15.0.0
     react-native-svg-transformer: ^1.0.0
     react-test-renderer: 18.2.0
     rimraf: ^5.0.1
@@ -4363,7 +4363,7 @@ __metadata:
     react: 18.2.0
     react-native: ^0.73.0
     react-native-macos: ^0.73.0
-    react-native-svg: ^14.0.0
+    react-native-svg: ^15.0.0
     react-native-svg-transformer: ^1.0.0
     react-native-test-app: ^3.4.7
     react-native-windows: ^0.73.0
@@ -4747,7 +4747,7 @@ __metadata:
     react: 18.2.0
     react-native: ^0.73.0
     react-native-macos: ^0.73.0
-    react-native-svg: ^14.0.0
+    react-native-svg: ^15.0.0
     react-native-windows: ^0.73.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
@@ -18825,16 +18825,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-svg@npm:^14.0.0":
-  version: 14.1.0
-  resolution: "react-native-svg@npm:14.1.0"
+"react-native-svg@npm:^15.0.0":
+  version: 15.1.0
+  resolution: "react-native-svg@npm:15.1.0"
   dependencies:
     css-select: ^5.1.0
     css-tree: ^1.1.3
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: ed94adac9bf3144c5dcbf37a2956ab672d402f11c0ed75cda247d1d9136ce8977f4d01bcfc813ba576bd61ece420d66306c148057e2552828aa8fe9bad173d46
+  checksum: a3694b74097e56a810a9142c9480532b63fb9cac0ff8b74c038478172d09acdb4077d93cfa53a8bb31e7ec1a9fc9f6e81a95b028c64af5370b5b3534c99aee0b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [ ] win32 (Office)
- [x] windows
- [x] android

### Description of changes

React Native SVG version 15 is the minimum needed for visionOS support. Let's update it across the repo to help unblock #3561 

### Verification

CI should pass

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
