### PR TITLE
[FURN Icons] Added Accessibility Labels

### DIFF
--- a/apps/fluent-tester/src/TestComponents/Icon/IconLegacyE2ETest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Icon/IconLegacyE2ETest.tsx
@@ -27,7 +27,7 @@ export const E2ETestingIcon: React.FunctionComponent = () => {
             color="green"
             accessibilityLabel={ICON_ACCESSIBILITY_LABEL}
           />
-          <Icon rasterImageSource={rasterChessProps} width={100} height={100} color="blue" />
+          <Icon rasterImageSource={rasterChessProps} width={100} height={100} color="blue" accessibilityLabel="Chess pieces" />
         </View>
       ) : null}
     </View>

--- a/apps/fluent-tester/src/TestComponents/Icon/IconTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Icon/IconTest.tsx
@@ -75,7 +75,7 @@ const Icons: React.FunctionComponent = () => {
             // TODO: Causes TypeError: Network request failed on Android
             shouldShowDataUri ? <Icon svgSource={svgD20DataUriProps} width={100} height={100} color="#7a7" /> : null
           }
-          <Icon svgSource={svgUriProps} width={100} height={100} color="red" />
+          <Icon svgSource={svgUriProps} width={100} height={100} color="red" accessibilityLabel="Just another example" />
           {Platform.OS === ('win32' as any) && (
             <Icon svgSource={svgProps} width={100} height={100} color={PlatformColor('WindowText')} accessibilityLabel="Wheelchair" />
           )}
@@ -84,8 +84,8 @@ const Icons: React.FunctionComponent = () => {
       {showRasterIcons ? (
         <View>
           <Text>Raster icons</Text>
-          <Icon rasterImageSource={rasterRainbowSpectrumProps} width={100} height={100} color="green" />
-          <Icon rasterImageSource={rasterChessProps} width={100} height={100} color="blue" />
+          <Icon rasterImageSource={rasterRainbowSpectrumProps} width={100} height={100} color="green" accessibilityLabel="Atom" />
+          <Icon rasterImageSource={rasterChessProps} width={100} height={100} color="blue" accessibilityLabel="Chess pieces" />
         </View>
       ) : null}
     </View>

--- a/apps/fluent-tester/src/TestComponents/Icon/IconV1Test.tsx
+++ b/apps/fluent-tester/src/TestComponents/Icon/IconV1Test.tsx
@@ -18,6 +18,7 @@ const svgUriProps: SvgIconPropsV1 = {
   viewBox: '0 0 1000 1000',
   width: 100,
   height: 100,
+  accessibilityLabel: 'Just another example',
 };
 
 const svgSrcProps: SvgIconPropsV1 = {
@@ -25,6 +26,7 @@ const svgSrcProps: SvgIconPropsV1 = {
   src: TestSvg,
   width: 72,
   height: 72,
+  accessibilityLabel: 'Wheelchair',
 };
 
 export const IconV1Test: React.FunctionComponent = () => {
@@ -32,6 +34,7 @@ export const IconV1Test: React.FunctionComponent = () => {
     () => ({
       color: 'lightgreen',
       ...svgSrcProps,
+      accessibilityLabel: 'Wheelchair',
     }),
     [],
   );

--- a/change/@fluentui-react-native-tester-91b4c013-4d18-4a84-87f1-caa90bd450d6.json
+++ b/change/@fluentui-react-native-tester-91b4c013-4d18-4a84-87f1-caa90bd450d6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "added accessiblity labels on icons",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "gulnazsayed@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

This is a fix for a FURN tester accessibility bug where alt text for some icons on the IconV1 tester page were not provided. This led to the narrator not having descriptive text to read on announcement.

### Verification

Used Narrator Buddy to scan and verify alt text is set on every icon the test page.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
