### PR TITLE
[Mac] [Focus Zone] Restore broken direction = none functionality

### DIFF
--- a/change/@fluentui-react-native-focus-zone-1e63be00-70e8-4c8d-88be-e75acdcdaf39.json
+++ b/change/@fluentui-react-native-focus-zone-1e63be00-70e8-4c8d-88be-e75acdcdaf39.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[Mac] [Focus Zone] Restore broken direction = none functionality",
+  "packageName": "@fluentui-react-native/focus-zone",
+  "email": "nakambo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/FocusZone/macos/RCTFocusZone.m
+++ b/packages/components/FocusZone/macos/RCTFocusZone.m
@@ -538,10 +538,10 @@ static BOOL ShouldSkipFocusZone(NSView *view)
 
 	BOOL forward = action != FocusZoneActionShiftTab;
 	NSView *firstResponder = GetFirstResponder([self window]);
-	NSView *nextViewToFocus = action == forward ? [firstResponder nextValidKeyView] : [firstResponder previousValidKeyView];
+	NSView *nextViewToFocus = forward ? [firstResponder nextValidKeyView] : [firstResponder previousValidKeyView];
 
 	if (nextViewToFocus == self)
-		nextViewToFocus = action == forward ? [nextViewToFocus nextValidKeyView] : [nextViewToFocus previousValidKeyView];;
+		nextViewToFocus = forward ? [nextViewToFocus nextValidKeyView] : [nextViewToFocus previousValidKeyView];;
 
 	if ([@"Normal" isEqual:tabKeyNavigation] || [nextViewToFocus isDescendantOf:self])
 		return nextViewToFocus;

--- a/packages/components/FocusZone/macos/RCTFocusZone.m
+++ b/packages/components/FocusZone/macos/RCTFocusZone.m
@@ -573,17 +573,21 @@ static BOOL ShouldSkipFocusZone(NSView *view)
 
 	BOOL passthrough = NO;
 	NSView *viewToFocus = nil;
-	if ([self disabled] || action == FocusZoneActionNone
-		|| (focusZoneDirection == FocusZoneDirectionVertical
-			&& (action == FocusZoneActionRightArrow || action == FocusZoneActionLeftArrow))
-		|| (focusZoneDirection == FocusZoneDirectionHorizontal
-			&& (action == FocusZoneActionUpArrow || action == FocusZoneActionDownArrow)))
+	if ([self disabled] || action == FocusZoneActionNone)
 	{
 		passthrough = YES;
 	}
 	else if (action == FocusZoneActionTab || action == FocusZoneActionShiftTab)
 	{
 		viewToFocus = [self nextViewToFocusForTab:action];
+	}
+	else if ((focusZoneDirection == FocusZoneDirectionVertical
+			&& (action == FocusZoneActionRightArrow || action == FocusZoneActionLeftArrow))
+		|| (focusZoneDirection == FocusZoneDirectionHorizontal
+			&& (action == FocusZoneActionUpArrow || action == FocusZoneActionDownArrow))
+		|| (focusZoneDirection == FocusZoneDirectionNone))
+	{
+		passthrough = YES;
 	}
 	else
 	{


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

In a previous change, I incorrectly refactored some functionality that caused focus zone to respond to arrow keys even when direction was set to none. This change restores direction = none functionality.

### Verification

Manual testing:

* Disabled focus zone: tab works normally (as if no focus zone is present), arrow keys beep
* Arrow keys on direction = none zone: tab works like focus zone (move to outside the zone), arrow keys beep
* Arrow keys on direction = horizontal zone: tab works like focus zone (move to outside the zone), vertical arrow keys beep, horizontal arrow keys move in zone
* Arrow keys on direction = vertical zone: tab works like focus zone (move to outside the zone), horizontal arrow keys beep, vertical arrow keys move in zone
* Arrow keys on direction = bidirectional zone: tab works like focus zone (move to outside the zone), arrow keys move in zone

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [x] Keyboard Accessibility
- [x] Voiceover: n/a
- [ ] Internationalization and Right-to-left Layouts
