### PR TITLE
[Mac] [Focus Zone] Tweak tab\shift behavior

### DIFF
--- a/apps/fluent-tester/src/TestComponents/FocusZone/FocusZoneTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/FocusZone/FocusZoneTest.tsx
@@ -181,6 +181,32 @@ const NestedFocusZone: React.FunctionComponent = () => {
   );
 };
 
+const FocusZoneGrid: React.FunctionComponent = () => {
+  const [isCircularNavigation, setCircularNavigation] = React.useState(true);
+  const [tabNavigation, setTabNavigation] = React.useState<FocusZoneTabNavigation>('None');
+  const onCircularNavigationChange = React.useCallback((_, isChecked: boolean) => setCircularNavigation(isChecked), []);
+
+  return (
+    <FocusZoneListWrapper>
+      <>
+        <Text>FocusZone Grid</Text>
+        <Checkbox label="Circular Navigation" checked={isCircularNavigation} onChange={onCircularNavigationChange} />
+        <MenuButton
+          content={`Tab key navigation: ${tabNavigation}`}
+          menuItems={FocusZoneTabNavigations.map((dir) => ({
+            itemKey: dir,
+            text: dir,
+          }))}
+          onItemClick={(dir) => setTabNavigation(dir as FocusZoneTabNavigation)}
+        />
+        <FocusZone isCircularNavigation tabKeyNavigation={tabNavigation}>
+          <GridOfButtons gridWidth={3} gridHeight={3} />
+        </FocusZone>
+      </>
+    </FocusZoneListWrapper>
+  );
+};
+
 const focusZoneSections: TestSection[] = [
   {
     name: 'Common FocusZone Usage',
@@ -214,6 +240,10 @@ const focusZoneSections: TestSection[] = [
   {
     name: 'Nested FocusZone',
     component: NestedFocusZone,
+  },
+  {
+    name: 'FocusZone Grid',
+    component: FocusZoneGrid,
   },
 ];
 

--- a/change/@fluentui-react-native-focus-zone-c24b7807-cc1d-49fb-9a75-f7005fa8fa1b.json
+++ b/change/@fluentui-react-native-focus-zone-c24b7807-cc1d-49fb-9a75-f7005fa8fa1b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[Mac] [Focus Zone] Tweak tab\\shift behavior",
+  "packageName": "@fluentui-react-native/focus-zone",
+  "email": "nakambo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-778cff04-e7d2-44c8-8890-c10c258c5e7c.json
+++ b/change/@fluentui-react-native-tester-778cff04-e7d2-44c8-8890-c10c258c5e7c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add FocusZone Grid test case",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "nakambo@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION

### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

In a previous commit, I added `tabKeyNavigation` behavior. However, it ultimately relied on translating the tab\shift+tab action into arrow keys to figure out which view to focus. It didn't occur to me before though that arrow keys *CAN* behave differently depending on whether they're horizontal or vertical (easily observable when the focus zone controls are not all laid out on a single row or column), and there *might* be scenarios where either don't behave right, especially with circular navigation.

I also noticed arrow key behaviors (including the non-circular cases) as implemented on macOS are different in the Win32 (Office) version AND the web version of Fluent. But this change doesn't aim to address only of that. In this change we will only update tab\shift+tab to behave like the system key view loop, which should provide a more predictable behavior than arrow keys.

### Verification

Manual testing:

* Navigation, including wrap around, behaves consistently with tab and shift+tab for various cases of `tabKeyNavigation` in the newly added "FocusZone Grid" case.


Old behavior: https://github.com/user-attachments/assets/657a760d-4132-4513-8247-a913d75dfec7
New behavior: https://github.com/user-attachments/assets/3d5a0bd1-5606-4d9f-866c-e265e49142e1

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [x] Keyboard Accessibility
- [x] Voiceover: n/a
- [x] Internationalization and Right-to-left Layouts
