### PR TITLE
fix(react-native): mark as side-effects free

### DIFF
--- a/change/@fluentui-react-native-7e8c0421-d39e-41a4-8d8a-d3f887c463d7.json
+++ b/change/@fluentui-react-native-7e8c0421-d39e-41a4-8d8a-d3f887c463d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Mark as side-effects free",
+  "packageName": "@fluentui/react-native",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/libraries/core/package.json
+++ b/packages/libraries/core/package.json
@@ -2,6 +2,7 @@
   "name": "@fluentui/react-native",
   "version": "0.41.3",
   "description": "A react-native component library that implements the Fluent Design System.",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git@github.com:microsoft/fluentui-react-native.git",
@@ -9,10 +10,6 @@
   },
   "main": "src/index.ts",
   "module": "src/index.ts",
-  "onPublish": {
-    "main": "lib-commonjs/index.js",
-    "module": "lib/index.js"
-  },
   "typings": "lib/index.d.ts",
   "scripts": {
     "build": "fluentui-scripts build",
@@ -45,14 +42,6 @@
     "@fluentui-react-native/tablist": "workspace:*",
     "@fluentui-react-native/text": "workspace:*"
   },
-  "devDependencies": {
-    "@fluentui-react-native/eslint-config-rules": "workspace:*",
-    "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
-    "react": "18.2.0",
-    "react-native": "^0.73.0"
-  },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
@@ -60,25 +49,6 @@
     "react-native-macos": "^0.73.0",
     "react-native-svg": "^15.0.0",
     "react-native-windows": "^0.73.0"
-  },
-  "author": "",
-  "license": "MIT",
-  "rnx-kit": {
-    "kitType": "library",
-    "alignDeps": {
-      "presets": [
-        "microsoft/react-native"
-      ],
-      "requirements": [
-        "react-native@0.73"
-      ],
-      "capabilities": [
-        "core",
-        "core-android",
-        "core-ios",
-        "react"
-      ]
-    }
   },
   "peerDependenciesMeta": {
     "@office-iss/react-native-win32": {
@@ -90,5 +60,32 @@
     "react-native-windows": {
       "optional": true
     }
-  }
+  },
+  "devDependencies": {
+    "@fluentui-react-native/eslint-config-rules": "workspace:*",
+    "@fluentui-react-native/scripts": "workspace:*",
+    "@react-native/babel-preset": "^0.73.0",
+    "@react-native/metro-config": "^0.73.0",
+    "react": "18.2.0",
+    "react-native": "^0.73.0"
+  },
+  "onPublish": {
+    "main": "lib-commonjs/index.js",
+    "module": "lib/index.js"
+  },
+  "rnx-kit": {
+    "kitType": "library",
+    "alignDeps": {
+      "requirements": [
+        "react-native@0.73"
+      ],
+      "capabilities": [
+        "core",
+        "core-android",
+        "core-ios",
+        "react"
+      ]
+    }
+  },
+  "sideEffects": false
 }


### PR DESCRIPTION
### Platforms Impacted

- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

`@fluentui/react-native` can be safely marked as side-effects free. It only re-exports symbols from dependencies.

### Verification

n/a

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
