### PR TITLE
[win32] Inline link support

### DIFF
--- a/apps/fluent-tester/src/TestComponents/LinkV1/InlineLinksTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/LinkV1/InlineLinksTest.tsx
@@ -24,7 +24,7 @@ export const InlineLinks: React.FunctionComponent = () => {
         <Link inline onPress={doPress} disabled focusable>
           link
         </Link>{' '}
-        is disabled but focusable.
+        is disabled and not focusable.
       </Text>
       <Text>
         Follow this{' '}

--- a/apps/fluent-tester/src/TestComponents/LinkV1/InlineLinksTest.win32.tsx
+++ b/apps/fluent-tester/src/TestComponents/LinkV1/InlineLinksTest.win32.tsx
@@ -1,9 +1,0 @@
-import * as React from 'react';
-
-import { TextV1 as Text } from '@fluentui/react-native';
-
-// Platform.select not available for win32
-// Forking test instead
-export const InlineLinks: React.FunctionComponent = () => {
-  return <Text>Inline links are not supported on win32.</Text>;
-};

--- a/change/@fluentui-react-native-link-87d92852-5532-438f-8172-32e95c84fde9.json
+++ b/change/@fluentui-react-native-link-87d92852-5532-438f-8172-32e95c84fde9.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Enable inline link support for win32",
+  "packageName": "@fluentui-react-native/link",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-00d5e830-41aa-4ac0-a85c-c0890cc97ab9.json
+++ b/change/@fluentui-react-native-tester-00d5e830-41aa-4ac0-a85c-c0890cc97ab9.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Enable inline link support for win32",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Link/SPEC.md
+++ b/packages/components/Link/SPEC.md
@@ -90,7 +90,6 @@ export interface LinkProps extends IWithPressableOptions<TextProps> {
   enableFocusRing?: boolean;
   /**
    * Whether the link is inline with text
-   * Note: Not supported for win32
    * @default false
    */
   inline?: boolean;

--- a/packages/components/Link/src/Link.tsx
+++ b/packages/components/Link/src/Link.tsx
@@ -1,6 +1,5 @@
 /** @jsxRuntime classic */
 /** @jsx withSlots */
-import * as React from 'react';
 import { Platform, View } from 'react-native';
 
 import type { UseSlots } from '@fluentui-react-native/framework';
@@ -36,7 +35,7 @@ export const Link = compose<LinkType>({
     // grab the styled slots
     const Slots = useSlots(userProps, (layer) => linkLookup(layer, link.state, userProps));
     // now return the handler for finishing render
-    return (final: LinkProps, ...children: React.ReactNode[]) => {
+    return (final: LinkProps, children: string) => {
       // the event fires twice due to native's implementation of inline link
       const { inline, ...mergedProps } = mergeProps(link.props, final);
 

--- a/packages/components/Link/src/Link.tsx
+++ b/packages/components/Link/src/Link.tsx
@@ -35,7 +35,7 @@ export const Link = compose<LinkType>({
     // grab the styled slots
     const Slots = useSlots(userProps, (layer) => linkLookup(layer, link.state, userProps));
     // now return the handler for finishing render
-    return (final: LinkProps, children: string) => {
+    return (final: LinkProps, ...children: React.ReactNode[]) => {
       // the event fires twice due to native's implementation of inline link
       const { inline, ...mergedProps } = mergeProps(link.props, final);
 

--- a/packages/components/Link/src/Link.types.ts
+++ b/packages/components/Link/src/Link.types.ts
@@ -59,6 +59,8 @@ export interface LinkProps extends IWithPressableOptions<TextProps> {
    * @default default
    */
   appearance?: LinkAppearance;
+
+  children?: string;
   /**
    * A RefObject to access the IButton interface. Use this to access the public methods and properties of the component.
    */

--- a/packages/components/Link/src/Link.types.ts
+++ b/packages/components/Link/src/Link.types.ts
@@ -59,8 +59,6 @@ export interface LinkProps extends IWithPressableOptions<TextProps> {
    * @default default
    */
   appearance?: LinkAppearance;
-
-  children?: string;
   /**
    * A RefObject to access the IButton interface. Use this to access the public methods and properties of the component.
    */

--- a/packages/components/Link/src/Link.types.ts
+++ b/packages/components/Link/src/Link.types.ts
@@ -70,7 +70,6 @@ export interface LinkProps extends IWithPressableOptions<TextProps> {
   enableFocusRing?: boolean;
   /**
    * Whether the link is inline with text
-   * Note: Not supported for win32
    * @default false
    */
   inline?: boolean;

--- a/packages/components/Link/src/useLink.ts
+++ b/packages/components/Link/src/useLink.ts
@@ -82,19 +82,6 @@ export const useLink = (props: LinkProps): LinkInfo => {
 
   const linkTooltip = tooltip ?? url ?? undefined;
 
-  let inline = props.inline;
-  const supportsInlineLinks = Platform.OS !== ('win32' as any);
-  if (inline && !supportsInlineLinks) {
-    if (__DEV__) {
-      throw new Error('Inline Links are not supported on ' + Platform.OS + '. Component will fail to render.');
-    }
-
-    // Force Links to not be inline on win32.
-    // This will cause errors to be thrown in RN code if the Link is placed inline with Text,
-    // since Views are not allows to be children of Text components.
-    inline = false;
-  }
-
   return {
     props: {
       ...rest,
@@ -110,7 +97,6 @@ export const useLink = (props: LinkProps): LinkInfo => {
       cursor: isDisabled ? 'not-allowed' : 'pointer',
       ref: useViewCommandFocus(componentRef),
       tooltip: linkTooltip,
-      inline,
     },
     state: newState,
   };


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Allowing inline links on win32 - infra is there, mostly just removing the error that forces links to not be inline in win32.
Also making the child type stricter per suggestion.

### Verification
![image](https://github.com/user-attachments/assets/48202e5e-1c45-4342-8187-c906e011d5bf)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
