### PR TITLE
[ios] Add missing include statement

### DIFF
--- a/change/@fluentui-react-native-experimental-avatar-84e79204-7c82-41ae-bcbc-731c752370f2.json
+++ b/change/@fluentui-react-native-experimental-avatar-84e79204-7c82-41ae-bcbc-731c752370f2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add missing include",
+  "packageName": "@fluentui-react-native/experimental-avatar",
+  "email": "araje@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/experimental/Avatar/ios/FRNAvatarViewManager.m
+++ b/packages/experimental/Avatar/ios/FRNAvatarViewManager.m
@@ -1,3 +1,4 @@
+#import <Foundation/Foundation.h>
 #import <React/RCTViewManager.h>
 
 @import FluentUI;


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Problem:
We have a file which uses things from Foundation, but never actually declares that as an input. It's unclear how the compiler is able to resolve these symbols (guessing something related to module caching), but doesn't work when built with other build systems.

Fix:
Add the explicit include

### Verification

Just a local build and standard PR verification. Not product impacting.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
