### PR TITLE
fix: Re-enable iOS E2E tests

### DIFF
--- a/.ado/azure-pipelines.yml
+++ b/.ado/azure-pipelines.yml
@@ -140,8 +140,7 @@ jobs:
         env:
           CCACHE_DISABLE: 1
 
-      # Disable iOS E2E tests as they fail on macOS-13 images
-      # - template: templates/e2e-testing-ios.yml
+      - template: templates/e2e-testing-ios.yml
 
   # Windows bundling and end to end testing
   - job: WindowsPR


### PR DESCRIPTION
Try and hope it works?

### Platforms Impacted
- [x] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Re-enable the iOS E2E tests. We might need a `open -a simulator` somewhere

### Verification

Ci should pass

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
