### PR TITLE
fix(macOS Button): Set default size to small

### DIFF
--- a/change/@fluentui-react-native-button-2a12fbe6-8f1c-4407-b7ad-f7323555269e.json
+++ b/change/@fluentui-react-native-button-2a12fbe6-8f1c-4407-b7ad-f7323555269e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix(macOS Button): Set default size to small",
+  "packageName": "@fluentui-react-native/button",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Button/src/Button.styling.ts
+++ b/packages/components/Button/src/Button.styling.ts
@@ -111,8 +111,9 @@ export const getDefaultSize = (): ButtonSize => {
     return 'medium';
   } else if ((Platform.OS as any) === 'win32') {
     return 'small';
+  } else if (Platform.OS === 'macos') {
+    return 'small';
   }
-
   return 'medium';
 };
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Set the default size of the macOS button to small. This will require verifying (or following up with) downstream dependencies to make sure we don't break them.

### Verification

Small buttons!

<img width="860" alt="Screenshot 2024-10-08 at 8 27 24 PM" src="https://github.com/user-attachments/assets/94155595-242f-400c-8e56-c87fccc5e0e9">


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
