### PR TITLE
Fixing numberOfLines prop on Text

### DIFF
--- a/change/@fluentui-react-native-text-0fec4e82-aaf2-47d3-969f-56fbd4b4a5ce.json
+++ b/change/@fluentui-react-native-text-0fec4e82-aaf2-47d3-969f-56fbd4b4a5ce.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix bug",
+  "packageName": "@fluentui-react-native/text",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Text/src/Text.tsx
+++ b/packages/components/Text/src/Text.tsx
@@ -137,7 +137,7 @@ export const Text = compressible<TextProps, TextTokens>((props: TextProps, useTo
       ...extra,
       ...maxFontSizeScaleAdjustment,
       onPress,
-      numberOfLines: numberOfLines ?? (truncate || !wrap) ? 1 : 0,
+      numberOfLines: numberOfLines ?? (truncate || !wrap ? 1 : 0),
       style: mergeStyles(tokenStyle, props.style, extra?.style),
     };
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Turns out the nullish coalescing operator (??) is more binding than ternary operator (? :)

This means that when passing in a value for numberOfLines to Text, it was evaluating numberOfLines ?? (truncate || !wrap) as the condition and always returning 1 or 0, instead of pasasing numberOfLines through when set, which is the intended behavior.

Wrapping (truncate || !wrap ? 1 : 0) in parens fixes the behavior

### Verification

Tested with console logs and button customizations.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
