### PR TITLE
fix(menu): Add a border on macOS in dark mode and increased contrast

### DIFF
--- a/change/@fluentui-react-native-menu-78776bfa-776c-4b08-973b-37297433e905.json
+++ b/change/@fluentui-react-native-menu-78776bfa-776c-4b08-973b-37297433e905.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(menu): Add High Contrast border on macOS",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/package.json
+++ b/packages/components/Menu/package.json
@@ -34,6 +34,7 @@
     "@fluentui-react-native/interactive-hooks": "workspace:*",
     "@fluentui-react-native/text": "workspace:*",
     "@fluentui-react-native/theme-tokens": "workspace:*",
+    "@fluentui-react-native/theming-utils": "workspace:*",
     "@fluentui-react-native/tokens": "workspace:*",
     "@fluentui-react-native/use-styling": "workspace:*",
     "tslib": "^2.3.1"

--- a/packages/components/Menu/src/MenuPopover/MenuPopoverTokens.macos.ts
+++ b/packages/components/Menu/src/MenuPopover/MenuPopoverTokens.macos.ts
@@ -1,16 +1,20 @@
 import type { Theme } from '@fluentui-react-native/framework';
 import { buildUseTokens } from '@fluentui-react-native/framework';
-import { isHighContrast } from '@fluentui-react-native/theming-utils';
+import { getCurrentAppearance, isHighContrast } from '@fluentui-react-native/theming-utils';
 
 import type { MenuPopoverTokens } from './MenuPopover.types';
 import { menuPopoverName } from './MenuPopover.types';
 
-
 export const useMenuPopoverTokens = buildUseTokens<MenuPopoverTokens>(
   (t: Theme) => ({
+    overflow: 'hidden',
     borderWidth: 1,
     borderRadius: 5,
-    borderColor: isHighContrast() ? t.colors.neutralStroke1 : t.colors.transparentStroke,
+    borderColor: isHighContrast()
+      ? t.colors.neutralStroke1
+      : getCurrentAppearance(t.host.appearance, 'light') === 'dark'
+      ? t.colors.neutralStroke3
+      : t.colors.transparentStroke,
   }),
   menuPopoverName,
 );

--- a/packages/components/Menu/src/MenuPopover/MenuPopoverTokens.macos.ts
+++ b/packages/components/Menu/src/MenuPopover/MenuPopoverTokens.macos.ts
@@ -4,10 +4,13 @@ import { buildUseTokens } from '@fluentui-react-native/framework';
 import type { MenuPopoverTokens } from './MenuPopover.types';
 import { menuPopoverName } from './MenuPopover.types';
 
+import { isHighContrast } from '@fluentui-react-native/theming-utils';
+
 export const useMenuPopoverTokens = buildUseTokens<MenuPopoverTokens>(
-  (_t: Theme) => ({
-    borderWidth: 0,
+  (t: Theme) => ({
+    borderWidth: 1,
     borderRadius: 5,
+    borderColor: isHighContrast() ? t.colors.neutralStroke1 : t.colors.transparentStroke,
   }),
   menuPopoverName,
 );

--- a/packages/components/Menu/src/MenuPopover/MenuPopoverTokens.macos.ts
+++ b/packages/components/Menu/src/MenuPopover/MenuPopoverTokens.macos.ts
@@ -7,7 +7,6 @@ import { menuPopoverName } from './MenuPopover.types';
 
 export const useMenuPopoverTokens = buildUseTokens<MenuPopoverTokens>(
   (t: Theme) => ({
-    overflow: 'hidden',
     borderWidth: 1,
     borderRadius: 5,
     borderColor: isHighContrast()

--- a/packages/components/Menu/src/MenuPopover/MenuPopoverTokens.macos.ts
+++ b/packages/components/Menu/src/MenuPopover/MenuPopoverTokens.macos.ts
@@ -1,10 +1,10 @@
 import type { Theme } from '@fluentui-react-native/framework';
 import { buildUseTokens } from '@fluentui-react-native/framework';
+import { isHighContrast } from '@fluentui-react-native/theming-utils';
 
 import type { MenuPopoverTokens } from './MenuPopover.types';
 import { menuPopoverName } from './MenuPopover.types';
 
-import { isHighContrast } from '@fluentui-react-native/theming-utils';
 
 export const useMenuPopoverTokens = buildUseTokens<MenuPopoverTokens>(
   (t: Theme) => ({

--- a/yarn.lock
+++ b/yarn.lock
@@ -4376,6 +4376,7 @@ __metadata:
     "@fluentui-react-native/test-tools": "workspace:*"
     "@fluentui-react-native/text": "workspace:*"
     "@fluentui-react-native/theme-tokens": "workspace:*"
+    "@fluentui-react-native/theming-utils": "workspace:*"
     "@fluentui-react-native/tokens": "workspace:*"
     "@fluentui-react-native/use-styling": "workspace:*"
     "@office-iss/react-native-win32": "npm:^0.73.0"


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Add a border to MenuV1 on macOS when increased contrast is enabled. Technically the Menu is now 1 px bigger in Increased contrast is on, but I think that's OK. 

### Verification
Dark Mode:
<img width="157" alt="Screenshot 2024-06-21 at 1 09 12 PM" src="https://github.com/microsoft/fluentui-react-native/assets/6722175/5ca21d55-1ec1-45d6-aa0f-4c7a99b93474">

Increased Contrast Light:
![image](https://github.com/microsoft/fluentui-react-native/assets/6722175/036982c3-21fe-4ddf-9a1b-24fa1a37fe59)

Increased Contrast Dark:

![Screenshot 2024-06-20 at 1 50 21 PM](https://github.com/microsoft/fluentui-react-native/assets/6722175/20664e14-edde-4dd5-ae0a-119998b309ad)



### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
