### PR TITLE
Textv1 component ref

### DIFF
--- a/change/@fluentui-react-native-text-d484f183-ab2e-4127-9de9-d0efac4554a7.json
+++ b/change/@fluentui-react-native-text-d484f183-ab2e-4127-9de9-d0efac4554a7.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add componentRef to TextV1",
+  "packageName": "@fluentui-react-native/text",
+  "email": "patboyd@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/text/src/Text.tsx
+++ b/packages/components/text/src/Text.tsx
@@ -23,6 +23,7 @@ export const Text = compressible<TextProps, TextTokens>((props: TextProps, useTo
     align = undefined,
     block,
     color,
+    componentRef,
     font,
     italic,
     numberOfLines,
@@ -146,7 +147,7 @@ export const Text = compressible<TextProps, TextTokens>((props: TextProps, useTo
     delete (mergedProps.style as TextTokens).maximumFontSize;
 
     return (
-      <RNText ellipsizeMode={!wrap && !truncate ? 'clip' : 'tail'} {...mergedProps}>
+      <RNText ref={componentRef} ellipsizeMode={!wrap && !truncate ? 'clip' : 'tail'} {...mergedProps}>
         {children}
       </RNText>
     );

--- a/packages/components/text/src/Text.types.ts
+++ b/packages/components/text/src/Text.types.ts
@@ -1,4 +1,4 @@
-import type { ColorValue, TextStyle } from 'react-native';
+import type { ColorValue, Text, TextStyle } from 'react-native';
 
 import type { ITextProps } from '@fluentui-react-native/adapters';
 import type { FontTokens, FontVariantTokens, IForegroundColorTokens } from '@fluentui-react-native/framework';
@@ -53,6 +53,11 @@ export type TextProps<TBase = ITextProps> = TBase &
      * @defaultValue false
      */
     block?: boolean;
+
+    /**
+     * A RefObject to the Text object. Use this to access the public methods and properties of the component.
+     */
+    componentRef?: React.RefObject<Text>;
 
     /**
      * Applies the font family to the content.


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

Adds a componentRef prop to TextV1 that maps to the inner `RN.Text ref` property

### Verification

Verified locally that the ref assigns (and per downstream intention can be used for callout anchoring)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
