### PR TITLE
Export menu delay constant

### DIFF
--- a/change/@fluentui-react-native-menu-2e86fb2f-67bc-47b2-8e84-70b47097d92f.json
+++ b/change/@fluentui-react-native-menu-2e86fb2f-67bc-47b2-8e84-70b47097d92f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Export menu delay",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/index.ts
+++ b/packages/components/Menu/src/index.ts
@@ -42,4 +42,4 @@ export type { MenuGroupProps, MenuGroupSlotProps, MenuGroupTokens, MenuGroupType
 export { MenuGroup, menuGroupName } from './MenuGroup';
 export type { MenuGroupHeaderProps, MenuGroupHeaderSlotProps, MenuGroupHeaderTokens, MenuGroupHeaderType } from './MenuGroupHeader';
 export { MenuGroupHeader, menuGroupHeaderName } from './MenuGroupHeader';
-export { hoverDelayDefault } from './consts';
+export { hoverDelayDefault as menuHoverDelay } from './consts';

--- a/packages/components/Menu/src/index.ts
+++ b/packages/components/Menu/src/index.ts
@@ -42,3 +42,4 @@ export type { MenuGroupProps, MenuGroupSlotProps, MenuGroupTokens, MenuGroupType
 export { MenuGroup, menuGroupName } from './MenuGroup';
 export type { MenuGroupHeaderProps, MenuGroupHeaderSlotProps, MenuGroupHeaderTokens, MenuGroupHeaderType } from './MenuGroupHeader';
 export { MenuGroupHeader, menuGroupHeaderName } from './MenuGroupHeader';
+export { hoverDelayDefault } from './consts';


### PR DESCRIPTION
Exporting the menu delay constant for use in other projects. This allows consistency with Menu behavior across platforms
