### PR TITLE
Fix typo in `DirectionalHint` Callout type

### DIFF
--- a/change/@fluentui-react-native-callout-50213cd4-3583-401a-b8cc-d16cde4e24bc.json
+++ b/change/@fluentui-react-native-callout-50213cd4-3583-401a-b8cc-d16cde4e24bc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix typo in `DirectionalHint` type",
+  "packageName": "@fluentui-react-native/callout",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-contextual-menu-b276b61c-0bd8-4a39-a199-ddc13dee546a.json
+++ b/change/@fluentui-react-native-contextual-menu-b276b61c-0bd8-4a39-a199-ddc13dee546a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix typo in `DirectionalHint` type",
+  "packageName": "@fluentui-react-native/contextual-menu",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Callout/macos/FRNCalloutManager.m
+++ b/packages/components/Callout/macos/FRNCalloutManager.m
@@ -26,7 +26,7 @@ RCT_ENUM_CONVERTER(NSRectEdge, (@{
 	@"rightTopEdge": @(NSRectEdgeMaxX),
 	@"rightCenter": @(NSRectEdgeMaxX),
 	@"rightBottomEdge": @(NSRectEdgeMaxX),
-	@"bottonLeftEdge": @(NSRectEdgeMinY),
+	@"bottomLeftEdge": @(NSRectEdgeMinY),
 	@"bottomAutoEdge": @(NSRectEdgeMinY),
 	@"bottomCenter": @(NSRectEdgeMinY),
 	@"bottomRightEdge": @(NSRectEdgeMinY),

--- a/packages/components/Callout/src/Callout.settings.macos.ts
+++ b/packages/components/Callout/src/Callout.settings.macos.ts
@@ -10,7 +10,7 @@ export const settings: IComposeSettings<ICalloutType> = [
       borderColor: 'transparent',
       borderWidth: 0,
       borderRadius: 5,
-      directionalHint: 'bottonLeftEdge',
+      directionalHint: 'bottomLeftEdge',
     },
     root: {
       style: {

--- a/packages/components/Callout/src/Callout.settings.ts
+++ b/packages/components/Callout/src/Callout.settings.ts
@@ -10,7 +10,7 @@ export const settings: IComposeSettings<ICalloutType> = [
       beakWidth: 20,
       borderColor: 'bodyFrameBackground',
       borderWidth: 1,
-      directionalHint: 'bottonLeftEdge',
+      directionalHint: 'bottomLeftEdge',
       gapSpace: 0,
       minPadding: 0,
     },

--- a/packages/components/Callout/src/Callout.types.ts
+++ b/packages/components/Callout/src/Callout.types.ts
@@ -22,7 +22,7 @@ export type DirectionalHint =
   | 'rightTopEdge'
   | 'rightCenter'
   | 'rightBottomEdge'
-  | 'bottonLeftEdge'
+  | 'bottomLeftEdge'
   | 'bottomAutoEdge'
   | 'bottomCenter'
   | 'bottomRightEdge';

--- a/packages/components/Callout/src/CalloutNativeComponent.ts
+++ b/packages/components/Callout/src/CalloutNativeComponent.ts
@@ -35,11 +35,11 @@ export interface NativeProps extends ViewProps {
     | 'rightTopEdge'
     | 'rightCenter'
     | 'rightBottomEdge'
-    | 'bottonLeftEdge'
+    | 'bottomLeftEdge'
     | 'bottomAutoEdge'
     | 'bottomCenter'
     | 'bottomRightEdge',
-    'bottonLeftEdge'
+    'bottomLeftEdge'
   >;
   dismissBehaviors?: string[];
   doNotTakePointerCapture?: boolean;

--- a/packages/components/Callout/src/MacOSCalloutNativeComponent.ts
+++ b/packages/components/Callout/src/MacOSCalloutNativeComponent.ts
@@ -31,7 +31,7 @@ export interface NativeProps extends ViewProps {
     | 'rightTopEdge'
     | 'rightCenter'
     | 'rightBottomEdge'
-    | 'bottonLeftEdge'
+    | 'bottomLeftEdge'
     | 'bottomAutoEdge'
     | 'bottomCenter'
     | 'bottomRightEdge',

--- a/packages/components/ContextualMenu/src/ContextualMenu.settings.macos.ts
+++ b/packages/components/ContextualMenu/src/ContextualMenu.settings.macos.ts
@@ -8,7 +8,7 @@ import { contextualMenuName } from './ContextualMenu.types';
 export const settings: IComposeSettings<ContextualMenuType> = [
   {
     tokens: {
-      directionalHint: I18nManager.isRTL ? 'bottomRightEdge' : 'bottonLeftEdge',
+      directionalHint: I18nManager.isRTL ? 'bottomRightEdge' : 'bottomLeftEdge',
     },
     container: {
       style: {

--- a/packages/components/ContextualMenu/src/ContextualMenu.settings.ts
+++ b/packages/components/ContextualMenu/src/ContextualMenu.settings.ts
@@ -10,7 +10,7 @@ export const settings: IComposeSettings<ContextualMenuType> = [
       beakWidth: 20,
       borderColor: 'buttonBorder',
       borderWidth: 1,
-      directionalHint: 'bottonLeftEdge',
+      directionalHint: 'bottomLeftEdge',
       gapSpace: 0,
       minPadding: 0,
     },


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

There's a typo in the `DirectionalHint` type for Callout's `directionalHint` prop, where `"bottomLeftEdge"` is spelled as `"bottonLeftEdge"`. This PR fixes this so the linter stops spitting an incorrect error. 

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
