### PR TITLE
use latest MacOS image available for Android PR

### DIFF
--- a/.ado/azure-pipelines.yml
+++ b/.ado/azure-pipelines.yml
@@ -39,7 +39,7 @@ jobs:
   - job: AndroidPR
     displayName: Android PR
     pool:
-      vmImage: 'macos-11'
+      vmImage: 'macos-latest'
     variables:
       platform: 'android'
     timeoutInMinutes: 60 # how long to run the job before automatically cancelling


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [x] android

### Description of changes

Use `macos-latest` for Android PRs instead of the deprecated `macos-11`.

### Verification

...verifying with this PR :)

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
