### PR TITLE
Implement Focus Zone circular navigation and tab key behaviors for macOS

### DIFF
--- a/apps/fluent-tester/src/TestComponents/FocusZone/FocusZoneE2ETest.tsx
+++ b/apps/fluent-tester/src/TestComponents/FocusZone/FocusZoneE2ETest.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 
-import type { FocusZoneDirection, FocusZoneTabNavigation } from '@fluentui/react-native';
+import type { FocusZoneDirection, FocusZoneTabNavigation, IFocusable } from '@fluentui/react-native';
 import { FocusZone, MenuButton, Text } from '@fluentui/react-native';
 import type { ButtonProps } from '@fluentui-react-native/button';
 import { ButtonV1 as Button } from '@fluentui-react-native/button';
@@ -27,6 +27,13 @@ import { testProps } from '../Common/TestProps';
 export const FocusZoneDirections: FocusZoneDirection[] = ['bidirectional', 'horizontal', 'vertical', 'none'];
 export const FocusZoneTabNavigations: FocusZoneTabNavigation[] = ['None', 'NavigateWrap', 'NavigateStopAtEnds', 'Normal'];
 
+// Buttons by default focus on click on Win32, but they don't on the Mac, so place focus explicitly for convenience
+function useFocusOnClickForMac(): Partial<ButtonProps> {
+  const componentRef = React.useRef<IFocusable>();
+  const onClick = React.useCallback(() => componentRef.current?.focus(), [componentRef]);
+  return Platform.OS === 'macos' ? { componentRef, onClick } : {};
+}
+
 type FocusZoneListWrapperProps = React.PropsWithChildren<{
   beforeID?: string;
   afterID?: string;
@@ -37,12 +44,14 @@ export const FocusZoneListWrapper: React.FunctionComponent<FocusZoneListWrapperP
     <>
       <Button
         {...buttonProps}
+        {...useFocusOnClickForMac()}
         /* For Android E2E testing purposes, testProps must be passed in after accessibilityLabel. */
         {...testProps(beforeID)}
       />
       {children}
       <Button
         {...buttonProps}
+        {...useFocusOnClickForMac()}
         /* For Android E2E testing purposes, testProps must be passed in after accessibilityLabel. */
         {...testProps(afterID)}
       />

--- a/apps/fluent-tester/src/TestComponents/FocusZone/styles.ts
+++ b/apps/fluent-tester/src/TestComponents/FocusZone/styles.ts
@@ -1,4 +1,4 @@
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 
 import { Text } from '@fluentui/react-native';
 import { ButtonV1 as Button } from '@fluentui-react-native/button';
@@ -47,14 +47,16 @@ export const focusZoneTestStyles = StyleSheet.create({
   smallBoxStyle: {
     width: 20,
     height: 20,
-    backgroundColor: 'lightgrey',
     margin: 5,
+    // something is wrong with setting the background color on this style on the Mac, and until we fix that, let's not do this
+    ...Platform.select({ macos: { borderWidth: 1 }, default: { backgroundColor: 'lightgrey' } }),
   },
   wideBoxStyle: {
     width: 150,
     height: 20,
-    backgroundColor: 'lightgrey',
     margin: 5,
+    // something is wrong with setting the background color on this style on the Mac, and until we fix that, let's not do this
+    ...Platform.select({ macos: { borderWidth: 1 }, default: { backgroundColor: 'lightgrey' } }),
   },
 });
 

--- a/change/@fluentui-react-native-focus-zone-1ea1ea52-e787-46d6-b2f6-807002ef609f.json
+++ b/change/@fluentui-react-native-focus-zone-1ea1ea52-e787-46d6-b2f6-807002ef609f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Implement Focus Zone circular navigation and tab key behaviors for macOS",
+  "packageName": "@fluentui-react-native/focus-zone",
+  "email": "nakambo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-b9bf314a-ee60-4115-8a3c-946dee879510.json
+++ b/change/@fluentui-react-native-tester-b9bf314a-ee60-4115-8a3c-946dee879510.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Minor tweaks for Mac behavior",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "nakambo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/FocusZone/macos/RCTFocusZone.h
+++ b/packages/components/FocusZone/macos/RCTFocusZone.h
@@ -15,6 +15,7 @@ typedef NS_ENUM(NSInteger, FocusZoneDirection) {
 @property(nonatomic) BOOL disabled;
 @property(nonatomic) FocusZoneDirection focusZoneDirection;
 @property(nonatomic) NSString *navigateAtEnd;
+@property(nonatomic) NSString *tabKeyNavigation;
 @property(nonatomic) NSView *defaultResponder;
 
 @end

--- a/packages/components/FocusZone/macos/RCTFocusZoneManager.m
+++ b/packages/components/FocusZone/macos/RCTFocusZoneManager.m
@@ -34,6 +34,7 @@ RCT_CUSTOM_VIEW_PROPERTY(focusZoneDirection, NSString, RCTFocusZone)
 }
 
 RCT_EXPORT_VIEW_PROPERTY(navigateAtEnd, NSString)
+RCT_EXPORT_VIEW_PROPERTY(tabKeyNavigation, NSString)
 
 RCT_CUSTOM_VIEW_PROPERTY(defaultTabbableElement, NSNumber, RCTFocusZone)
 {

--- a/packages/components/FocusZone/src/FocusZone.types.ts
+++ b/packages/components/FocusZone/src/FocusZone.types.ts
@@ -39,7 +39,6 @@ export type FocusZoneProps = React.PropsWithChildren<{
   use2DNavigation?: boolean;
 
   /**
-   * @platform win32
    * By default, pressing Tab within a FocusZone moves focus out of the FocusZone.
    * This prop allows you to change that behavior.
    *


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Initial (protoype) implementation for `navigateAtEnd` and `tabKeyNavigation` for macOS implementation of focus zone.

### Verification

Manual testing performed:

* "FocusZone with Circular Navigation": all arrow keys (left, right, up, down), and tab (Tab, Shift+Tab)
* "FocusZone with Tab Key Abstraction": all keys for all of Normal, NavigateWrap, NavigateStopAtEnds, None

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [x] Documentation and examples
- [x] Keyboard Accessibility
- [x] Voiceover: n/a
- [x] Internationalization and Right-to-left Layouts
