### PR TITLE
Cache results of theme module getConstants

### DIFF
--- a/change/@fluentui-react-native-win32-theme-0129023c-c1e8-43a8-b702-b1b0d14dfe3b.json
+++ b/change/@fluentui-react-native-win32-theme-0129023c-c1e8-43a8-b702-b1b0d14dfe3b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Cache results of theme module getConstants",
+  "packageName": "@fluentui-react-native/win32-theme",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/theming/win32-theme/src/NativeModule/getThemingModule.native.ts
+++ b/packages/theming/win32-theme/src/NativeModule/getThemingModule.native.ts
@@ -15,22 +15,42 @@ function disableGetPalette(): boolean {
   return disabled;
 }
 
+function themeGetConstants(): ReturnType<OfficeThemingModule['getConstants']> {
+  return themingModuleConstants;
+}
+
+let themingModule: OfficeThemingModule = undefined;
+let themingModuleConstants: ReturnType<OfficeThemingModule['getConstants']> = undefined;
+let themingModuleEmitter: NativeEventEmitter = undefined;
 export function getThemingModule(): [OfficeThemingModule, NativeEventEmitter | undefined] {
-  const module = TurboModuleRegistry.get<OfficeThemingModule>('Theming');
-  // if the native module exists return the module + an emitter for it
-  if (module) {
-    if (!isInstantiated) {
-      // We need to store the host theme so that when themes are created
-      // they can use this information.
-      setCurrentHostThemeSetting(module.getConstants().initialHostThemeSetting);
-      isInstantiated = true;
+
+  if (!themingModule) {
+    const module = TurboModuleRegistry.get<OfficeThemingModule>('Theming');
+    // if the native module exists return the module + an emitter for it
+    if (module) {
+      if (!isInstantiated) {
+        // We need to store the host theme so that when themes are created
+        // they can use this information.
+        setCurrentHostThemeSetting(module.getConstants().initialHostThemeSetting);
+        isInstantiated = true;
+      }
+
+      // Cache the result of getConstants to avoid continuous Native->JS marshalling
+      themingModuleConstants = module.getConstants();
+
+      // mock getPalette if it should be disabled
+      if (disableGetPalette()) {
+        themingModule = { ...module, getPalette: fallbackGetPalette, getConstants: themeGetConstants };
+      } else {
+        themingModule = {...module, getConstants: themeGetConstants };
+      }
+      themingModuleEmitter = new NativeEventEmitter(module);
+    } else {
+      themingModule = fallbackOfficeModule;
     }
-    // mock getPalette if it should be disabled, otherwise return the module directly
-    return [disableGetPalette() ? { ...module, getPalette: fallbackGetPalette } : module, new NativeEventEmitter(module)];
   }
 
-  // otherwise use the fallback module
-  return [fallbackOfficeModule, undefined];
+  return [themingModule, themingModuleEmitter];
 }
 
 let isInstantiated = false;

--- a/packages/theming/win32-theme/src/NativeModule/getThemingModule.native.ts
+++ b/packages/theming/win32-theme/src/NativeModule/getThemingModule.native.ts
@@ -23,7 +23,6 @@ let themingModule: OfficeThemingModule = undefined;
 let themingModuleConstants: ReturnType<OfficeThemingModule['getConstants']> = undefined;
 let themingModuleEmitter: NativeEventEmitter = undefined;
 export function getThemingModule(): [OfficeThemingModule, NativeEventEmitter | undefined] {
-
   if (!themingModule) {
     const module = TurboModuleRegistry.get<OfficeThemingModule>('Theming');
     // if the native module exists return the module + an emitter for it
@@ -42,7 +41,7 @@ export function getThemingModule(): [OfficeThemingModule, NativeEventEmitter | u
       if (disableGetPalette()) {
         themingModule = { ...module, getPalette: fallbackGetPalette, getConstants: themeGetConstants };
       } else {
-        themingModule = {...module, getConstants: themeGetConstants };
+        themingModule = { ...module, getConstants: themeGetConstants };
       }
       themingModuleEmitter = new NativeEventEmitter(module);
     } else {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes
When running react-native in bridgeless mode, the results of getConstants are no longer cached by the JS side.  This causes 100s of calls into the theming modules getConstants method, which then has to load and marshall the whole theming data from native to JS.

With this change we'll cache the result of getConstants to avoid the performance cost of calling it multiple times.