### PR TITLE
RadioButton on macOS shouldn't move the focus ring with every click

### DIFF
--- a/change/@fluentui-react-native-radio-group-b6d7ecfe-fa32-4b0f-ba07-08d760c0cc10.json
+++ b/change/@fluentui-react-native-radio-group-b6d7ecfe-fa32-4b0f-ba07-08d760c0cc10.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix radiobutton focus ring moving with every click",
+  "packageName": "@fluentui-react-native/radio-group",
+  "email": "7664112+FalseLobster@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/RadioGroup/macos/RadioButton.swift
+++ b/packages/components/RadioGroup/macos/RadioButton.swift
@@ -16,7 +16,6 @@ class RadioButton: NSButton {
 	}
 
 	@objc public func sendCallback() {
-		self.window?.makeFirstResponder(self)
 		if (onPress != nil) {
 			onPress!(nil)
 		}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Remove a call to makeFirstResponder which causes the focus ring to move with every click on macOS.

### Verification

Tested behavior in Fluent Tester

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [x] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
