### PR TITLE
chore: Update to React Native 0.74

### DIFF
--- a/.yarn/patches/@office-iss-react-native-win32-npm-0.73.6-c1424dfcf6.patch
+++ b/.yarn/patches/@office-iss-react-native-win32-npm-0.73.6-c1424dfcf6.patch
@@ -1,0 +1,26 @@
+diff --git a/Libraries/Components/View/ViewPropTypes.d.ts b/Libraries/Components/View/ViewPropTypes.d.ts
+index be61e9e59a514bf602b3c1d4efb8ac3cb32427e7..b482a328c704d44d46d17d86ad5c167e3e2ec1e8 100644
+--- a/Libraries/Components/View/ViewPropTypes.d.ts
++++ b/Libraries/Components/View/ViewPropTypes.d.ts
+@@ -316,7 +316,7 @@ export interface ViewProps
+    * the Z-index of sibling views always takes precedence if a touch
+    * hits two overlapping views.
+    */
+-  hitSlop?: Insets | undefined;
++  hitSlop?: null | Insets | number | undefined;
+ 
+   /**
+    * Used to reference react managed views from native code.
+diff --git a/src/Libraries/Components/View/ViewPropTypes.d.ts b/src/Libraries/Components/View/ViewPropTypes.d.ts
+index be61e9e59a514bf602b3c1d4efb8ac3cb32427e7..b482a328c704d44d46d17d86ad5c167e3e2ec1e8 100644
+--- a/src/Libraries/Components/View/ViewPropTypes.d.ts
++++ b/src/Libraries/Components/View/ViewPropTypes.d.ts
+@@ -316,7 +316,7 @@ export interface ViewProps
+    * the Z-index of sibling views always takes precedence if a touch
+    * hits two overlapping views.
+    */
+-  hitSlop?: Insets | undefined;
++  hitSlop?: null | Insets | number | undefined;
+ 
+   /**
+    * Used to reference react managed views from native code.

--- a/apps/E2E/package.json
+++ b/apps/E2E/package.json
@@ -23,9 +23,9 @@
   ],
   "dependencies": {
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.0",
@@ -33,9 +33,9 @@
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/focus-zone": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-babel-transformer": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-babel-transformer": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "@rnx-kit/metro-config": "^1.3.1",
     "@types/jasmine": "5.1.4",
     "@types/react": "^18.2.0",
@@ -51,7 +51,7 @@
     "appium-uiautomator2-driver": "^3.0.5",
     "appium-windows-driver": "^2.12.18",
     "appium-xcuitest-driver": "^7.9.1",
-    "metro-config": "^0.80.0",
+    "metro-config": "^0.80.3",
     "rimraf": "^5.0.1",
     "ts-node": "^10.7.0",
     "typescript": "4.9.4",
@@ -67,7 +67,7 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
         "core",
@@ -75,7 +75,8 @@
         "core-windows",
         "react",
         "metro-config",
-        "babel-preset-react-native"
+        "babel-preset-react-native",
+        "metro-react-native-babel-transformer"
       ]
     }
   }

--- a/apps/fluent-tester/macos/Podfile.lock
+++ b/apps/fluent-tester/macos/Podfile.lock
@@ -1,27 +1,18 @@
 PODS:
   - boost (1.83.0)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.73.23)
-  - FBReactNativeSpec (0.73.23):
-    - RCT-Folly (= 2022.05.16.00)
-    - RCTRequired (= 0.73.23)
-    - RCTTypeSafety (= 0.73.23)
-    - React-Core (= 0.73.23)
-    - React-jsi (= 0.73.23)
-    - ReactCommon/turbomodule/core (= 0.73.23)
+  - FBLazyVector (0.74.9)
   - fmt (9.1.0)
-  - FRNAvatar (0.20.12):
+  - FRNAvatar (0.21.2):
     - MicrosoftFluentUI (= 0.13.1)
     - React
-  - FRNCallout (0.25.16):
+  - FRNCheckbox (0.17.5):
     - React
-  - FRNCheckbox (0.16.15):
+  - FRNMenuButton (0.13.11):
     - React
-  - FRNMenuButton (0.12.22):
+  - FRNRadioButton (0.21.10):
     - React
-  - FRNRadioButton (0.20.17):
-    - React
-  - FRNVibrancyView (0.1.5):
+  - FRNVibrancyView (0.2.1):
     - React
   - glog (0.3.5)
   - MicrosoftFluentUI (0.13.1):
@@ -93,290 +84,340 @@ PODS:
     - MicrosoftFluentUI/Core_mac
   - MicrosoftFluentUI/Separator_mac (0.13.1):
     - MicrosoftFluentUI/Core_mac
-  - RCT-Folly (2022.05.16.00):
+  - RCT-Folly (2024.01.01.00):
     - boost
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-    - RCT-Folly/Default (= 2022.05.16.00)
-  - RCT-Folly/Default (2022.05.16.00):
+    - RCT-Folly/Default (= 2024.01.01.00)
+  - RCT-Folly/Default (2024.01.01.00):
     - boost
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-  - RCT-Folly/Fabric (2022.05.16.00):
+  - RCT-Folly/Fabric (2024.01.01.00):
     - boost
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-  - RCTFocusZone (0.16.15):
+  - RCTDeprecation (0.74.9)
+  - RCTFocusZone (0.19.2):
     - React
-  - RCTRequired (0.73.23)
-  - RCTTypeSafety (0.73.23):
-    - FBLazyVector (= 0.73.23)
-    - RCTRequired (= 0.73.23)
-    - React-Core (= 0.73.23)
-  - React (0.73.23):
-    - React-Core (= 0.73.23)
-    - React-Core/DevSupport (= 0.73.23)
-    - React-Core/RCTWebSocket (= 0.73.23)
-    - React-RCTActionSheet (= 0.73.23)
-    - React-RCTAnimation (= 0.73.23)
-    - React-RCTBlob (= 0.73.23)
-    - React-RCTImage (= 0.73.23)
-    - React-RCTLinking (= 0.73.23)
-    - React-RCTNetwork (= 0.73.23)
-    - React-RCTSettings (= 0.73.23)
-    - React-RCTText (= 0.73.23)
-    - React-RCTVibration (= 0.73.23)
-  - React-callinvoker (0.73.23)
-  - React-Codegen (0.73.23):
+  - RCTRequired (0.74.9)
+  - RCTTypeSafety (0.74.9):
+    - FBLazyVector (= 0.74.9)
+    - RCTRequired (= 0.74.9)
+    - React-Core (= 0.74.9)
+  - React (0.74.9):
+    - React-Core (= 0.74.9)
+    - React-Core/DevSupport (= 0.74.9)
+    - React-Core/RCTWebSocket (= 0.74.9)
+    - React-RCTActionSheet (= 0.74.9)
+    - React-RCTAnimation (= 0.74.9)
+    - React-RCTBlob (= 0.74.9)
+    - React-RCTImage (= 0.74.9)
+    - React-RCTLinking (= 0.74.9)
+    - React-RCTNetwork (= 0.74.9)
+    - React-RCTSettings (= 0.74.9)
+    - React-RCTText (= 0.74.9)
+    - React-RCTVibration (= 0.74.9)
+  - React-callinvoker (0.74.9)
+  - React-Codegen (0.74.9):
     - DoubleConversion
-    - FBReactNativeSpec
     - glog
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-FabricImage
+    - React-featureflags
+    - React-graphics
     - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-NativeModulesApple
-    - React-rncore
+    - React-rendererdebug
+    - React-utils
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-Core (0.73.23):
+  - React-Core (0.74.9):
     - glog
-    - RCT-Folly (= 2022.05.16.00)
-    - React-Core/Default (= 0.73.23)
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
+    - React-Core/Default (= 0.74.9)
     - React-cxxreact
+    - React-featureflags
     - React-jsc
     - React-jsi
     - React-jsiexecutor
+    - React-jsinspector
     - React-perflogger
     - React-runtimescheduler
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.73.23):
+  - React-Core/CoreModulesHeaders (0.74.9):
     - glog
-    - RCT-Folly (= 2022.05.16.00)
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
     - React-Core/Default
     - React-cxxreact
+    - React-featureflags
     - React-jsc
     - React-jsi
     - React-jsiexecutor
+    - React-jsinspector
     - React-perflogger
     - React-runtimescheduler
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/Default (0.73.23):
+  - React-Core/Default (0.74.9):
     - glog
-    - RCT-Folly (= 2022.05.16.00)
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
     - React-cxxreact
+    - React-featureflags
     - React-jsc
     - React-jsi
     - React-jsiexecutor
+    - React-jsinspector
     - React-perflogger
     - React-runtimescheduler
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/DevSupport (0.73.23):
+  - React-Core/DevSupport (0.74.9):
     - glog
-    - RCT-Folly (= 2022.05.16.00)
-    - React-Core/Default (= 0.73.23)
-    - React-Core/RCTWebSocket (= 0.73.23)
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
+    - React-Core/Default (= 0.74.9)
+    - React-Core/RCTWebSocket (= 0.74.9)
     - React-cxxreact
+    - React-featureflags
     - React-jsc
     - React-jsi
     - React-jsiexecutor
-    - React-jsinspector (= 0.73.23)
+    - React-jsinspector
     - React-perflogger
     - React-runtimescheduler
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTActionSheetHeaders (0.73.23):
+  - React-Core/RCTActionSheetHeaders (0.74.9):
     - glog
-    - RCT-Folly (= 2022.05.16.00)
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
     - React-Core/Default
     - React-cxxreact
+    - React-featureflags
     - React-jsc
     - React-jsi
     - React-jsiexecutor
+    - React-jsinspector
     - React-perflogger
     - React-runtimescheduler
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.73.23):
+  - React-Core/RCTAnimationHeaders (0.74.9):
     - glog
-    - RCT-Folly (= 2022.05.16.00)
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
     - React-Core/Default
     - React-cxxreact
+    - React-featureflags
     - React-jsc
     - React-jsi
     - React-jsiexecutor
+    - React-jsinspector
     - React-perflogger
     - React-runtimescheduler
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.73.23):
+  - React-Core/RCTBlobHeaders (0.74.9):
     - glog
-    - RCT-Folly (= 2022.05.16.00)
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
     - React-Core/Default
     - React-cxxreact
+    - React-featureflags
     - React-jsc
     - React-jsi
     - React-jsiexecutor
+    - React-jsinspector
     - React-perflogger
     - React-runtimescheduler
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTImageHeaders (0.73.23):
+  - React-Core/RCTImageHeaders (0.74.9):
     - glog
-    - RCT-Folly (= 2022.05.16.00)
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
     - React-Core/Default
     - React-cxxreact
+    - React-featureflags
     - React-jsc
     - React-jsi
     - React-jsiexecutor
+    - React-jsinspector
     - React-perflogger
     - React-runtimescheduler
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.73.23):
+  - React-Core/RCTLinkingHeaders (0.74.9):
     - glog
-    - RCT-Folly (= 2022.05.16.00)
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
     - React-Core/Default
     - React-cxxreact
+    - React-featureflags
     - React-jsc
     - React-jsi
     - React-jsiexecutor
+    - React-jsinspector
     - React-perflogger
     - React-runtimescheduler
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.73.23):
+  - React-Core/RCTNetworkHeaders (0.74.9):
     - glog
-    - RCT-Folly (= 2022.05.16.00)
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
     - React-Core/Default
     - React-cxxreact
+    - React-featureflags
     - React-jsc
     - React-jsi
     - React-jsiexecutor
+    - React-jsinspector
     - React-perflogger
     - React-runtimescheduler
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.73.23):
+  - React-Core/RCTSettingsHeaders (0.74.9):
     - glog
-    - RCT-Folly (= 2022.05.16.00)
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
     - React-Core/Default
     - React-cxxreact
+    - React-featureflags
     - React-jsc
     - React-jsi
     - React-jsiexecutor
+    - React-jsinspector
     - React-perflogger
     - React-runtimescheduler
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTTextHeaders (0.73.23):
+  - React-Core/RCTTextHeaders (0.74.9):
     - glog
-    - RCT-Folly (= 2022.05.16.00)
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
     - React-Core/Default
     - React-cxxreact
+    - React-featureflags
     - React-jsc
     - React-jsi
     - React-jsiexecutor
+    - React-jsinspector
     - React-perflogger
     - React-runtimescheduler
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.73.23):
+  - React-Core/RCTVibrationHeaders (0.74.9):
     - glog
-    - RCT-Folly (= 2022.05.16.00)
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
     - React-Core/Default
     - React-cxxreact
+    - React-featureflags
     - React-jsc
     - React-jsi
     - React-jsiexecutor
+    - React-jsinspector
     - React-perflogger
     - React-runtimescheduler
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTWebSocket (0.73.23):
+  - React-Core/RCTWebSocket (0.74.9):
     - glog
-    - RCT-Folly (= 2022.05.16.00)
-    - React-Core/Default (= 0.73.23)
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
+    - React-Core/Default (= 0.74.9)
     - React-cxxreact
+    - React-featureflags
     - React-jsc
     - React-jsi
     - React-jsiexecutor
+    - React-jsinspector
     - React-perflogger
     - React-runtimescheduler
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-CoreModules (0.73.23):
-    - RCT-Folly (= 2022.05.16.00)
-    - RCTTypeSafety (= 0.73.23)
+  - React-CoreModules (0.74.9):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTTypeSafety (= 0.74.9)
     - React-Codegen
-    - React-Core/CoreModulesHeaders (= 0.73.23)
-    - React-jsi (= 0.73.23)
+    - React-Core/CoreModulesHeaders (= 0.74.9)
+    - React-jsi (= 0.74.9)
+    - React-jsinspector
     - React-NativeModulesApple
     - React-RCTBlob
-    - React-RCTImage (= 0.73.23)
+    - React-RCTImage (= 0.74.9)
     - ReactCommon
     - SocketRocket (= 0.7.0)
-  - React-cxxreact (0.73.23):
+  - React-cxxreact (0.74.9):
     - boost (= 1.83.0)
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-    - RCT-Folly (= 2022.05.16.00)
-    - React-callinvoker (= 0.73.23)
-    - React-debug (= 0.73.23)
-    - React-jsi (= 0.73.23)
-    - React-jsinspector (= 0.73.23)
-    - React-logger (= 0.73.23)
-    - React-perflogger (= 0.73.23)
-    - React-runtimeexecutor (= 0.73.23)
-  - React-debug (0.73.23)
-  - React-Fabric (0.73.23):
+    - RCT-Folly (= 2024.01.01.00)
+    - React-callinvoker (= 0.74.9)
+    - React-debug (= 0.74.9)
+    - React-jsi (= 0.74.9)
+    - React-jsinspector
+    - React-logger (= 0.74.9)
+    - React-perflogger (= 0.74.9)
+    - React-runtimeexecutor (= 0.74.9)
+  - React-debug (0.74.9)
+  - React-Fabric (0.74.9):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - RCT-Folly/Fabric (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.73.23)
-    - React-Fabric/attributedstring (= 0.73.23)
-    - React-Fabric/componentregistry (= 0.73.23)
-    - React-Fabric/componentregistrynative (= 0.73.23)
-    - React-Fabric/components (= 0.73.23)
-    - React-Fabric/core (= 0.73.23)
-    - React-Fabric/imagemanager (= 0.73.23)
-    - React-Fabric/leakchecker (= 0.73.23)
-    - React-Fabric/mounting (= 0.73.23)
-    - React-Fabric/scheduler (= 0.73.23)
-    - React-Fabric/telemetry (= 0.73.23)
-    - React-Fabric/templateprocessor (= 0.73.23)
-    - React-Fabric/textlayoutmanager (= 0.73.23)
-    - React-Fabric/uimanager (= 0.73.23)
+    - React-Fabric/animations (= 0.74.9)
+    - React-Fabric/attributedstring (= 0.74.9)
+    - React-Fabric/componentregistry (= 0.74.9)
+    - React-Fabric/componentregistrynative (= 0.74.9)
+    - React-Fabric/components (= 0.74.9)
+    - React-Fabric/core (= 0.74.9)
+    - React-Fabric/imagemanager (= 0.74.9)
+    - React-Fabric/leakchecker (= 0.74.9)
+    - React-Fabric/mounting (= 0.74.9)
+    - React-Fabric/scheduler (= 0.74.9)
+    - React-Fabric/telemetry (= 0.74.9)
+    - React-Fabric/templateprocessor (= 0.74.9)
+    - React-Fabric/textlayoutmanager (= 0.74.9)
+    - React-Fabric/uimanager (= 0.74.9)
     - React-graphics
     - React-jsc
     - React-jsi
@@ -386,30 +427,11 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/animations (0.73.23):
+  - React-Fabric/animations (0.74.9):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-    - RCT-Folly/Fabric (= 2022.05.16.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-graphics
-    - React-jsc
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/attributedstring (0.73.23):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - RCT-Folly/Fabric (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Core
@@ -424,11 +446,11 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistry (0.73.23):
+  - React-Fabric/attributedstring (0.74.9):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - RCT-Folly/Fabric (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Core
@@ -443,11 +465,11 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistrynative (0.73.23):
+  - React-Fabric/componentregistry (0.74.9):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - RCT-Folly/Fabric (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Core
@@ -462,41 +484,11 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components (0.73.23):
+  - React-Fabric/componentregistrynative (0.74.9):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-    - RCT-Folly/Fabric (= 2022.05.16.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/inputaccessory (= 0.73.23)
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.73.23)
-    - React-Fabric/components/modal (= 0.73.23)
-    - React-Fabric/components/rncore (= 0.73.23)
-    - React-Fabric/components/root (= 0.73.23)
-    - React-Fabric/components/safeareaview (= 0.73.23)
-    - React-Fabric/components/scrollview (= 0.73.23)
-    - React-Fabric/components/text (= 0.73.23)
-    - React-Fabric/components/textinput (= 0.73.23)
-    - React-Fabric/components/unimplementedview (= 0.73.23)
-    - React-Fabric/components/view (= 0.73.23)
-    - React-graphics
-    - React-jsc
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/components/inputaccessory (0.73.23):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - RCT-Folly/Fabric (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Core
@@ -511,11 +503,41 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/legacyviewmanagerinterop (0.73.23):
+  - React-Fabric/components (0.74.9):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/inputaccessory (= 0.74.9)
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.74.9)
+    - React-Fabric/components/modal (= 0.74.9)
+    - React-Fabric/components/rncore (= 0.74.9)
+    - React-Fabric/components/root (= 0.74.9)
+    - React-Fabric/components/safeareaview (= 0.74.9)
+    - React-Fabric/components/scrollview (= 0.74.9)
+    - React-Fabric/components/text (= 0.74.9)
+    - React-Fabric/components/textinput (= 0.74.9)
+    - React-Fabric/components/unimplementedview (= 0.74.9)
+    - React-Fabric/components/view (= 0.74.9)
+    - React-graphics
+    - React-jsc
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/inputaccessory (0.74.9):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - RCT-Folly/Fabric (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Core
@@ -530,11 +552,11 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/modal (0.73.23):
+  - React-Fabric/components/legacyviewmanagerinterop (0.74.9):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - RCT-Folly/Fabric (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Core
@@ -549,11 +571,11 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/rncore (0.73.23):
+  - React-Fabric/components/modal (0.74.9):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - RCT-Folly/Fabric (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Core
@@ -568,11 +590,11 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/root (0.73.23):
+  - React-Fabric/components/rncore (0.74.9):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - RCT-Folly/Fabric (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Core
@@ -587,11 +609,11 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/safeareaview (0.73.23):
+  - React-Fabric/components/root (0.74.9):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - RCT-Folly/Fabric (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Core
@@ -606,11 +628,11 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/scrollview (0.73.23):
+  - React-Fabric/components/safeareaview (0.74.9):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - RCT-Folly/Fabric (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Core
@@ -625,11 +647,11 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/text (0.73.23):
+  - React-Fabric/components/scrollview (0.74.9):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - RCT-Folly/Fabric (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Core
@@ -644,11 +666,11 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/textinput (0.73.23):
+  - React-Fabric/components/text (0.74.9):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - RCT-Folly/Fabric (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Core
@@ -663,11 +685,11 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/unimplementedview (0.73.23):
+  - React-Fabric/components/textinput (0.74.9):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - RCT-Folly/Fabric (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Core
@@ -682,11 +704,30 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/view (0.73.23):
+  - React-Fabric/components/unimplementedview (0.74.9):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-graphics
+    - React-jsc
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/view (0.74.9):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - RCT-Folly/Fabric (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Core
@@ -702,11 +743,11 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-Fabric/core (0.73.23):
+  - React-Fabric/core (0.74.9):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - RCT-Folly/Fabric (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Core
@@ -721,11 +762,11 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/imagemanager (0.73.23):
+  - React-Fabric/imagemanager (0.74.9):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - RCT-Folly/Fabric (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Core
@@ -740,11 +781,11 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/leakchecker (0.73.23):
+  - React-Fabric/leakchecker (0.74.9):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - RCT-Folly/Fabric (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Core
@@ -759,11 +800,11 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/mounting (0.73.23):
+  - React-Fabric/mounting (0.74.9):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - RCT-Folly/Fabric (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Core
@@ -778,11 +819,11 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/scheduler (0.73.23):
+  - React-Fabric/scheduler (0.74.9):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - RCT-Folly/Fabric (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Core
@@ -797,11 +838,11 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/telemetry (0.73.23):
+  - React-Fabric/telemetry (0.74.9):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - RCT-Folly/Fabric (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Core
@@ -816,11 +857,11 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/templateprocessor (0.73.23):
+  - React-Fabric/templateprocessor (0.74.9):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - RCT-Folly/Fabric (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Core
@@ -835,11 +876,11 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/textlayoutmanager (0.73.23):
+  - React-Fabric/textlayoutmanager (0.74.9):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - RCT-Folly/Fabric (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Core
@@ -855,11 +896,11 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/uimanager (0.73.23):
+  - React-Fabric/uimanager (0.74.9):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - RCT-Folly/Fabric (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Core
@@ -874,30 +915,33 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-FabricImage (0.73.23):
+  - React-FabricImage (0.74.9):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-    - RCT-Folly/Fabric (= 2022.05.16.00)
-    - RCTRequired (= 0.73.23)
-    - RCTTypeSafety (= 0.73.23)
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired (= 0.74.9)
+    - RCTTypeSafety (= 0.74.9)
     - React-Fabric
     - React-graphics
     - React-ImageManager
     - React-jsc
     - React-jsi
-    - React-jsiexecutor (= 0.73.23)
+    - React-jsiexecutor (= 0.74.9)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - Yoga
-  - React-graphics (0.73.23):
+  - React-featureflags (0.74.9)
+  - React-graphics (0.74.9):
+    - DoubleConversion
+    - fmt (= 9.1.0)
     - glog
-    - RCT-Folly/Fabric (= 2022.05.16.00)
-    - React-Core/Default (= 0.73.23)
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - React-Core/Default (= 0.74.9)
     - React-utils
-  - React-ImageManager (0.73.23):
+  - React-ImageManager (0.74.9):
     - glog
     - RCT-Folly/Fabric
     - React-Core/Default
@@ -906,92 +950,116 @@ PODS:
     - React-graphics
     - React-rendererdebug
     - React-utils
-  - React-jsc (0.73.23):
-    - React-jsc/Fabric (= 0.73.23)
-    - React-jsi (= 0.73.23)
-  - React-jsc/Fabric (0.73.23):
-    - React-jsi (= 0.73.23)
-  - React-jserrorhandler (0.73.23):
-    - RCT-Folly/Fabric (= 2022.05.16.00)
+  - React-jsc (0.74.9):
+    - React-jsc/Fabric (= 0.74.9)
+    - React-jsi (= 0.74.9)
+  - React-jsc/Fabric (0.74.9):
+    - React-jsi (= 0.74.9)
+  - React-jserrorhandler (0.74.9):
+    - RCT-Folly/Fabric (= 2024.01.01.00)
     - React-debug
     - React-jsi
     - React-Mapbuffer
-  - React-jsi (0.73.23):
+  - React-jsi (0.74.9):
     - boost (= 1.83.0)
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-    - RCT-Folly (= 2022.05.16.00)
-  - React-jsiexecutor (0.73.23):
+    - RCT-Folly (= 2024.01.01.00)
+  - React-jsiexecutor (0.74.9):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-    - RCT-Folly (= 2022.05.16.00)
-    - React-cxxreact (= 0.73.23)
-    - React-jsi (= 0.73.23)
-    - React-perflogger (= 0.73.23)
-  - React-jsinspector (0.73.23)
-  - React-logger (0.73.23):
+    - RCT-Folly (= 2024.01.01.00)
+    - React-cxxreact (= 0.74.9)
+    - React-jsi (= 0.74.9)
+    - React-jsinspector
+    - React-perflogger (= 0.74.9)
+  - React-jsinspector (0.74.9):
+    - DoubleConversion
     - glog
-  - React-Mapbuffer (0.73.23):
+    - RCT-Folly (= 2024.01.01.00)
+    - React-featureflags
+    - React-jsi
+    - React-runtimeexecutor (= 0.74.9)
+  - React-jsitracing (0.74.9):
+    - React-jsi
+  - React-logger (0.74.9):
+    - glog
+  - React-Mapbuffer (0.74.9):
     - glog
     - React-debug
-  - React-nativeconfig (0.73.23)
-  - React-NativeModulesApple (0.73.23):
+  - React-nativeconfig (0.74.9)
+  - React-NativeModulesApple (0.74.9):
     - glog
     - React-callinvoker
     - React-Core
     - React-cxxreact
     - React-jsc
     - React-jsi
+    - React-jsinspector
     - React-runtimeexecutor
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-perflogger (0.73.23)
-  - React-RCTActionSheet (0.73.23):
-    - React-Core/RCTActionSheetHeaders (= 0.73.23)
-  - React-RCTAnimation (0.73.23):
-    - RCT-Folly (= 2022.05.16.00)
+  - React-perflogger (0.74.9)
+  - React-RCTActionSheet (0.74.9):
+    - React-Core/RCTActionSheetHeaders (= 0.74.9)
+  - React-RCTAnimation (0.74.9):
+    - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Codegen
     - React-Core/RCTAnimationHeaders
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTAppDelegate (0.73.23):
-    - RCT-Folly
+  - React-RCTAppDelegate (0.74.9):
+    - RCT-Folly (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
+    - React-Codegen
     - React-Core
     - React-CoreModules
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
     - React-jsc
     - React-nativeconfig
     - React-NativeModulesApple
     - React-RCTFabric
     - React-RCTImage
     - React-RCTNetwork
+    - React-rendererdebug
+    - React-RuntimeApple
+    - React-RuntimeCore
     - React-runtimescheduler
+    - React-utils
     - ReactCommon
-  - React-RCTBlob (0.73.23):
-    - RCT-Folly (= 2022.05.16.00)
+  - React-RCTBlob (0.74.9):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - RCT-Folly (= 2024.01.01.00)
     - React-Codegen
     - React-Core/RCTBlobHeaders
     - React-Core/RCTWebSocket
     - React-jsi
+    - React-jsinspector
     - React-NativeModulesApple
     - React-RCTNetwork
     - ReactCommon
-  - React-RCTFabric (0.73.23):
+  - React-RCTFabric (0.74.9):
     - glog
-    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - RCT-Folly/Fabric (= 2024.01.01.00)
     - React-Core
     - React-debug
     - React-Fabric
     - React-FabricImage
+    - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsc
     - React-jsi
+    - React-jsinspector
     - React-nativeconfig
     - React-RCTImage
     - React-RCTText
@@ -999,8 +1067,8 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - Yoga
-  - React-RCTImage (0.73.23):
-    - RCT-Folly (= 2022.05.16.00)
+  - React-RCTImage (0.74.9):
+    - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Codegen
     - React-Core/RCTImageHeaders
@@ -1008,122 +1076,170 @@ PODS:
     - React-NativeModulesApple
     - React-RCTNetwork
     - ReactCommon
-  - React-RCTLinking (0.73.23):
+  - React-RCTLinking (0.74.9):
     - React-Codegen
-    - React-Core/RCTLinkingHeaders (= 0.73.23)
-    - React-jsi (= 0.73.23)
+    - React-Core/RCTLinkingHeaders (= 0.74.9)
+    - React-jsi (= 0.74.9)
     - React-NativeModulesApple
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.73.23)
-  - React-RCTNetwork (0.73.23):
-    - RCT-Folly (= 2022.05.16.00)
+    - ReactCommon/turbomodule/core (= 0.74.9)
+  - React-RCTNetwork (0.74.9):
+    - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Codegen
     - React-Core/RCTNetworkHeaders
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTSettings (0.73.23):
-    - RCT-Folly (= 2022.05.16.00)
+  - React-RCTSettings (0.74.9):
+    - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Codegen
     - React-Core/RCTSettingsHeaders
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTText (0.73.23):
-    - React-Core/RCTTextHeaders (= 0.73.23)
+  - React-RCTText (0.74.9):
+    - React-Core/RCTTextHeaders (= 0.74.9)
     - Yoga
-  - React-RCTVibration (0.73.23):
-    - RCT-Folly (= 2022.05.16.00)
+  - React-RCTVibration (0.74.9):
+    - RCT-Folly (= 2024.01.01.00)
     - React-Codegen
     - React-Core/RCTVibrationHeaders
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-rendererdebug (0.73.23):
+  - React-rendererdebug (0.74.9):
     - DoubleConversion
     - fmt (= 9.1.0)
-    - RCT-Folly (= 2022.05.16.00)
+    - RCT-Folly (= 2024.01.01.00)
     - React-debug
-  - React-rncore (0.73.23)
-  - React-runtimeexecutor (0.73.23):
-    - React-jsi (= 0.73.23)
-  - React-runtimescheduler (0.73.23):
+  - React-rncore (0.74.9)
+  - React-RuntimeApple (0.74.9):
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - React-callinvoker
+    - React-Core/Default
+    - React-CoreModules
+    - React-cxxreact
+    - React-jsc
+    - React-jserrorhandler
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-Mapbuffer
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-RuntimeCore
+    - React-runtimeexecutor
+    - React-utils
+  - React-RuntimeCore (0.74.9):
     - glog
-    - RCT-Folly (= 2022.05.16.00)
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - React-cxxreact
+    - React-featureflags
+    - React-jsc
+    - React-jserrorhandler
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+  - React-runtimeexecutor (0.74.9):
+    - React-jsi (= 0.74.9)
+  - React-runtimescheduler (0.74.9):
+    - glog
+    - RCT-Folly (= 2024.01.01.00)
     - React-callinvoker
     - React-cxxreact
     - React-debug
+    - React-featureflags
     - React-jsc
     - React-jsi
     - React-rendererdebug
     - React-runtimeexecutor
     - React-utils
-  - React-utils (0.73.23):
+  - React-utils (0.74.9):
     - glog
-    - RCT-Folly (= 2022.05.16.00)
+    - RCT-Folly (= 2024.01.01.00)
     - React-debug
-  - ReactCommon (0.73.23):
-    - React-logger (= 0.73.23)
-    - ReactCommon/turbomodule (= 0.73.23)
-  - ReactCommon/turbomodule (0.73.23):
+    - React-jsc
+    - React-jsi (= 0.74.9)
+  - ReactCommon (0.74.9):
+    - ReactCommon/turbomodule (= 0.74.9)
+  - ReactCommon/turbomodule (0.74.9):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-    - RCT-Folly (= 2022.05.16.00)
-    - React-callinvoker (= 0.73.23)
-    - React-cxxreact (= 0.73.23)
-    - React-jsi (= 0.73.23)
-    - React-logger (= 0.73.23)
-    - React-perflogger (= 0.73.23)
-    - ReactCommon/turbomodule/bridging (= 0.73.23)
-    - ReactCommon/turbomodule/core (= 0.73.23)
-  - ReactCommon/turbomodule/bridging (0.73.23):
+    - RCT-Folly (= 2024.01.01.00)
+    - React-callinvoker (= 0.74.9)
+    - React-cxxreact (= 0.74.9)
+    - React-jsi (= 0.74.9)
+    - React-logger (= 0.74.9)
+    - React-perflogger (= 0.74.9)
+    - ReactCommon/turbomodule/bridging (= 0.74.9)
+    - ReactCommon/turbomodule/core (= 0.74.9)
+  - ReactCommon/turbomodule/bridging (0.74.9):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-    - RCT-Folly (= 2022.05.16.00)
-    - React-callinvoker (= 0.73.23)
-    - React-cxxreact (= 0.73.23)
-    - React-jsi (= 0.73.23)
-    - React-logger (= 0.73.23)
-    - React-perflogger (= 0.73.23)
-  - ReactCommon/turbomodule/core (0.73.23):
+    - RCT-Folly (= 2024.01.01.00)
+    - React-callinvoker (= 0.74.9)
+    - React-cxxreact (= 0.74.9)
+    - React-jsi (= 0.74.9)
+    - React-logger (= 0.74.9)
+    - React-perflogger (= 0.74.9)
+  - ReactCommon/turbomodule/core (0.74.9):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-    - RCT-Folly (= 2022.05.16.00)
-    - React-callinvoker (= 0.73.23)
-    - React-cxxreact (= 0.73.23)
-    - React-jsi (= 0.73.23)
-    - React-logger (= 0.73.23)
-    - React-perflogger (= 0.73.23)
-  - ReactNativeHost (0.4.6):
+    - RCT-Folly (= 2024.01.01.00)
+    - React-callinvoker (= 0.74.9)
+    - React-cxxreact (= 0.74.9)
+    - React-debug (= 0.74.9)
+    - React-jsi (= 0.74.9)
+    - React-logger (= 0.74.9)
+    - React-perflogger (= 0.74.9)
+    - React-utils (= 0.74.9)
+  - ReactNativeHost (0.5.0):
+    - DoubleConversion
     - glog
-    - RCT-Folly (= 2022.05.16.00)
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Codegen
     - React-Core
     - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - ReactTestApp-DevSupport (3.5.3):
+    - Yoga
+  - ReactTestApp-DevSupport (3.10.14):
     - React-Core
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
-  - RNCPicker (2.7.2):
+  - RNCPicker (2.8.1):
     - React-Core
-  - RNSVG (14.1.0):
+  - RNSVG (15.1.0):
     - React-Core
   - SocketRocket (0.7.0)
-  - Yoga (1.14.0)
+  - Yoga (0.0.0)
 
 DEPENDENCIES:
   - boost (from `../../../node_modules/react-native-macos/third-party-podspecs/boost.podspec`)
   - DoubleConversion (from `../../../node_modules/react-native-macos/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../../../node_modules/react-native-macos/Libraries/FBLazyVector`)
-  - FBReactNativeSpec (from `../../../node_modules/react-native-macos/React/FBReactNativeSpec`)
   - fmt (from `../../../node_modules/react-native-macos/third-party-podspecs/fmt.podspec`)
   - FRNAvatar (from `../../../packages/experimental/Avatar/FRNAvatar.podspec`)
-  - FRNCallout (from `../../../packages/components/Callout/FRNCallout.podspec`)
   - FRNCheckbox (from `../../../packages/experimental/Checkbox/FRNCheckbox.podspec`)
   - FRNMenuButton (from `../../../packages/components/MenuButton/FRNMenuButton.podspec`)
   - FRNRadioButton (from `../../../packages/components/RadioGroup/FRNRadioButton.podspec`)
@@ -1131,8 +1247,9 @@ DEPENDENCIES:
   - glog (from `../../../node_modules/react-native-macos/third-party-podspecs/glog.podspec`)
   - RCT-Folly (from `../../../node_modules/react-native-macos/third-party-podspecs/RCT-Folly.podspec`)
   - RCT-Folly/Fabric (from `../../../node_modules/react-native-macos/third-party-podspecs/RCT-Folly.podspec`)
+  - RCTDeprecation (from `../../../node_modules/react-native-macos/ReactApple/Libraries/RCTFoundation/RCTDeprecation`)
   - RCTFocusZone (from `../../../packages/components/FocusZone/RCTFocusZone.podspec`)
-  - RCTRequired (from `../../../node_modules/react-native-macos/Libraries/RCTRequired`)
+  - RCTRequired (from `../../../node_modules/react-native-macos/Libraries/Required`)
   - RCTTypeSafety (from `../../../node_modules/react-native-macos/Libraries/TypeSafety`)
   - React (from `../../../node_modules/react-native-macos/`)
   - React-callinvoker (from `../../../node_modules/react-native-macos/ReactCommon/callinvoker`)
@@ -1144,6 +1261,7 @@ DEPENDENCIES:
   - React-debug (from `../../../node_modules/react-native-macos/ReactCommon/react/debug`)
   - React-Fabric (from `../../../node_modules/react-native-macos/ReactCommon`)
   - React-FabricImage (from `../../../node_modules/react-native-macos/ReactCommon`)
+  - React-featureflags (from `../../../node_modules/react-native-macos/ReactCommon/react/featureflags`)
   - React-graphics (from `../../../node_modules/react-native-macos/ReactCommon/react/renderer/graphics`)
   - React-ImageManager (from `../../../node_modules/react-native-macos/ReactCommon/react/renderer/imagemanager/platform/ios`)
   - React-jsc (from `../../../node_modules/react-native-macos/ReactCommon/jsc`)
@@ -1151,6 +1269,7 @@ DEPENDENCIES:
   - React-jsi (from `../../../node_modules/react-native-macos/ReactCommon/jsi`)
   - React-jsiexecutor (from `../../../node_modules/react-native-macos/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../../../node_modules/react-native-macos/ReactCommon/jsinspector-modern`)
+  - React-jsitracing (from `../../../node_modules/react-native-macos/ReactCommon/hermes/executor/`)
   - React-logger (from `../../../node_modules/react-native-macos/ReactCommon/logger`)
   - React-Mapbuffer (from `../../../node_modules/react-native-macos/ReactCommon`)
   - React-nativeconfig (from `../../../node_modules/react-native-macos/ReactCommon`)
@@ -1169,6 +1288,8 @@ DEPENDENCIES:
   - React-RCTVibration (from `../../../node_modules/react-native-macos/Libraries/Vibration`)
   - React-rendererdebug (from `../../../node_modules/react-native-macos/ReactCommon/react/renderer/debug`)
   - React-rncore (from `../../../node_modules/react-native-macos/ReactCommon`)
+  - React-RuntimeApple (from `../../../node_modules/react-native-macos/ReactCommon/react/runtime/platform/ios`)
+  - React-RuntimeCore (from `../../../node_modules/react-native-macos/ReactCommon/react/runtime`)
   - React-runtimeexecutor (from `../../../node_modules/react-native-macos/ReactCommon/runtimeexecutor`)
   - React-runtimescheduler (from `../../../node_modules/react-native-macos/ReactCommon/react/renderer/runtimescheduler`)
   - React-utils (from `../../../node_modules/react-native-macos/ReactCommon/react/utils`)
@@ -1192,14 +1313,10 @@ EXTERNAL SOURCES:
     :podspec: "../../../node_modules/react-native-macos/third-party-podspecs/DoubleConversion.podspec"
   FBLazyVector:
     :path: "../../../node_modules/react-native-macos/Libraries/FBLazyVector"
-  FBReactNativeSpec:
-    :path: "../../../node_modules/react-native-macos/React/FBReactNativeSpec"
   fmt:
     :podspec: "../../../node_modules/react-native-macos/third-party-podspecs/fmt.podspec"
   FRNAvatar:
     :path: "../../../packages/experimental/Avatar/FRNAvatar.podspec"
-  FRNCallout:
-    :path: "../../../packages/components/Callout/FRNCallout.podspec"
   FRNCheckbox:
     :path: "../../../packages/experimental/Checkbox/FRNCheckbox.podspec"
   FRNMenuButton:
@@ -1212,10 +1329,12 @@ EXTERNAL SOURCES:
     :podspec: "../../../node_modules/react-native-macos/third-party-podspecs/glog.podspec"
   RCT-Folly:
     :podspec: "../../../node_modules/react-native-macos/third-party-podspecs/RCT-Folly.podspec"
+  RCTDeprecation:
+    :path: "../../../node_modules/react-native-macos/ReactApple/Libraries/RCTFoundation/RCTDeprecation"
   RCTFocusZone:
     :path: "../../../packages/components/FocusZone/RCTFocusZone.podspec"
   RCTRequired:
-    :path: "../../../node_modules/react-native-macos/Libraries/RCTRequired"
+    :path: "../../../node_modules/react-native-macos/Libraries/Required"
   RCTTypeSafety:
     :path: "../../../node_modules/react-native-macos/Libraries/TypeSafety"
   React:
@@ -1236,6 +1355,8 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native-macos/ReactCommon"
   React-FabricImage:
     :path: "../../../node_modules/react-native-macos/ReactCommon"
+  React-featureflags:
+    :path: "../../../node_modules/react-native-macos/ReactCommon/react/featureflags"
   React-graphics:
     :path: "../../../node_modules/react-native-macos/ReactCommon/react/renderer/graphics"
   React-ImageManager:
@@ -1250,6 +1371,8 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native-macos/ReactCommon/jsiexecutor"
   React-jsinspector:
     :path: "../../../node_modules/react-native-macos/ReactCommon/jsinspector-modern"
+  React-jsitracing:
+    :path: "../../../node_modules/react-native-macos/ReactCommon/hermes/executor/"
   React-logger:
     :path: "../../../node_modules/react-native-macos/ReactCommon/logger"
   React-Mapbuffer:
@@ -1286,6 +1409,10 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native-macos/ReactCommon/react/renderer/debug"
   React-rncore:
     :path: "../../../node_modules/react-native-macos/ReactCommon"
+  React-RuntimeApple:
+    :path: "../../../node_modules/react-native-macos/ReactCommon/react/runtime/platform/ios"
+  React-RuntimeCore:
+    :path: "../../../node_modules/react-native-macos/ReactCommon/react/runtime"
   React-runtimeexecutor:
     :path: "../../../node_modules/react-native-macos/ReactCommon/runtimeexecutor"
   React-runtimescheduler:
@@ -1311,68 +1438,71 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 0686b6af8cbd638c784fea5afb789be66699823c
-  DoubleConversion: b27dc0920d7399c3d0135ef9089b1dc4d0403a2a
-  FBLazyVector: 306614a81f027c2c55fd9af49c88251faf39fc4b
-  FBReactNativeSpec: ca9057568381185351d63a8ba8477b84e6114b87
-  fmt: c62421983dfc7fa3d78183aad21a532cb344a337
-  FRNAvatar: 8644d96d82d5c218d46332a019584ef59a31d18f
-  FRNCallout: 4f51ee161a31a1587dae60c775903dc74f2da4c4
-  FRNCheckbox: 013604c9fbb9b62cd9d08d159b3fb9e5db4ccb4e
-  FRNMenuButton: 1afccb6313e5efd3edfa96ede7a6adfb2181e358
-  FRNRadioButton: dbd7f95df09409c9dd711f17c8f7df3a19fe37d8
-  FRNVibrancyView: 3841406eefe2f664738c7d44cd6c2fbe3f47f122
-  glog: 48990dc5c7733bd923abbd8f3acf1f4e0df9e1c8
+  DoubleConversion: ca54355f8932558971f6643521d62b9bc8231cee
+  FBLazyVector: 4fe2810f698c4db28170d97799a2f77d14939172
+  fmt: 03574da4b7ba40de39da59677ca66610ce8c4a02
+  FRNAvatar: b3f7b3d328e6aaf765c506e3b866869cc4e0afd0
+  FRNCheckbox: 17cca10dc53dcdabf8df34b54e135ad3b4b3f5c9
+  FRNMenuButton: cf45a2932e4c7387aca4a5167d0434310f2195eb
+  FRNRadioButton: f8bd0c15755dd4c4808dddfed5e5afd3c5f8ce9f
+  FRNVibrancyView: 4fc67aa9b2dadf4fe8f05821b918d2ac48df62e1
+  glog: 3a72874c0322c7caf24931d3a2777cb7a3090529
   MicrosoftFluentUI: dde98d8ed3fc306d9ddd0a6f0bc0c1f24fe5275e
-  RCT-Folly: 68e9c0fd4c0f05964afd447041d3ac2d67298f27
-  RCTFocusZone: db671ff4a42eb27e499d9de89c703ad9df39742d
-  RCTRequired: 0d86be1af8c4ef765557018e0476ac9022869d5f
-  RCTTypeSafety: 6afc74501d2c6c6ee4a4bbb484b9c53752103392
-  React: 2ce06df35da7f52e4694191aedcb4e1b0d76a4e2
-  React-callinvoker: f8e323be64fe9103f115e940770d7b7b95748ee6
-  React-Codegen: ca6740b126856a4e3f9992c657cc88ccf2bab6c6
-  React-Core: fb631c38b23dc9338a06fb1aefe08e135cd1cd1b
-  React-CoreModules: 11f65474d81f8e8eb4f488171cd2ecc092ccfc4a
-  React-cxxreact: a192ff47771277cc249858102455df80ca890797
-  React-debug: 066858ace3f13a7089d00e48f8c8f6edb001bbd6
-  React-Fabric: 2f94d59320d5d6c204d46342bb12080545464b77
-  React-FabricImage: 0f49b7e9b1fea6b0f3671edf2f5523c94b215878
-  React-graphics: 6695b24bab2fbb0b6f7542682dffc14d7ccb9f08
-  React-ImageManager: 76a2b4bac6301bd8b76e93c9883b60e44a558134
-  React-jsc: c3f9b675ee7e0e04bf5ec08271c26486441a94d1
-  React-jserrorhandler: 15512c239e42fe9c57fa208b838f9f1374bd56bc
-  React-jsi: 2f4b3d64f6de749272b7a8865e8fedd7276fe62f
-  React-jsiexecutor: ebddf58370b1d2639653f90a828504c6ef24ddd3
-  React-jsinspector: 00ef5ca7a85d38df1fbd99f52bc2d6de53c6f9ca
-  React-logger: 6b658acd36f2adfc44e6ce3b49ada0fc485b40fb
-  React-Mapbuffer: e1b65b681fd6c1eed166e34fa8a97c0eec3df991
-  React-nativeconfig: 9499f81b5c4a3e2d38a1f612348b9329f55dc9c7
-  React-NativeModulesApple: 25277fd60bac5be1c47c192da9133f9ef0142a00
-  React-perflogger: 60cbd75448ce8020b6be1fd7ea9525c1c3e36317
-  React-RCTActionSheet: 3175e96cc9673847c3be43ba0415ca6f959406e8
-  React-RCTAnimation: 021bd715fb8ced2e3d5d51a7f6d6ca9a2f7d10b9
-  React-RCTAppDelegate: 9114972fb31617b632fabe6ed7172fd478e67738
-  React-RCTBlob: 3c8bb397750b4da22aef85e698adeb13cb9cf0e6
-  React-RCTFabric: 200c3a969798078db9962b4a1697d4c7aeb6150a
-  React-RCTImage: 3f09e959ede8078cb72fe247767f2354e2eed0db
-  React-RCTLinking: c9c1df5590dd6e9aa141c97f37076000278e26ca
-  React-RCTNetwork: 8aea848d1be5433b2c0a27effff123e2c5efd07c
-  React-RCTSettings: 04b5b7e3896a88ab3a05d23d8dd882b5cd917589
-  React-RCTText: dd8c5c5d86e993660c63c259153da01a38a131f8
-  React-RCTVibration: d62c50fa38f98631ada2581375c8c2902d615e7a
-  React-rendererdebug: c568e7b539e2e1ec724c787acfc61789ce6e9542
-  React-rncore: aee6e4b7c81d0c25feb6536b93fe96eb6e9f5e04
-  React-runtimeexecutor: 4bf7dfbc9fcba46ce9d8ae12be9e0012875fb002
-  React-runtimescheduler: d9517fb3a156aedd5f9a61cb79d917fa90cf041a
-  React-utils: d73a33aabc2a19f844c40c51cdc2efbf9d8adea0
-  ReactCommon: 041adad16b85208228af27e8ed5aeb317b50802e
-  ReactNativeHost: 339df34d3c2050f37e8909ade6693465e8a947f7
-  ReactTestApp-DevSupport: 1fe22a4a29414ec3227d20b3eb96217ba1ff13d0
+  RCT-Folly: 2edbb9597acadc2312235c7ad6243d49852047a3
+  RCTDeprecation: bb0e3d264084832f3dea6815668d1a4bdbe7ad64
+  RCTFocusZone: ebdc9dece94d549bf564fc0bb9f01bf41ebf08e4
+  RCTRequired: 8cdf4bd042e5a4858537c2334981e07ecd0f2fc9
+  RCTTypeSafety: 017f97087d73f3cc1808d69038f0ccfcfc6fc1e3
+  React: 7cfd84b2162de9a0231d864d5184b20341612fe8
+  React-callinvoker: a4372f204113a5ab98062861a131a437feaef853
+  React-Codegen: 919fa7a601043e682332099436244f34f69a037c
+  React-Core: 725a9009eae7e61b03fef9db99c25d09e577c6e0
+  React-CoreModules: 816df3d3ddd54c487ee2106fbe193d613cf7a6c4
+  React-cxxreact: 2f91d84fcd41903d1b22455231771a333de696ed
+  React-debug: cacd6513ad1193c1888edc66cc4a50e8679a25d5
+  React-Fabric: c6286f26a0de790b01dc60b9e6c6fc739ea53d84
+  React-FabricImage: 085e9db6f8e41c8ee8006d2989b8a72aea129fbd
+  React-featureflags: c72030670d828622685ab19de63cafea2336bc60
+  React-graphics: 59222db3397439c6b72bd243cfebca3df89c262b
+  React-ImageManager: 08118f4d91c899d9e8946dc259efb0e002306a6b
+  React-jsc: a88efeb5f4021825c95260f0bfef3b228c3688ac
+  React-jserrorhandler: 1de2861a88173cc769d95686ee4c8f8a70371a78
+  React-jsi: f21491dbca0260d88f8628b3e26030f6e6dbeb3d
+  React-jsiexecutor: 9a06e41eefa6bd35d8200acd503a78c9b9fe9ccd
+  React-jsinspector: c1d638ad7c57391571971284009ba33825a38ac4
+  React-jsitracing: 342703081d9a6ce473d2484f84e0b929deb76f4f
+  React-logger: 8fcd3d6473fdf4aef9297144e672753c9e2236b7
+  React-Mapbuffer: 2eaa63a2b2a980a29faa8746a6c9a1b43649e044
+  React-nativeconfig: 2d2da33a71f9db6825578591e12c3ecebc47a351
+  React-NativeModulesApple: 1d9dfb458f97c5691e76b7baf0103943833a04a4
+  React-perflogger: 424f08cffc86420ec0a6cf490ef94baf908c8434
+  React-RCTActionSheet: 14591aef7c12b5b0abe41fe25fb475d705b1ca7d
+  React-RCTAnimation: 533c1b6a14f32b9ee5ff8115a07f9d04f0d4a575
+  React-RCTAppDelegate: 642fec4d21c35a56ab13f7cd0bbe0cf14275dc46
+  React-RCTBlob: a4b33cd5068e6809bcb912b1ed0a909e8bad708e
+  React-RCTFabric: 4b13d24c05ab272a32f8a4b3425ad41f033bc670
+  React-RCTImage: b6b544d6b86673e1f1af4acd3d32c1fb11dab8bb
+  React-RCTLinking: 4efd117d1c8c7308e3a973d5f3e32fbc999d4fc1
+  React-RCTNetwork: c27d43d92823c1c81dfa0b9197efc56573575480
+  React-RCTSettings: 2d6480209df10e557d1afbb73289ac395244e4e6
+  React-RCTText: 2d30b412d215d835c5d22878f64976578eb0787f
+  React-RCTVibration: 443b31e1f47126ae5d2e31c125a64f630825aec3
+  React-rendererdebug: 62954934e6ff0fd70154ce628930f33fec047de4
+  React-rncore: cc6ee4792b4a2a6f9fe76acfb044f7fbfa7bcaa3
+  React-RuntimeApple: 5443a97dc40cab35cff35ddaa4724ec225e8b0eb
+  React-RuntimeCore: 90536623f616f5453e820460be8976635e4f8a5a
+  React-runtimeexecutor: 454020388acbd21fe7745f8f4eddd191947b4c88
+  React-runtimescheduler: b27c96402f848a2f6042bfde002965350027fee6
+  React-utils: 3c4b2e52aeccd0b288bf4d32c79ea6ec4791c723
+  ReactCommon: dd6896d5e059fb52f3a7eb45c5beaf90ed22f9a7
+  ReactNativeHost: dce645b2e9026bb18485762c2599509ead34447b
+  ReactTestApp-DevSupport: ed439cce949caf074af3ae05051b4bd157ed4019
   ReactTestApp-Resources: 3c8739a3e3ed26f67f8ab68f13102fb9591301c8
-  RNCPicker: 82ccad5b08259dc09310082118cbb6c136d7da67
-  RNSVG: ba3e7232f45e34b7b47e74472386cf4e1a676d0a
-  SocketRocket: ffef1e643b17817e1ab75f76928e68f8e6d6a3ce
-  Yoga: ebb9d1d4cb060397d5f3e929c9a71f45f136264a
+  RNCPicker: 0b6860a6b208d4046227d2f626ad0722f99a969c
+  RNSVG: 50cf2c7018e57cf5d3522d98d0a3a4dd6bf9d093
+  SocketRocket: f6c6249082c011e6de2de60ed641ef8bbe0cfac9
+  Yoga: 1fe20d495411f7d24ec422b620a0b10abc2c0239
 
-PODFILE CHECKSUM: 0e740f9fca1901b692b84c05390764ca72e2fb41
+PODFILE CHECKSUM: 1c580785758db094d8282f8e1360afc97dfac817
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.15.2

--- a/apps/fluent-tester/macos/Podfile.lock
+++ b/apps/fluent-tester/macos/Podfile.lock
@@ -1,18 +1,18 @@
 PODS:
   - boost (1.83.0)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.74.9)
+  - FBLazyVector (0.74.26)
   - fmt (9.1.0)
-  - FRNAvatar (0.21.2):
+  - FRNAvatar (0.21.4):
     - MicrosoftFluentUI (= 0.13.1)
     - React
-  - FRNCheckbox (0.17.5):
+  - FRNCheckbox (0.17.9):
     - React
-  - FRNMenuButton (0.13.11):
+  - FRNMenuButton (0.13.18):
     - React
-  - FRNRadioButton (0.21.10):
+  - FRNRadioButton (0.21.15):
     - React
-  - FRNVibrancyView (0.2.1):
+  - FRNVibrancyView (0.2.2):
     - React
   - glog (0.3.5)
   - MicrosoftFluentUI (0.13.1):
@@ -100,29 +100,29 @@ PODS:
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-  - RCTDeprecation (0.74.9)
-  - RCTFocusZone (0.19.2):
+  - RCTDeprecation (0.74.26)
+  - RCTFocusZone (0.20.0):
     - React
-  - RCTRequired (0.74.9)
-  - RCTTypeSafety (0.74.9):
-    - FBLazyVector (= 0.74.9)
-    - RCTRequired (= 0.74.9)
-    - React-Core (= 0.74.9)
-  - React (0.74.9):
-    - React-Core (= 0.74.9)
-    - React-Core/DevSupport (= 0.74.9)
-    - React-Core/RCTWebSocket (= 0.74.9)
-    - React-RCTActionSheet (= 0.74.9)
-    - React-RCTAnimation (= 0.74.9)
-    - React-RCTBlob (= 0.74.9)
-    - React-RCTImage (= 0.74.9)
-    - React-RCTLinking (= 0.74.9)
-    - React-RCTNetwork (= 0.74.9)
-    - React-RCTSettings (= 0.74.9)
-    - React-RCTText (= 0.74.9)
-    - React-RCTVibration (= 0.74.9)
-  - React-callinvoker (0.74.9)
-  - React-Codegen (0.74.9):
+  - RCTRequired (0.74.26)
+  - RCTTypeSafety (0.74.26):
+    - FBLazyVector (= 0.74.26)
+    - RCTRequired (= 0.74.26)
+    - React-Core (= 0.74.26)
+  - React (0.74.26):
+    - React-Core (= 0.74.26)
+    - React-Core/DevSupport (= 0.74.26)
+    - React-Core/RCTWebSocket (= 0.74.26)
+    - React-RCTActionSheet (= 0.74.26)
+    - React-RCTAnimation (= 0.74.26)
+    - React-RCTBlob (= 0.74.26)
+    - React-RCTImage (= 0.74.26)
+    - React-RCTLinking (= 0.74.26)
+    - React-RCTNetwork (= 0.74.26)
+    - React-RCTSettings (= 0.74.26)
+    - React-RCTText (= 0.74.26)
+    - React-RCTVibration (= 0.74.26)
+  - React-callinvoker (0.74.26)
+  - React-Codegen (0.74.26):
     - DoubleConversion
     - glog
     - RCT-Folly
@@ -142,11 +142,11 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-Core (0.74.9):
+  - React-Core (0.74.26):
     - glog
     - RCT-Folly (= 2024.01.01.00)
     - RCTDeprecation
-    - React-Core/Default (= 0.74.9)
+    - React-Core/Default (= 0.74.26)
     - React-cxxreact
     - React-featureflags
     - React-jsc
@@ -158,55 +158,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.74.9):
-    - glog
-    - RCT-Folly (= 2024.01.01.00)
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-jsc
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.0)
-    - Yoga
-  - React-Core/Default (0.74.9):
-    - glog
-    - RCT-Folly (= 2024.01.01.00)
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-jsc
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.0)
-    - Yoga
-  - React-Core/DevSupport (0.74.9):
-    - glog
-    - RCT-Folly (= 2024.01.01.00)
-    - RCTDeprecation
-    - React-Core/Default (= 0.74.9)
-    - React-Core/RCTWebSocket (= 0.74.9)
-    - React-cxxreact
-    - React-featureflags
-    - React-jsc
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.0)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.74.9):
+  - React-Core/CoreModulesHeaders (0.74.26):
     - glog
     - RCT-Folly (= 2024.01.01.00)
     - RCTDeprecation
@@ -222,7 +174,39 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.74.9):
+  - React-Core/Default (0.74.26):
+    - glog
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-jsc
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.0)
+    - Yoga
+  - React-Core/DevSupport (0.74.26):
+    - glog
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
+    - React-Core/Default (= 0.74.26)
+    - React-Core/RCTWebSocket (= 0.74.26)
+    - React-cxxreact
+    - React-featureflags
+    - React-jsc
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.0)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.74.26):
     - glog
     - RCT-Folly (= 2024.01.01.00)
     - RCTDeprecation
@@ -238,7 +222,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.74.9):
+  - React-Core/RCTAnimationHeaders (0.74.26):
     - glog
     - RCT-Folly (= 2024.01.01.00)
     - RCTDeprecation
@@ -254,7 +238,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTImageHeaders (0.74.9):
+  - React-Core/RCTBlobHeaders (0.74.26):
     - glog
     - RCT-Folly (= 2024.01.01.00)
     - RCTDeprecation
@@ -270,7 +254,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.74.9):
+  - React-Core/RCTImageHeaders (0.74.26):
     - glog
     - RCT-Folly (= 2024.01.01.00)
     - RCTDeprecation
@@ -286,7 +270,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.74.9):
+  - React-Core/RCTLinkingHeaders (0.74.26):
     - glog
     - RCT-Folly (= 2024.01.01.00)
     - RCTDeprecation
@@ -302,7 +286,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.74.9):
+  - React-Core/RCTNetworkHeaders (0.74.26):
     - glog
     - RCT-Folly (= 2024.01.01.00)
     - RCTDeprecation
@@ -318,7 +302,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTTextHeaders (0.74.9):
+  - React-Core/RCTSettingsHeaders (0.74.26):
     - glog
     - RCT-Folly (= 2024.01.01.00)
     - RCTDeprecation
@@ -334,7 +318,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.74.9):
+  - React-Core/RCTTextHeaders (0.74.26):
     - glog
     - RCT-Folly (= 2024.01.01.00)
     - RCTDeprecation
@@ -350,11 +334,11 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTWebSocket (0.74.9):
+  - React-Core/RCTVibrationHeaders (0.74.26):
     - glog
     - RCT-Folly (= 2024.01.01.00)
     - RCTDeprecation
-    - React-Core/Default (= 0.74.9)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-jsc
@@ -366,35 +350,51 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-CoreModules (0.74.9):
+  - React-Core/RCTWebSocket (0.74.26):
+    - glog
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
+    - React-Core/Default (= 0.74.26)
+    - React-cxxreact
+    - React-featureflags
+    - React-jsc
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.0)
+    - Yoga
+  - React-CoreModules (0.74.26):
     - DoubleConversion
     - fmt (= 9.1.0)
     - RCT-Folly (= 2024.01.01.00)
-    - RCTTypeSafety (= 0.74.9)
+    - RCTTypeSafety (= 0.74.26)
     - React-Codegen
-    - React-Core/CoreModulesHeaders (= 0.74.9)
-    - React-jsi (= 0.74.9)
+    - React-Core/CoreModulesHeaders (= 0.74.26)
+    - React-jsi (= 0.74.26)
     - React-jsinspector
     - React-NativeModulesApple
     - React-RCTBlob
-    - React-RCTImage (= 0.74.9)
+    - React-RCTImage (= 0.74.26)
     - ReactCommon
     - SocketRocket (= 0.7.0)
-  - React-cxxreact (0.74.9):
+  - React-cxxreact (0.74.26):
     - boost (= 1.83.0)
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.74.9)
-    - React-debug (= 0.74.9)
-    - React-jsi (= 0.74.9)
+    - React-callinvoker (= 0.74.26)
+    - React-debug (= 0.74.26)
+    - React-jsi (= 0.74.26)
     - React-jsinspector
-    - React-logger (= 0.74.9)
-    - React-perflogger (= 0.74.9)
-    - React-runtimeexecutor (= 0.74.9)
-  - React-debug (0.74.9)
-  - React-Fabric (0.74.9):
+    - React-logger (= 0.74.26)
+    - React-perflogger (= 0.74.26)
+    - React-runtimeexecutor (= 0.74.26)
+  - React-debug (0.74.26)
+  - React-Fabric (0.74.26):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -404,20 +404,20 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.74.9)
-    - React-Fabric/attributedstring (= 0.74.9)
-    - React-Fabric/componentregistry (= 0.74.9)
-    - React-Fabric/componentregistrynative (= 0.74.9)
-    - React-Fabric/components (= 0.74.9)
-    - React-Fabric/core (= 0.74.9)
-    - React-Fabric/imagemanager (= 0.74.9)
-    - React-Fabric/leakchecker (= 0.74.9)
-    - React-Fabric/mounting (= 0.74.9)
-    - React-Fabric/scheduler (= 0.74.9)
-    - React-Fabric/telemetry (= 0.74.9)
-    - React-Fabric/templateprocessor (= 0.74.9)
-    - React-Fabric/textlayoutmanager (= 0.74.9)
-    - React-Fabric/uimanager (= 0.74.9)
+    - React-Fabric/animations (= 0.74.26)
+    - React-Fabric/attributedstring (= 0.74.26)
+    - React-Fabric/componentregistry (= 0.74.26)
+    - React-Fabric/componentregistrynative (= 0.74.26)
+    - React-Fabric/components (= 0.74.26)
+    - React-Fabric/core (= 0.74.26)
+    - React-Fabric/imagemanager (= 0.74.26)
+    - React-Fabric/leakchecker (= 0.74.26)
+    - React-Fabric/mounting (= 0.74.26)
+    - React-Fabric/scheduler (= 0.74.26)
+    - React-Fabric/telemetry (= 0.74.26)
+    - React-Fabric/templateprocessor (= 0.74.26)
+    - React-Fabric/textlayoutmanager (= 0.74.26)
+    - React-Fabric/uimanager (= 0.74.26)
     - React-graphics
     - React-jsc
     - React-jsi
@@ -427,26 +427,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/animations (0.74.9):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-graphics
-    - React-jsc
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/attributedstring (0.74.9):
+  - React-Fabric/animations (0.74.26):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -465,7 +446,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistry (0.74.9):
+  - React-Fabric/attributedstring (0.74.26):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -484,7 +465,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistrynative (0.74.9):
+  - React-Fabric/componentregistry (0.74.26):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -503,37 +484,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components (0.74.9):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/inputaccessory (= 0.74.9)
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.74.9)
-    - React-Fabric/components/modal (= 0.74.9)
-    - React-Fabric/components/rncore (= 0.74.9)
-    - React-Fabric/components/root (= 0.74.9)
-    - React-Fabric/components/safeareaview (= 0.74.9)
-    - React-Fabric/components/scrollview (= 0.74.9)
-    - React-Fabric/components/text (= 0.74.9)
-    - React-Fabric/components/textinput (= 0.74.9)
-    - React-Fabric/components/unimplementedview (= 0.74.9)
-    - React-Fabric/components/view (= 0.74.9)
-    - React-graphics
-    - React-jsc
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/components/inputaccessory (0.74.9):
+  - React-Fabric/componentregistrynative (0.74.26):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -552,7 +503,37 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/legacyviewmanagerinterop (0.74.9):
+  - React-Fabric/components (0.74.26):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/inputaccessory (= 0.74.26)
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.74.26)
+    - React-Fabric/components/modal (= 0.74.26)
+    - React-Fabric/components/rncore (= 0.74.26)
+    - React-Fabric/components/root (= 0.74.26)
+    - React-Fabric/components/safeareaview (= 0.74.26)
+    - React-Fabric/components/scrollview (= 0.74.26)
+    - React-Fabric/components/text (= 0.74.26)
+    - React-Fabric/components/textinput (= 0.74.26)
+    - React-Fabric/components/unimplementedview (= 0.74.26)
+    - React-Fabric/components/view (= 0.74.26)
+    - React-graphics
+    - React-jsc
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/inputaccessory (0.74.26):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -571,7 +552,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/modal (0.74.9):
+  - React-Fabric/components/legacyviewmanagerinterop (0.74.26):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -590,7 +571,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/rncore (0.74.9):
+  - React-Fabric/components/modal (0.74.26):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -609,7 +590,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/root (0.74.9):
+  - React-Fabric/components/rncore (0.74.26):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -628,7 +609,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/safeareaview (0.74.9):
+  - React-Fabric/components/root (0.74.26):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -647,7 +628,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/scrollview (0.74.9):
+  - React-Fabric/components/safeareaview (0.74.26):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -666,7 +647,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/text (0.74.9):
+  - React-Fabric/components/scrollview (0.74.26):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -685,7 +666,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/textinput (0.74.9):
+  - React-Fabric/components/text (0.74.26):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -704,7 +685,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/unimplementedview (0.74.9):
+  - React-Fabric/components/textinput (0.74.26):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -723,7 +704,26 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/view (0.74.9):
+  - React-Fabric/components/unimplementedview (0.74.26):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-graphics
+    - React-jsc
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/view (0.74.26):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -743,7 +743,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-Fabric/core (0.74.9):
+  - React-Fabric/core (0.74.26):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -762,7 +762,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/imagemanager (0.74.9):
+  - React-Fabric/imagemanager (0.74.26):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -781,7 +781,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/leakchecker (0.74.9):
+  - React-Fabric/leakchecker (0.74.26):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -800,7 +800,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/mounting (0.74.9):
+  - React-Fabric/mounting (0.74.26):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -819,7 +819,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/scheduler (0.74.9):
+  - React-Fabric/scheduler (0.74.26):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -838,7 +838,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/telemetry (0.74.9):
+  - React-Fabric/telemetry (0.74.26):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -857,7 +857,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/templateprocessor (0.74.9):
+  - React-Fabric/templateprocessor (0.74.26):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -876,7 +876,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/textlayoutmanager (0.74.9):
+  - React-Fabric/textlayoutmanager (0.74.26):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -896,7 +896,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/uimanager (0.74.9):
+  - React-Fabric/uimanager (0.74.26):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -915,33 +915,33 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-FabricImage (0.74.9):
+  - React-FabricImage (0.74.26):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired (= 0.74.9)
-    - RCTTypeSafety (= 0.74.9)
+    - RCTRequired (= 0.74.26)
+    - RCTTypeSafety (= 0.74.26)
     - React-Fabric
     - React-graphics
     - React-ImageManager
     - React-jsc
     - React-jsi
-    - React-jsiexecutor (= 0.74.9)
+    - React-jsiexecutor (= 0.74.26)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - Yoga
-  - React-featureflags (0.74.9)
-  - React-graphics (0.74.9):
+  - React-featureflags (0.74.26)
+  - React-graphics (0.74.26):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - RCT-Folly/Fabric (= 2024.01.01.00)
-    - React-Core/Default (= 0.74.9)
+    - React-Core/Default (= 0.74.26)
     - React-utils
-  - React-ImageManager (0.74.9):
+  - React-ImageManager (0.74.26):
     - glog
     - RCT-Folly/Fabric
     - React-Core/Default
@@ -950,47 +950,47 @@ PODS:
     - React-graphics
     - React-rendererdebug
     - React-utils
-  - React-jsc (0.74.9):
-    - React-jsc/Fabric (= 0.74.9)
-    - React-jsi (= 0.74.9)
-  - React-jsc/Fabric (0.74.9):
-    - React-jsi (= 0.74.9)
-  - React-jserrorhandler (0.74.9):
+  - React-jsc (0.74.26):
+    - React-jsc/Fabric (= 0.74.26)
+    - React-jsi (= 0.74.26)
+  - React-jsc/Fabric (0.74.26):
+    - React-jsi (= 0.74.26)
+  - React-jserrorhandler (0.74.26):
     - RCT-Folly/Fabric (= 2024.01.01.00)
     - React-debug
     - React-jsi
     - React-Mapbuffer
-  - React-jsi (0.74.9):
+  - React-jsi (0.74.26):
     - boost (= 1.83.0)
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - RCT-Folly (= 2024.01.01.00)
-  - React-jsiexecutor (0.74.9):
+  - React-jsiexecutor (0.74.26):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - RCT-Folly (= 2024.01.01.00)
-    - React-cxxreact (= 0.74.9)
-    - React-jsi (= 0.74.9)
+    - React-cxxreact (= 0.74.26)
+    - React-jsi (= 0.74.26)
     - React-jsinspector
-    - React-perflogger (= 0.74.9)
-  - React-jsinspector (0.74.9):
+    - React-perflogger (= 0.74.26)
+  - React-jsinspector (0.74.26):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2024.01.01.00)
     - React-featureflags
     - React-jsi
-    - React-runtimeexecutor (= 0.74.9)
-  - React-jsitracing (0.74.9):
+    - React-runtimeexecutor (= 0.74.26)
+  - React-jsitracing (0.74.26):
     - React-jsi
-  - React-logger (0.74.9):
+  - React-logger (0.74.26):
     - glog
-  - React-Mapbuffer (0.74.9):
+  - React-Mapbuffer (0.74.26):
     - glog
     - React-debug
-  - React-nativeconfig (0.74.9)
-  - React-NativeModulesApple (0.74.9):
+  - React-nativeconfig (0.74.26)
+  - React-NativeModulesApple (0.74.26):
     - glog
     - React-callinvoker
     - React-Core
@@ -1001,10 +1001,10 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-perflogger (0.74.9)
-  - React-RCTActionSheet (0.74.9):
-    - React-Core/RCTActionSheetHeaders (= 0.74.9)
-  - React-RCTAnimation (0.74.9):
+  - React-perflogger (0.74.26)
+  - React-RCTActionSheet (0.74.26):
+    - React-Core/RCTActionSheetHeaders (= 0.74.26)
+  - React-RCTAnimation (0.74.26):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Codegen
@@ -1012,7 +1012,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTAppDelegate (0.74.9):
+  - React-RCTAppDelegate (0.74.26):
     - RCT-Folly (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
@@ -1035,7 +1035,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon
-  - React-RCTBlob (0.74.9):
+  - React-RCTBlob (0.74.26):
     - DoubleConversion
     - fmt (= 9.1.0)
     - RCT-Folly (= 2024.01.01.00)
@@ -1047,7 +1047,7 @@ PODS:
     - React-NativeModulesApple
     - React-RCTNetwork
     - ReactCommon
-  - React-RCTFabric (0.74.9):
+  - React-RCTFabric (0.74.26):
     - glog
     - RCT-Folly/Fabric (= 2024.01.01.00)
     - React-Core
@@ -1067,7 +1067,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - Yoga
-  - React-RCTImage (0.74.9):
+  - React-RCTImage (0.74.26):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Codegen
@@ -1076,14 +1076,14 @@ PODS:
     - React-NativeModulesApple
     - React-RCTNetwork
     - ReactCommon
-  - React-RCTLinking (0.74.9):
+  - React-RCTLinking (0.74.26):
     - React-Codegen
-    - React-Core/RCTLinkingHeaders (= 0.74.9)
-    - React-jsi (= 0.74.9)
+    - React-Core/RCTLinkingHeaders (= 0.74.26)
+    - React-jsi (= 0.74.26)
     - React-NativeModulesApple
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.74.9)
-  - React-RCTNetwork (0.74.9):
+    - ReactCommon/turbomodule/core (= 0.74.26)
+  - React-RCTNetwork (0.74.26):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Codegen
@@ -1091,7 +1091,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTSettings (0.74.9):
+  - React-RCTSettings (0.74.26):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Codegen
@@ -1099,23 +1099,23 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTText (0.74.9):
-    - React-Core/RCTTextHeaders (= 0.74.9)
+  - React-RCTText (0.74.26):
+    - React-Core/RCTTextHeaders (= 0.74.26)
     - Yoga
-  - React-RCTVibration (0.74.9):
+  - React-RCTVibration (0.74.26):
     - RCT-Folly (= 2024.01.01.00)
     - React-Codegen
     - React-Core/RCTVibrationHeaders
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-rendererdebug (0.74.9):
+  - React-rendererdebug (0.74.26):
     - DoubleConversion
     - fmt (= 9.1.0)
     - RCT-Folly (= 2024.01.01.00)
     - React-debug
-  - React-rncore (0.74.9)
-  - React-RuntimeApple (0.74.9):
+  - React-rncore (0.74.26)
+  - React-RuntimeApple (0.74.26):
     - RCT-Folly/Fabric (= 2024.01.01.00)
     - React-callinvoker
     - React-Core/Default
@@ -1132,7 +1132,7 @@ PODS:
     - React-RuntimeCore
     - React-runtimeexecutor
     - React-utils
-  - React-RuntimeCore (0.74.9):
+  - React-RuntimeCore (0.74.26):
     - glog
     - RCT-Folly/Fabric (= 2024.01.01.00)
     - React-cxxreact
@@ -1145,9 +1145,9 @@ PODS:
     - React-runtimeexecutor
     - React-runtimescheduler
     - React-utils
-  - React-runtimeexecutor (0.74.9):
-    - React-jsi (= 0.74.9)
-  - React-runtimescheduler (0.74.9):
+  - React-runtimeexecutor (0.74.26):
+    - React-jsi (= 0.74.26)
+  - React-runtimescheduler (0.74.26):
     - glog
     - RCT-Folly (= 2024.01.01.00)
     - React-callinvoker
@@ -1159,48 +1159,48 @@ PODS:
     - React-rendererdebug
     - React-runtimeexecutor
     - React-utils
-  - React-utils (0.74.9):
+  - React-utils (0.74.26):
     - glog
     - RCT-Folly (= 2024.01.01.00)
     - React-debug
     - React-jsc
-    - React-jsi (= 0.74.9)
-  - ReactCommon (0.74.9):
-    - ReactCommon/turbomodule (= 0.74.9)
-  - ReactCommon/turbomodule (0.74.9):
+    - React-jsi (= 0.74.26)
+  - ReactCommon (0.74.26):
+    - ReactCommon/turbomodule (= 0.74.26)
+  - ReactCommon/turbomodule (0.74.26):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.74.9)
-    - React-cxxreact (= 0.74.9)
-    - React-jsi (= 0.74.9)
-    - React-logger (= 0.74.9)
-    - React-perflogger (= 0.74.9)
-    - ReactCommon/turbomodule/bridging (= 0.74.9)
-    - ReactCommon/turbomodule/core (= 0.74.9)
-  - ReactCommon/turbomodule/bridging (0.74.9):
+    - React-callinvoker (= 0.74.26)
+    - React-cxxreact (= 0.74.26)
+    - React-jsi (= 0.74.26)
+    - React-logger (= 0.74.26)
+    - React-perflogger (= 0.74.26)
+    - ReactCommon/turbomodule/bridging (= 0.74.26)
+    - ReactCommon/turbomodule/core (= 0.74.26)
+  - ReactCommon/turbomodule/bridging (0.74.26):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.74.9)
-    - React-cxxreact (= 0.74.9)
-    - React-jsi (= 0.74.9)
-    - React-logger (= 0.74.9)
-    - React-perflogger (= 0.74.9)
-  - ReactCommon/turbomodule/core (0.74.9):
+    - React-callinvoker (= 0.74.26)
+    - React-cxxreact (= 0.74.26)
+    - React-jsi (= 0.74.26)
+    - React-logger (= 0.74.26)
+    - React-perflogger (= 0.74.26)
+  - ReactCommon/turbomodule/core (0.74.26):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.74.9)
-    - React-cxxreact (= 0.74.9)
-    - React-debug (= 0.74.9)
-    - React-jsi (= 0.74.9)
-    - React-logger (= 0.74.9)
-    - React-perflogger (= 0.74.9)
-    - React-utils (= 0.74.9)
+    - React-callinvoker (= 0.74.26)
+    - React-cxxreact (= 0.74.26)
+    - React-debug (= 0.74.26)
+    - React-jsi (= 0.74.26)
+    - React-logger (= 0.74.26)
+    - React-perflogger (= 0.74.26)
+    - React-utils (= 0.74.26)
   - ReactNativeHost (0.5.0):
     - DoubleConversion
     - glog
@@ -1227,7 +1227,7 @@ PODS:
     - React-Core
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
-  - RNCPicker (2.8.1):
+  - RNCPicker (2.11.0):
     - React-Core
   - RNSVG (15.1.0):
     - React-Core
@@ -1439,69 +1439,69 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: 0686b6af8cbd638c784fea5afb789be66699823c
   DoubleConversion: ca54355f8932558971f6643521d62b9bc8231cee
-  FBLazyVector: 4fe2810f698c4db28170d97799a2f77d14939172
+  FBLazyVector: c0a16f4c0c4b1dcbb3bcab8f6d0f23a0504db29f
   fmt: 03574da4b7ba40de39da59677ca66610ce8c4a02
-  FRNAvatar: b3f7b3d328e6aaf765c506e3b866869cc4e0afd0
-  FRNCheckbox: 17cca10dc53dcdabf8df34b54e135ad3b4b3f5c9
-  FRNMenuButton: cf45a2932e4c7387aca4a5167d0434310f2195eb
-  FRNRadioButton: f8bd0c15755dd4c4808dddfed5e5afd3c5f8ce9f
-  FRNVibrancyView: 4fc67aa9b2dadf4fe8f05821b918d2ac48df62e1
+  FRNAvatar: ec4d219c71bfd3d74306a1fcf94f71393b63359f
+  FRNCheckbox: 80e3700277629ce802b1f07123e564f954d0e9b1
+  FRNMenuButton: f8d84f5ba808757d75d3475b06d735062b482a10
+  FRNRadioButton: 8a2d538d8827eb729457b1356aba3306322cb15c
+  FRNVibrancyView: 0bea754212e6beda209959a701d9d931bbbb4514
   glog: 3a72874c0322c7caf24931d3a2777cb7a3090529
   MicrosoftFluentUI: dde98d8ed3fc306d9ddd0a6f0bc0c1f24fe5275e
-  RCT-Folly: 2edbb9597acadc2312235c7ad6243d49852047a3
-  RCTDeprecation: bb0e3d264084832f3dea6815668d1a4bdbe7ad64
-  RCTFocusZone: ebdc9dece94d549bf564fc0bb9f01bf41ebf08e4
-  RCTRequired: 8cdf4bd042e5a4858537c2334981e07ecd0f2fc9
-  RCTTypeSafety: 017f97087d73f3cc1808d69038f0ccfcfc6fc1e3
-  React: 7cfd84b2162de9a0231d864d5184b20341612fe8
-  React-callinvoker: a4372f204113a5ab98062861a131a437feaef853
-  React-Codegen: 919fa7a601043e682332099436244f34f69a037c
-  React-Core: 725a9009eae7e61b03fef9db99c25d09e577c6e0
-  React-CoreModules: 816df3d3ddd54c487ee2106fbe193d613cf7a6c4
-  React-cxxreact: 2f91d84fcd41903d1b22455231771a333de696ed
-  React-debug: cacd6513ad1193c1888edc66cc4a50e8679a25d5
-  React-Fabric: c6286f26a0de790b01dc60b9e6c6fc739ea53d84
-  React-FabricImage: 085e9db6f8e41c8ee8006d2989b8a72aea129fbd
-  React-featureflags: c72030670d828622685ab19de63cafea2336bc60
-  React-graphics: 59222db3397439c6b72bd243cfebca3df89c262b
-  React-ImageManager: 08118f4d91c899d9e8946dc259efb0e002306a6b
-  React-jsc: a88efeb5f4021825c95260f0bfef3b228c3688ac
-  React-jserrorhandler: 1de2861a88173cc769d95686ee4c8f8a70371a78
-  React-jsi: f21491dbca0260d88f8628b3e26030f6e6dbeb3d
-  React-jsiexecutor: 9a06e41eefa6bd35d8200acd503a78c9b9fe9ccd
-  React-jsinspector: c1d638ad7c57391571971284009ba33825a38ac4
-  React-jsitracing: 342703081d9a6ce473d2484f84e0b929deb76f4f
-  React-logger: 8fcd3d6473fdf4aef9297144e672753c9e2236b7
-  React-Mapbuffer: 2eaa63a2b2a980a29faa8746a6c9a1b43649e044
-  React-nativeconfig: 2d2da33a71f9db6825578591e12c3ecebc47a351
-  React-NativeModulesApple: 1d9dfb458f97c5691e76b7baf0103943833a04a4
-  React-perflogger: 424f08cffc86420ec0a6cf490ef94baf908c8434
-  React-RCTActionSheet: 14591aef7c12b5b0abe41fe25fb475d705b1ca7d
-  React-RCTAnimation: 533c1b6a14f32b9ee5ff8115a07f9d04f0d4a575
-  React-RCTAppDelegate: 642fec4d21c35a56ab13f7cd0bbe0cf14275dc46
-  React-RCTBlob: a4b33cd5068e6809bcb912b1ed0a909e8bad708e
-  React-RCTFabric: 4b13d24c05ab272a32f8a4b3425ad41f033bc670
-  React-RCTImage: b6b544d6b86673e1f1af4acd3d32c1fb11dab8bb
-  React-RCTLinking: 4efd117d1c8c7308e3a973d5f3e32fbc999d4fc1
-  React-RCTNetwork: c27d43d92823c1c81dfa0b9197efc56573575480
-  React-RCTSettings: 2d6480209df10e557d1afbb73289ac395244e4e6
-  React-RCTText: 2d30b412d215d835c5d22878f64976578eb0787f
-  React-RCTVibration: 443b31e1f47126ae5d2e31c125a64f630825aec3
-  React-rendererdebug: 62954934e6ff0fd70154ce628930f33fec047de4
-  React-rncore: cc6ee4792b4a2a6f9fe76acfb044f7fbfa7bcaa3
-  React-RuntimeApple: 5443a97dc40cab35cff35ddaa4724ec225e8b0eb
-  React-RuntimeCore: 90536623f616f5453e820460be8976635e4f8a5a
-  React-runtimeexecutor: 454020388acbd21fe7745f8f4eddd191947b4c88
-  React-runtimescheduler: b27c96402f848a2f6042bfde002965350027fee6
-  React-utils: 3c4b2e52aeccd0b288bf4d32c79ea6ec4791c723
-  ReactCommon: dd6896d5e059fb52f3a7eb45c5beaf90ed22f9a7
-  ReactNativeHost: dce645b2e9026bb18485762c2599509ead34447b
-  ReactTestApp-DevSupport: ed439cce949caf074af3ae05051b4bd157ed4019
+  RCT-Folly: f47da9a444aae485a0528b3bccf0336156009d60
+  RCTDeprecation: a4ed02b64338259139525770b7f3949f2ef80039
+  RCTFocusZone: c4f0729d49acb5fb6c1356632c8b4a845a321f9c
+  RCTRequired: c74accb5f66f64837b8121b2ec2dabb8b4f4fc0f
+  RCTTypeSafety: 6fb2ff6179ac254223084d6ecd7bc032345a1f28
+  React: fc963dbd01b2ce22f712aa15d1d598f1e9b3a9a3
+  React-callinvoker: 82e7d889b86ba300b54ef18940b16fa20ab04965
+  React-Codegen: 62cb9766e5107d025fedf48bf7a8a2b8aebb2abc
+  React-Core: 46ea9111662468e40787fda07159ef913ed3b467
+  React-CoreModules: 7882ae860e267ced43ef3b8225bbaa2dcb4b8b8e
+  React-cxxreact: c1d384a50a8586419cedc9720484e1bb37d5de0d
+  React-debug: 883d0580607f19268a59d33844bf7fb4238b7a98
+  React-Fabric: fd4ac1ef7d074ec79ea1bfada551f79e5660e1e3
+  React-FabricImage: 9a424ee4cbbf1e7472cbb0e8f670d475711b4728
+  React-featureflags: 53e0c285973e169941840536f436d1f4e60d72f7
+  React-graphics: 1c3b80ef125bb9707313bd56bbcf1517b94010f7
+  React-ImageManager: ddb7ff8d125010dd2437b623dbb7445eb35c3335
+  React-jsc: b24475f7f248022aa45d89c03a30723508d13c53
+  React-jserrorhandler: 4cf59f373dd22cb51ac7466ac1ed957a667a8f0b
+  React-jsi: 7ec8d9c4e51760f608a225f6cd2c107ffeebb567
+  React-jsiexecutor: fbe91bb37ee3de573d17f1e4f234561639f331b9
+  React-jsinspector: 45d4292f47d955b8a5cd3e8df2230329e17adcd8
+  React-jsitracing: d261599e03626dd9897b357164b16278d71fd8bb
+  React-logger: bf03a47ee6524d19fe5b0dfbee496727007f84e5
+  React-Mapbuffer: 09644b0a397f34540702d603aaee0c0ddb29a725
+  React-nativeconfig: 6568b63c37a63bdbdd742aa2e82545c54e28e344
+  React-NativeModulesApple: 233995dca705f40a8020fe2a30faa3f0bfe8f54a
+  React-perflogger: b4d8950961480a8b6151422053d70f7f6d403a39
+  React-RCTActionSheet: 6820531bc07b8f90ee80b7fba4aef35dee1d360b
+  React-RCTAnimation: 8b654e11112a6612b355970b9a0a1338968de540
+  React-RCTAppDelegate: 194bec4e71421d48a762d3fee5850f307c70d17f
+  React-RCTBlob: 3be52237fe74e75c6e4465310efd0e2032153d71
+  React-RCTFabric: 6bbdf5d8e18e664a9b9cdb77c82ec6f81fbc0f53
+  React-RCTImage: 8f698818d6c3692266fea59460d6a10a40cc658e
+  React-RCTLinking: 152f62317fa6ddc7cb42ebd566b0c06510f9c1a0
+  React-RCTNetwork: 8183a7705e993d342d7dac0a044d4ae1f49dcb9f
+  React-RCTSettings: 18f042eb55d4dc1dea0a3cc4622749b8c363ef99
+  React-RCTText: 0b60da669ed94f1b653afd7bbfe41b132ac09a4e
+  React-RCTVibration: 7b7120c0ffec903a8137174b35d6116492517c11
+  React-rendererdebug: 438bc2d55acd2f17a3abffea75333297a358cac0
+  React-rncore: 18685b22bb66be0b46bb220821957ad936d2d4f4
+  React-RuntimeApple: 7c23b35e51d3ce632198d709c9d0dccda5b7582c
+  React-RuntimeCore: 58e3bdf47896736e2a89572b05d1e7af2d76fa73
+  React-runtimeexecutor: 75b8822c170990e3f7e69e5c62e9612506aa5f6f
+  React-runtimescheduler: 5005e37d744f42b69d8c03b6dee814b3602186a5
+  React-utils: a3b8f5201246e13dae2d96ff6d31d4cf097cf99c
+  ReactCommon: 45d7a177fdb3e4775690c14090ed33ea304b915f
+  ReactNativeHost: 9205ed2a753cd228224a46304fbc0a870739aaf3
+  ReactTestApp-DevSupport: 43823cc40f7f4a3022ba44e4e46fa3f92037b4a4
   ReactTestApp-Resources: 3c8739a3e3ed26f67f8ab68f13102fb9591301c8
-  RNCPicker: 0b6860a6b208d4046227d2f626ad0722f99a969c
-  RNSVG: 50cf2c7018e57cf5d3522d98d0a3a4dd6bf9d093
+  RNCPicker: 124b4fb5859ba1a3fd53a91e16d1e7a0fc016e59
+  RNSVG: a31e321979e3001f56ba9331d10ac917f8ad1851
   SocketRocket: f6c6249082c011e6de2de60ed641ef8bbe0cfac9
-  Yoga: 1fe20d495411f7d24ec422b620a0b10abc2c0239
+  Yoga: a8083ca7391c2934c00e0435bd8db19eba8a0d54
 
 PODFILE CHECKSUM: 1c580785758db094d8282f8e1360afc97dfac817
 

--- a/apps/fluent-tester/package.json
+++ b/apps/fluent-tester/package.json
@@ -88,10 +88,10 @@
     "@react-native-picker/picker": "^2.7.0",
     "@warren-ms/react-native-icons": "^0.0.13",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-svg": "^15.0.0",
-    "react-native-windows": "^0.73.0",
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0",
     "tslib": "^2.3.1"
   },
   "devDependencies": {
@@ -100,9 +100,9 @@
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/focus-zone": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-babel-transformer": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-babel-transformer": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "@rnx-kit/cli": "^0.16.2",
     "@rnx-kit/metro-config": "^1.3.1",
     "@types/jasmine": "5.1.4",
@@ -110,9 +110,9 @@
     "@wdio/globals": "^8.40.0",
     "@wdio/jasmine-framework": "^8.40.0",
     "flow-bin": "^0.113.0",
-    "metro-config": "^0.80.0",
+    "metro-config": "^0.80.3",
     "react-native-svg-transformer": "^1.0.0",
-    "react-native-test-app": "^3.4.7",
+    "react-native-test-app": "^3.9.2",
     "react-test-renderer": "18.2.0",
     "webdriverio": "^8.40.0"
   },
@@ -176,7 +176,7 @@
         "@fluentui-react-native/scripts/align-deps-preset.js"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
         "core-android",
@@ -188,7 +188,8 @@
         "react",
         "react-test-renderer",
         "svg",
-        "test-app"
+        "test-app",
+        "metro-react-native-babel-transformer"
       ]
     }
   },

--- a/apps/win32/package.json
+++ b/apps/win32/package.json
@@ -32,8 +32,8 @@
   "dependencies": {
     "@fluentui-react-native/tester": "workspace:*",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-svg": "^15.0.0",
+    "react-native": "^0.74.0",
+    "react-native-svg": "^15.4.0",
     "tslib": "^2.3.1"
   },
   "devDependencies": {
@@ -41,13 +41,13 @@
     "@fluentui-react-native/scripts": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",
     "@office-iss/rex-win32": "0.73.11-devmain.16.0.17614.15010",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-babel-transformer": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-babel-transformer": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "@rnx-kit/cli": "^0.16.2",
     "@rnx-kit/metro-config": "^1.3.1",
     "@types/react": "^18.2.0",
-    "metro-config": "^0.80.0",
+    "metro-config": "^0.80.3",
     "react-native-svg-transformer": "^1.0.0",
     "react-test-renderer": "18.2.0",
     "rimraf": "^5.0.1",
@@ -92,12 +92,13 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
         "babel-preset-react-native",
         "core",
         "metro-config",
+        "metro-react-native-babel-transformer",
         "react",
         "react-test-renderer",
         "svg"

--- a/change/@fluentui-react-native-6be2e06c-11a8-4871-a4bd-672065217720.json
+++ b/change/@fluentui-react-native-6be2e06c-11a8-4871-a4bd-672065217720.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui/react-native",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-adapters-bd056313-f02d-4a43-b660-4150e14ac6b2.json
+++ b/change/@fluentui-react-native-adapters-bd056313-f02d-4a43-b660-4150e14ac6b2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/adapters",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-android-theme-5242572c-8af8-4c8b-a25d-1d897183170a.json
+++ b/change/@fluentui-react-native-android-theme-5242572c-8af8-4c8b-a25d-1d897183170a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/android-theme",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-apple-theme-93326605-bc78-4104-82bd-abb4c46e3e1f.json
+++ b/change/@fluentui-react-native-apple-theme-93326605-bc78-4104-82bd-abb4c46e3e1f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/apple-theme",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-avatar-57cf412f-0498-4320-b3af-f89b83507035.json
+++ b/change/@fluentui-react-native-avatar-57cf412f-0498-4320-b3af-f89b83507035.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/avatar",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-badge-69cd7fdc-7bfc-4fb0-9528-6cef5fcbc118.json
+++ b/change/@fluentui-react-native-badge-69cd7fdc-7bfc-4fb0-9528-6cef5fcbc118.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/badge",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-button-6cf3f38d-b08c-4874-897c-6355fb4472a5.json
+++ b/change/@fluentui-react-native-button-6cf3f38d-b08c-4874-897c-6355fb4472a5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/button",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-callout-8145de24-915e-4f13-9e3c-a935011aec3a.json
+++ b/change/@fluentui-react-native-callout-8145de24-915e-4f13-9e3c-a935011aec3a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/callout",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-checkbox-ef8904cd-e677-4f87-9ccc-8fa1931b433c.json
+++ b/change/@fluentui-react-native-checkbox-ef8904cd-e677-4f87-9ccc-8fa1931b433c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/checkbox",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-chip-321bfc94-fe46-4e2d-a009-368eb6e11d29.json
+++ b/change/@fluentui-react-native-chip-321bfc94-fe46-4e2d-a009-368eb6e11d29.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/chip",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-composition-d8cd24d0-ed46-4ace-a430-8144bafb1908.json
+++ b/change/@fluentui-react-native-composition-d8cd24d0-ed46-4ace-a430-8144bafb1908.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/composition",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-contextual-menu-401652fa-318e-45cf-9b90-4a40e9b5634d.json
+++ b/change/@fluentui-react-native-contextual-menu-401652fa-318e-45cf-9b90-4a40e9b5634d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/contextual-menu",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-default-theme-4db8877a-f526-40bd-9a9b-66c28493c3ce.json
+++ b/change/@fluentui-react-native-default-theme-4db8877a-f526-40bd-9a9b-66c28493c3ce.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/default-theme",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-dependency-profiles-1b9ca962-60f3-4572-8c10-475c220b07b7.json
+++ b/change/@fluentui-react-native-dependency-profiles-1b9ca962-60f3-4572-8c10-475c220b07b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/dependency-profiles",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-divider-3e014081-49bb-414e-8f86-35f53d18e93d.json
+++ b/change/@fluentui-react-native-divider-3e014081-49bb-414e-8f86-35f53d18e93d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/divider",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-drawer-9afe69fe-075c-41a2-9e47-bb2d0f37d3ef.json
+++ b/change/@fluentui-react-native-drawer-9afe69fe-075c-41a2-9e47-bb2d0f37d3ef.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/drawer",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-dropdown-1c732a80-09ed-45ae-8576-677fd514608f.json
+++ b/change/@fluentui-react-native-dropdown-1c732a80-09ed-45ae-8576-677fd514608f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/dropdown",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-e2e-testing-8565f3a7-109c-4650-809c-85ac541b819e.json
+++ b/change/@fluentui-react-native-e2e-testing-8565f3a7-109c-4650-809c-85ac541b819e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/e2e-testing",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-activity-indicator-9192f13c-5abb-4856-8de0-121b14cf4021.json
+++ b/change/@fluentui-react-native-experimental-activity-indicator-9192f13c-5abb-4856-8de0-121b14cf4021.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/experimental-activity-indicator",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-appearance-additions-884b13b3-e8bf-4180-8d0c-05a940700cd9.json
+++ b/change/@fluentui-react-native-experimental-appearance-additions-884b13b3-e8bf-4180-8d0c-05a940700cd9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/experimental-appearance-additions",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-avatar-eb20d1ef-44f1-4bd6-9555-180db006fa5e.json
+++ b/change/@fluentui-react-native-experimental-avatar-eb20d1ef-44f1-4bd6-9555-180db006fa5e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/experimental-avatar",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-checkbox-53faa70e-1a13-4ea1-9e01-a8caace0fe33.json
+++ b/change/@fluentui-react-native-experimental-checkbox-53faa70e-1a13-4ea1-9e01-a8caace0fe33.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/experimental-checkbox",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-expander-812593ab-753c-4493-8c42-b3f48c66bb79.json
+++ b/change/@fluentui-react-native-experimental-expander-812593ab-753c-4493-8c42-b3f48c66bb79.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/experimental-expander",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-menu-button-985a2d4b-aebb-4a4d-bd6d-f4ec079c059d.json
+++ b/change/@fluentui-react-native-experimental-menu-button-985a2d4b-aebb-4a4d-bd6d-f4ec079c059d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/experimental-menu-button",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-native-date-picker-54ea9289-70f3-4f84-9bd9-061f0150761f.json
+++ b/change/@fluentui-react-native-experimental-native-date-picker-54ea9289-70f3-4f84-9bd9-061f0150761f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/experimental-native-date-picker",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-native-font-metrics-3d99c705-a501-4d2c-981a-5dd8311f3a94.json
+++ b/change/@fluentui-react-native-experimental-native-font-metrics-3d99c705-a501-4d2c-981a-5dd8311f3a94.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/experimental-native-font-metrics",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-shadow-590eba81-39fb-4f9d-b8c0-194b3d59c943.json
+++ b/change/@fluentui-react-native-experimental-shadow-590eba81-39fb-4f9d-b8c0-194b3d59c943.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/experimental-shadow",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-shimmer-74d57ef2-e179-46bc-a593-e9cb1d7f75f4.json
+++ b/change/@fluentui-react-native-experimental-shimmer-74d57ef2-e179-46bc-a593-e9cb1d7f75f4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/experimental-shimmer",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-focus-trap-zone-cea2e0df-6794-4f22-a9a0-8c4742b45e59.json
+++ b/change/@fluentui-react-native-focus-trap-zone-cea2e0df-6794-4f22-a9a0-8c4742b45e59.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/focus-trap-zone",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-focus-zone-450b86b3-e827-4054-ab3c-965f21ca2e8c.json
+++ b/change/@fluentui-react-native-focus-zone-450b86b3-e827-4054-ab3c-965f21ca2e8c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/focus-zone",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-framework-4714bb7c-ed0f-4f85-8a32-798ff85e65fb.json
+++ b/change/@fluentui-react-native-framework-4714bb7c-ed0f-4f85-8a32-798ff85e65fb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/framework",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-icon-2369cbfa-0d0b-4e39-8411-b22effea2e60.json
+++ b/change/@fluentui-react-native-icon-2369cbfa-0d0b-4e39-8411-b22effea2e60.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/icon",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-input-94144590-492d-4aa8-ae04-87307bc042a4.json
+++ b/change/@fluentui-react-native-input-94144590-492d-4aa8-ae04-87307bc042a4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/input",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-interactive-hooks-5d1a4191-f18a-451e-8186-1b33f083ce99.json
+++ b/change/@fluentui-react-native-interactive-hooks-5d1a4191-f18a-451e-8186-1b33f083ce99.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/interactive-hooks",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-link-c84d31bc-3975-48bb-ad65-fff0c703383a.json
+++ b/change/@fluentui-react-native-link-c84d31bc-3975-48bb-ad65-fff0c703383a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/link",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-menu-button-bd96991c-6523-4119-a7f1-b5302845c94c.json
+++ b/change/@fluentui-react-native-menu-button-bd96991c-6523-4119-a7f1-b5302845c94c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/menu-button",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-menu-d7ba6a5f-e0e8-4b3c-8076-07051532f572.json
+++ b/change/@fluentui-react-native-menu-d7ba6a5f-e0e8-4b3c-8076-07051532f572.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-merge-props-a9aff95b-b8d6-49ed-9153-440622d905ec.json
+++ b/change/@fluentui-react-native-merge-props-a9aff95b-b8d6-49ed-9153-440622d905ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/merge-props",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-notification-3ebeee24-819c-4f6d-a73a-d8fb5651a908.json
+++ b/change/@fluentui-react-native-notification-3ebeee24-819c-4f6d-a73a-d8fb5651a908.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/notification",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-overflow-219839f0-578c-4458-9a07-600accaad47f.json
+++ b/change/@fluentui-react-native-overflow-219839f0-578c-4458-9a07-600accaad47f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/overflow",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-persona-5106242a-844e-4cea-a917-15d0be7332c0.json
+++ b/change/@fluentui-react-native-persona-5106242a-844e-4cea-a917-15d0be7332c0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/persona",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-persona-coin-6c7b98bb-9f30-4fb5-9424-eb661ca8e4b6.json
+++ b/change/@fluentui-react-native-persona-coin-6c7b98bb-9f30-4fb5-9424-eb661ca8e4b6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/persona-coin",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-popover-a21cf26f-6e12-41c4-99d7-1a1e4dafddba.json
+++ b/change/@fluentui-react-native-popover-a21cf26f-6e12-41c4-99d7-1a1e4dafddba.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/popover",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-pressable-ca310547-7100-46bb-bca9-7870f453cb13.json
+++ b/change/@fluentui-react-native-pressable-ca310547-7100-46bb-bca9-7870f453cb13.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/pressable",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-radio-group-09fde559-3919-4942-9893-0d7c2c16ea3b.json
+++ b/change/@fluentui-react-native-radio-group-09fde559-3919-4942-9893-0d7c2c16ea3b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/radio-group",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-separator-b2139a3b-cb78-4dce-85cf-00a56a8f11f5.json
+++ b/change/@fluentui-react-native-separator-b2139a3b-cb78-4dce-85cf-00a56a8f11f5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/separator",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-spinner-bff4f043-2ed5-4937-a0bc-8eef9d062cfc.json
+++ b/change/@fluentui-react-native-spinner-bff4f043-2ed5-4937-a0bc-8eef9d062cfc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/spinner",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-stack-f29dda24-d366-42f0-a0e1-8e24c12bf3f6.json
+++ b/change/@fluentui-react-native-stack-f29dda24-d366-42f0-a0e1-8e24c12bf3f6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/stack",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-styling-utils-121903c6-beff-4317-ae72-1fc89ba8f0e6.json
+++ b/change/@fluentui-react-native-styling-utils-121903c6-beff-4317-ae72-1fc89ba8f0e6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/styling-utils",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-switch-26102b72-39d8-47fc-a176-d4d17f8dc77a.json
+++ b/change/@fluentui-react-native-switch-26102b72-39d8-47fc-a176-d4d17f8dc77a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/switch",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tablist-2b77d039-332e-4804-8e2d-d66de481d37b.json
+++ b/change/@fluentui-react-native-tablist-2b77d039-332e-4804-8e2d-d66de481d37b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/tablist",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-6f869f92-8fce-48bf-9f59-60c0bd8bd5c3.json
+++ b/change/@fluentui-react-native-tester-6f869f92-8fce-48bf-9f59-60c0bd8bd5c3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-win32-63b98743-1d12-4a5b-a1e0-0905fcc940f3.json
+++ b/change/@fluentui-react-native-tester-win32-63b98743-1d12-4a5b-a1e0-0905fcc940f3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/tester-win32",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-text-d68dcd15-8272-46b5-9275-61642faf0916.json
+++ b/change/@fluentui-react-native-text-d68dcd15-8272-46b5-9275-61642faf0916.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/text",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-theme-7dfa43ce-2977-4e7b-af04-269aeb76249d.json
+++ b/change/@fluentui-react-native-theme-7dfa43ce-2977-4e7b-af04-269aeb76249d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/theme",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-theme-tokens-27294711-474b-46d5-a8f1-dd31c200cc11.json
+++ b/change/@fluentui-react-native-theme-tokens-27294711-474b-46d5-a8f1-dd31c200cc11.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/theme-tokens",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-theme-types-1ff9925d-9ad7-49a9-aa65-7a257cfbd4b7.json
+++ b/change/@fluentui-react-native-theme-types-1ff9925d-9ad7-49a9-aa65-7a257cfbd4b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/theme-types",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-themed-stylesheet-82a95e0b-a5a6-4275-83ba-fc5a455a5378.json
+++ b/change/@fluentui-react-native-themed-stylesheet-82a95e0b-a5a6-4275-83ba-fc5a455a5378.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/themed-stylesheet",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-theming-utils-943791b0-f395-4c84-a741-e806764e407d.json
+++ b/change/@fluentui-react-native-theming-utils-943791b0-f395-4c84-a741-e806764e407d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/theming-utils",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tokens-a77a6d53-eba2-4a03-b537-4d88ac073a2f.json
+++ b/change/@fluentui-react-native-tokens-a77a6d53-eba2-4a03-b537-4d88ac073a2f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/tokens",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tooltip-fa3d9178-c6f5-4eb7-8eb9-f928d85e3840.json
+++ b/change/@fluentui-react-native-tooltip-fa3d9178-c6f5-4eb7-8eb9-f928d85e3840.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/tooltip",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-use-slot-872c2470-7aae-45ad-a54a-b168fc4a91a9.json
+++ b/change/@fluentui-react-native-use-slot-872c2470-7aae-45ad-a54a-b168fc4a91a9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/use-slot",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-use-slots-772d642d-4fda-41a8-9d2a-074de045a6b0.json
+++ b/change/@fluentui-react-native-use-slots-772d642d-4fda-41a8-9d2a-074de045a6b0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/use-slots",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-use-styling-cc238971-896e-4a3b-b1ad-ecc230d265c6.json
+++ b/change/@fluentui-react-native-use-styling-cc238971-896e-4a3b-b1ad-ecc230d265c6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/use-styling",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-use-tokens-a7516d01-0a15-426f-884e-39bdd6143d64.json
+++ b/change/@fluentui-react-native-use-tokens-a7516d01-0a15-426f-884e-39bdd6143d64.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/use-tokens",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-vibrancy-view-c3b88e33-3507-411b-a0c8-d31207d4351f.json
+++ b/change/@fluentui-react-native-vibrancy-view-c3b88e33-3507-411b-a0c8-d31207d4351f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/vibrancy-view",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-win32-theme-63493ad5-237d-4e9d-8e11-a1b6a39c4524.json
+++ b/change/@fluentui-react-native-win32-theme-63493ad5-237d-4e9d-8e11-a1b6a39c4524.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@fluentui-react-native/win32-theme",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabricshared-foundation-composable-1a4882b6-692e-4449-ae56-7cf2c796861b.json
+++ b/change/@uifabricshared-foundation-composable-1a4882b6-692e-4449-ae56-7cf2c796861b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@uifabricshared/foundation-composable",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabricshared-foundation-compose-dedde85e-baaf-4b95-a3fc-0760beb94e65.json
+++ b/change/@uifabricshared-foundation-compose-dedde85e-baaf-4b95-a3fc-0760beb94e65.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@uifabricshared/foundation-compose",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabricshared-foundation-settings-d6f4949c-e26f-4181-90ed-3a4cd4d57c0f.json
+++ b/change/@uifabricshared-foundation-settings-d6f4949c-e26f-4181-90ed-3a4cd4d57c0f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@uifabricshared/foundation-settings",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabricshared-foundation-tokens-88d7dc5d-817f-4e48-84be-5e8f3c149383.json
+++ b/change/@uifabricshared-foundation-tokens-88d7dc5d-817f-4e48-84be-5e8f3c149383.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@uifabricshared/foundation-tokens",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabricshared-theme-registry-769ed697-5639-45ab-9260-155f793d9c59.json
+++ b/change/@uifabricshared-theme-registry-769ed697-5639-45ab-9260-155f793d9c59.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@uifabricshared/theme-registry",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabricshared-themed-settings-933b144d-12ac-43a4-a775-a2bf660a0fdc.json
+++ b/change/@uifabricshared-themed-settings-933b144d-12ac-43a4-a775-a2bf660a0fdc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@uifabricshared/themed-settings",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabricshared-theming-ramp-20ecdf50-ec06-4ea3-b1f4-af4bf74dced7.json
+++ b/change/@uifabricshared-theming-ramp-20ecdf50-ec06-4ea3-b1f4-af4bf74dced7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@uifabricshared/theming-ramp",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabricshared-theming-react-native-0182f5ba-d3b1-4a11-a15b-11284909985c.json
+++ b/change/@uifabricshared-theming-react-native-0182f5ba-d3b1-4a11-a15b-11284909985c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update to React Native 0.74",
+  "packageName": "@uifabricshared/theming-react-native",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "change": "beachball change",
     "check-for-changed-files": "cd scripts && yarn fluentui-scripts checkForModifiedFiles",
     "checkchange": "beachball check --changehint \"Run 'yarn change' to generate a change file\"",
-    "align-deps": "rnx-align-deps --requirements react-native@0.73",
+    "align-deps": "rnx-align-deps --requirements react-native@0.74",
     "depcheck": "yarn align-deps && lage depcheck",
     "lint": "lage lint",
     "preinstall": "node ./scripts/use-yarn-please.js",
@@ -39,9 +39,9 @@
     "@babel/preset-env": "^7.8.0",
     "@babel/preset-react": "^7.8.0",
     "@babel/preset-typescript": "^7.8.0",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-babel-transformer": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-babel-transformer": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "@rnx-kit/align-deps": "^2.2.5",
     "babel-jest": "^29.7.0",
     "beachball": "^2.20.0",
@@ -51,12 +51,12 @@
     "markdown-link-check": "^3.8.7",
     "react": "18.2.0",
     "react-dom": "^18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   },
   "peerDependencies": {
     "react": "18.2.0",
     "react-dom": "^18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   },
   "workspaces": [
     "apps/*",
@@ -82,11 +82,12 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
         "babel-preset-react-native",
         "core",
+        "metro-react-native-babel-transformer",
         "react-dom"
       ]
     }

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "scripts"
   ],
   "resolutions": {
+    "@office-iss/react-native-win32": "patch:@office-iss/react-native-win32@npm%3A0.73.6#~/.yarn/patches/@office-iss-react-native-win32-npm-0.73.6-c1424dfcf6.patch",
     "axios": "^1.7.4",
     "es5-ext": "0.10.63",
     "express": "^4.19.2",

--- a/packages/components/Avatar/package.json
+++ b/packages/components/Avatar/package.json
@@ -42,19 +42,21 @@
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-svg": "^14.0.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-svg": "^15.0.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "rnx-kit": {
     "kitType": "library",
@@ -63,12 +65,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react",
         "svg"
       ]

--- a/packages/components/Badge/package.json
+++ b/packages/components/Badge/package.json
@@ -40,19 +40,21 @@
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-svg": "^14.0.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-svg": "^15.0.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "sideEffects": false,
   "rnx-kit": {
@@ -62,12 +64,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react",
         "svg"
       ]

--- a/packages/components/Button/package.json
+++ b/packages/components/Button/package.json
@@ -50,18 +50,21 @@
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-svg": "^15.0.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -73,13 +76,17 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
-        "react"
+        "core-macos",
+        "core-windows",
+        "react",
+        "svg"
       ]
     }
   },

--- a/packages/components/Callout/package.json
+++ b/packages/components/Callout/package.json
@@ -39,17 +39,19 @@
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "rnx-kit": {
     "kitType": "library",
@@ -58,12 +60,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react"
       ]
     }

--- a/packages/components/Checkbox/package.json
+++ b/packages/components/Checkbox/package.json
@@ -50,13 +50,15 @@
     "@react-native/metro-config": "^0.73.0",
     "react": "18.2.0",
     "react-native": "^0.73.0",
-    "react-native-svg": "^14.0.0"
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.0.0",
+    "react-native-windows": "^0.73.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
     "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
+    "react-native-macos": "^0.74.0",
     "react-native-svg": "^15.0.0",
     "react-native-windows": "^0.73.0"
   },
@@ -73,9 +75,12 @@
         "react-native@0.73"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react",
         "svg"
       ]

--- a/packages/components/Chip/package.json
+++ b/packages/components/Chip/package.json
@@ -38,19 +38,21 @@
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-svg": "^14.0.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-svg": "^15.0.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "rnx-kit": {
     "kitType": "library",
@@ -59,12 +61,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react",
         "svg"
       ]

--- a/packages/components/ContextualMenu/package.json
+++ b/packages/components/ContextualMenu/package.json
@@ -45,20 +45,22 @@
     "@fluentui-react-native/pressable": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-svg": "^15.0.0",
-    "react-native-svg-transformer": "^1.0.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-svg-transformer": "^1.0.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-svg": "^15.0.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "rnx-kit": {
     "kitType": "library",
@@ -67,12 +69,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react",
         "svg"
       ]

--- a/packages/components/Divider/package.json
+++ b/packages/components/Divider/package.json
@@ -37,18 +37,21 @@
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-svg": "^15.0.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -59,13 +62,17 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
-        "react"
+        "core-macos",
+        "core-windows",
+        "react",
+        "svg"
       ]
     }
   },

--- a/packages/components/FocusTrapZone/package.json
+++ b/packages/components/FocusTrapZone/package.json
@@ -35,17 +35,19 @@
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -56,12 +58,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react"
       ]
     }

--- a/packages/components/FocusZone/package.json
+++ b/packages/components/FocusZone/package.json
@@ -35,17 +35,19 @@
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -56,12 +58,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react"
       ]
     }

--- a/packages/components/Icon/package.json
+++ b/packages/components/Icon/package.json
@@ -35,19 +35,21 @@
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-svg": "^14.0.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-svg": "^15.0.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -58,12 +60,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react",
         "svg"
       ]

--- a/packages/components/Input/package.json
+++ b/packages/components/Input/package.json
@@ -39,19 +39,21 @@
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-svg": "^14.0.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-svg": "^15.0.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -62,12 +64,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react",
         "svg"
       ]

--- a/packages/components/Link/package.json
+++ b/packages/components/Link/package.json
@@ -41,17 +41,19 @@
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -62,12 +64,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react"
       ]
     }

--- a/packages/components/Menu/package.json
+++ b/packages/components/Menu/package.json
@@ -45,19 +45,21 @@
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-svg": "^14.0.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-svg": "^15.0.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -69,12 +71,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react",
         "svg"
       ]

--- a/packages/components/MenuButton/package.json
+++ b/packages/components/MenuButton/package.json
@@ -41,19 +41,21 @@
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-svg": "^14.0.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-svg": "^15.0.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "rnx-kit": {
     "kitType": "library",
@@ -62,12 +64,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react",
         "svg"
       ]

--- a/packages/components/Notification/package.json
+++ b/packages/components/Notification/package.json
@@ -45,19 +45,21 @@
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-svg": "^14.0.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-svg": "^15.0.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -68,12 +70,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react",
         "svg"
       ]

--- a/packages/components/Persona/package.json
+++ b/packages/components/Persona/package.json
@@ -38,17 +38,19 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -59,12 +61,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react"
       ]
     }

--- a/packages/components/PersonaCoin/package.json
+++ b/packages/components/PersonaCoin/package.json
@@ -39,17 +39,19 @@
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -60,12 +62,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react"
       ]
     }

--- a/packages/components/Pressable/package.json
+++ b/packages/components/Pressable/package.json
@@ -34,17 +34,19 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -55,12 +57,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react"
       ]
     }

--- a/packages/components/RadioGroup/package.json
+++ b/packages/components/RadioGroup/package.json
@@ -45,19 +45,21 @@
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-svg": "^14.0.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-svg": "^15.0.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -69,12 +71,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react",
         "svg"
       ]

--- a/packages/components/Separator/package.json
+++ b/packages/components/Separator/package.json
@@ -34,17 +34,19 @@
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -55,12 +57,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react"
       ]
     }

--- a/packages/components/Stack/package.json
+++ b/packages/components/Stack/package.json
@@ -38,17 +38,19 @@
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/text": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -59,12 +61,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react"
       ]
     }

--- a/packages/components/Switch/package.json
+++ b/packages/components/Switch/package.json
@@ -40,17 +40,19 @@
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -61,12 +63,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react"
       ]
     }

--- a/packages/components/TabList/package.json
+++ b/packages/components/TabList/package.json
@@ -42,18 +42,21 @@
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-svg": "^15.0.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -64,13 +67,17 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
-        "react"
+        "core-macos",
+        "core-windows",
+        "react",
+        "svg"
       ]
     }
   },

--- a/packages/components/Text/package.json
+++ b/packages/components/Text/package.json
@@ -38,17 +38,19 @@
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -59,12 +61,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react"
       ]
     }

--- a/packages/dependency-profiles/package.json
+++ b/packages/dependency-profiles/package.json
@@ -91,10 +91,10 @@
     "@uifabricshared/theming-ramp": "*",
     "@uifabricshared/theming-react-native": "*",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-svg": "^15.0.0",
-    "react-native-windows": "^0.73.0",
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0",
     "workspace-tools": "^0.26.3"
   }
 }

--- a/packages/deprecated/foundation-composable/package.json
+++ b/packages/deprecated/foundation-composable/package.json
@@ -43,6 +43,6 @@
   },
   "peerDependencies": {
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   }
 }

--- a/packages/deprecated/foundation-compose/package.json
+++ b/packages/deprecated/foundation-compose/package.json
@@ -49,9 +49,9 @@
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "depcheck": {
     "ignoreMatches": [

--- a/packages/deprecated/foundation-settings/package.json
+++ b/packages/deprecated/foundation-settings/package.json
@@ -37,15 +37,15 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "@types/jest": "^29.0.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   },
   "peerDependencies": {
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   },
   "rnx-kit": {
     "kitType": "library",
@@ -54,9 +54,10 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios"

--- a/packages/deprecated/foundation-tokens/package.json
+++ b/packages/deprecated/foundation-tokens/package.json
@@ -38,19 +38,21 @@
   "devDependencies": {
     "@fluentui-react-native/memo-cache": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "@types/jest": "^29.0.0",
     "@types/react": "^18.2.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "rnx-kit": {
     "kitType": "library",
@@ -59,12 +61,16 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
-        "core-ios"
+        "core-ios",
+        "core-macos",
+        "core-windows",
+        "react"
       ]
     }
   },

--- a/packages/deprecated/theme-registry/package.json
+++ b/packages/deprecated/theme-registry/package.json
@@ -34,11 +34,11 @@
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/immutable-merge": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "@types/jest": "^29.0.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   },
   "rnx-kit": {
     "kitType": "library",
@@ -47,9 +47,10 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios"
@@ -58,6 +59,6 @@
   },
   "peerDependencies": {
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   }
 }

--- a/packages/deprecated/themed-settings/package.json
+++ b/packages/deprecated/themed-settings/package.json
@@ -37,16 +37,16 @@
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/memo-cache": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "@types/jest": "^29.0.0",
     "@types/node": "^10.3.5",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   },
   "peerDependencies": {
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   },
   "rnx-kit": {
     "kitType": "library",
@@ -55,9 +55,10 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios"

--- a/packages/deprecated/theming-ramp/package.json
+++ b/packages/deprecated/theming-ramp/package.json
@@ -45,6 +45,6 @@
   },
   "peerDependencies": {
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   }
 }

--- a/packages/deprecated/theming-react-native/package.json
+++ b/packages/deprecated/theming-react-native/package.json
@@ -39,20 +39,22 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "@types/jest": "^29.0.0",
     "@types/react": "^18.2.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0",
     "typescript": "4.9.4"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "rnx-kit": {
     "kitType": "library",
@@ -61,12 +63,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react"
       ]
     }

--- a/packages/experimental/ActivityIndicator/package.json
+++ b/packages/experimental/ActivityIndicator/package.json
@@ -32,19 +32,21 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-svg": "^14.0.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-svg": "^15.0.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -55,12 +57,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react",
         "svg"
       ]

--- a/packages/experimental/AppearanceAdditions/package.json
+++ b/packages/experimental/AppearanceAdditions/package.json
@@ -36,18 +36,20 @@
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/framework": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "@types/use-subscription": "1.0.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "rnx-kit": {
     "kitType": "library",
@@ -56,11 +58,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
+        "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react"
       ]
     }

--- a/packages/experimental/Avatar/package.json
+++ b/packages/experimental/Avatar/package.json
@@ -34,17 +34,19 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "rnx-kit": {
     "kitType": "library",
@@ -53,12 +55,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react"
       ]
     }

--- a/packages/experimental/Checkbox/package.json
+++ b/packages/experimental/Checkbox/package.json
@@ -35,18 +35,21 @@
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-svg": "^15.0.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -57,13 +60,17 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
-        "react"
+        "core-macos",
+        "core-windows",
+        "react",
+        "svg"
       ]
     }
   },

--- a/packages/experimental/Drawer/package.json
+++ b/packages/experimental/Drawer/package.json
@@ -34,17 +34,21 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -55,13 +59,17 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
-        "react"
+        "core-macos",
+        "core-windows",
+        "react",
+        "svg"
       ]
     }
   },

--- a/packages/experimental/Dropdown/package.json
+++ b/packages/experimental/Dropdown/package.json
@@ -38,19 +38,21 @@
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-svg": "^14.0.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-svg": "^15.0.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -61,12 +63,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react",
         "svg"
       ]

--- a/packages/experimental/Expander/package.json
+++ b/packages/experimental/Expander/package.json
@@ -35,18 +35,21 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "rnx-kit": {
     "kitType": "library",
@@ -55,14 +58,17 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
         "core-windows",
-        "react"
+        "react",
+        "svg"
       ]
     }
   },

--- a/packages/experimental/MenuButton/package.json
+++ b/packages/experimental/MenuButton/package.json
@@ -35,19 +35,21 @@
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-svg": "^14.0.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-svg": "^15.0.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -58,12 +60,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react",
         "svg"
       ]

--- a/packages/experimental/NativeDatePicker/package.json
+++ b/packages/experimental/NativeDatePicker/package.json
@@ -31,14 +31,14 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   },
   "peerDependencies": {
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   },
   "rnx-kit": {
     "kitType": "library",
@@ -47,9 +47,10 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",

--- a/packages/experimental/NativeDatePicker/src/NativeDatePicker.tsx
+++ b/packages/experimental/NativeDatePicker/src/NativeDatePicker.tsx
@@ -1,4 +1,3 @@
 import type { NativeDatePickerInterface } from './NativeDatePicker.types.mobile';
 
 export const NativeDatePicker = null as NativeDatePickerInterface;
-console.warn('DatePicker not supported');

--- a/packages/experimental/NativeFontMetrics/package.json
+++ b/packages/experimental/NativeFontMetrics/package.json
@@ -34,15 +34,15 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "@types/use-subscription": "1.0.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   },
   "peerDependencies": {
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   },
   "rnx-kit": {
     "kitType": "library",
@@ -51,9 +51,10 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-ios",
         "react"

--- a/packages/experimental/Overflow/package.json
+++ b/packages/experimental/Overflow/package.json
@@ -36,18 +36,21 @@
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-svg": "^14.0.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -58,11 +61,17 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
-        "react"
+        "core-android",
+        "core-ios",
+        "core-macos",
+        "core-windows",
+        "react",
+        "svg"
       ]
     }
   },

--- a/packages/experimental/Popover/package.json
+++ b/packages/experimental/Popover/package.json
@@ -33,17 +33,19 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -54,12 +56,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react"
       ]
     }

--- a/packages/experimental/Shadow/package.json
+++ b/packages/experimental/Shadow/package.json
@@ -34,17 +34,19 @@
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -55,12 +57,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react"
       ]
     }

--- a/packages/experimental/Shimmer/package.json
+++ b/packages/experimental/Shimmer/package.json
@@ -35,19 +35,21 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-svg": "^14.0.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-svg": "^15.0.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -58,12 +60,16 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
+        "react",
         "svg"
       ]
     }

--- a/packages/experimental/Spinner/package.json
+++ b/packages/experimental/Spinner/package.json
@@ -34,19 +34,21 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-svg": "^14.0.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-svg": "^15.0.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -57,12 +59,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react",
         "svg"
       ]

--- a/packages/experimental/Stack/package.json
+++ b/packages/experimental/Stack/package.json
@@ -35,18 +35,20 @@
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/text": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0",
     "tslib": "^2.3.1"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -57,12 +59,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react"
       ]
     }

--- a/packages/experimental/Tooltip/package.json
+++ b/packages/experimental/Tooltip/package.json
@@ -36,18 +36,21 @@
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-svg": "^14.0.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -58,11 +61,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
-        "react"
+        "core-macos",
+        "core-windows",
+        "react",
+        "svg"
       ]
     }
   },

--- a/packages/experimental/VibrancyView/package.json
+++ b/packages/experimental/VibrancyView/package.json
@@ -33,17 +33,19 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -54,12 +56,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react"
       ]
     }

--- a/packages/framework/composition/package.json
+++ b/packages/framework/composition/package.json
@@ -38,14 +38,14 @@
   },
   "devDependencies": {
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   },
   "peerDependencies": {
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   },
   "rnx-kit": {
     "kitType": "library",
@@ -54,9 +54,10 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios"

--- a/packages/framework/framework/package.json
+++ b/packages/framework/framework/package.json
@@ -44,18 +44,22 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "@types/react": "^18.2.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -66,13 +70,17 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
-        "react"
+        "core-macos",
+        "core-windows",
+        "react",
+        "svg"
       ]
     }
   },

--- a/packages/framework/merge-props/package.json
+++ b/packages/framework/merge-props/package.json
@@ -38,15 +38,15 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "@types/jest": "^29.0.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   },
   "peerDependencies": {
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   },
   "rnx-kit": {
     "kitType": "library",
@@ -55,9 +55,10 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios"

--- a/packages/framework/theme/package.json
+++ b/packages/framework/theme/package.json
@@ -37,14 +37,14 @@
   "devDependencies": {
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   },
   "peerDependencies": {
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   },
   "rnx-kit": {
     "kitType": "library",
@@ -53,9 +53,10 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",

--- a/packages/framework/themed-stylesheet/package.json
+++ b/packages/framework/themed-stylesheet/package.json
@@ -36,14 +36,14 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   },
   "peerDependencies": {
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   },
   "rnx-kit": {
     "kitType": "library",
@@ -52,9 +52,10 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios"

--- a/packages/framework/use-slot/package.json
+++ b/packages/framework/use-slot/package.json
@@ -36,14 +36,14 @@
   },
   "devDependencies": {
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   },
   "peerDependencies": {
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   },
   "rnx-kit": {
     "kitType": "library",
@@ -52,9 +52,10 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",

--- a/packages/framework/use-slots/package.json
+++ b/packages/framework/use-slots/package.json
@@ -36,14 +36,14 @@
   "devDependencies": {
     "@fluentui-react-native/merge-props": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   },
   "peerDependencies": {
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   },
   "rnx-kit": {
     "kitType": "library",
@@ -52,9 +52,10 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",

--- a/packages/framework/use-styling/package.json
+++ b/packages/framework/use-styling/package.json
@@ -37,11 +37,11 @@
   },
   "devDependencies": {
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "@types/jest": "^29.0.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   },
   "rnx-kit": {
     "kitType": "library",
@@ -50,9 +50,10 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
@@ -62,6 +63,6 @@
   },
   "peerDependencies": {
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   }
 }

--- a/packages/framework/use-tokens/package.json
+++ b/packages/framework/use-tokens/package.json
@@ -38,11 +38,11 @@
   "devDependencies": {
     "@fluentui-react-native/merge-props": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "@types/jest": "^29.0.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   },
   "rnx-kit": {
     "kitType": "library",
@@ -51,9 +51,10 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
@@ -63,6 +64,6 @@
   },
   "peerDependencies": {
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   }
 }

--- a/packages/libraries/core/package.json
+++ b/packages/libraries/core/package.json
@@ -45,10 +45,10 @@
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-svg": "^15.0.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependenciesMeta": {
     "@office-iss/react-native-win32": {
@@ -64,10 +64,13 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-svg": "^15.4.0",
+    "react-native-windows": "^0.74.0"
   },
   "onPublish": {
     "main": "lib-commonjs/index.js",
@@ -77,13 +80,17 @@
     "kitType": "library",
     "alignDeps": {
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
-        "react"
+        "core-macos",
+        "core-windows",
+        "react",
+        "svg"
       ]
     }
   },

--- a/packages/theming/android-theme/package.json
+++ b/packages/theming/android-theme/package.json
@@ -40,17 +40,19 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "rnx-kit": {
     "kitType": "library",
@@ -59,12 +61,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react"
       ]
     }

--- a/packages/theming/apple-theme/package.json
+++ b/packages/theming/apple-theme/package.json
@@ -45,19 +45,20 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "@types/react": "^18.2.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "rnx-kit": {
     "kitType": "library",
@@ -66,13 +67,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
         "core-macos",
+        "core-windows",
         "react"
       ]
     }

--- a/packages/theming/default-theme/package.json
+++ b/packages/theming/default-theme/package.json
@@ -42,18 +42,20 @@
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "@types/react": "^18.2.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "rnx-kit": {
     "kitType": "library",
@@ -62,12 +64,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react"
       ]
     }

--- a/packages/theming/theme-tokens/package.json
+++ b/packages/theming/theme-tokens/package.json
@@ -41,14 +41,14 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   },
   "peerDependencies": {
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   },
   "rnx-kit": {
     "kitType": "library",
@@ -57,9 +57,10 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",

--- a/packages/theming/theme-types/package.json
+++ b/packages/theming/theme-types/package.json
@@ -33,15 +33,15 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "@types/react": "^18.2.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   },
   "peerDependencies": {
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   },
   "rnx-kit": {
     "kitType": "library",
@@ -50,9 +50,10 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",

--- a/packages/theming/theming-utils/package.json
+++ b/packages/theming/theming-utils/package.json
@@ -34,18 +34,19 @@
     "@fluentui-react-native/design-tokens-windows": "^0.53.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -56,12 +57,14 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
         "core-windows",
         "react"
       ]

--- a/packages/theming/win32-theme/package.json
+++ b/packages/theming/win32-theme/package.json
@@ -44,18 +44,20 @@
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "@types/react": "^18.2.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "rnx-kit": {
     "kitType": "library",
@@ -64,12 +66,15 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",
+        "core-macos",
+        "core-windows",
         "react"
       ]
     }

--- a/packages/utils/adapters/package.json
+++ b/packages/utils/adapters/package.json
@@ -28,20 +28,20 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "@types/jest": "^29.0.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -52,9 +52,10 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",

--- a/packages/utils/interactive-hooks/package.json
+++ b/packages/utils/interactive-hooks/package.json
@@ -37,22 +37,22 @@
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "@types/invariant": "^2.2.0",
     "@types/jest": "^29.0.0",
     "@types/react": "^18.2.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -63,9 +63,10 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",

--- a/packages/utils/styling/package.json
+++ b/packages/utils/styling/package.json
@@ -28,14 +28,14 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   },
   "peerDependencies": {
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -46,9 +46,10 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
         "core-ios",

--- a/packages/utils/test-tools/package.json
+++ b/packages/utils/test-tools/package.json
@@ -29,11 +29,11 @@
     "@fluentui-react-native/scripts": "workspace:*",
     "@types/react": "^18.2.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   },
   "peerDependencies": {
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0"
   },
   "author": "",
   "license": "MIT",

--- a/packages/utils/tokens/package.json
+++ b/packages/utils/tokens/package.json
@@ -33,17 +33,19 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
-    "@react-native/babel-preset": "^0.73.0",
-    "@react-native/metro-config": "^0.73.0",
+    "@react-native/babel-preset": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-macos": "^0.73.0",
-    "react-native-windows": "^0.73.0"
+    "react-native": "^0.74.0",
+    "react-native-macos": "^0.74.0",
+    "react-native-windows": "^0.74.0"
   },
   "author": "",
   "license": "MIT",
@@ -54,12 +56,16 @@
         "microsoft/react-native"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
+        "babel-preset-react-native",
         "core",
         "core-android",
-        "core-ios"
+        "core-ios",
+        "core-macos",
+        "core-windows",
+        "react"
       ]
     }
   },

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -20,13 +20,17 @@
   },
   "peerDependencies": {
     "just-scripts": "^2.3.2",
-    "react": "18.2.0"
+    "react": "18.2.0",
+    "react-dom": "^18.2.0",
+    "react-native": "^0.74.0",
+    "react-native-svg": "^15.4.0"
   },
   "devDependencies": {
-    "@react-native-community/cli": "^12.1.1",
-    "@react-native-community/cli-platform-android": "^12.1.1",
-    "@react-native-community/cli-platform-ios": "^12.1.1",
-    "@react-native/metro-babel-transformer": "^0.73.0",
+    "@react-native-community/cli": "^13.6.4",
+    "@react-native-community/cli-platform-android": "^13.6.4",
+    "@react-native-community/cli-platform-ios": "^13.6.4",
+    "@react-native/metro-babel-transformer": "^0.74.0",
+    "@react-native/metro-config": "^0.74.0",
     "@rnx-kit/jest-preset": "^0.1.14",
     "@types/es6-collections": "^0.5.29",
     "@types/es6-promise": "0.0.32",
@@ -42,13 +46,13 @@
     "jsdom": "^25.0.0",
     "just-scripts": "^2.3.2",
     "just-task": "^1.4.2",
-    "metro-config": "^0.80.0",
+    "metro-config": "^0.80.3",
     "metro-react-native-babel-transformer": "^0.76.5",
     "prettier": "^2.4.1",
     "react": "18.2.0",
     "react-dom": "^18.2.0",
-    "react-native": "^0.73.0",
-    "react-native-svg": "^15.0.0",
+    "react-native": "^0.74.0",
+    "react-native-svg": "^15.4.0",
     "react-native-svg-transformer": "^1.0.0",
     "react-test-renderer": "18.2.0",
     "rimraf": "^5.0.1",
@@ -75,14 +79,17 @@
         "./align-deps-preset.js"
       ],
       "requirements": [
-        "react-native@0.73"
+        "react-native@0.74"
       ],
       "capabilities": [
         "community/cli",
+        "core",
         "jest",
         "metro-config",
         "metro-react-native-babel-transformer",
-        "react-test-renderer"
+        "react-test-renderer",
+        "react-dom",
+        "svg"
       ]
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5510,7 +5510,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@office-iss/react-native-win32@npm:^0.73.0":
+"@office-iss/react-native-win32@npm:0.73.6":
   version: 0.73.6
   resolution: "@office-iss/react-native-win32@npm:0.73.6"
   dependencies:
@@ -5560,6 +5560,59 @@ __metadata:
     react: 18.2.0
     react-native: ^0.73.0
   checksum: 10c0/81d11fd6f5b60a0c02fd448ecd99e662aba632234ee6093aa10b18183fbbfd155ba7d885959fb7c26d72122849c0e106bd3631d875ae87095dc5dfcb661f4718
+  languageName: node
+  linkType: hard
+
+"@office-iss/react-native-win32@patch:@office-iss/react-native-win32@npm%3A0.73.6#~/.yarn/patches/@office-iss-react-native-win32-npm-0.73.6-c1424dfcf6.patch":
+  version: 0.73.6
+  resolution: "@office-iss/react-native-win32@patch:@office-iss/react-native-win32@npm%3A0.73.6#~/.yarn/patches/@office-iss-react-native-win32-npm-0.73.6-c1424dfcf6.patch::version=0.73.6&hash=0a60c5"
+  dependencies:
+    "@babel/runtime": "npm:^7.0.0"
+    "@jest/create-cache-key-function": "npm:^29.6.3"
+    "@react-native-community/cli": "npm:12.3.6"
+    "@react-native-community/cli-platform-android": "npm:12.3.6"
+    "@react-native-community/cli-platform-ios": "npm:12.3.6"
+    "@react-native/assets-registry": "npm:0.73.1"
+    "@react-native/codegen": "npm:0.73.3"
+    "@react-native/community-cli-plugin": "npm:0.73.17"
+    "@react-native/gradle-plugin": "npm:0.73.4"
+    "@react-native/js-polyfills": "npm:0.73.1"
+    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/normalize-colors": "npm:0.73.2"
+    "@react-native/virtualized-lists": "npm:0.73.4"
+    abort-controller: "npm:^3.0.0"
+    anser: "npm:^1.4.9"
+    ansi-regex: "npm:^5.0.0"
+    art: "npm:^0.10.0"
+    base64-js: "npm:^1.5.1"
+    chalk: "npm:^4.0.0"
+    deprecated-react-native-prop-types: "npm:^5.0.0"
+    event-target-shim: "npm:^5.0.1"
+    flow-enums-runtime: "npm:^0.0.6"
+    invariant: "npm:^2.2.4"
+    jest-environment-node: "npm:^29.6.3"
+    jsc-android: "npm:^250231.0.0"
+    memoize-one: "npm:^5.0.0"
+    metro-runtime: "npm:^0.80.3"
+    metro-source-map: "npm:^0.80.3"
+    mkdirp: "npm:^0.5.1"
+    nullthrows: "npm:^1.1.1"
+    pretty-format: "npm:^26.5.2"
+    promise: "npm:^8.3.0"
+    react-clone-referenced-element: "npm:^1.0.1"
+    react-devtools-core: "npm:^4.27.7"
+    react-refresh: "npm:^0.14.0"
+    react-shallow-renderer: "npm:^16.15.0"
+    regenerator-runtime: "npm:^0.13.2"
+    scheduler: "npm:0.24.0-canary-efb381bbf-20230505"
+    stacktrace-parser: "npm:^0.1.10"
+    whatwg-fetch: "npm:^3.0.0"
+    ws: "npm:^6.2.2"
+    yargs: "npm:^17.6.2"
+  peerDependencies:
+    react: 18.2.0
+    react-native: ^0.73.0
+  checksum: 10c0/aad78db4d10d5b92bedec85775a7251e0081802b0cb509abb99136e6da6aaff99d73dbbe5803ec98ec27ef5874ec487bd3726a345c6cb952527c5dea7f8a808b
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,44 +15,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@appium/base-driver@npm:^9.0.0, @appium/base-driver@npm:^9.1.0":
-  version: 9.11.5
-  resolution: "@appium/base-driver@npm:9.11.5"
-  dependencies:
-    "@appium/support": "npm:^5.1.4"
-    "@appium/types": "npm:^0.21.3"
-    "@colors/colors": "npm:1.6.0"
-    "@types/async-lock": "npm:1.4.2"
-    "@types/bluebird": "npm:3.5.42"
-    "@types/express": "npm:4.17.21"
-    "@types/lodash": "npm:4.17.9"
-    "@types/method-override": "npm:0.0.35"
-    "@types/serve-favicon": "npm:2.5.7"
-    async-lock: "npm:1.4.1"
-    asyncbox: "npm:3.0.0"
-    axios: "npm:1.7.7"
-    bluebird: "npm:3.7.2"
-    body-parser: "npm:1.20.3"
-    express: "npm:4.21.0"
-    http-status-codes: "npm:2.3.0"
-    lodash: "npm:4.17.21"
-    lru-cache: "npm:10.4.3"
-    method-override: "npm:3.0.0"
-    morgan: "npm:1.10.0"
-    path-to-regexp: "npm:8.1.0"
-    serve-favicon: "npm:2.5.0"
-    source-map-support: "npm:0.5.21"
-    spdy: "npm:4.0.2"
-    type-fest: "npm:4.26.1"
-    validate.js: "npm:0.13.1"
-  dependenciesMeta:
-    spdy:
-      optional: true
-  checksum: 10c0/ec50e70615e5cfa70e874c0ea2efd6a73d587a21df79a473a1ffcc518944b00cdf352254d4747a49ee47b5dad20d7a823ee9779fdba26bf69f24d5bc71d06859
-  languageName: node
-  linkType: hard
-
-"@appium/base-driver@npm:^9.15.0":
+"@appium/base-driver@npm:^9.0.0, @appium/base-driver@npm:^9.1.0, @appium/base-driver@npm:^9.15.0":
   version: 9.15.0
   resolution: "@appium/base-driver@npm:9.15.0"
   dependencies:
@@ -173,7 +136,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@appium/support@npm:^5.0.3, @appium/support@npm:^5.1.1, @appium/support@npm:^5.1.4":
+"@appium/support@npm:^5.0.3, @appium/support@npm:^5.1.1":
   version: 5.1.4
   resolution: "@appium/support@npm:5.1.4"
   dependencies:
@@ -356,6 +319,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@azure/core-auth@npm:1.5.0":
+  version: 1.5.0
+  resolution: "@azure/core-auth@npm:1.5.0"
+  dependencies:
+    "@azure/abort-controller": "npm:^1.0.0"
+    "@azure/core-util": "npm:^1.1.0"
+    tslib: "npm:^2.2.0"
+  checksum: 10c0/b141a542cad2d36ebe8e151967bc3e425939c28ab41819268b5e0beef557fbf6425030ded6e89992f07cea87f609788985a1e6e97bb1c987f1010d53fcb123d5
+  languageName: node
+  linkType: hard
+
 "@azure/core-auth@npm:^1.4.0, @azure/core-auth@npm:^1.5.0":
   version: 1.7.1
   resolution: "@azure/core-auth@npm:1.7.1"
@@ -386,11 +360,11 @@ __metadata:
   linkType: hard
 
 "@azure/core-tracing@npm:^1.0.0, @azure/core-tracing@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@azure/core-tracing@npm:1.0.1"
+  version: 1.2.0
+  resolution: "@azure/core-tracing@npm:1.2.0"
   dependencies:
-    tslib: "npm:^2.2.0"
-  checksum: 10c0/bc8ff602392b76e9a1b38be9b56f6bcb33b1c44fc0d19196cbf6f7b5834b264d6a5989db867b77884ffa9b3ff29633120b524cec64f5bbc89c72a1f89fdb4ea1
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/7cd114b3c11730a1b8b71d89b64f9d033dfe0710f2364ef65645683381e2701173c08ff8625a0b0bc65bb3c3e0de46c80fdb2735e37652425489b65a283f043d
   languageName: node
   linkType: hard
 
@@ -437,17 +411,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.21.4, @babel/code-frame@npm:^7.25.7":
-  version: 7.25.7
-  resolution: "@babel/code-frame@npm:7.25.7"
-  dependencies:
-    "@babel/highlight": "npm:^7.25.7"
-    picocolors: "npm:^1.0.0"
-  checksum: 10c0/14825c298bdec914caf3d24d1383b6d4cd6b030714686004992f4fc251831ecf432236652896f99d5d341f17170ae9a07b58d8d7b15aa0df8cfa1c5a7d5474bc
-  languageName: node
-  linkType: hard
-
-"@babel/code-frame@npm:^7.25.9, @babel/code-frame@npm:^7.26.2":
+"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.21.4, @babel/code-frame@npm:^7.25.9, @babel/code-frame@npm:^7.26.2":
   version: 7.26.2
   resolution: "@babel/code-frame@npm:7.26.2"
   dependencies:
@@ -458,21 +422,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/compat-data@npm:^7.20.5, @babel/compat-data@npm:^7.22.6, @babel/compat-data@npm:^7.25.7":
-  version: 7.25.8
-  resolution: "@babel/compat-data@npm:7.25.8"
-  checksum: 10c0/8b81c17580e5fb4cbb6a3c52079f8c283fc59c0c6bd2fe14cfcf9c44b32d2eaab71b02c5633e2c679f5896f73f8ac4036ba2e67a4c806e8f428e4b11f526d7f4
-  languageName: node
-  linkType: hard
-
-"@babel/compat-data@npm:^7.25.9":
-  version: 7.26.2
-  resolution: "@babel/compat-data@npm:7.26.2"
-  checksum: 10c0/c9b5f3724828d17f728a778f9d66c19b55c018d0d76de6d731178cca64f182c22b71400a73bf2b65dcc4fcfe52b630088a94d5902911b54206aa90e3ffe07d12
-  languageName: node
-  linkType: hard
-
-"@babel/compat-data@npm:^7.26.5":
+"@babel/compat-data@npm:^7.20.5, @babel/compat-data@npm:^7.22.6, @babel/compat-data@npm:^7.26.5":
   version: 7.26.5
   resolution: "@babel/compat-data@npm:7.26.5"
   checksum: 10c0/9d2b41f0948c3dfc5de44d9f789d2208c2ea1fd7eb896dfbb297fe955e696728d6f363c600cd211e7f58ccbc2d834fe516bb1e4cf883bbabed8a32b038afc1a0
@@ -502,32 +452,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.20.0, @babel/generator@npm:^7.25.7, @babel/generator@npm:^7.7.2":
-  version: 7.25.7
-  resolution: "@babel/generator@npm:7.25.7"
-  dependencies:
-    "@babel/types": "npm:^7.25.7"
-    "@jridgewell/gen-mapping": "npm:^0.3.5"
-    "@jridgewell/trace-mapping": "npm:^0.3.25"
-    jsesc: "npm:^3.0.2"
-  checksum: 10c0/c03a26c79864d60d04ce36b649c3fa0d6fd7b2bf6a22e22854a0457aa09206508392dd73ee40e7bc8d50b3602f9ff068afa47770cda091d332e7db1ca382ee96
-  languageName: node
-  linkType: hard
-
-"@babel/generator@npm:^7.25.9":
-  version: 7.26.2
-  resolution: "@babel/generator@npm:7.26.2"
-  dependencies:
-    "@babel/parser": "npm:^7.26.2"
-    "@babel/types": "npm:^7.26.0"
-    "@jridgewell/gen-mapping": "npm:^0.3.5"
-    "@jridgewell/trace-mapping": "npm:^0.3.25"
-    jsesc: "npm:^3.0.2"
-  checksum: 10c0/167ebce8977142f5012fad6bd91da51ac52bcd752f2261a54b7ab605d928aebe57e21636cdd2a9c7757e552652c68d9fcb5d40b06fcb66e02d9ee7526e118a5c
-  languageName: node
-  linkType: hard
-
-"@babel/generator@npm:^7.26.5":
+"@babel/generator@npm:^7.20.0, @babel/generator@npm:^7.26.5, @babel/generator@npm:^7.7.2":
   version: 7.26.5
   resolution: "@babel/generator@npm:7.26.5"
   dependencies:
@@ -540,16 +465,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-annotate-as-pure@npm:^7.18.6, @babel/helper-annotate-as-pure@npm:^7.25.7":
-  version: 7.25.7
-  resolution: "@babel/helper-annotate-as-pure@npm:7.25.7"
-  dependencies:
-    "@babel/types": "npm:^7.25.7"
-  checksum: 10c0/2f020b0fa9d336b5778485cc2de3141561ec436a7591b685457a5bcdae4ce41d9ddee68169c95504e0789e5a4327e73b8b7e72e5b60e82e96d730c4d19255248
-  languageName: node
-  linkType: hard
-
-"@babel/helper-annotate-as-pure@npm:^7.25.9":
+"@babel/helper-annotate-as-pure@npm:^7.18.6, @babel/helper-annotate-as-pure@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/helper-annotate-as-pure@npm:7.25.9"
   dependencies:
@@ -558,33 +474,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-compilation-targets@npm:^7.20.7, @babel/helper-compilation-targets@npm:^7.22.6, @babel/helper-compilation-targets@npm:^7.25.7":
-  version: 7.25.7
-  resolution: "@babel/helper-compilation-targets@npm:7.25.7"
-  dependencies:
-    "@babel/compat-data": "npm:^7.25.7"
-    "@babel/helper-validator-option": "npm:^7.25.7"
-    browserslist: "npm:^4.24.0"
-    lru-cache: "npm:^5.1.1"
-    semver: "npm:^6.3.1"
-  checksum: 10c0/705be7e5274a3fdade68e3e2cf42e2b600316ab52794e13b91299a16f16c926f15886b6e9d6df20eb943ccc1cdba5a363d4766f8d01e47b8e6f4e01175f5e66c
-  languageName: node
-  linkType: hard
-
-"@babel/helper-compilation-targets@npm:^7.25.9":
-  version: 7.25.9
-  resolution: "@babel/helper-compilation-targets@npm:7.25.9"
-  dependencies:
-    "@babel/compat-data": "npm:^7.25.9"
-    "@babel/helper-validator-option": "npm:^7.25.9"
-    browserslist: "npm:^4.24.0"
-    lru-cache: "npm:^5.1.1"
-    semver: "npm:^6.3.1"
-  checksum: 10c0/a6b26a1e4222e69ef8e62ee19374308f060b007828bc11c65025ecc9e814aba21ff2175d6d3f8bf53c863edd728ee8f94ba7870f8f90a37d39552ad9933a8aaa
-  languageName: node
-  linkType: hard
-
-"@babel/helper-compilation-targets@npm:^7.26.5":
+"@babel/helper-compilation-targets@npm:^7.20.7, @babel/helper-compilation-targets@npm:^7.22.6, @babel/helper-compilation-targets@npm:^7.25.9, @babel/helper-compilation-targets@npm:^7.26.5":
   version: 7.26.5
   resolution: "@babel/helper-compilation-targets@npm:7.26.5"
   dependencies:
@@ -597,24 +487,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-create-class-features-plugin@npm:^7.18.6, @babel/helper-create-class-features-plugin@npm:^7.21.0, @babel/helper-create-class-features-plugin@npm:^7.25.7":
-  version: 7.25.7
-  resolution: "@babel/helper-create-class-features-plugin@npm:7.25.7"
-  dependencies:
-    "@babel/helper-annotate-as-pure": "npm:^7.25.7"
-    "@babel/helper-member-expression-to-functions": "npm:^7.25.7"
-    "@babel/helper-optimise-call-expression": "npm:^7.25.7"
-    "@babel/helper-replace-supers": "npm:^7.25.7"
-    "@babel/helper-skip-transparent-expression-wrappers": "npm:^7.25.7"
-    "@babel/traverse": "npm:^7.25.7"
-    semver: "npm:^6.3.1"
-  peerDependencies:
-    "@babel/core": ^7.0.0
-  checksum: 10c0/405c3c1a137acda1206380a96993cf2cfd808b3bee1c11c4af47ee0f03a20858497aa53394d6adc5431793c543be5e02010620e871a5ab39d938ae90a54b50f2
-  languageName: node
-  linkType: hard
-
-"@babel/helper-create-class-features-plugin@npm:^7.25.9":
+"@babel/helper-create-class-features-plugin@npm:^7.18.6, @babel/helper-create-class-features-plugin@npm:^7.21.0, @babel/helper-create-class-features-plugin@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/helper-create-class-features-plugin@npm:7.25.9"
   dependencies:
@@ -631,20 +504,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-create-regexp-features-plugin@npm:^7.18.6, @babel/helper-create-regexp-features-plugin@npm:^7.25.7":
-  version: 7.25.7
-  resolution: "@babel/helper-create-regexp-features-plugin@npm:7.25.7"
-  dependencies:
-    "@babel/helper-annotate-as-pure": "npm:^7.25.7"
-    regexpu-core: "npm:^6.1.1"
-    semver: "npm:^6.3.1"
-  peerDependencies:
-    "@babel/core": ^7.0.0
-  checksum: 10c0/75919fd5a67cd7be8497b56f7b9ed6b4843cb401956ba8d403aa9ae5b005bc28e35c7f27e704d820edbd1154394ed7a7984d4719916795d89d716f6980fe8bd4
-  languageName: node
-  linkType: hard
-
-"@babel/helper-create-regexp-features-plugin@npm:^7.25.9":
+"@babel/helper-create-regexp-features-plugin@npm:^7.18.6, @babel/helper-create-regexp-features-plugin@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/helper-create-regexp-features-plugin@npm:7.25.9"
   dependencies:
@@ -711,16 +571,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-member-expression-to-functions@npm:^7.25.7":
-  version: 7.25.7
-  resolution: "@babel/helper-member-expression-to-functions@npm:7.25.7"
-  dependencies:
-    "@babel/traverse": "npm:^7.25.7"
-    "@babel/types": "npm:^7.25.7"
-  checksum: 10c0/1e948162ab48d84593a7c6ec9570d14c906146f1697144fc369c59dbeb00e4a062da67dd06cb0d8f98a044cd8389002dcf2ab6f5613d99c35748307846ec63fc
-  languageName: node
-  linkType: hard
-
 "@babel/helper-member-expression-to-functions@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/helper-member-expression-to-functions@npm:7.25.9"
@@ -731,37 +581,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-imports@npm:^7.22.5, @babel/helper-module-imports@npm:^7.25.7":
-  version: 7.25.7
-  resolution: "@babel/helper-module-imports@npm:7.25.7"
-  dependencies:
-    "@babel/traverse": "npm:^7.25.7"
-    "@babel/types": "npm:^7.25.7"
-  checksum: 10c0/0fd0c3673835e5bf75558e184bcadc47c1f6dd2fe2016d53ebe1e5a6ae931a44e093015c2f9a6651c1a89f25c76d9246710c2b0b460b95ee069c464f2837fa2c
-  languageName: node
-  linkType: hard
-
-"@babel/helper-module-imports@npm:^7.25.9":
+"@babel/helper-module-imports@npm:^7.22.5, @babel/helper-module-imports@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/helper-module-imports@npm:7.25.9"
   dependencies:
     "@babel/traverse": "npm:^7.25.9"
     "@babel/types": "npm:^7.25.9"
   checksum: 10c0/078d3c2b45d1f97ffe6bb47f61961be4785d2342a4156d8b42c92ee4e1b7b9e365655dd6cb25329e8fe1a675c91eeac7e3d04f0c518b67e417e29d6e27b6aa70
-  languageName: node
-  linkType: hard
-
-"@babel/helper-module-transforms@npm:^7.25.7":
-  version: 7.25.7
-  resolution: "@babel/helper-module-transforms@npm:7.25.7"
-  dependencies:
-    "@babel/helper-module-imports": "npm:^7.25.7"
-    "@babel/helper-simple-access": "npm:^7.25.7"
-    "@babel/helper-validator-identifier": "npm:^7.25.7"
-    "@babel/traverse": "npm:^7.25.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0
-  checksum: 10c0/f37fa7d1d4df21690535b278468cbd5faf0133a3080f282000cfa4f3ffc9462a1458f866b04b6a2f2d1eec4691236cba9a867da61270dab3ab19846e62f05090
   languageName: node
   linkType: hard
 
@@ -778,15 +604,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-optimise-call-expression@npm:^7.25.7":
-  version: 7.25.7
-  resolution: "@babel/helper-optimise-call-expression@npm:7.25.7"
-  dependencies:
-    "@babel/types": "npm:^7.25.7"
-  checksum: 10c0/19b4cc7e77811b1fedca4928dbc14026afef913c2ba4142e5e110ebdcb5c3b2efc0f0fbee9f362c23a194674147b9d627adea71c289b9be08b9067bc0085308b
-  languageName: node
-  linkType: hard
-
 "@babel/helper-optimise-call-expression@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/helper-optimise-call-expression@npm:7.25.9"
@@ -796,41 +613,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-plugin-utils@npm:^7.0.0, @babel/helper-plugin-utils@npm:^7.10.4, @babel/helper-plugin-utils@npm:^7.12.13, @babel/helper-plugin-utils@npm:^7.14.5, @babel/helper-plugin-utils@npm:^7.18.6, @babel/helper-plugin-utils@npm:^7.20.2, @babel/helper-plugin-utils@npm:^7.22.5, @babel/helper-plugin-utils@npm:^7.24.7, @babel/helper-plugin-utils@npm:^7.24.8, @babel/helper-plugin-utils@npm:^7.25.7, @babel/helper-plugin-utils@npm:^7.8.0":
-  version: 7.25.7
-  resolution: "@babel/helper-plugin-utils@npm:7.25.7"
-  checksum: 10c0/241f8cf3c5b7700e91cab7cfe5b432a3c710ae3cd5bb96dc554da536a6d25f5b9f000cc0c0917501ceb4f76ba92599ee3beb25e10adaf96be59f8df89a842faf
-  languageName: node
-  linkType: hard
-
-"@babel/helper-plugin-utils@npm:^7.25.9":
-  version: 7.25.9
-  resolution: "@babel/helper-plugin-utils@npm:7.25.9"
-  checksum: 10c0/483066a1ba36ff16c0116cd24f93de05de746a603a777cd695ac7a1b034928a65a4ecb35f255761ca56626435d7abdb73219eba196f9aa83b6c3c3169325599d
-  languageName: node
-  linkType: hard
-
-"@babel/helper-plugin-utils@npm:^7.26.5":
+"@babel/helper-plugin-utils@npm:^7.0.0, @babel/helper-plugin-utils@npm:^7.10.4, @babel/helper-plugin-utils@npm:^7.12.13, @babel/helper-plugin-utils@npm:^7.14.5, @babel/helper-plugin-utils@npm:^7.18.6, @babel/helper-plugin-utils@npm:^7.20.2, @babel/helper-plugin-utils@npm:^7.22.5, @babel/helper-plugin-utils@npm:^7.24.7, @babel/helper-plugin-utils@npm:^7.25.7, @babel/helper-plugin-utils@npm:^7.25.9, @babel/helper-plugin-utils@npm:^7.26.5, @babel/helper-plugin-utils@npm:^7.8.0":
   version: 7.26.5
   resolution: "@babel/helper-plugin-utils@npm:7.26.5"
   checksum: 10c0/cdaba71d4b891aa6a8dfbe5bac2f94effb13e5fa4c2c487667fdbaa04eae059b78b28d85a885071f45f7205aeb56d16759e1bed9c118b94b16e4720ef1ab0f65
   languageName: node
   linkType: hard
 
-"@babel/helper-remap-async-to-generator@npm:^7.18.9, @babel/helper-remap-async-to-generator@npm:^7.25.7":
-  version: 7.25.7
-  resolution: "@babel/helper-remap-async-to-generator@npm:7.25.7"
-  dependencies:
-    "@babel/helper-annotate-as-pure": "npm:^7.25.7"
-    "@babel/helper-wrap-function": "npm:^7.25.7"
-    "@babel/traverse": "npm:^7.25.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0
-  checksum: 10c0/972d84876adce6ab61c87a2df47e1afc790b73cff0d1767d0a1c5d9f7aa5e91d8c581a272b66b2051a26cfbb167d8a780564705e488e3ce1f477f1c15059bc5f
-  languageName: node
-  linkType: hard
-
-"@babel/helper-remap-async-to-generator@npm:^7.25.9":
+"@babel/helper-remap-async-to-generator@npm:^7.18.9, @babel/helper-remap-async-to-generator@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/helper-remap-async-to-generator@npm:7.25.9"
   dependencies:
@@ -840,19 +630,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: 10c0/6798b562f2788210980f29c5ee96056d90dc73458c88af5bd32f9c82e28e01975588aa2a57bb866c35556bd9b76bac937e824ee63ba472b6430224b91b4879e9
-  languageName: node
-  linkType: hard
-
-"@babel/helper-replace-supers@npm:^7.25.7":
-  version: 7.25.7
-  resolution: "@babel/helper-replace-supers@npm:7.25.7"
-  dependencies:
-    "@babel/helper-member-expression-to-functions": "npm:^7.25.7"
-    "@babel/helper-optimise-call-expression": "npm:^7.25.7"
-    "@babel/traverse": "npm:^7.25.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0
-  checksum: 10c0/761d64ee74429f7326a6aa65e2cd5bfcb8de9e3bc3f1efb14b8f610d2410f003b0fca52778dc801d49ff8fbc90b057e8f51b27c62b0b05c95eaf23140ca1287b
   languageName: node
   linkType: hard
 
@@ -869,50 +646,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-simple-access@npm:^7.25.7":
-  version: 7.25.7
-  resolution: "@babel/helper-simple-access@npm:7.25.7"
-  dependencies:
-    "@babel/traverse": "npm:^7.25.7"
-    "@babel/types": "npm:^7.25.7"
-  checksum: 10c0/eed1b499bfb4f613c18debd61517e3de77b6da2727ca025aa05ac81599e0269f1dddb5237db04e8bb598115d015874752e0a7f11ff38672d74a4976097417059
-  languageName: node
-  linkType: hard
-
-"@babel/helper-simple-access@npm:^7.25.9":
-  version: 7.25.9
-  resolution: "@babel/helper-simple-access@npm:7.25.9"
-  dependencies:
-    "@babel/traverse": "npm:^7.25.9"
-    "@babel/types": "npm:^7.25.9"
-  checksum: 10c0/3f1bcdb88ee3883ccf86959869a867f6bbf8c4737cd44fb9f799c38e54f67474590bc66802500ae9fe18161792875b2cfb7ec15673f48ed6c8663f6d09686ca8
-  languageName: node
-  linkType: hard
-
-"@babel/helper-skip-transparent-expression-wrappers@npm:^7.20.0, @babel/helper-skip-transparent-expression-wrappers@npm:^7.25.7":
-  version: 7.25.7
-  resolution: "@babel/helper-skip-transparent-expression-wrappers@npm:7.25.7"
-  dependencies:
-    "@babel/traverse": "npm:^7.25.7"
-    "@babel/types": "npm:^7.25.7"
-  checksum: 10c0/5804adb893849a9d8cfb548e3812566a81d95cb0c9a10d66b52912d13f488e577c33063bf19bc06ac70e6333162a7370d67ba1a1c3544d37fb50d5f4a00db4de
-  languageName: node
-  linkType: hard
-
-"@babel/helper-skip-transparent-expression-wrappers@npm:^7.25.9":
+"@babel/helper-skip-transparent-expression-wrappers@npm:^7.20.0, @babel/helper-skip-transparent-expression-wrappers@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/helper-skip-transparent-expression-wrappers@npm:7.25.9"
   dependencies:
     "@babel/traverse": "npm:^7.25.9"
     "@babel/types": "npm:^7.25.9"
   checksum: 10c0/09ace0c6156961624ac9524329ce7f45350bab94bbe24335cbe0da7dfaa1448e658771831983cb83fe91cf6635b15d0a3cab57c03b92657480bfb49fb56dd184
-  languageName: node
-  linkType: hard
-
-"@babel/helper-string-parser@npm:^7.25.7":
-  version: 7.25.7
-  resolution: "@babel/helper-string-parser@npm:7.25.7"
-  checksum: 10c0/73ef2ceb81f8294678a0afe8ab0103729c0370cac2e830e0d5128b03be5f6a2635838af31d391d763e3c5a4460ed96f42fd7c9b552130670d525be665913bc4c
   languageName: node
   linkType: hard
 
@@ -923,13 +663,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-identifier@npm:^7.25.7":
-  version: 7.25.7
-  resolution: "@babel/helper-validator-identifier@npm:7.25.7"
-  checksum: 10c0/07438e5bf01ab2882a15027fdf39ac3b0ba1b251774a5130917907014684e2f70fef8fd620137ca062c4c4eedc388508d2ea7a3a7d9936a32785f4fe116c68c0
-  languageName: node
-  linkType: hard
-
 "@babel/helper-validator-identifier@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/helper-validator-identifier@npm:7.25.9"
@@ -937,28 +670,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-option@npm:^7.24.7, @babel/helper-validator-option@npm:^7.25.7":
-  version: 7.25.7
-  resolution: "@babel/helper-validator-option@npm:7.25.7"
-  checksum: 10c0/12ed418c8e3ed9ed44c8c80d823f4e42d399b5eb2e423adccb975e31a31a008cd3b5d8eab688b31f740caff4a1bb28fe06ea2fa7d635aee34cc0ad6995d50f0a
-  languageName: node
-  linkType: hard
-
-"@babel/helper-validator-option@npm:^7.25.9":
+"@babel/helper-validator-option@npm:^7.24.7, @babel/helper-validator-option@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/helper-validator-option@npm:7.25.9"
   checksum: 10c0/27fb195d14c7dcb07f14e58fe77c44eea19a6a40a74472ec05c441478fa0bb49fa1c32b2d64be7a38870ee48ef6601bdebe98d512f0253aea0b39756c4014f3e
-  languageName: node
-  linkType: hard
-
-"@babel/helper-wrap-function@npm:^7.25.7":
-  version: 7.25.7
-  resolution: "@babel/helper-wrap-function@npm:7.25.7"
-  dependencies:
-    "@babel/template": "npm:^7.25.7"
-    "@babel/traverse": "npm:^7.25.7"
-    "@babel/types": "npm:^7.25.7"
-  checksum: 10c0/b5d412f72697f4a4ce4cb9784fbaf82501c63cf95066c0eadd3179e3439cbbf0aa5fa4858d93590083671943cd357aeb87286958df34aa56fdf8a4c9dea39755
   languageName: node
   linkType: hard
 
@@ -983,41 +698,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/highlight@npm:^7.25.7":
-  version: 7.25.7
-  resolution: "@babel/highlight@npm:7.25.7"
-  dependencies:
-    "@babel/helper-validator-identifier": "npm:^7.25.7"
-    chalk: "npm:^2.4.2"
-    js-tokens: "npm:^4.0.0"
-    picocolors: "npm:^1.0.0"
-  checksum: 10c0/1f5894fdb0a0af6101fb2822369b2eeeae32cbeae2ef73ff73fc6a0a4a20471565cd9cfa589f54ed69df66adeca7c57266031ca9134b7bd244d023a488d419aa
-  languageName: node
-  linkType: hard
-
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.13.16, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.0, @babel/parser@npm:^7.20.15, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.21.3, @babel/parser@npm:^7.23.0, @babel/parser@npm:^7.24.7, @babel/parser@npm:^7.25.7":
-  version: 7.25.8
-  resolution: "@babel/parser@npm:7.25.8"
-  dependencies:
-    "@babel/types": "npm:^7.25.8"
-  bin:
-    parser: ./bin/babel-parser.js
-  checksum: 10c0/a1a13845b7e8dda4c970791814a4bbf60004969882f18f470e260ad822d2e1f8941948f851e9335895563610f240fa6c98481ce8019865e469502bbf21daafa4
-  languageName: node
-  linkType: hard
-
-"@babel/parser@npm:^7.25.9, @babel/parser@npm:^7.26.2":
-  version: 7.26.2
-  resolution: "@babel/parser@npm:7.26.2"
-  dependencies:
-    "@babel/types": "npm:^7.26.0"
-  bin:
-    parser: ./bin/babel-parser.js
-  checksum: 10c0/751a743087b3a9172a7599f1421830d44c38f065ef781588d2bfb1c98f9b461719a226feb13c868d7a284783eee120c88ea522593118f2668f46ebfb1105c4d7
-  languageName: node
-  linkType: hard
-
-"@babel/parser@npm:^7.26.5, @babel/parser@npm:^7.26.7":
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.13.16, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.0, @babel/parser@npm:^7.20.15, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.21.3, @babel/parser@npm:^7.23.0, @babel/parser@npm:^7.24.7, @babel/parser@npm:^7.25.9, @babel/parser@npm:^7.26.5, @babel/parser@npm:^7.26.7":
   version: 7.26.7
   resolution: "@babel/parser@npm:7.26.7"
   dependencies:
@@ -1122,6 +803,18 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 10c0/db5d0df5bb8d13078cf2793900ca89075622e4a8c4c5246328b1b62ad3c99990b18e4716de10123a34649fea885d8a615082a21db905903d27fa0bcbd53da799
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-logical-assignment-operators@npm:^7.18.0":
+  version: 7.20.7
+  resolution: "@babel/plugin-proposal-logical-assignment-operators@npm:7.20.7"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.20.2"
+    "@babel/plugin-syntax-logical-assignment-operators": "npm:^7.10.4"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10c0/436c1ee9f983813fc52788980a7231414351bd34d80b16b83bddb09115386292fe4912cc6d172304eabbaf0c4813625331b9b5bc798acb0e8925cf0d2b394d4d
   languageName: node
   linkType: hard
 
@@ -1257,24 +950,24 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-syntax-export-default-from@npm:^7.0.0, @babel/plugin-syntax-export-default-from@npm:^7.22.5":
-  version: 7.22.5
-  resolution: "@babel/plugin-syntax-export-default-from@npm:7.22.5"
+  version: 7.25.7
+  resolution: "@babel/plugin-syntax-export-default-from@npm:7.25.7"
   dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.22.5"
+    "@babel/helper-plugin-utils": "npm:^7.25.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/57fae17e0db773fa6f11263cf59e9c1946145c3dde01b399c364c6a6b0b7c9df18051d697ad95b5c6927d7f081921aa1f1096bbd9a2762746e92c1144810c32c
+  checksum: 10c0/490344179679e380f36349d937b2b5d31bfdbb41b011bbd0a4b5dcb07d0491c3cd69e0e3d01d98482be08e3411bd60c343d32b9cd137c899d7d6da3ff5e910d0
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-flow@npm:^7.0.0, @babel/plugin-syntax-flow@npm:^7.12.1, @babel/plugin-syntax-flow@npm:^7.18.0, @babel/plugin-syntax-flow@npm:^7.24.7":
-  version: 7.24.7
-  resolution: "@babel/plugin-syntax-flow@npm:7.24.7"
+"@babel/plugin-syntax-flow@npm:^7.0.0, @babel/plugin-syntax-flow@npm:^7.12.1, @babel/plugin-syntax-flow@npm:^7.18.0, @babel/plugin-syntax-flow@npm:^7.25.7":
+  version: 7.25.7
+  resolution: "@babel/plugin-syntax-flow@npm:7.25.7"
   dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.24.7"
+    "@babel/helper-plugin-utils": "npm:^7.25.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/2f0cb7a78379029707e61f6665634a5b758c8b4ccb602a72d798e41d36b0647c2f2de59f90e0c1d522b026962918e54d82f3aee0c194dc87cd340455aa58562a
+  checksum: 10c0/36799e0af9cab97b688c46caef0fc596323dea7f8772abea229267be9a2c205db27b74bdac26e29ea4f9f116a0337fc40e7b96644a87f26572e6ba1723ed0bbb
   languageName: node
   linkType: hard
 
@@ -1322,18 +1015,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-jsx@npm:^7.0.0, @babel/plugin-syntax-jsx@npm:^7.25.7, @babel/plugin-syntax-jsx@npm:^7.7.2":
-  version: 7.25.7
-  resolution: "@babel/plugin-syntax-jsx@npm:7.25.7"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.25.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/17db499c31fcfaa94d5408726d943955d51d478353d1e2dd84eda6024f7e3d104b9456a77f8aabfae0db7f4dc32f810d08357112f7fcbe305e7c9fcf5b3cac13
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-syntax-jsx@npm:^7.25.9":
+"@babel/plugin-syntax-jsx@npm:^7.0.0, @babel/plugin-syntax-jsx@npm:^7.25.9, @babel/plugin-syntax-jsx@npm:^7.7.2":
   version: 7.25.9
   resolution: "@babel/plugin-syntax-jsx@npm:7.25.9"
   dependencies:
@@ -1344,7 +1026,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-logical-assignment-operators@npm:^7.8.3":
+"@babel/plugin-syntax-logical-assignment-operators@npm:^7.10.4, @babel/plugin-syntax-logical-assignment-operators@npm:^7.8.3":
   version: 7.10.4
   resolution: "@babel/plugin-syntax-logical-assignment-operators@npm:7.10.4"
   dependencies:
@@ -1432,18 +1114,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-typescript@npm:^7.25.7, @babel/plugin-syntax-typescript@npm:^7.7.2":
-  version: 7.25.7
-  resolution: "@babel/plugin-syntax-typescript@npm:7.25.7"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.25.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/ed51fd81a5cf571a89fc4cf4c0e3b0b91285c367237374c133d2e5e718f3963cfa61b81997df39220a8837dc99f9e9a8ab7701d259c09fae379e4843d9db60c2
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-syntax-typescript@npm:^7.25.9":
+"@babel/plugin-syntax-typescript@npm:^7.25.9, @babel/plugin-syntax-typescript@npm:^7.7.2":
   version: 7.25.9
   resolution: "@babel/plugin-syntax-typescript@npm:7.25.9"
   dependencies:
@@ -1466,18 +1137,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-arrow-functions@npm:^7.0.0":
-  version: 7.25.7
-  resolution: "@babel/plugin-transform-arrow-functions@npm:7.25.7"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.25.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/c8d75ead93f130bf113b6d29493aca695092661ef039336d2a227169c3b7895aa5e9bcc548c42a95a6eaaaf49e512317b00699940bd40ccefd77443e703d3935
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-arrow-functions@npm:^7.25.9":
+"@babel/plugin-transform-arrow-functions@npm:^7.0.0, @babel/plugin-transform-arrow-functions@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/plugin-transform-arrow-functions@npm:7.25.9"
   dependencies:
@@ -1501,20 +1161,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-async-to-generator@npm:^7.20.0":
-  version: 7.25.7
-  resolution: "@babel/plugin-transform-async-to-generator@npm:7.25.7"
-  dependencies:
-    "@babel/helper-module-imports": "npm:^7.25.7"
-    "@babel/helper-plugin-utils": "npm:^7.25.7"
-    "@babel/helper-remap-async-to-generator": "npm:^7.25.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/1dbefba9c1455f7a92b8c59a93c622091db945294c936fc2c09b1648308c5b4cb2ecaae92baae0d07a324ab890a8a2ee27ceb046bc120932845d27aede275821
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-async-to-generator@npm:^7.25.9":
+"@babel/plugin-transform-async-to-generator@npm:^7.20.0, @babel/plugin-transform-async-to-generator@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/plugin-transform-async-to-generator@npm:7.25.9"
   dependencies:
@@ -1527,18 +1174,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-block-scoped-functions@npm:^7.0.0":
-  version: 7.25.7
-  resolution: "@babel/plugin-transform-block-scoped-functions@npm:7.25.7"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.25.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/b1e77492295d1b271ef850a81b0404cf3d0dd6a2bcbeab28a0fd99e61c6de4bda91dff583bb42138eec61bf71282bdd3b1bebcb53b7e373035e77fd6ba66caeb
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-block-scoped-functions@npm:^7.26.5":
+"@babel/plugin-transform-block-scoped-functions@npm:^7.0.0, @babel/plugin-transform-block-scoped-functions@npm:^7.26.5":
   version: 7.26.5
   resolution: "@babel/plugin-transform-block-scoped-functions@npm:7.26.5"
   dependencies:
@@ -1549,18 +1185,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-block-scoping@npm:^7.0.0":
-  version: 7.25.7
-  resolution: "@babel/plugin-transform-block-scoping@npm:7.25.7"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.25.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/b2057e00535cd0e8bd5ee5d4640aa2e952564aeafb1bcf4e7b6de33442422877bb0ca8669ad0a48262ec077271978c61eae87b6b3bc8f472d830fa781d6f7e44
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-block-scoping@npm:^7.25.9":
+"@babel/plugin-transform-block-scoping@npm:^7.0.0, @babel/plugin-transform-block-scoping@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/plugin-transform-block-scoping@npm:7.25.9"
   dependencies:
@@ -1571,19 +1196,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-class-properties@npm:^7.24.7":
-  version: 7.25.7
-  resolution: "@babel/plugin-transform-class-properties@npm:7.25.7"
-  dependencies:
-    "@babel/helper-create-class-features-plugin": "npm:^7.25.7"
-    "@babel/helper-plugin-utils": "npm:^7.25.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/1f41e6934b20ad3e05df63959cff9bc600ff3119153b9acbbd44c1731e7df04866397e6e17799173f4c53cdee6115e155632859aee20bf47ec7dcef3f2168a47
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-class-properties@npm:^7.25.9":
+"@babel/plugin-transform-class-properties@npm:^7.24.7, @babel/plugin-transform-class-properties@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/plugin-transform-class-properties@npm:7.25.9"
   dependencies:
@@ -1607,23 +1220,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-classes@npm:^7.0.0":
-  version: 7.25.7
-  resolution: "@babel/plugin-transform-classes@npm:7.25.7"
-  dependencies:
-    "@babel/helper-annotate-as-pure": "npm:^7.25.7"
-    "@babel/helper-compilation-targets": "npm:^7.25.7"
-    "@babel/helper-plugin-utils": "npm:^7.25.7"
-    "@babel/helper-replace-supers": "npm:^7.25.7"
-    "@babel/traverse": "npm:^7.25.7"
-    globals: "npm:^11.1.0"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/8121781e1d8acd80e6169019106f73a399475ad9c895c1988a344dfed5a6ddd340938ac55123dc1e423bb8f25f255f5d11031116ad756ba3c314595a97c973af
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-classes@npm:^7.25.9":
+"@babel/plugin-transform-classes@npm:^7.0.0, @babel/plugin-transform-classes@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/plugin-transform-classes@npm:7.25.9"
   dependencies:
@@ -1639,19 +1236,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-computed-properties@npm:^7.0.0":
-  version: 7.25.7
-  resolution: "@babel/plugin-transform-computed-properties@npm:7.25.7"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.25.7"
-    "@babel/template": "npm:^7.25.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/7ad0a1c126f50935a02e77d438ebc39078a9d644b3a60de60bec32c5d9f49e7f2b193fcecb8c61bb1bc3cdd4af1e93f72d022d448511fa76a171527c633cd1bf
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-computed-properties@npm:^7.25.9":
+"@babel/plugin-transform-computed-properties@npm:^7.0.0, @babel/plugin-transform-computed-properties@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/plugin-transform-computed-properties@npm:7.25.9"
   dependencies:
@@ -1663,18 +1248,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-destructuring@npm:^7.0.0, @babel/plugin-transform-destructuring@npm:^7.20.0":
-  version: 7.25.7
-  resolution: "@babel/plugin-transform-destructuring@npm:7.25.7"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.25.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/a563123b2fb267e03aa50104005f00b56226a685938906c42c1b251462e0cc9fc89e587d5656d3324159071eb8ebda8c68a6011f11d5a00fb1436cb5a5411b7b
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-destructuring@npm:^7.25.9":
+"@babel/plugin-transform-destructuring@npm:^7.0.0, @babel/plugin-transform-destructuring@npm:^7.20.0, @babel/plugin-transform-destructuring@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/plugin-transform-destructuring@npm:7.25.9"
   dependencies:
@@ -1754,30 +1328,18 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-transform-flow-strip-types@npm:^7.0.0, @babel/plugin-transform-flow-strip-types@npm:^7.20.0, @babel/plugin-transform-flow-strip-types@npm:^7.24.7":
-  version: 7.25.2
-  resolution: "@babel/plugin-transform-flow-strip-types@npm:7.25.2"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.24.8"
-    "@babel/plugin-syntax-flow": "npm:^7.24.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/821f5ccdb8104e09764d8a24d4c0dd4fe9e264d95e6477269c911e15240a63343d3fe71b6cf9382273766a0e86a015c2867d26fd75e5827134d990c93fa9e605
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-for-of@npm:^7.0.0":
   version: 7.25.7
-  resolution: "@babel/plugin-transform-for-of@npm:7.25.7"
+  resolution: "@babel/plugin-transform-flow-strip-types@npm:7.25.7"
   dependencies:
     "@babel/helper-plugin-utils": "npm:^7.25.7"
-    "@babel/helper-skip-transparent-expression-wrappers": "npm:^7.25.7"
+    "@babel/plugin-syntax-flow": "npm:^7.25.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/08a37a1742368a422d095c998ed76f60f6bf3f9cc060033be121d803fd2dddc08fe543e48ee49c022bdc9ed80893ca79d084958d83d30684178b088774754277
+  checksum: 10c0/01afd2196c99ace415d58d939cc568a17e9925fcc4cbf8ff16a659053be3f7ce2b1fa254b5662aa36e6a3300620bcc81d9399d849288a012fe2dc337e4efa49e
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-for-of@npm:^7.25.9":
+"@babel/plugin-transform-for-of@npm:^7.0.0, @babel/plugin-transform-for-of@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/plugin-transform-for-of@npm:7.25.9"
   dependencies:
@@ -1789,20 +1351,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-function-name@npm:^7.0.0":
-  version: 7.25.7
-  resolution: "@babel/plugin-transform-function-name@npm:7.25.7"
-  dependencies:
-    "@babel/helper-compilation-targets": "npm:^7.25.7"
-    "@babel/helper-plugin-utils": "npm:^7.25.7"
-    "@babel/traverse": "npm:^7.25.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/ca98e1116c0ada7211ed43e4b7f21ca15f95bbbdad70f2fbe1ec2d90a97daedf9f22fcb0a25c8b164a5e394f509f2e4d1f7609d26dc938a58d37c5ee9b80088a
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-function-name@npm:^7.25.9":
+"@babel/plugin-transform-function-name@npm:^7.0.0, @babel/plugin-transform-function-name@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/plugin-transform-function-name@npm:7.25.9"
   dependencies:
@@ -1826,18 +1375,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-literals@npm:^7.0.0":
-  version: 7.25.7
-  resolution: "@babel/plugin-transform-literals@npm:7.25.7"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.25.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/c2c2488102f33e566f45becdcb632e53bd052ecfb2879deb07a614b3e9437e3b624c3b16d080096d50b0b622edebd03e438acbf9260bcc41167897963f64560e
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-literals@npm:^7.25.9":
+"@babel/plugin-transform-literals@npm:^7.0.0, @babel/plugin-transform-literals@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/plugin-transform-literals@npm:7.25.9"
   dependencies:
@@ -1859,18 +1397,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-member-expression-literals@npm:^7.0.0":
-  version: 7.25.7
-  resolution: "@babel/plugin-transform-member-expression-literals@npm:7.25.7"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.25.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/d6936b98ae4d3daed850dc4e064042ea4375f815219ba9d8591373bf1fba4cfdb5be42623ae8882f2d666cc34af650a4855e2a5ad89e3c235d73a6f172f9969c
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-member-expression-literals@npm:^7.25.9":
+"@babel/plugin-transform-member-expression-literals@npm:^7.0.0, @babel/plugin-transform-member-expression-literals@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/plugin-transform-member-expression-literals@npm:7.25.9"
   dependencies:
@@ -1893,33 +1420,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-modules-commonjs@npm:^7.0.0, @babel/plugin-transform-modules-commonjs@npm:^7.13.8, @babel/plugin-transform-modules-commonjs@npm:^7.24.7":
-  version: 7.25.7
-  resolution: "@babel/plugin-transform-modules-commonjs@npm:7.25.7"
-  dependencies:
-    "@babel/helper-module-transforms": "npm:^7.25.7"
-    "@babel/helper-plugin-utils": "npm:^7.25.7"
-    "@babel/helper-simple-access": "npm:^7.25.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/2f1c945fc3c9b690b0ddcf2c80156b2e4fbf2cf15aac43ac8fe6e4b34125869528839a53d07c564e62e4aed394ebdc1d2c3b796b547374455522581c11b7599c
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-modules-commonjs@npm:^7.25.9":
-  version: 7.25.9
-  resolution: "@babel/plugin-transform-modules-commonjs@npm:7.25.9"
-  dependencies:
-    "@babel/helper-module-transforms": "npm:^7.25.9"
-    "@babel/helper-plugin-utils": "npm:^7.25.9"
-    "@babel/helper-simple-access": "npm:^7.25.9"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/6ce771fb04d4810257fc8900374fece877dacaed74b05eaa16ad9224b390f43795c4d046cbe9ae304e1eb5aad035d37383895e3c64496d647c2128d183916e74
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-modules-commonjs@npm:^7.26.3":
+"@babel/plugin-transform-modules-commonjs@npm:^7.0.0, @babel/plugin-transform-modules-commonjs@npm:^7.13.8, @babel/plugin-transform-modules-commonjs@npm:^7.24.7, @babel/plugin-transform-modules-commonjs@npm:^7.25.9, @babel/plugin-transform-modules-commonjs@npm:^7.26.3":
   version: 7.26.3
   resolution: "@babel/plugin-transform-modules-commonjs@npm:7.26.3"
   dependencies:
@@ -1957,19 +1458,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-named-capturing-groups-regex@npm:^7.0.0":
-  version: 7.25.7
-  resolution: "@babel/plugin-transform-named-capturing-groups-regex@npm:7.25.7"
-  dependencies:
-    "@babel/helper-create-regexp-features-plugin": "npm:^7.25.7"
-    "@babel/helper-plugin-utils": "npm:^7.25.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0
-  checksum: 10c0/eb55fec55dc930cd122911f3e4a421320fa8b1b4de85bfd7ef11b46c611ec69b0213c114a6e1c6bc224d6b954ff183a0caa7251267d5258ecc0f00d6d9ca1d52
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-named-capturing-groups-regex@npm:^7.25.9":
+"@babel/plugin-transform-named-capturing-groups-regex@npm:^7.0.0, @babel/plugin-transform-named-capturing-groups-regex@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/plugin-transform-named-capturing-groups-regex@npm:7.25.9"
   dependencies:
@@ -1992,18 +1481,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-nullish-coalescing-operator@npm:^7.24.7":
-  version: 7.25.8
-  resolution: "@babel/plugin-transform-nullish-coalescing-operator@npm:7.25.8"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.25.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/3cb7c44cffccae42e104755acb31b4f00bc27d8c88102ae6f30dca508832f98fa5b746bead0fc7c0c6ddcf83f336829be4b64245c6c7ce26b3ef591937ec54a4
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-nullish-coalescing-operator@npm:^7.26.6":
+"@babel/plugin-transform-nullish-coalescing-operator@npm:^7.24.7, @babel/plugin-transform-nullish-coalescing-operator@npm:^7.26.6":
   version: 7.26.6
   resolution: "@babel/plugin-transform-nullish-coalescing-operator@npm:7.26.6"
   dependencies:
@@ -2038,19 +1516,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-object-super@npm:^7.0.0":
-  version: 7.25.7
-  resolution: "@babel/plugin-transform-object-super@npm:7.25.7"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.25.7"
-    "@babel/helper-replace-supers": "npm:^7.25.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/7f2968d4da997101b63fd3b74445c9b16f56bd32cd8a0a16c368af9d3e983e7675c1b05d18601f32307cb06e7d884ee11d13ff18a1f6830c0db243a9a852afab
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-object-super@npm:^7.25.9":
+"@babel/plugin-transform-object-super@npm:^7.0.0, @babel/plugin-transform-object-super@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/plugin-transform-object-super@npm:7.25.9"
   dependencies:
@@ -2073,19 +1539,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-optional-chaining@npm:^7.24.7":
-  version: 7.25.8
-  resolution: "@babel/plugin-transform-optional-chaining@npm:7.25.8"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.25.7"
-    "@babel/helper-skip-transparent-expression-wrappers": "npm:^7.25.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/a1cdbfc249619fa6b37e57f81600701281629d86a57e616b0c2b29816d0c43114a2296ce089564afd3aa7870c8aad62e907658ffef2c110662af14ee23d5247f
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-optional-chaining@npm:^7.25.9":
+"@babel/plugin-transform-optional-chaining@npm:^7.24.7, @babel/plugin-transform-optional-chaining@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/plugin-transform-optional-chaining@npm:7.25.9"
   dependencies:
@@ -2097,18 +1551,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-parameters@npm:^7.0.0, @babel/plugin-transform-parameters@npm:^7.20.7":
-  version: 7.25.7
-  resolution: "@babel/plugin-transform-parameters@npm:7.25.7"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.25.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/b40ba70278842ce1e800d7ab400df730994941550da547ef453780023bd61a9b8acf4b9fb8419c1b5bcbe09819a1146ff59369db11db07eb71870bef86a12422
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-parameters@npm:^7.25.9":
+"@babel/plugin-transform-parameters@npm:^7.0.0, @babel/plugin-transform-parameters@npm:^7.20.7, @babel/plugin-transform-parameters@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/plugin-transform-parameters@npm:7.25.9"
   dependencies:
@@ -2119,19 +1562,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-private-methods@npm:^7.22.5, @babel/plugin-transform-private-methods@npm:^7.24.7":
-  version: 7.25.7
-  resolution: "@babel/plugin-transform-private-methods@npm:7.25.7"
-  dependencies:
-    "@babel/helper-create-class-features-plugin": "npm:^7.25.7"
-    "@babel/helper-plugin-utils": "npm:^7.25.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/92e076f63f7c4696e1321dafdd56c4212eb41784cdadba0ebc39091f959a76d357c3df61a6c668be81d6b6ad8964ee458e85752ab0c6cfbbaf2066903edda732
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-private-methods@npm:^7.25.9":
+"@babel/plugin-transform-private-methods@npm:^7.22.5, @babel/plugin-transform-private-methods@npm:^7.24.7, @babel/plugin-transform-private-methods@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/plugin-transform-private-methods@npm:7.25.9"
   dependencies:
@@ -2143,20 +1574,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-private-property-in-object@npm:^7.22.11":
-  version: 7.25.8
-  resolution: "@babel/plugin-transform-private-property-in-object@npm:7.25.8"
-  dependencies:
-    "@babel/helper-annotate-as-pure": "npm:^7.25.7"
-    "@babel/helper-create-class-features-plugin": "npm:^7.25.7"
-    "@babel/helper-plugin-utils": "npm:^7.25.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/61b5e3a4eb94caf38d6e9ff7bff1ac8927758141aaa4891036d3490866ecee53beaefd7893519fec42a4c55f33374a17fc0e49694cdaf95668082073f0fe4a79
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-private-property-in-object@npm:^7.25.9":
+"@babel/plugin-transform-private-property-in-object@npm:^7.22.11, @babel/plugin-transform-private-property-in-object@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/plugin-transform-private-property-in-object@npm:7.25.9"
   dependencies:
@@ -2169,18 +1587,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-property-literals@npm:^7.0.0":
-  version: 7.25.7
-  resolution: "@babel/plugin-transform-property-literals@npm:7.25.7"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.25.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/6d5bccdc772207906666ad5201bd91e4e132e1d806dbcf4163a1d08e18c57cc3795578c4e10596514bcd6afaf9696f478ea4f0dea890176d93b9cb077b9e5c55
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-property-literals@npm:^7.25.9":
+"@babel/plugin-transform-property-literals@npm:^7.0.0, @babel/plugin-transform-property-literals@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/plugin-transform-property-literals@npm:7.25.9"
   dependencies:
@@ -2191,18 +1598,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-react-display-name@npm:^7.0.0":
-  version: 7.25.7
-  resolution: "@babel/plugin-transform-react-display-name@npm:7.25.7"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.25.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/a0c537cc7c328ed7468d3b6a37bf0d9cb15d94afcdf3f2849ce6e5a68494fc61f0fa4fc529482a6b95b00f3c5c734f310bf18085293bff40702789f06c816f36
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-react-display-name@npm:^7.25.9":
+"@babel/plugin-transform-react-display-name@npm:^7.0.0, @babel/plugin-transform-react-display-name@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/plugin-transform-react-display-name@npm:7.25.9"
   dependencies:
@@ -2246,22 +1642,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-react-jsx@npm:^7.0.0":
-  version: 7.25.7
-  resolution: "@babel/plugin-transform-react-jsx@npm:7.25.7"
-  dependencies:
-    "@babel/helper-annotate-as-pure": "npm:^7.25.7"
-    "@babel/helper-module-imports": "npm:^7.25.7"
-    "@babel/helper-plugin-utils": "npm:^7.25.7"
-    "@babel/plugin-syntax-jsx": "npm:^7.25.7"
-    "@babel/types": "npm:^7.25.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/6766b0357b8bbfcb77fca5350f06cf822c89bbe75ddcaea24614601ef23957504da24e76597d743038ce8fa081373b0663c8ad0c86d7c7226e8185f0680b8b56
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-react-jsx@npm:^7.25.9":
+"@babel/plugin-transform-react-jsx@npm:^7.0.0, @babel/plugin-transform-react-jsx@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/plugin-transform-react-jsx@npm:7.25.9"
   dependencies:
@@ -2339,18 +1720,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-shorthand-properties@npm:^7.0.0":
-  version: 7.25.7
-  resolution: "@babel/plugin-transform-shorthand-properties@npm:7.25.7"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.25.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/4250f89a0072f0f400be7a2e3515227b8e2518737899bd57d497e5173284a0e05d812e4a3c219ffcd484e9fa9a01c19fce5acd77bbb898f4d594512c56701eb4
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-shorthand-properties@npm:^7.25.9":
+"@babel/plugin-transform-shorthand-properties@npm:^7.0.0, @babel/plugin-transform-shorthand-properties@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/plugin-transform-shorthand-properties@npm:7.25.9"
   dependencies:
@@ -2361,19 +1731,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-spread@npm:^7.0.0":
-  version: 7.25.7
-  resolution: "@babel/plugin-transform-spread@npm:7.25.7"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.25.7"
-    "@babel/helper-skip-transparent-expression-wrappers": "npm:^7.25.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/258bd1b52388cd7425d0ae25fa39538734f7540ea503a1d8a72211d33f6f214cb4e3b73d6cd03016cbcff5d41169f1e578b9ea331965ad224d223591983e90a7
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-spread@npm:^7.25.9":
+"@babel/plugin-transform-spread@npm:^7.0.0, @babel/plugin-transform-spread@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/plugin-transform-spread@npm:7.25.9"
   dependencies:
@@ -2385,18 +1743,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-sticky-regex@npm:^7.0.0":
-  version: 7.25.7
-  resolution: "@babel/plugin-transform-sticky-regex@npm:7.25.7"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.25.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/0e466cfc3ca1e0db4bb11eb630215b0e1f43066d7678325e5ddadcf5a118b2351a528f67205729c32ac5b78ab68ab7f40517dd33bcb1fb6b456509f5f54ce097
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-sticky-regex@npm:^7.25.9":
+"@babel/plugin-transform-sticky-regex@npm:^7.0.0, @babel/plugin-transform-sticky-regex@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/plugin-transform-sticky-regex@npm:7.25.9"
   dependencies:
@@ -2407,18 +1754,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-template-literals@npm:^7.0.0":
-  version: 7.25.7
-  resolution: "@babel/plugin-transform-template-literals@npm:7.25.7"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.25.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/a3455303b6841cb536ac66d1a2d03c194b9f371519482d8d1e8edbd33bf5ca7cdd5db1586b2b0ea5f909ebf74a0eafacf0fb28d257e4905445282dcdccfa6139
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-template-literals@npm:^7.25.9":
+"@babel/plugin-transform-template-literals@npm:^7.0.0, @babel/plugin-transform-template-literals@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/plugin-transform-template-literals@npm:7.25.9"
   dependencies:
@@ -2440,7 +1776,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-typescript@npm:^7.25.9":
+"@babel/plugin-transform-typescript@npm:^7.25.9, @babel/plugin-transform-typescript@npm:^7.5.0":
   version: 7.25.9
   resolution: "@babel/plugin-transform-typescript@npm:7.25.9"
   dependencies:
@@ -2452,21 +1788,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 10c0/c607ddb45f7e33cfcb928aad05cb1b18b1ecb564d2329d8f8e427f75192511aa821dee42d26871f1bdffbd883853e150ba81436664646c6e6b13063e65ce1475
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-typescript@npm:^7.5.0":
-  version: 7.25.7
-  resolution: "@babel/plugin-transform-typescript@npm:7.25.7"
-  dependencies:
-    "@babel/helper-annotate-as-pure": "npm:^7.25.7"
-    "@babel/helper-create-class-features-plugin": "npm:^7.25.7"
-    "@babel/helper-plugin-utils": "npm:^7.25.7"
-    "@babel/helper-skip-transparent-expression-wrappers": "npm:^7.25.7"
-    "@babel/plugin-syntax-typescript": "npm:^7.25.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/5fa839b9560221698edff5e00b5cccc658c7875efaa7971c66d478f5b026770f12dd47b1be024463a44f9e29b4e14e8ddddbf4a2b324b0b94f58370dd5ae7195
   languageName: node
   linkType: hard
 
@@ -2493,19 +1814,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-unicode-regex@npm:^7.0.0":
-  version: 7.25.7
-  resolution: "@babel/plugin-transform-unicode-regex@npm:7.25.7"
-  dependencies:
-    "@babel/helper-create-regexp-features-plugin": "npm:^7.25.7"
-    "@babel/helper-plugin-utils": "npm:^7.25.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/73ae34c02ea8b7ac7e4efa690f8c226089c074e3fef658d2a630ad898a93550d84146ce05e073c271c8b2bbba61cbbfd5a2002a7ea940dcad3274e5b5dcb6bcf
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-unicode-regex@npm:^7.25.9":
+"@babel/plugin-transform-unicode-regex@npm:^7.0.0, @babel/plugin-transform-unicode-regex@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/plugin-transform-unicode-regex@npm:7.25.9"
   dependencies:
@@ -2689,18 +1998,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/template@npm:^7.0.0, @babel/template@npm:^7.25.7, @babel/template@npm:^7.3.3":
-  version: 7.25.7
-  resolution: "@babel/template@npm:7.25.7"
-  dependencies:
-    "@babel/code-frame": "npm:^7.25.7"
-    "@babel/parser": "npm:^7.25.7"
-    "@babel/types": "npm:^7.25.7"
-  checksum: 10c0/8ae9e36e4330ee83d4832531d1d9bec7dc2ef6a2a8afa1ef1229506fd60667abcb17f306d1c3d7e582251270597022990c845d5d69e7add70a5aea66720decb9
-  languageName: node
-  linkType: hard
-
-"@babel/template@npm:^7.25.9":
+"@babel/template@npm:^7.0.0, @babel/template@npm:^7.25.9, @babel/template@npm:^7.3.3":
   version: 7.25.9
   resolution: "@babel/template@npm:7.25.9"
   dependencies:
@@ -2711,37 +2009,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.20.0, @babel/traverse@npm:^7.23.2, @babel/traverse@npm:^7.25.7":
-  version: 7.25.7
-  resolution: "@babel/traverse@npm:7.25.7"
-  dependencies:
-    "@babel/code-frame": "npm:^7.25.7"
-    "@babel/generator": "npm:^7.25.7"
-    "@babel/parser": "npm:^7.25.7"
-    "@babel/template": "npm:^7.25.7"
-    "@babel/types": "npm:^7.25.7"
-    debug: "npm:^4.3.1"
-    globals: "npm:^11.1.0"
-  checksum: 10c0/75d73e52c507a7a7a4c7971d6bf4f8f26fdd094e0d3a0193d77edf6a5efa36fc3db91ec5cc48e8b94e6eb5d5ad21af0a1040e71309172851209415fd105efb1a
-  languageName: node
-  linkType: hard
-
-"@babel/traverse@npm:^7.25.9":
-  version: 7.25.9
-  resolution: "@babel/traverse@npm:7.25.9"
-  dependencies:
-    "@babel/code-frame": "npm:^7.25.9"
-    "@babel/generator": "npm:^7.25.9"
-    "@babel/parser": "npm:^7.25.9"
-    "@babel/template": "npm:^7.25.9"
-    "@babel/types": "npm:^7.25.9"
-    debug: "npm:^4.3.1"
-    globals: "npm:^11.1.0"
-  checksum: 10c0/e90be586a714da4adb80e6cb6a3c5cfcaa9b28148abdafb065e34cc109676fc3db22cf98cd2b2fff66ffb9b50c0ef882cab0f466b6844be0f6c637b82719bba1
-  languageName: node
-  linkType: hard
-
-"@babel/traverse@npm:^7.26.7":
+"@babel/traverse@npm:^7.20.0, @babel/traverse@npm:^7.23.2, @babel/traverse@npm:^7.25.9, @babel/traverse@npm:^7.26.7":
   version: 7.26.7
   resolution: "@babel/traverse@npm:7.26.7"
   dependencies:
@@ -2756,28 +2024,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.21.3, @babel/types@npm:^7.24.7, @babel/types@npm:^7.25.7, @babel/types@npm:^7.25.8, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4":
-  version: 7.25.8
-  resolution: "@babel/types@npm:7.25.8"
-  dependencies:
-    "@babel/helper-string-parser": "npm:^7.25.7"
-    "@babel/helper-validator-identifier": "npm:^7.25.7"
-    to-fast-properties: "npm:^2.0.0"
-  checksum: 10c0/55ca2d6df6426c98db2769ce884ce5e9de83a512ea2dd7bcf56c811984dc14351cacf42932a723630c5afcff2455809323decd645820762182f10b7b5252b59f
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.25.9, @babel/types@npm:^7.26.0":
-  version: 7.26.0
-  resolution: "@babel/types@npm:7.26.0"
-  dependencies:
-    "@babel/helper-string-parser": "npm:^7.25.9"
-    "@babel/helper-validator-identifier": "npm:^7.25.9"
-  checksum: 10c0/b694f41ad1597127e16024d766c33a641508aad037abd08d0d1f73af753e1119fa03b4a107d04b5f92cc19c095a594660547ae9bead1db2299212d644b0a5cb8
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.26.5, @babel/types@npm:^7.26.7":
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.21.3, @babel/types@npm:^7.24.7, @babel/types@npm:^7.25.9, @babel/types@npm:^7.26.5, @babel/types@npm:^7.26.7, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4":
   version: 7.26.7
   resolution: "@babel/types@npm:7.26.7"
   dependencies:
@@ -3053,19 +2300,19 @@ __metadata:
   dependencies:
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     "@types/jest": "npm:^29.0.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
-    react-native-macos: "npm:^0.73.0"
-    react-native-windows: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-windows: "npm:^0.74.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -3087,16 +2334,18 @@ __metadata:
     "@fluentui-react-native/theme-tokens": "workspace:*"
     "@fluentui-react-native/theme-types": "workspace:*"
     "@fluentui-react-native/theming-utils": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-windows: "npm:^0.74.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -3122,19 +2371,20 @@ __metadata:
     "@fluentui-react-native/theme-tokens": "workspace:*"
     "@fluentui-react-native/theme-types": "workspace:*"
     "@fluentui-react-native/theming-utils": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     "@types/react": "npm:^18.2.0"
     assert-never: "npm:^1.2.1"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
-    react-native-macos: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-windows: "npm:^0.74.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -3160,18 +2410,20 @@ __metadata:
     "@fluentui-react-native/tokens": "workspace:*"
     "@fluentui-react-native/use-styling": "workspace:*"
     "@office-iss/react-native-win32": "npm:^0.73.0"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
-    react-native-svg: "npm:^14.0.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-svg: "npm:^15.4.0"
+    react-native-windows: "npm:^0.74.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-svg: ^15.0.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-svg: ^15.4.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -3200,18 +2452,20 @@ __metadata:
     "@fluentui-react-native/tokens": "workspace:*"
     "@fluentui-react-native/use-styling": "workspace:*"
     "@office-iss/react-native-win32": "npm:^0.73.0"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
-    react-native-svg: "npm:^14.0.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-svg: "npm:^15.4.0"
+    react-native-windows: "npm:^0.74.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-svg: ^15.0.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-svg: ^15.4.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -3244,21 +2498,24 @@ __metadata:
     "@fluentui-react-native/tokens": "workspace:*"
     "@fluentui-react-native/use-styling": "workspace:*"
     "@office-iss/react-native-win32": "npm:^0.73.0"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     "@uifabricshared/foundation-composable": "workspace:*"
     "@uifabricshared/foundation-compose": "workspace:*"
     "@uifabricshared/foundation-settings": "workspace:*"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-svg: "npm:^15.4.0"
+    react-native-windows: "npm:^0.74.0"
     tslib: "npm:^2.3.1"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-svg: ^15.0.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-svg: ^15.4.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -3278,19 +2535,21 @@ __metadata:
     "@fluentui-react-native/scripts": "workspace:*"
     "@fluentui-react-native/tokens": "workspace:*"
     "@office-iss/react-native-win32": "npm:^0.73.0"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     "@uifabricshared/foundation-composable": "workspace:*"
     "@uifabricshared/foundation-compose": "workspace:*"
     "@uifabricshared/foundation-settings": "workspace:*"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-windows: "npm:^0.74.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -3326,13 +2585,15 @@ __metadata:
     "@uifabricshared/foundation-settings": "workspace:*"
     react: "npm:18.2.0"
     react-native: "npm:^0.73.0"
-    react-native-svg: "npm:^14.0.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-svg: "npm:^15.0.0"
+    react-native-windows: "npm:^0.73.0"
     tslib: "npm:^2.3.1"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
     react-native: ^0.73.0
-    react-native-macos: ^0.73.0
+    react-native-macos: ^0.74.0
     react-native-svg: ^15.0.0
     react-native-windows: ^0.73.0
   peerDependenciesMeta:
@@ -3361,18 +2622,20 @@ __metadata:
     "@fluentui-react-native/tokens": "workspace:*"
     "@fluentui-react-native/use-styling": "workspace:*"
     "@office-iss/react-native-win32": "npm:^0.73.0"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
-    react-native-svg: "npm:^14.0.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-svg: "npm:^15.4.0"
+    react-native-windows: "npm:^0.74.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-svg: ^15.0.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-svg: ^15.4.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -3409,13 +2672,13 @@ __metadata:
     "@fluentui-react-native/use-slot": "workspace:*"
     "@fluentui-react-native/use-slots": "workspace:*"
     "@fluentui-react-native/use-styling": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
   peerDependencies:
     react: 18.2.0
-    react-native: ^0.73.0
+    react-native: ^0.74.0
   languageName: unknown
   linkType: soft
 
@@ -3434,22 +2697,24 @@ __metadata:
     "@fluentui-react-native/text": "workspace:*"
     "@fluentui-react-native/tokens": "workspace:*"
     "@office-iss/react-native-win32": "npm:^0.73.0"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     "@uifabricshared/foundation-composable": "workspace:*"
     "@uifabricshared/foundation-compose": "workspace:*"
     "@uifabricshared/foundation-settings": "workspace:*"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
-    react-native-svg: "npm:^15.0.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-svg: "npm:^15.4.0"
     react-native-svg-transformer: "npm:^1.0.0"
+    react-native-windows: "npm:^0.74.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-svg: ^15.0.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-svg: ^15.4.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -3472,18 +2737,20 @@ __metadata:
     "@fluentui-react-native/theme-types": "workspace:*"
     "@fluentui-react-native/theming-utils": "workspace:*"
     "@office-iss/react-native-win32": "npm:^0.73.0"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     "@types/react": "npm:^18.2.0"
     assert-never: "npm:^1.2.1"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-windows: "npm:^0.74.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -3572,10 +2839,10 @@ __metadata:
     "@uifabricshared/theming-ramp": "npm:*"
     "@uifabricshared/theming-react-native": "npm:*"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
-    react-native-macos: "npm:^0.73.0"
-    react-native-svg: "npm:^15.0.0"
-    react-native-windows: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-svg: "npm:^15.4.0"
+    react-native-windows: "npm:^0.74.0"
     workspace-tools: "npm:^0.26.3"
   languageName: unknown
   linkType: soft
@@ -3628,17 +2895,20 @@ __metadata:
     "@fluentui-react-native/theme-tokens": "workspace:*"
     "@fluentui-react-native/tokens": "workspace:*"
     "@office-iss/react-native-win32": "npm:^0.73.0"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-svg: "npm:^15.4.0"
+    react-native-windows: "npm:^0.74.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-svg: ^15.0.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-svg: ^15.4.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -3659,16 +2929,20 @@ __metadata:
     "@fluentui-react-native/scripts": "workspace:*"
     "@fluentui-react-native/theme-tokens": "workspace:*"
     "@fluentui-react-native/use-styling": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-svg: "npm:^15.4.0"
+    react-native-windows: "npm:^0.74.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-svg: ^15.4.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -3693,18 +2967,20 @@ __metadata:
     "@fluentui-react-native/test-tools": "workspace:*"
     "@fluentui-react-native/text": "workspace:*"
     "@fluentui-react-native/theme-tokens": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
-    react-native-svg: "npm:^14.0.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-svg: "npm:^15.4.0"
+    react-native-windows: "npm:^0.74.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-svg: ^15.0.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-svg: ^15.4.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -3724,9 +3000,9 @@ __metadata:
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/focus-zone": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-babel-transformer": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-babel-transformer": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     "@rnx-kit/metro-config": "npm:^1.3.1"
     "@types/jasmine": "npm:5.1.4"
     "@types/react": "npm:^18.2.0"
@@ -3742,11 +3018,11 @@ __metadata:
     appium-uiautomator2-driver: "npm:^3.0.5"
     appium-windows-driver: "npm:^2.12.18"
     appium-xcuitest-driver: "npm:^7.9.1"
-    metro-config: "npm:^0.80.0"
+    metro-config: "npm:^0.80.3"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
-    react-native-macos: "npm:^0.73.0"
-    react-native-windows: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-windows: "npm:^0.74.0"
     rimraf: "npm:^5.0.1"
     ts-node: "npm:^10.7.0"
     typescript: "npm:4.9.4"
@@ -3771,19 +3047,21 @@ __metadata:
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/framework": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     assert-never: "npm:^1.2.1"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
-    react-native-svg: "npm:^14.0.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-svg: "npm:^15.4.0"
+    react-native-windows: "npm:^0.74.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-svg: ^15.0.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-svg: ^15.4.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -3801,18 +3079,20 @@ __metadata:
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/framework": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     "@types/use-subscription": "npm:1.0.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-windows: "npm:^0.74.0"
     use-subscription: "npm:>=1.0.0 <1.6.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -3830,16 +3110,18 @@ __metadata:
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/framework": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-windows: "npm:^0.74.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -3860,18 +3142,21 @@ __metadata:
     "@fluentui-react-native/framework": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
     "@office-iss/react-native-win32": "npm:^0.73.0"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-svg: "npm:^15.4.0"
+    react-native-windows: "npm:^0.74.0"
     tslib: "npm:^2.3.1"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-svg: ^15.0.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-svg: ^15.4.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -3889,17 +3174,20 @@ __metadata:
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/framework": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
-    react-native-windows: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-svg: "npm:^15.4.0"
+    react-native-windows: "npm:^0.74.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-svg: ^15.4.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -3921,18 +3209,20 @@ __metadata:
     "@fluentui-react-native/scripts": "workspace:*"
     "@fluentui-react-native/tokens": "workspace:*"
     "@office-iss/react-native-win32": "npm:^0.73.0"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
-    react-native-svg: "npm:^14.0.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-svg: "npm:^15.4.0"
+    react-native-windows: "npm:^0.74.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-svg: ^15.0.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-svg: ^15.4.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -3949,13 +3239,13 @@ __metadata:
   dependencies:
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
   peerDependencies:
     react: 18.2.0
-    react-native: ^0.73.0
+    react-native: ^0.74.0
   languageName: unknown
   linkType: soft
 
@@ -3965,15 +3255,15 @@ __metadata:
   dependencies:
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     "@types/use-subscription": "npm:1.0.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
     use-subscription: "npm:>=1.0.0 <1.6.0"
   peerDependencies:
     react: 18.2.0
-    react-native: ^0.73.0
+    react-native: ^0.74.0
   languageName: unknown
   linkType: soft
 
@@ -3987,16 +3277,18 @@ __metadata:
     "@fluentui-react-native/scripts": "workspace:*"
     "@fluentui-react-native/test-tools": "workspace:*"
     "@fluentui-react-native/theme-types": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-windows: "npm:^0.74.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -4017,19 +3309,21 @@ __metadata:
     "@fluentui-react-native/theming-utils": "workspace:*"
     "@fluentui-react-native/tokens": "workspace:*"
     "@fluentui-react-native/use-styling": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     assert-never: "npm:^1.2.1"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
-    react-native-svg: "npm:^14.0.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-svg: "npm:^15.4.0"
+    react-native-windows: "npm:^0.74.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-svg: ^15.0.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-svg: ^15.4.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -4050,17 +3344,19 @@ __metadata:
     "@fluentui-react-native/scripts": "workspace:*"
     "@fluentui-react-native/text": "workspace:*"
     "@fluentui-react-native/tokens": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-windows: "npm:^0.74.0"
     tslib: "npm:^2.3.1"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -4080,18 +3376,20 @@ __metadata:
     "@fluentui-react-native/interactive-hooks": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
     "@office-iss/react-native-win32": "npm:^0.73.0"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     "@uifabricshared/foundation-composable": "workspace:*"
     "@uifabricshared/foundation-settings": "workspace:*"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-windows: "npm:^0.74.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -4111,18 +3409,20 @@ __metadata:
     "@fluentui-react-native/interactive-hooks": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
     "@office-iss/react-native-win32": "npm:^0.73.0"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     "@uifabricshared/foundation-composable": "workspace:*"
     "@uifabricshared/foundation-settings": "workspace:*"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-windows: "npm:^0.74.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -4150,18 +3450,22 @@ __metadata:
     "@fluentui-react-native/use-slots": "workspace:*"
     "@fluentui-react-native/use-styling": "workspace:*"
     "@fluentui-react-native/use-tokens": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     "@types/react": "npm:^18.2.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-svg: "npm:^15.4.0"
+    react-native-windows: "npm:^0.74.0"
     tslib: "npm:^2.3.1"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-svg: ^15.4.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -4183,18 +3487,20 @@ __metadata:
     "@fluentui-react-native/test-tools": "workspace:*"
     "@fluentui-react-native/text": "workspace:*"
     "@office-iss/react-native-win32": "npm:^0.73.0"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
-    react-native-svg: "npm:^14.0.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-svg: "npm:^15.4.0"
+    react-native-windows: "npm:^0.74.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-svg: ^15.0.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-svg: ^15.4.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -4232,18 +3538,20 @@ __metadata:
     "@fluentui-react-native/theme-tokens": "workspace:*"
     "@fluentui-react-native/tokens": "workspace:*"
     "@fluentui-react-native/use-styling": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
-    react-native-svg: "npm:^14.0.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-svg: "npm:^15.4.0"
+    react-native-windows: "npm:^0.74.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-svg: ^15.0.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-svg: ^15.4.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -4265,23 +3573,23 @@ __metadata:
     "@fluentui-react-native/scripts": "workspace:*"
     "@fluentui-react-native/test-tools": "workspace:*"
     "@office-iss/react-native-win32": "npm:^0.73.0"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     "@types/invariant": "npm:^2.2.0"
     "@types/jest": "npm:^29.0.0"
     "@types/react": "npm:^18.2.0"
     invariant: "npm:^2.2.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
-    react-native-macos: "npm:^0.73.0"
-    react-native-windows: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-windows: "npm:^0.74.0"
     tslib: "npm:^2.3.1"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -4305,20 +3613,22 @@ __metadata:
     "@fluentui-react-native/text": "workspace:*"
     "@fluentui-react-native/tokens": "workspace:*"
     "@fluentui-react-native/use-styling": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     "@uifabricshared/foundation-composable": "workspace:*"
     "@uifabricshared/foundation-compose": "workspace:*"
     "@uifabricshared/foundation-settings": "workspace:*"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-windows: "npm:^0.74.0"
     tslib: "npm:^2.3.1"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -4352,21 +3662,23 @@ __metadata:
     "@fluentui-react-native/scripts": "workspace:*"
     "@fluentui-react-native/tokens": "workspace:*"
     "@office-iss/react-native-win32": "npm:^0.73.0"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     "@uifabricshared/foundation-composable": "workspace:*"
     "@uifabricshared/foundation-compose": "workspace:*"
     "@uifabricshared/foundation-settings": "workspace:*"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
-    react-native-svg: "npm:^14.0.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-svg: "npm:^15.4.0"
+    react-native-windows: "npm:^0.74.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-svg: ^15.0.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-svg: ^15.4.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -4397,19 +3709,21 @@ __metadata:
     "@fluentui-react-native/tokens": "workspace:*"
     "@fluentui-react-native/use-styling": "workspace:*"
     "@office-iss/react-native-win32": "npm:^0.73.0"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
-    react-native-svg: "npm:^14.0.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-svg: "npm:^15.4.0"
+    react-native-windows: "npm:^0.74.0"
     tslib: "npm:^2.3.1"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-svg: ^15.0.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-svg: ^15.4.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -4428,15 +3742,15 @@ __metadata:
     "@fluentui-react-native/immutable-merge": "workspace:*"
     "@fluentui-react-native/memo-cache": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     "@types/jest": "npm:^29.0.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
     tslib: "npm:^2.3.1"
   peerDependencies:
     react: 18.2.0
-    react-native: ^0.73.0
+    react-native: ^0.74.0
   languageName: unknown
   linkType: soft
 
@@ -4461,18 +3775,20 @@ __metadata:
     "@fluentui-react-native/tokens": "workspace:*"
     "@fluentui-react-native/use-styling": "workspace:*"
     "@office-iss/react-native-win32": "npm:^0.73.0"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
-    react-native-svg: "npm:^14.0.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-svg: "npm:^15.4.0"
+    react-native-windows: "npm:^0.74.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-svg: ^15.0.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-svg: ^15.4.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -4494,18 +3810,21 @@ __metadata:
     "@fluentui-react-native/scripts": "workspace:*"
     "@fluentui-react-native/test-tools": "workspace:*"
     "@office-iss/react-native-win32": "npm:^0.73.0"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
-    react-native-svg: "npm:^14.0.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-svg: "npm:^15.4.0"
+    react-native-windows: "npm:^0.74.0"
     tslib: "npm:^2.3.1"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-svg: ^15.4.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -4527,20 +3846,22 @@ __metadata:
     "@fluentui-react-native/theme-tokens": "workspace:*"
     "@fluentui-react-native/tokens": "workspace:*"
     "@office-iss/react-native-win32": "npm:^0.73.0"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     "@uifabricshared/foundation-composable": "workspace:*"
     "@uifabricshared/foundation-compose": "workspace:*"
     "@uifabricshared/foundation-settings": "workspace:*"
     "@uifabricshared/foundation-tokens": "workspace:*"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-windows: "npm:^0.74.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -4561,20 +3882,22 @@ __metadata:
     "@fluentui-react-native/persona-coin": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
     "@fluentui-react-native/tokens": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     "@uifabricshared/foundation-composable": "workspace:*"
     "@uifabricshared/foundation-compose": "workspace:*"
     "@uifabricshared/foundation-settings": "workspace:*"
     "@uifabricshared/foundation-tokens": "workspace:*"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-windows: "npm:^0.74.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -4593,17 +3916,19 @@ __metadata:
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/framework": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-windows: "npm:^0.74.0"
     tslib: "npm:^2.3.1"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -4622,18 +3947,20 @@ __metadata:
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/interactive-hooks": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     "@uifabricshared/foundation-composable": "workspace:*"
     "@uifabricshared/foundation-settings": "workspace:*"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-windows: "npm:^0.74.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -4661,22 +3988,24 @@ __metadata:
     "@fluentui-react-native/tokens": "workspace:*"
     "@fluentui-react-native/use-styling": "workspace:*"
     "@office-iss/react-native-win32": "npm:^0.73.0"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     "@uifabricshared/foundation-composable": "workspace:*"
     "@uifabricshared/foundation-compose": "workspace:*"
     "@uifabricshared/foundation-settings": "workspace:*"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
-    react-native-svg: "npm:^14.0.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-svg: "npm:^15.4.0"
+    react-native-windows: "npm:^0.74.0"
     tslib: "npm:^2.3.1"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-svg: ^15.0.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-svg: ^15.4.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -4696,9 +4025,9 @@ __metadata:
     "@babel/preset-env": "npm:^7.8.0"
     "@babel/preset-react": "npm:^7.8.0"
     "@babel/preset-typescript": "npm:^7.8.0"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-babel-transformer": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-babel-transformer": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     "@rnx-kit/align-deps": "npm:^2.2.5"
     babel-jest: "npm:^29.7.0"
     beachball: "npm:^2.20.0"
@@ -4708,11 +4037,11 @@ __metadata:
     markdown-link-check: "npm:^3.8.7"
     react: "npm:18.2.0"
     react-dom: "npm:^18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
   peerDependencies:
     react: 18.2.0
     react-dom: ^18.2.0
-    react-native: ^0.73.0
+    react-native: ^0.74.0
   languageName: unknown
   linkType: soft
 
@@ -4720,10 +4049,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/scripts@workspace:scripts"
   dependencies:
-    "@react-native-community/cli": "npm:^12.1.1"
-    "@react-native-community/cli-platform-android": "npm:^12.1.1"
-    "@react-native-community/cli-platform-ios": "npm:^12.1.1"
-    "@react-native/metro-babel-transformer": "npm:^0.73.0"
+    "@react-native-community/cli": "npm:^13.6.4"
+    "@react-native-community/cli-platform-android": "npm:^13.6.4"
+    "@react-native-community/cli-platform-ios": "npm:^13.6.4"
+    "@react-native/metro-babel-transformer": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     "@rnx-kit/jest-preset": "npm:^0.1.14"
     "@types/es6-collections": "npm:^0.5.29"
     "@types/es6-promise": "npm:0.0.32"
@@ -4739,13 +4069,13 @@ __metadata:
     jsdom: "npm:^25.0.0"
     just-scripts: "npm:^2.3.2"
     just-task: "npm:^1.4.2"
-    metro-config: "npm:^0.80.0"
+    metro-config: "npm:^0.80.3"
     metro-react-native-babel-transformer: "npm:^0.76.5"
     prettier: "npm:^2.4.1"
     react: "npm:18.2.0"
     react-dom: "npm:^18.2.0"
-    react-native: "npm:^0.73.0"
-    react-native-svg: "npm:^15.0.0"
+    react-native: "npm:^0.74.0"
+    react-native-svg: "npm:^15.4.0"
     react-native-svg-transformer: "npm:^1.0.0"
     react-test-renderer: "npm:18.2.0"
     rimraf: "npm:^5.0.1"
@@ -4754,6 +4084,9 @@ __metadata:
   peerDependencies:
     just-scripts: ^2.3.2
     react: 18.2.0
+    react-dom: ^18.2.0
+    react-native: ^0.74.0
+    react-native-svg: ^15.4.0
   bin:
     fluentui-scripts: ./just-scripts.js
   languageName: unknown
@@ -4769,16 +4102,18 @@ __metadata:
     "@fluentui-react-native/theme-tokens": "workspace:*"
     "@fluentui-react-native/use-styling": "workspace:*"
     "@office-iss/react-native-win32": "npm:^0.73.0"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-windows: "npm:^0.74.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -4799,18 +4134,20 @@ __metadata:
     "@fluentui-react-native/text": "workspace:*"
     "@fluentui-react-native/theme-tokens": "workspace:*"
     "@fluentui-react-native/use-styling": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
-    react-native-svg: "npm:^14.0.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-svg: "npm:^15.4.0"
+    react-native-windows: "npm:^0.74.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-svg: ^15.0.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-svg: ^15.4.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -4831,20 +4168,22 @@ __metadata:
     "@fluentui-react-native/scripts": "workspace:*"
     "@fluentui-react-native/text": "workspace:*"
     "@fluentui-react-native/tokens": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     "@uifabricshared/foundation-composable": "workspace:*"
     "@uifabricshared/foundation-compose": "workspace:*"
     "@uifabricshared/foundation-settings": "workspace:*"
     "@uifabricshared/foundation-tokens": "workspace:*"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-windows: "npm:^0.74.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -4861,13 +4200,13 @@ __metadata:
   dependencies:
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
   peerDependencies:
     react: 18.2.0
-    react-native: ^0.73.0
+    react-native: ^0.74.0
   languageName: unknown
   linkType: soft
 
@@ -4886,17 +4225,19 @@ __metadata:
     "@fluentui-react-native/tokens": "workspace:*"
     "@fluentui-react-native/use-styling": "workspace:*"
     "@office-iss/react-native-win32": "npm:^0.73.0"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-windows: "npm:^0.74.0"
     tslib: "npm:^2.3.1"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -4924,18 +4265,21 @@ __metadata:
     "@fluentui-react-native/tokens": "workspace:*"
     "@fluentui-react-native/use-styling": "workspace:*"
     "@office-iss/react-native-win32": "npm:^0.73.0"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-svg: "npm:^15.4.0"
+    react-native-windows: "npm:^0.74.0"
     tslib: "npm:^2.3.1"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-svg: ^15.0.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-svg: ^15.4.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -4955,10 +4299,10 @@ __metadata:
     "@fluentui-react-native/theme-types": "workspace:*"
     "@types/react": "npm:^18.2.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
   peerDependencies:
     react: 18.2.0
-    react-native: ^0.73.0
+    react-native: ^0.74.0
   languageName: unknown
   linkType: soft
 
@@ -4971,16 +4315,16 @@ __metadata:
     "@fluentui-react-native/tester": "workspace:*"
     "@office-iss/react-native-win32": "npm:^0.73.0"
     "@office-iss/rex-win32": "npm:0.73.11-devmain.16.0.17614.15010"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-babel-transformer": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-babel-transformer": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     "@rnx-kit/cli": "npm:^0.16.2"
     "@rnx-kit/metro-config": "npm:^1.3.1"
     "@types/react": "npm:^18.2.0"
-    metro-config: "npm:^0.80.0"
+    metro-config: "npm:^0.80.3"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
-    react-native-svg: "npm:^15.0.0"
+    react-native: "npm:^0.74.0"
+    react-native-svg: "npm:^15.4.0"
     react-native-svg-transformer: "npm:^1.0.0"
     react-test-renderer: "npm:18.2.0"
     rimraf: "npm:^5.0.1"
@@ -5053,9 +4397,9 @@ __metadata:
     "@react-native-community/slider": "npm:^4.2.0"
     "@react-native-menu/menu": "npm:^0.7.3"
     "@react-native-picker/picker": "npm:^2.7.0"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-babel-transformer": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-babel-transformer": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     "@rnx-kit/cli": "npm:^0.16.2"
     "@rnx-kit/metro-config": "npm:^1.3.1"
     "@types/jasmine": "npm:5.1.4"
@@ -5064,14 +4408,14 @@ __metadata:
     "@wdio/globals": "npm:^8.40.0"
     "@wdio/jasmine-framework": "npm:^8.40.0"
     flow-bin: "npm:^0.113.0"
-    metro-config: "npm:^0.80.0"
+    metro-config: "npm:^0.80.3"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
-    react-native-macos: "npm:^0.73.0"
-    react-native-svg: "npm:^15.0.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-svg: "npm:^15.4.0"
     react-native-svg-transformer: "npm:^1.0.0"
-    react-native-test-app: "npm:^3.4.7"
-    react-native-windows: "npm:^0.73.0"
+    react-native-test-app: "npm:^3.9.2"
+    react-native-windows: "npm:^0.74.0"
     react-test-renderer: "npm:18.2.0"
     tslib: "npm:^2.3.1"
     webdriverio: "npm:^8.40.0"
@@ -5095,18 +4439,20 @@ __metadata:
     "@fluentui-react-native/test-tools": "workspace:*"
     "@fluentui-react-native/theme-tokens": "workspace:*"
     "@fluentui-react-native/tokens": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     "@uifabricshared/foundation-compose": "workspace:*"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-windows: "npm:^0.74.0"
     tslib: "npm:^2.3.1"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -5128,14 +4474,14 @@ __metadata:
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
     "@fluentui-react-native/theme-types": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     assert-never: "npm:^1.2.1"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
   peerDependencies:
     react: 18.2.0
-    react-native: ^0.73.0
+    react-native: ^0.74.0
   languageName: unknown
   linkType: soft
 
@@ -5145,14 +4491,14 @@ __metadata:
   dependencies:
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     "@types/react": "npm:^18.2.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
   peerDependencies:
     react: 18.2.0
-    react-native: ^0.73.0
+    react-native: ^0.74.0
   languageName: unknown
   linkType: soft
 
@@ -5164,13 +4510,13 @@ __metadata:
     "@fluentui-react-native/scripts": "workspace:*"
     "@fluentui-react-native/test-tools": "workspace:*"
     "@fluentui-react-native/theme-types": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
   peerDependencies:
     react: 18.2.0
-    react-native: ^0.73.0
+    react-native: ^0.74.0
   languageName: unknown
   linkType: soft
 
@@ -5181,13 +4527,13 @@ __metadata:
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/memo-cache": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
   peerDependencies:
     react: 18.2.0
-    react-native: ^0.73.0
+    react-native: ^0.74.0
   languageName: unknown
   linkType: soft
 
@@ -5201,17 +4547,18 @@ __metadata:
     "@fluentui-react-native/scripts": "workspace:*"
     "@fluentui-react-native/theme-types": "workspace:*"
     "@fluentui-react-native/tokens": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
-    react-native-windows: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-windows: "npm:^0.74.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -5230,17 +4577,19 @@ __metadata:
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
     "@fluentui-react-native/theme-types": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-windows: "npm:^0.74.0"
     tslib: "npm:^2.3.1"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -5262,18 +4611,21 @@ __metadata:
     "@fluentui-react-native/scripts": "workspace:*"
     "@fluentui-react-native/test-tools": "workspace:*"
     "@office-iss/react-native-win32": "npm:^0.73.0"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
-    react-native-svg: "npm:^14.0.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-svg: "npm:^15.4.0"
+    react-native-windows: "npm:^0.74.0"
     tslib: "npm:^2.3.1"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-svg: ^15.4.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -5290,14 +4642,14 @@ __metadata:
   dependencies:
     "@fluentui-react-native/merge-props": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
     tslib: "npm:^2.3.1"
   peerDependencies:
     react: 18.2.0
-    react-native: ^0.73.0
+    react-native: ^0.74.0
   languageName: unknown
   linkType: soft
 
@@ -5308,13 +4660,13 @@ __metadata:
     "@fluentui-react-native/merge-props": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
     "@fluentui-react-native/use-slot": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
   peerDependencies:
     react: 18.2.0
-    react-native: ^0.73.0
+    react-native: ^0.74.0
   languageName: unknown
   linkType: soft
 
@@ -5325,15 +4677,15 @@ __metadata:
     "@fluentui-react-native/memo-cache": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
     "@fluentui-react-native/use-tokens": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     "@types/jest": "npm:^29.0.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
     tslib: "npm:^2.3.1"
   peerDependencies:
     react: 18.2.0
-    react-native: ^0.73.0
+    react-native: ^0.74.0
   languageName: unknown
   linkType: soft
 
@@ -5345,15 +4697,15 @@ __metadata:
     "@fluentui-react-native/memo-cache": "workspace:*"
     "@fluentui-react-native/merge-props": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     "@types/jest": "npm:^29.0.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
     tslib: "npm:^2.3.1"
   peerDependencies:
     react: 18.2.0
-    react-native: ^0.73.0
+    react-native: ^0.74.0
   languageName: unknown
   linkType: soft
 
@@ -5364,17 +4716,19 @@ __metadata:
     "@fluentui-react-native/adapters": "workspace:*"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-windows: "npm:^0.74.0"
     tslib: "npm:^2.3.1"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -5399,18 +4753,20 @@ __metadata:
     "@fluentui-react-native/theme-types": "workspace:*"
     "@fluentui-react-native/theming-utils": "workspace:*"
     "@office-iss/react-native-win32": "npm:^0.73.0"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     "@types/react": "npm:^18.2.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-windows: "npm:^0.74.0"
     tslib: "npm:^2.3.1"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -5443,17 +4799,20 @@ __metadata:
     "@fluentui-react-native/separator": "workspace:*"
     "@fluentui-react-native/tablist": "workspace:*"
     "@fluentui-react-native/text": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-svg: "npm:^15.4.0"
+    react-native-windows: "npm:^0.74.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-svg: ^15.0.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-svg: ^15.4.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -6223,7 +5582,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/core@npm:1.23.0, @opentelemetry/core@npm:^1.15.2":
+"@opentelemetry/core@npm:1.23.0":
   version: 1.23.0
   resolution: "@opentelemetry/core@npm:1.23.0"
   dependencies:
@@ -6231,6 +5590,17 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ">=1.0.0 <1.9.0"
   checksum: 10c0/b68442034315c182fd5e6c1bcca7b249a4995dc219c6935718fb143d24b13cee5e7884c6750b9f55ae8f4477b7edb9b3140c6663112485b49f2a9bc5a243f5f2
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/core@npm:^1.15.2":
+  version: 1.26.0
+  resolution: "@opentelemetry/core@npm:1.26.0"
+  dependencies:
+    "@opentelemetry/semantic-conventions": "npm:1.27.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
+  checksum: 10c0/8038a3b9124a0b3b48dceb3949f88726c6853eac33b79fc049856f78dcf4b7ee453db1e6f4d5205a79b315caba809cb7d2f853946cf14773e50ce6a87fd5260e
   languageName: node
   linkType: hard
 
@@ -6274,10 +5644,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/semantic-conventions@npm:1.23.0, @opentelemetry/semantic-conventions@npm:^1.15.2":
+"@opentelemetry/semantic-conventions@npm:1.23.0":
   version: 1.23.0
   resolution: "@opentelemetry/semantic-conventions@npm:1.23.0"
   checksum: 10c0/2712f3874a45607bc7024e0d1a01c91a7e4671e7b925e2fcc79227f350c16c59a29ba36d8ab5f0842fe003ff464d24ab576033b35390316886bb120477f96ca6
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/semantic-conventions@npm:1.27.0, @opentelemetry/semantic-conventions@npm:^1.15.2":
+  version: 1.27.0
+  resolution: "@opentelemetry/semantic-conventions@npm:1.27.0"
+  checksum: 10c0/b859773ba06b7e53dd9c6b45a171bf3000e405733adbf462ae91004ed011bc80edb5beecb817fb344a085adfd06045ab5b729c9bd0f1479650ad377134fb798c
   languageName: node
   linkType: hard
 
@@ -6327,6 +5704,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native-community/cli-clean@npm:13.6.9":
+  version: 13.6.9
+  resolution: "@react-native-community/cli-clean@npm:13.6.9"
+  dependencies:
+    "@react-native-community/cli-tools": "npm:13.6.9"
+    chalk: "npm:^4.1.2"
+    execa: "npm:^5.0.0"
+    fast-glob: "npm:^3.3.2"
+  checksum: 10c0/b40e4f0479c7ee419f1ce33f1d1278c2cf4d74fd9402852479a052f91ce56ee2e0b849e8d5cafea13f9fe246202823d5b2f8e1773eff610fcd84c1e190871624
+  languageName: node
+  linkType: hard
+
 "@react-native-community/cli-config@npm:12.3.6":
   version: 12.3.6
   resolution: "@react-native-community/cli-config@npm:12.3.6"
@@ -6355,6 +5744,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native-community/cli-config@npm:13.6.9":
+  version: 13.6.9
+  resolution: "@react-native-community/cli-config@npm:13.6.9"
+  dependencies:
+    "@react-native-community/cli-tools": "npm:13.6.9"
+    chalk: "npm:^4.1.2"
+    cosmiconfig: "npm:^5.1.0"
+    deepmerge: "npm:^4.3.0"
+    fast-glob: "npm:^3.3.2"
+    joi: "npm:^17.2.1"
+  checksum: 10c0/f5635c1a02964d6ad36231acd1e0eda5bd0a47306939721bdc1f0c2258d989c3bcee1b5b77c5addb036d7846ec5c87fec72059e77f6b0d68815f079ef5d7d960
+  languageName: node
+  linkType: hard
+
 "@react-native-community/cli-debugger-ui@npm:12.3.6":
   version: 12.3.6
   resolution: "@react-native-community/cli-debugger-ui@npm:12.3.6"
@@ -6370,6 +5773,15 @@ __metadata:
   dependencies:
     serve-static: "npm:^1.13.1"
   checksum: 10c0/2a82f6c4f34b21dc1d90aa91a0b22adb90619d0b263514989fd07f7a3759560839d834a65bb4043736ab8995881c5f03e0aaca5a4689eef9b99fb4bc9fe2288a
+  languageName: node
+  linkType: hard
+
+"@react-native-community/cli-debugger-ui@npm:13.6.9":
+  version: 13.6.9
+  resolution: "@react-native-community/cli-debugger-ui@npm:13.6.9"
+  dependencies:
+    serve-static: "npm:^1.13.1"
+  checksum: 10c0/9673c6ab96c84319e8b4b9df7b608fbf4bac1611e60b6363778aa0cec3ac2135d04212cc114122aee6007b3954054c5df27cc1fa59fe5edb2be2f0a4b9442afc
   languageName: node
   linkType: hard
 
@@ -6421,6 +5833,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native-community/cli-doctor@npm:13.6.9":
+  version: 13.6.9
+  resolution: "@react-native-community/cli-doctor@npm:13.6.9"
+  dependencies:
+    "@react-native-community/cli-config": "npm:13.6.9"
+    "@react-native-community/cli-platform-android": "npm:13.6.9"
+    "@react-native-community/cli-platform-apple": "npm:13.6.9"
+    "@react-native-community/cli-platform-ios": "npm:13.6.9"
+    "@react-native-community/cli-tools": "npm:13.6.9"
+    chalk: "npm:^4.1.2"
+    command-exists: "npm:^1.2.8"
+    deepmerge: "npm:^4.3.0"
+    envinfo: "npm:^7.10.0"
+    execa: "npm:^5.0.0"
+    hermes-profile-transformer: "npm:^0.0.6"
+    node-stream-zip: "npm:^1.9.1"
+    ora: "npm:^5.4.1"
+    semver: "npm:^7.5.2"
+    strip-ansi: "npm:^5.2.0"
+    wcwidth: "npm:^1.0.1"
+    yaml: "npm:^2.2.1"
+  checksum: 10c0/d39e5e31e58e849fa70c2430c83af6f1ec4468bd0995ebf944b2d9cdda008b82b347f15deef1aa026dbe4502691aabf9698f022c0739b980a73a07c3f6c090f0
+  languageName: node
+  linkType: hard
+
 "@react-native-community/cli-hermes@npm:12.3.6":
   version: 12.3.6
   resolution: "@react-native-community/cli-hermes@npm:12.3.6"
@@ -6445,6 +5882,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native-community/cli-hermes@npm:13.6.9":
+  version: 13.6.9
+  resolution: "@react-native-community/cli-hermes@npm:13.6.9"
+  dependencies:
+    "@react-native-community/cli-platform-android": "npm:13.6.9"
+    "@react-native-community/cli-tools": "npm:13.6.9"
+    chalk: "npm:^4.1.2"
+    hermes-profile-transformer: "npm:^0.0.6"
+  checksum: 10c0/8e182570a65a1e57bde9dcaafe2d19741feac83a5e64f9c1828d0b24adcc78ea837720a12ad98769aab972647955f3b46c28b3ca2f465390c1ed44186d2d1b8e
+  languageName: node
+  linkType: hard
+
 "@react-native-community/cli-platform-android@npm:12.3.6":
   version: 12.3.6
   resolution: "@react-native-community/cli-platform-android@npm:12.3.6"
@@ -6459,7 +5908,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native-community/cli-platform-android@npm:12.3.7, @react-native-community/cli-platform-android@npm:^12.1.1":
+"@react-native-community/cli-platform-android@npm:12.3.7":
   version: 12.3.7
   resolution: "@react-native-community/cli-platform-android@npm:12.3.7"
   dependencies:
@@ -6470,6 +5919,34 @@ __metadata:
     glob: "npm:^7.1.3"
     logkitty: "npm:^0.7.1"
   checksum: 10c0/76a281fcb22b29567eb45515bc3c7a3c5e3a43418676e39db6b97cbc53ad9cd94c3131db05ca39a486df54f8a35aa7682827dc77789f490a72d67f8674fbfd96
+  languageName: node
+  linkType: hard
+
+"@react-native-community/cli-platform-android@npm:13.6.9, @react-native-community/cli-platform-android@npm:^13.6.4":
+  version: 13.6.9
+  resolution: "@react-native-community/cli-platform-android@npm:13.6.9"
+  dependencies:
+    "@react-native-community/cli-tools": "npm:13.6.9"
+    chalk: "npm:^4.1.2"
+    execa: "npm:^5.0.0"
+    fast-glob: "npm:^3.3.2"
+    fast-xml-parser: "npm:^4.2.4"
+    logkitty: "npm:^0.7.1"
+  checksum: 10c0/6083fe862e2166982b844d7b50d121ddf6e2a12c221b5e4ad950db3da4c2c6f92e030447eb301e254b7a43e593a6f4436dd34cad136d9cd8182517032264c409
+  languageName: node
+  linkType: hard
+
+"@react-native-community/cli-platform-apple@npm:13.6.9":
+  version: 13.6.9
+  resolution: "@react-native-community/cli-platform-apple@npm:13.6.9"
+  dependencies:
+    "@react-native-community/cli-tools": "npm:13.6.9"
+    chalk: "npm:^4.1.2"
+    execa: "npm:^5.0.0"
+    fast-glob: "npm:^3.3.2"
+    fast-xml-parser: "npm:^4.0.12"
+    ora: "npm:^5.4.1"
+  checksum: 10c0/3a9c900ebbb141083f5d7ebc2494a580010a9df73d2bd589f7707d23e6b3feacdf259c98c8cc774851e3fea21aab6366e255bf489c710dd5712b33c984f58812
   languageName: node
   linkType: hard
 
@@ -6487,7 +5964,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native-community/cli-platform-ios@npm:12.3.7, @react-native-community/cli-platform-ios@npm:^12.1.1":
+"@react-native-community/cli-platform-ios@npm:12.3.7":
   version: 12.3.7
   resolution: "@react-native-community/cli-platform-ios@npm:12.3.7"
   dependencies:
@@ -6498,6 +5975,15 @@ __metadata:
     glob: "npm:^7.1.3"
     ora: "npm:^5.4.1"
   checksum: 10c0/7cac9b2a908ea69f54870445ee1ee8b3d485951d89c1c154b8e0903fee40e81136423b0f7817f811a22877eb1ca5bc51b34ce7aff940d180c769b1109bb63010
+  languageName: node
+  linkType: hard
+
+"@react-native-community/cli-platform-ios@npm:13.6.9, @react-native-community/cli-platform-ios@npm:^13.6.4":
+  version: 13.6.9
+  resolution: "@react-native-community/cli-platform-ios@npm:13.6.9"
+  dependencies:
+    "@react-native-community/cli-platform-apple": "npm:13.6.9"
+  checksum: 10c0/e4d9b47a3ca945ab58c5087cbe6740f22b1f3ccf4e5d48250bfbb7d57d20026e8c1d5216618047f0ddf82a77b387910b6f2f7c73d5d4d44d0702096e380b4f96
   languageName: node
   linkType: hard
 
@@ -6549,6 +6035,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native-community/cli-server-api@npm:13.6.9":
+  version: 13.6.9
+  resolution: "@react-native-community/cli-server-api@npm:13.6.9"
+  dependencies:
+    "@react-native-community/cli-debugger-ui": "npm:13.6.9"
+    "@react-native-community/cli-tools": "npm:13.6.9"
+    compression: "npm:^1.7.1"
+    connect: "npm:^3.6.5"
+    errorhandler: "npm:^1.5.1"
+    nocache: "npm:^3.0.1"
+    pretty-format: "npm:^26.6.2"
+    serve-static: "npm:^1.13.1"
+    ws: "npm:^6.2.2"
+  checksum: 10c0/4061c25e66f5eaf5b397ae776feb4c5fcd1ee0ed4748e0694ba387870e67519145f255b69c2ea0583e8704580f3c7ba12d9e0181f80cc6f5e739c9c4f4f4e407
+  languageName: node
+  linkType: hard
+
 "@react-native-community/cli-tools@npm:12.3.6":
   version: 12.3.6
   resolution: "@react-native-community/cli-tools@npm:12.3.6"
@@ -6585,6 +6088,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native-community/cli-tools@npm:13.6.9":
+  version: 13.6.9
+  resolution: "@react-native-community/cli-tools@npm:13.6.9"
+  dependencies:
+    appdirsjs: "npm:^1.2.4"
+    chalk: "npm:^4.1.2"
+    execa: "npm:^5.0.0"
+    find-up: "npm:^5.0.0"
+    mime: "npm:^2.4.1"
+    node-fetch: "npm:^2.6.0"
+    open: "npm:^6.2.0"
+    ora: "npm:^5.4.1"
+    semver: "npm:^7.5.2"
+    shell-quote: "npm:^1.7.3"
+    sudo-prompt: "npm:^9.0.0"
+  checksum: 10c0/a9b85cae49202aae81db33d3b62d06574c504bce634fbf0939dfa6ad6cae8f1b2728d4873fb5115023757a500280237992317c245e1b54dd96ca8c63c0f2582e
+  languageName: node
+  linkType: hard
+
 "@react-native-community/cli-types@npm:12.3.6":
   version: 12.3.6
   resolution: "@react-native-community/cli-types@npm:12.3.6"
@@ -6600,6 +6122,15 @@ __metadata:
   dependencies:
     joi: "npm:^17.2.1"
   checksum: 10c0/5ae3dad9f70ea79823156b1d86ff0b011c1ae6116c03d281d9bf23f64903e1e32a6336898de99784c73df0b7f679a59a8499d3e9bc773a19702d25dabd945cfd
+  languageName: node
+  linkType: hard
+
+"@react-native-community/cli-types@npm:13.6.9":
+  version: 13.6.9
+  resolution: "@react-native-community/cli-types@npm:13.6.9"
+  dependencies:
+    joi: "npm:^17.2.1"
+  checksum: 10c0/07be9711034265e6d602c659319ac3663adcc95b4633fd235ea6ce697681aaa3980c0bd13aa2e82e5f1309e21010619fef1e580e672f4649a7d4a91146c9a666
   languageName: node
   linkType: hard
 
@@ -6631,7 +6162,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native-community/cli@npm:12.3.7, @react-native-community/cli@npm:^12.1.1":
+"@react-native-community/cli@npm:12.3.7":
   version: 12.3.7
   resolution: "@react-native-community/cli@npm:12.3.7"
   dependencies:
@@ -6659,6 +6190,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native-community/cli@npm:13.6.9, @react-native-community/cli@npm:^13.6.4":
+  version: 13.6.9
+  resolution: "@react-native-community/cli@npm:13.6.9"
+  dependencies:
+    "@react-native-community/cli-clean": "npm:13.6.9"
+    "@react-native-community/cli-config": "npm:13.6.9"
+    "@react-native-community/cli-debugger-ui": "npm:13.6.9"
+    "@react-native-community/cli-doctor": "npm:13.6.9"
+    "@react-native-community/cli-hermes": "npm:13.6.9"
+    "@react-native-community/cli-server-api": "npm:13.6.9"
+    "@react-native-community/cli-tools": "npm:13.6.9"
+    "@react-native-community/cli-types": "npm:13.6.9"
+    chalk: "npm:^4.1.2"
+    commander: "npm:^9.4.1"
+    deepmerge: "npm:^4.3.0"
+    execa: "npm:^5.0.0"
+    find-up: "npm:^4.1.0"
+    fs-extra: "npm:^8.1.0"
+    graceful-fs: "npm:^4.1.3"
+    prompts: "npm:^2.4.2"
+    semver: "npm:^7.5.2"
+  bin:
+    rnc-cli: build/bin.js
+  checksum: 10c0/4f2404301e7d12134dfa3f540d89f6a7b0ee9dd2125fe67d8c91a75cb6aa53367fc4db834c840b484cf1781cf5f4370b26ff9289beeba0e143b5febfadfd305d
+  languageName: node
+  linkType: hard
+
 "@react-native-community/slider@npm:^4.2.0":
   version: 4.5.3
   resolution: "@react-native-community/slider@npm:4.5.3"
@@ -6666,15 +6224,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native-mac/virtualized-lists@npm:^0.73.3":
-  version: 0.73.3
-  resolution: "@react-native-mac/virtualized-lists@npm:0.73.3"
+"@react-native-mac/virtualized-lists@npm:0.74.87":
+  version: 0.74.87
+  resolution: "@react-native-mac/virtualized-lists@npm:0.74.87"
   dependencies:
     invariant: "npm:^2.2.4"
     nullthrows: "npm:^1.1.1"
   peerDependencies:
+    "@types/react": ^18.2.6
+    react: "*"
     react-native: "*"
-  checksum: 10c0/882cf5c2109aaaead587d0c190df2a416731db32c30ab71e747eaba0995eee265bd96ab2d585369c9e6caee49834df7dad72e965658bf35594d77ca123395ed7
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/1f722bd59149d65676c6ebb6f13d78e87bb1b6a5f48fa033f0a6d002fa0c7d85ff3919fbe00e4d96e8133bb1194055f90c2a75664dba01056cc1bc42da472fa3
   languageName: node
   linkType: hard
 
@@ -6729,6 +6292,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native-windows/cli@npm:0.74.5":
+  version: 0.74.5
+  resolution: "@react-native-windows/cli@npm:0.74.5"
+  dependencies:
+    "@react-native-windows/codegen": "npm:0.74.3"
+    "@react-native-windows/fs": "npm:0.74.1"
+    "@react-native-windows/package-utils": "npm:0.74.1"
+    "@react-native-windows/telemetry": "npm:0.74.2"
+    "@xmldom/xmldom": "npm:^0.7.7"
+    chalk: "npm:^4.1.0"
+    cli-spinners: "npm:^2.2.0"
+    envinfo: "npm:^7.5.0"
+    find-up: "npm:^4.1.0"
+    glob: "npm:^7.1.1"
+    lodash: "npm:^4.17.15"
+    mustache: "npm:^4.0.1"
+    ora: "npm:^3.4.0"
+    prompts: "npm:^2.4.1"
+    semver: "npm:^7.3.2"
+    shelljs: "npm:^0.8.4"
+    username: "npm:^5.1.0"
+    uuid: "npm:^3.3.2"
+    xml-formatter: "npm:^2.4.0"
+    xml-parser: "npm:^1.2.1"
+    xpath: "npm:^0.0.27"
+  peerDependencies:
+    react-native: "*"
+  checksum: 10c0/0a270adb943e51ce6de852d05a07ea5c671fd00b6d22444ec931ba48eb4a6a8008c1e9a53d946477b2cdd7f1cb20a2b51d40cb159fced5aa714f352f9e26bb0b
+  languageName: node
+  linkType: hard
+
 "@react-native-windows/codegen@npm:0.73.2":
   version: 0.73.2
   resolution: "@react-native-windows/codegen@npm:0.73.2"
@@ -6747,6 +6341,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native-windows/codegen@npm:0.74.3":
+  version: 0.74.3
+  resolution: "@react-native-windows/codegen@npm:0.74.3"
+  dependencies:
+    "@react-native-windows/fs": "npm:0.74.1"
+    chalk: "npm:^4.1.0"
+    globby: "npm:^11.1.0"
+    mustache: "npm:^4.0.1"
+    source-map-support: "npm:^0.5.19"
+    yargs: "npm:^16.2.0"
+  peerDependencies:
+    react-native: "*"
+  bin:
+    react-native-windows-codegen: bin.js
+  checksum: 10c0/edb809f823e2d82b6a849bab129fb9e49d7a68fc41c105f453e995ac251ac56193742efff316dc7ff58d5a2476bb8a8c335ebaf3812e4808a235b8312a1cc67a
+  languageName: node
+  linkType: hard
+
 "@react-native-windows/find-repo-root@npm:0.73.1":
   version: 0.73.1
   resolution: "@react-native-windows/find-repo-root@npm:0.73.1"
@@ -6754,6 +6366,16 @@ __metadata:
     "@react-native-windows/fs": "npm:0.73.1"
     find-up: "npm:^4.1.0"
   checksum: 10c0/5e9874fe327b7f246c14bc88b4ff65b6b41b3a7a4eb7bb51c2941957a63731b75b878b509780b80445e00c710aa7530c056de8de96b164ec16992dd0e7ca896c
+  languageName: node
+  linkType: hard
+
+"@react-native-windows/find-repo-root@npm:0.74.1":
+  version: 0.74.1
+  resolution: "@react-native-windows/find-repo-root@npm:0.74.1"
+  dependencies:
+    "@react-native-windows/fs": "npm:0.74.1"
+    find-up: "npm:^4.1.0"
+  checksum: 10c0/4a6633e40ede3b68ace04fa09927b3c204ca7ae15ef1038bbc54dfce49b8e506fa8c52354a468241d32d92fd19463abafc895d68d1fd4d89d1b534ff006e989d
   languageName: node
   linkType: hard
 
@@ -6766,6 +6388,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native-windows/fs@npm:0.74.1":
+  version: 0.74.1
+  resolution: "@react-native-windows/fs@npm:0.74.1"
+  dependencies:
+    graceful-fs: "npm:^4.2.8"
+  checksum: 10c0/3d58568d033e08e208b863d856e8580f1e43a7733c4262a81e680b0c87f12be1ef075763f9dd6d4b5426cba5e3a5e2d3f053ace374793a7459f22f5c707c2548
+  languageName: node
+  linkType: hard
+
 "@react-native-windows/package-utils@npm:0.73.1":
   version: 0.73.1
   resolution: "@react-native-windows/package-utils@npm:0.73.1"
@@ -6775,6 +6406,18 @@ __metadata:
     get-monorepo-packages: "npm:^1.2.0"
     lodash: "npm:^4.17.15"
   checksum: 10c0/51597b087f5d88d22a4808d66be129630aa922680fc836f93085fcb1e5e6b4af116022bf972af70e751f2fefea660dd058a098b8f65a50249f36fdb5b8b62f3d
+  languageName: node
+  linkType: hard
+
+"@react-native-windows/package-utils@npm:0.74.1":
+  version: 0.74.1
+  resolution: "@react-native-windows/package-utils@npm:0.74.1"
+  dependencies:
+    "@react-native-windows/find-repo-root": "npm:0.74.1"
+    "@react-native-windows/fs": "npm:0.74.1"
+    get-monorepo-packages: "npm:^1.2.0"
+    lodash: "npm:^4.17.15"
+  checksum: 10c0/419219428af3664b2b927a7b75202fe94683febf90c36da990cae958c86e22c6a4692e0c6fa5f9d8105fded12f8082eece8f8873f17c3337ad1faf56fe226dd5
   languageName: node
   linkType: hard
 
@@ -6794,10 +6437,48 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native-windows/telemetry@npm:0.74.2":
+  version: 0.74.2
+  resolution: "@react-native-windows/telemetry@npm:0.74.2"
+  dependencies:
+    "@azure/core-auth": "npm:1.5.0"
+    "@react-native-windows/fs": "npm:0.74.1"
+    "@xmldom/xmldom": "npm:^0.7.7"
+    applicationinsights: "npm:2.9.1"
+    ci-info: "npm:^3.2.0"
+    envinfo: "npm:^7.8.1"
+    lodash: "npm:^4.17.21"
+    os-locale: "npm:^5.0.0"
+    xpath: "npm:^0.0.27"
+  checksum: 10c0/e37268a1bc4b41134cf35fb0fb31b9cbb625fe5e3f36504a981c6eee403a267acd468641dfd129144b3adc883a12fae5f435ad8b2371df911bfe223d6842c24c
+  languageName: node
+  linkType: hard
+
 "@react-native/assets-registry@npm:0.73.1":
   version: 0.73.1
   resolution: "@react-native/assets-registry@npm:0.73.1"
   checksum: 10c0/6e7de3c97da678c6a85e856ddb9ed96d87398a2fd7691d9c61962e482d554b2d7982705a1a4e0b6c8830eaae9001e3fbc5c349eecef6af018ffe24624022445b
+  languageName: node
+  linkType: hard
+
+"@react-native/assets-registry@npm:0.74.87":
+  version: 0.74.87
+  resolution: "@react-native/assets-registry@npm:0.74.87"
+  checksum: 10c0/3a074d492ecc87916ad8a857969e23242f506d331776fc4128aa5be52feb3f035750ddcca6d57adce912fa774538366ed7e3dab9a39416d241f220f5f48d29c8
+  languageName: node
+  linkType: hard
+
+"@react-native/assets-registry@npm:0.74.88":
+  version: 0.74.88
+  resolution: "@react-native/assets-registry@npm:0.74.88"
+  checksum: 10c0/ad9291fe645aa77687a5c2da229ce5507dd128794693630cdfa096ff08d27a6596ddd426cb53fa6aef6ce81381d75afc1ce7d315f807c2f10778219dda5e9772
+  languageName: node
+  linkType: hard
+
+"@react-native/assets@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@react-native/assets@npm:1.0.0"
+  checksum: 10c0/5b0d96279ff65cd6c98a28a9fd368c9e15eae613c685d5a0ad07bc57bbc6f8e5c101ebea5f81df881e803b633b8bbf17b1ea4bba9ccc42958732a38abc6fdf0f
   languageName: node
   linkType: hard
 
@@ -6807,6 +6488,24 @@ __metadata:
   dependencies:
     "@react-native/codegen": "npm:0.73.3"
   checksum: 10c0/51f151c9e4d6e35cb9b2b601281418535143f9c7ffd9ad5e5b8281da3b6881630c8aaa98565e98b9d8b946b3451168fede228e6c545050ce2831d1ea57cd40c1
+  languageName: node
+  linkType: hard
+
+"@react-native/babel-plugin-codegen@npm:0.74.87":
+  version: 0.74.87
+  resolution: "@react-native/babel-plugin-codegen@npm:0.74.87"
+  dependencies:
+    "@react-native/codegen": "npm:0.74.87"
+  checksum: 10c0/9c299db211c607d6ddfd96577fdda5990909ee833590650f250a6fa01b07c414d240b2637e714a852dab5fba28a4056b42e5e023661eb54743cc4269bbe5e693
+  languageName: node
+  linkType: hard
+
+"@react-native/babel-plugin-codegen@npm:0.74.88":
+  version: 0.74.88
+  resolution: "@react-native/babel-plugin-codegen@npm:0.74.88"
+  dependencies:
+    "@react-native/codegen": "npm:0.74.88"
+  checksum: 10c0/7f568ba58a7614d16f3a384d5b3bc692433be954d4abf27e4f3280a2540aa58b9c554ff3838cea6b2b0cbe8bc371286da1c2e5814d51edefe4a021c6f118efcd
   languageName: node
   linkType: hard
 
@@ -6862,6 +6561,112 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native/babel-preset@npm:0.74.87":
+  version: 0.74.87
+  resolution: "@react-native/babel-preset@npm:0.74.87"
+  dependencies:
+    "@babel/core": "npm:^7.20.0"
+    "@babel/plugin-proposal-async-generator-functions": "npm:^7.0.0"
+    "@babel/plugin-proposal-class-properties": "npm:^7.18.0"
+    "@babel/plugin-proposal-export-default-from": "npm:^7.0.0"
+    "@babel/plugin-proposal-logical-assignment-operators": "npm:^7.18.0"
+    "@babel/plugin-proposal-nullish-coalescing-operator": "npm:^7.18.0"
+    "@babel/plugin-proposal-numeric-separator": "npm:^7.0.0"
+    "@babel/plugin-proposal-object-rest-spread": "npm:^7.20.0"
+    "@babel/plugin-proposal-optional-catch-binding": "npm:^7.0.0"
+    "@babel/plugin-proposal-optional-chaining": "npm:^7.20.0"
+    "@babel/plugin-syntax-dynamic-import": "npm:^7.8.0"
+    "@babel/plugin-syntax-export-default-from": "npm:^7.0.0"
+    "@babel/plugin-syntax-flow": "npm:^7.18.0"
+    "@babel/plugin-syntax-nullish-coalescing-operator": "npm:^7.0.0"
+    "@babel/plugin-syntax-optional-chaining": "npm:^7.0.0"
+    "@babel/plugin-transform-arrow-functions": "npm:^7.0.0"
+    "@babel/plugin-transform-async-to-generator": "npm:^7.20.0"
+    "@babel/plugin-transform-block-scoping": "npm:^7.0.0"
+    "@babel/plugin-transform-classes": "npm:^7.0.0"
+    "@babel/plugin-transform-computed-properties": "npm:^7.0.0"
+    "@babel/plugin-transform-destructuring": "npm:^7.20.0"
+    "@babel/plugin-transform-flow-strip-types": "npm:^7.20.0"
+    "@babel/plugin-transform-function-name": "npm:^7.0.0"
+    "@babel/plugin-transform-literals": "npm:^7.0.0"
+    "@babel/plugin-transform-modules-commonjs": "npm:^7.0.0"
+    "@babel/plugin-transform-named-capturing-groups-regex": "npm:^7.0.0"
+    "@babel/plugin-transform-parameters": "npm:^7.0.0"
+    "@babel/plugin-transform-private-methods": "npm:^7.22.5"
+    "@babel/plugin-transform-private-property-in-object": "npm:^7.22.11"
+    "@babel/plugin-transform-react-display-name": "npm:^7.0.0"
+    "@babel/plugin-transform-react-jsx": "npm:^7.0.0"
+    "@babel/plugin-transform-react-jsx-self": "npm:^7.0.0"
+    "@babel/plugin-transform-react-jsx-source": "npm:^7.0.0"
+    "@babel/plugin-transform-runtime": "npm:^7.0.0"
+    "@babel/plugin-transform-shorthand-properties": "npm:^7.0.0"
+    "@babel/plugin-transform-spread": "npm:^7.0.0"
+    "@babel/plugin-transform-sticky-regex": "npm:^7.0.0"
+    "@babel/plugin-transform-typescript": "npm:^7.5.0"
+    "@babel/plugin-transform-unicode-regex": "npm:^7.0.0"
+    "@babel/template": "npm:^7.0.0"
+    "@react-native/babel-plugin-codegen": "npm:0.74.87"
+    babel-plugin-transform-flow-enums: "npm:^0.0.2"
+    react-refresh: "npm:^0.14.0"
+  peerDependencies:
+    "@babel/core": "*"
+  checksum: 10c0/b8db68da99891eeea3991e74bde06fa07e5668106c6e0dbee03458a58005111004e426fedb750b888a19310037335caace14ef324245d3a7469808b9f7e822f3
+  languageName: node
+  linkType: hard
+
+"@react-native/babel-preset@npm:0.74.88, @react-native/babel-preset@npm:^0.74.0":
+  version: 0.74.88
+  resolution: "@react-native/babel-preset@npm:0.74.88"
+  dependencies:
+    "@babel/core": "npm:^7.20.0"
+    "@babel/plugin-proposal-async-generator-functions": "npm:^7.0.0"
+    "@babel/plugin-proposal-class-properties": "npm:^7.18.0"
+    "@babel/plugin-proposal-export-default-from": "npm:^7.0.0"
+    "@babel/plugin-proposal-logical-assignment-operators": "npm:^7.18.0"
+    "@babel/plugin-proposal-nullish-coalescing-operator": "npm:^7.18.0"
+    "@babel/plugin-proposal-numeric-separator": "npm:^7.0.0"
+    "@babel/plugin-proposal-object-rest-spread": "npm:^7.20.0"
+    "@babel/plugin-proposal-optional-catch-binding": "npm:^7.0.0"
+    "@babel/plugin-proposal-optional-chaining": "npm:^7.20.0"
+    "@babel/plugin-syntax-dynamic-import": "npm:^7.8.0"
+    "@babel/plugin-syntax-export-default-from": "npm:^7.0.0"
+    "@babel/plugin-syntax-flow": "npm:^7.18.0"
+    "@babel/plugin-syntax-nullish-coalescing-operator": "npm:^7.0.0"
+    "@babel/plugin-syntax-optional-chaining": "npm:^7.0.0"
+    "@babel/plugin-transform-arrow-functions": "npm:^7.0.0"
+    "@babel/plugin-transform-async-to-generator": "npm:^7.20.0"
+    "@babel/plugin-transform-block-scoping": "npm:^7.0.0"
+    "@babel/plugin-transform-classes": "npm:^7.0.0"
+    "@babel/plugin-transform-computed-properties": "npm:^7.0.0"
+    "@babel/plugin-transform-destructuring": "npm:^7.20.0"
+    "@babel/plugin-transform-flow-strip-types": "npm:^7.20.0"
+    "@babel/plugin-transform-function-name": "npm:^7.0.0"
+    "@babel/plugin-transform-literals": "npm:^7.0.0"
+    "@babel/plugin-transform-modules-commonjs": "npm:^7.0.0"
+    "@babel/plugin-transform-named-capturing-groups-regex": "npm:^7.0.0"
+    "@babel/plugin-transform-parameters": "npm:^7.0.0"
+    "@babel/plugin-transform-private-methods": "npm:^7.22.5"
+    "@babel/plugin-transform-private-property-in-object": "npm:^7.22.11"
+    "@babel/plugin-transform-react-display-name": "npm:^7.0.0"
+    "@babel/plugin-transform-react-jsx": "npm:^7.0.0"
+    "@babel/plugin-transform-react-jsx-self": "npm:^7.0.0"
+    "@babel/plugin-transform-react-jsx-source": "npm:^7.0.0"
+    "@babel/plugin-transform-runtime": "npm:^7.0.0"
+    "@babel/plugin-transform-shorthand-properties": "npm:^7.0.0"
+    "@babel/plugin-transform-spread": "npm:^7.0.0"
+    "@babel/plugin-transform-sticky-regex": "npm:^7.0.0"
+    "@babel/plugin-transform-typescript": "npm:^7.5.0"
+    "@babel/plugin-transform-unicode-regex": "npm:^7.0.0"
+    "@babel/template": "npm:^7.0.0"
+    "@react-native/babel-plugin-codegen": "npm:0.74.88"
+    babel-plugin-transform-flow-enums: "npm:^0.0.2"
+    react-refresh: "npm:^0.14.0"
+  peerDependencies:
+    "@babel/core": "*"
+  checksum: 10c0/6bb9ff3fc843cfa81cf789fb8a27a5e2317549aa4b53f085d3fe64999ffec093a79676bbdef114c956d868886ce380072c77142fad470ff806e1343715362d67
+  languageName: node
+  linkType: hard
+
 "@react-native/codegen@npm:0.73.3":
   version: 0.73.3
   resolution: "@react-native/codegen@npm:0.73.3"
@@ -6876,6 +6681,41 @@ __metadata:
   peerDependencies:
     "@babel/preset-env": ^7.1.6
   checksum: 10c0/fe57bb33201252b40fcfeb67f2119a1b71c2ec2dd198ac0fd5ac8321f2971b25f6497a6fea5ee36355074418ae162a9934befee802e9189714a8ab5edb0929f7
+  languageName: node
+  linkType: hard
+
+"@react-native/codegen@npm:0.74.87":
+  version: 0.74.87
+  resolution: "@react-native/codegen@npm:0.74.87"
+  dependencies:
+    "@babel/parser": "npm:^7.20.0"
+    glob: "npm:^7.1.1"
+    hermes-parser: "npm:0.19.1"
+    invariant: "npm:^2.2.4"
+    jscodeshift: "npm:^0.14.0"
+    mkdirp: "npm:^0.5.1"
+    nullthrows: "npm:^1.1.1"
+  peerDependencies:
+    "@babel/preset-env": ^7.1.6
+  checksum: 10c0/753f55ab78c05e9eb2cae4e8f01e48f173de2dc75b56edd9003dad31e2bde3eaab592dfce95fa43cb2ab0468d9130d107ce854c1ed2eceb23b94122d897ed4ce
+  languageName: node
+  linkType: hard
+
+"@react-native/codegen@npm:0.74.88":
+  version: 0.74.88
+  resolution: "@react-native/codegen@npm:0.74.88"
+  dependencies:
+    "@babel/parser": "npm:^7.20.0"
+    glob: "npm:^7.1.1"
+    hermes-parser: "npm:0.19.1"
+    invariant: "npm:^2.2.4"
+    jscodeshift: "npm:^0.14.0"
+    mkdirp: "npm:^0.5.1"
+    nullthrows: "npm:^1.1.1"
+    yargs: "npm:^17.6.2"
+  peerDependencies:
+    "@babel/preset-env": ^7.1.6
+  checksum: 10c0/2d3e0ea4e82c84bafb53a78c85a8b8ca3c1fc4438ec03ce699b302adafe285c75209a9fc5e008d7d853eabd8b54d524391031b8e772222a19b202f5570d8a449
   languageName: node
   linkType: hard
 
@@ -6917,10 +6757,64 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native/community-cli-plugin@npm:0.74.87":
+  version: 0.74.87
+  resolution: "@react-native/community-cli-plugin@npm:0.74.87"
+  dependencies:
+    "@react-native-community/cli-server-api": "npm:13.6.9"
+    "@react-native-community/cli-tools": "npm:13.6.9"
+    "@react-native/dev-middleware": "npm:0.74.87"
+    "@react-native/metro-babel-transformer": "npm:0.74.87"
+    chalk: "npm:^4.0.0"
+    execa: "npm:^5.1.1"
+    metro: "npm:^0.80.3"
+    metro-config: "npm:^0.80.3"
+    metro-core: "npm:^0.80.3"
+    node-fetch: "npm:^2.2.0"
+    querystring: "npm:^0.2.1"
+    readline: "npm:^1.3.0"
+  checksum: 10c0/7db54907075a48707d55028557258120d4600b4131c7163acd147177cced638184371756e47101555b9636f3803c0f9df611a5c0383492a13d17e45addb07236
+  languageName: node
+  linkType: hard
+
+"@react-native/community-cli-plugin@npm:0.74.88":
+  version: 0.74.88
+  resolution: "@react-native/community-cli-plugin@npm:0.74.88"
+  dependencies:
+    "@react-native-community/cli-server-api": "npm:13.6.9"
+    "@react-native-community/cli-tools": "npm:13.6.9"
+    "@react-native/dev-middleware": "npm:0.74.88"
+    "@react-native/metro-babel-transformer": "npm:0.74.88"
+    chalk: "npm:^4.0.0"
+    execa: "npm:^5.1.1"
+    metro: "npm:^0.80.3"
+    metro-config: "npm:^0.80.3"
+    metro-core: "npm:^0.80.3"
+    node-fetch: "npm:^2.2.0"
+    querystring: "npm:^0.2.1"
+    readline: "npm:^1.3.0"
+  checksum: 10c0/cf49bf570a6ccfe6d0e01c08ef5c9d3394fa83603872d15a3fc325404f5583a493b7ee58b16321820a9f2023638639b146eadd2833610b08e1f8f55131caae64
+  languageName: node
+  linkType: hard
+
 "@react-native/debugger-frontend@npm:0.73.3":
   version: 0.73.3
   resolution: "@react-native/debugger-frontend@npm:0.73.3"
   checksum: 10c0/fee2c6b64e72fdacf94774585503302461819cca8ca2771205015cc1e1c0c4f2eba4081d66daf1e0b5bfbdc2c0a90e95eb2ffcd0a121815682d6149561f51d08
+  languageName: node
+  linkType: hard
+
+"@react-native/debugger-frontend@npm:0.74.87":
+  version: 0.74.87
+  resolution: "@react-native/debugger-frontend@npm:0.74.87"
+  checksum: 10c0/9b2bf0a2d1598d96af56d57226b5f6448c7ff63a7395226bd4c68f2319f1b4591468bb71e5aeeb2a2508d639d7752bbd036aa3f86a7a71436f9acbe6f1431b36
+  languageName: node
+  linkType: hard
+
+"@react-native/debugger-frontend@npm:0.74.88":
+  version: 0.74.88
+  resolution: "@react-native/debugger-frontend@npm:0.74.88"
+  checksum: 10c0/6025e43b6c446d8d36b7382c863225ae8629901386e5e5366f562ba98d336e23074908e9c3400888926abae865d31582834d9233aa049ecb8457acdf77b303b5
   languageName: node
   linkType: hard
 
@@ -6943,10 +6837,66 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native/dev-middleware@npm:0.74.87":
+  version: 0.74.87
+  resolution: "@react-native/dev-middleware@npm:0.74.87"
+  dependencies:
+    "@isaacs/ttlcache": "npm:^1.4.1"
+    "@react-native/debugger-frontend": "npm:0.74.87"
+    "@rnx-kit/chromium-edge-launcher": "npm:^1.0.0"
+    chrome-launcher: "npm:^0.15.2"
+    connect: "npm:^3.6.5"
+    debug: "npm:^2.2.0"
+    node-fetch: "npm:^2.2.0"
+    nullthrows: "npm:^1.1.1"
+    open: "npm:^7.0.3"
+    selfsigned: "npm:^2.4.1"
+    serve-static: "npm:^1.13.1"
+    temp-dir: "npm:^2.0.0"
+    ws: "npm:^6.2.2"
+  checksum: 10c0/d641799b9e0a8918e6e3b7500d376f11d3a33d736d03ed90b3cf55c6df45788bcf8aae047ca00b1e5f269fdf44d4884676bc0f397e9be3bbcec3a53a2db4d15f
+  languageName: node
+  linkType: hard
+
+"@react-native/dev-middleware@npm:0.74.88":
+  version: 0.74.88
+  resolution: "@react-native/dev-middleware@npm:0.74.88"
+  dependencies:
+    "@isaacs/ttlcache": "npm:^1.4.1"
+    "@react-native/debugger-frontend": "npm:0.74.88"
+    "@rnx-kit/chromium-edge-launcher": "npm:^1.0.0"
+    chrome-launcher: "npm:^0.15.2"
+    connect: "npm:^3.6.5"
+    debug: "npm:^2.2.0"
+    node-fetch: "npm:^2.2.0"
+    nullthrows: "npm:^1.1.1"
+    open: "npm:^7.0.3"
+    selfsigned: "npm:^2.4.1"
+    serve-static: "npm:^1.13.1"
+    temp-dir: "npm:^2.0.0"
+    ws: "npm:^6.2.2"
+  checksum: 10c0/896d7734e085b3463918c11891fb88c41a510c99445f0d65e016a19d9b5f0a40497cb95cee05e82f16b0817a78a700faff8917da1735d37d09bb5ed52cba5419
+  languageName: node
+  linkType: hard
+
 "@react-native/gradle-plugin@npm:0.73.4":
   version: 0.73.4
   resolution: "@react-native/gradle-plugin@npm:0.73.4"
   checksum: 10c0/2846ff600631322986abe49cf64f9c8fa91abac13f4c6e17099f47f46493ee5255f5d5d2f77f7c6b3d235056ef88cf56ce8de697b0f5269a4076606cc1320c84
+  languageName: node
+  linkType: hard
+
+"@react-native/gradle-plugin@npm:0.74.87":
+  version: 0.74.87
+  resolution: "@react-native/gradle-plugin@npm:0.74.87"
+  checksum: 10c0/99865aab4e7aeafa053b3b2cd4871ebddebd771ae747c0104e740bb592083162a53dba274199e87b5bed4a5b8fe2d99c0eeda4eeaa228304192a38a6406479b3
+  languageName: node
+  linkType: hard
+
+"@react-native/gradle-plugin@npm:0.74.88":
+  version: 0.74.88
+  resolution: "@react-native/gradle-plugin@npm:0.74.88"
+  checksum: 10c0/dca8299323f00853bc20b0c35ba90d65c2d3388ad81b620a4ae4bd8dbfde7c8f1ec2bbb2edde958437e42d596707a24e61dd1b102abe313f4f00b0e31c579e48
   languageName: node
   linkType: hard
 
@@ -6957,7 +6907,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native/metro-babel-transformer@npm:0.73.15, @react-native/metro-babel-transformer@npm:^0.73.0":
+"@react-native/js-polyfills@npm:0.74.87":
+  version: 0.74.87
+  resolution: "@react-native/js-polyfills@npm:0.74.87"
+  checksum: 10c0/8cfc367fd31798f13a4a6a379d91c21149632bb6d200873e26a4448cd37a18ee8c6d9ea08a71ba3e7c5f5aedbc0b41454e4d60e920e00727fef52f0820b9642d
+  languageName: node
+  linkType: hard
+
+"@react-native/js-polyfills@npm:0.74.88":
+  version: 0.74.88
+  resolution: "@react-native/js-polyfills@npm:0.74.88"
+  checksum: 10c0/12d01bc6d46faa82bb26fe060c25162aeb132ecbe3dd3cffc098cf6fdd0fd6b2bc951ecaf03d604094aecc28e7e21d8bb3524d529ec633a261a034d17ffe312a
+  languageName: node
+  linkType: hard
+
+"@react-native/metro-babel-transformer@npm:0.73.15":
   version: 0.73.15
   resolution: "@react-native/metro-babel-transformer@npm:0.73.15"
   dependencies:
@@ -6968,6 +6932,34 @@ __metadata:
   peerDependencies:
     "@babel/core": "*"
   checksum: 10c0/0af1aa2659264778419fe616213b742420494503cba28081fb251bf2fe9cbf224bde2204881f243db9b306f71b3c93a93869d5f7ba5e66160c794d982a04d9d0
+  languageName: node
+  linkType: hard
+
+"@react-native/metro-babel-transformer@npm:0.74.87":
+  version: 0.74.87
+  resolution: "@react-native/metro-babel-transformer@npm:0.74.87"
+  dependencies:
+    "@babel/core": "npm:^7.20.0"
+    "@react-native/babel-preset": "npm:0.74.87"
+    hermes-parser: "npm:0.19.1"
+    nullthrows: "npm:^1.1.1"
+  peerDependencies:
+    "@babel/core": "*"
+  checksum: 10c0/d5f62d268e6e18db0fb290017f8f168dcf9b7399df3f3772655b69d8e14752f786ef0bffc5ea079b4abdc16f9913b2163b966e0aa2022f1c5bb506055eda47b5
+  languageName: node
+  linkType: hard
+
+"@react-native/metro-babel-transformer@npm:0.74.88, @react-native/metro-babel-transformer@npm:^0.74.0":
+  version: 0.74.88
+  resolution: "@react-native/metro-babel-transformer@npm:0.74.88"
+  dependencies:
+    "@babel/core": "npm:^7.20.0"
+    "@react-native/babel-preset": "npm:0.74.88"
+    hermes-parser: "npm:0.19.1"
+    nullthrows: "npm:^1.1.1"
+  peerDependencies:
+    "@babel/core": "*"
+  checksum: 10c0/4f7845333720ebed85e4d0a8bd6bbf61ba19be9603f205557335fe3038a913b9c414776b6138f933cdbb21b9ed7c3e68eaeda0595cf697fe772b1a8a0e7dc1d3
   languageName: node
   linkType: hard
 
@@ -6983,10 +6975,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native/metro-config@npm:^0.74.0":
+  version: 0.74.88
+  resolution: "@react-native/metro-config@npm:0.74.88"
+  dependencies:
+    "@react-native/js-polyfills": "npm:0.74.88"
+    "@react-native/metro-babel-transformer": "npm:0.74.88"
+    metro-config: "npm:^0.80.3"
+    metro-runtime: "npm:^0.80.3"
+  checksum: 10c0/afbf59f9a49d57f1b1cba2600ca5d43eaa239ea98a1b2a610031c3c0b6798f99cd034f281b014620724cc04143feb36dfad9110f8471dc0a2a735fa78f6ae509
+  languageName: node
+  linkType: hard
+
 "@react-native/normalize-colors@npm:0.73.2, @react-native/normalize-colors@npm:^0.73.0":
   version: 0.73.2
   resolution: "@react-native/normalize-colors@npm:0.73.2"
   checksum: 10c0/b24d5bc68a28ae8c9b221766dbfaecb0ca79b8baa28d298df23e0b1edfc88054ebe0258d62e04594a7a47399356a8962f54e3a97328562c6915997f69b7bb446
+  languageName: node
+  linkType: hard
+
+"@react-native/normalize-colors@npm:0.74.87":
+  version: 0.74.87
+  resolution: "@react-native/normalize-colors@npm:0.74.87"
+  checksum: 10c0/7ab19e1d8df02d2c724d527993dc4f62f977b7836fa9648134e84d387d0af3a7697a688b19129223f23b972c37dd06ce753d914b5aa1667d25f0e8852eb7c335
+  languageName: node
+  linkType: hard
+
+"@react-native/normalize-colors@npm:0.74.88":
+  version: 0.74.88
+  resolution: "@react-native/normalize-colors@npm:0.74.88"
+  checksum: 10c0/0e18a287de4ec09fbde27b80b35ca8cad2f09802081d2a1037159a3bccafddba508ad705348cc1c2a812271b8b4a17a7c8f61d87e45fd1dfb74efedb1883f160
   languageName: node
   linkType: hard
 
@@ -7002,12 +7020,60 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native/virtualized-lists@npm:0.74.87":
+  version: 0.74.87
+  resolution: "@react-native/virtualized-lists@npm:0.74.87"
+  dependencies:
+    invariant: "npm:^2.2.4"
+    nullthrows: "npm:^1.1.1"
+  peerDependencies:
+    "@types/react": ^18.2.6
+    react: "*"
+    react-native: "*"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/0082a658efb2369f2c2bf052a8e842fd22b6895e1f25dfaae8220819aee1df4cd466c0b521bdd0cc5f6f1e505c6c1a56f97b998521e49898badf7e06b5da1907
+  languageName: node
+  linkType: hard
+
+"@react-native/virtualized-lists@npm:0.74.88":
+  version: 0.74.88
+  resolution: "@react-native/virtualized-lists@npm:0.74.88"
+  dependencies:
+    invariant: "npm:^2.2.4"
+    nullthrows: "npm:^1.1.1"
+  peerDependencies:
+    "@types/react": ^18.2.6
+    react: "*"
+    react-native: "*"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/b69aa5a12b903eaff8b0fda518920551def45c85bc59f6997241397f6a6ae0018538affd9b94b855def9a4445d289fd2865d9cc49a5ac2aeb1ebf49386bc437d
+  languageName: node
+  linkType: hard
+
 "@rnx-kit/align-deps@npm:^2.2.5, @rnx-kit/align-deps@npm:^2.5.0":
   version: 2.5.5
   resolution: "@rnx-kit/align-deps@npm:2.5.5"
   bin:
     rnx-align-deps: lib/index.js
   checksum: 10c0/3a0d2be01beb04f17dcc64e7ea1e73f1c22396c63d8f068d245e5a27535bedbaa424f9c345e100bc10475d936bbbadddc965b742487e3e155edcc0cb2651e2e8
+  languageName: node
+  linkType: hard
+
+"@rnx-kit/chromium-edge-launcher@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@rnx-kit/chromium-edge-launcher@npm:1.0.0"
+  dependencies:
+    "@types/node": "npm:^18.0.0"
+    escape-string-regexp: "npm:^4.0.0"
+    is-wsl: "npm:^2.2.0"
+    lighthouse-logger: "npm:^1.0.0"
+    mkdirp: "npm:^1.0.4"
+    rimraf: "npm:^3.0.2"
+  checksum: 10c0/21182379a914ad244b556e794eb6bc6dc63a099cbd2f3eb315a13bd431dc6f24ca096ffb465ad76465144d02969f538a93ef7ef1b2280135174fdae4db5206b3
   languageName: node
   linkType: hard
 
@@ -7228,9 +7294,9 @@ __metadata:
   linkType: hard
 
 "@rnx-kit/tools-node@npm:^2.0.0, @rnx-kit/tools-node@npm:^2.0.1, @rnx-kit/tools-node@npm:^2.1.0, @rnx-kit/tools-node@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "@rnx-kit/tools-node@npm:2.1.1"
-  checksum: 10c0/bed72f061e8d7c4791134ed42708e4df7db93dee745c3bf956948d55b830146a704ebec373c39b25d60d6e2ac8b3e0d2e9082c174146b29577213371d08b6903
+  version: 2.1.2
+  resolution: "@rnx-kit/tools-node@npm:2.1.2"
+  checksum: 10c0/bb1e3fdb0572d777b41ae5f3eb6c9c5b665b4952d348d27907b3e2198df54003ef7495d0dfc9f017a3baa6a8f98ec750b693433a9f5d7a97e67268e11c10188c
   languageName: node
   linkType: hard
 
@@ -7742,19 +7808,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/express@npm:*, @types/express@npm:4.17.21":
-  version: 4.17.21
-  resolution: "@types/express@npm:4.17.21"
-  dependencies:
-    "@types/body-parser": "npm:*"
-    "@types/express-serve-static-core": "npm:^4.17.33"
-    "@types/qs": "npm:*"
-    "@types/serve-static": "npm:*"
-  checksum: 10c0/12e562c4571da50c7d239e117e688dc434db1bac8be55613294762f84fd77fbd0658ccd553c7d3ab02408f385bc93980992369dd30e2ecd2c68c358e6af8fabf
-  languageName: node
-  linkType: hard
-
-"@types/express@npm:5.0.0":
+"@types/express@npm:*, @types/express@npm:5.0.0":
   version: 5.0.0
   resolution: "@types/express@npm:5.0.0"
   dependencies:
@@ -7763,6 +7817,18 @@ __metadata:
     "@types/qs": "npm:*"
     "@types/serve-static": "npm:*"
   checksum: 10c0/0d74b53aefa69c3b3817ee9b5145fd50d7dbac52a8986afc2d7500085c446656d0b6dc13158c04e2d9f18f4324d4d93b0452337c5ff73dd086dca3e4ff11f47b
+  languageName: node
+  linkType: hard
+
+"@types/express@npm:4.17.21":
+  version: 4.17.21
+  resolution: "@types/express@npm:4.17.21"
+  dependencies:
+    "@types/body-parser": "npm:*"
+    "@types/express-serve-static-core": "npm:^4.17.33"
+    "@types/qs": "npm:*"
+    "@types/serve-static": "npm:*"
+  checksum: 10c0/12e562c4571da50c7d239e117e688dc434db1bac8be55613294762f84fd77fbd0658ccd553c7d3ab02408f385bc93980992369dd30e2ecd2c68c358e6af8fabf
   languageName: node
   linkType: hard
 
@@ -7887,26 +7953,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/lodash@npm:4.17.14":
+"@types/lodash@npm:4.17.14, @types/lodash@npm:^4.14.192":
   version: 4.17.14
   resolution: "@types/lodash@npm:4.17.14"
   checksum: 10c0/343c6f722e0b39969036a885ad5aad6578479ead83987128c9b994e6b7f2fb9808244d802d4d332396bb09096f720a6c7060de16a492f5460e06a44560360322
-  languageName: node
-  linkType: hard
-
-"@types/lodash@npm:4.17.9, @types/lodash@npm:^4.14.192":
-  version: 4.17.9
-  resolution: "@types/lodash@npm:4.17.9"
-  checksum: 10c0/54de935e835508b5f835a5dfaedd2b9a299685a21d11e9c5cd2dde57331d03bc2f98b71d2424ca8460f447ecd55a673e45ccdb70e58f9f72745710f6b91abc60
-  languageName: node
-  linkType: hard
-
-"@types/method-override@npm:0.0.35":
-  version: 0.0.35
-  resolution: "@types/method-override@npm:0.0.35"
-  dependencies:
-    "@types/express": "npm:*"
-  checksum: 10c0/4d7164c6abed0e1cf2d9957cad0148f332e39ee27beeea4729ff5555cdefd718d972964842db637c8ed1228122ec53ffa7b65d8d3af131da6aa18020187fa848
   languageName: node
   linkType: hard
 
@@ -7956,6 +8006,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node-forge@npm:^1.3.0":
+  version: 1.3.11
+  resolution: "@types/node-forge@npm:1.3.11"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/3d7d23ca0ba38ac0cf74028393bd70f31169ab9aba43f21deb787840170d307d662644bac07287495effe2812ddd7ac8a14dbd43f16c2936bbb06312e96fc3b9
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:*, @types/node@npm:^22.2.0":
   version: 22.5.0
   resolution: "@types/node@npm:22.5.0"
@@ -7976,6 +8035,15 @@ __metadata:
   version: 12.20.55
   resolution: "@types/node@npm:12.20.55"
   checksum: 10c0/3b190bb0410047d489c49bbaab592d2e6630de6a50f00ba3d7d513d59401d279972a8f5a598b5bb8ddc1702f8a2f4ec57a65d93852f9c329639738e7053637d1
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^18.0.0":
+  version: 18.19.55
+  resolution: "@types/node@npm:18.19.55"
+  dependencies:
+    undici-types: "npm:~5.26.4"
+  checksum: 10c0/19ffeca0086b45cba08d4585623cd0d80fbacb659debde82a4baa008fc0c25ba6c21cd721f3a9f0be74f70940694b00458cac61c89f8b2a1e55ca4322a9aad2b
   languageName: node
   linkType: hard
 
@@ -8191,7 +8259,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/ws@npm:8.5.12, @types/ws@npm:^8.5.3":
+"@types/ws@npm:8.5.12":
   version: 8.5.12
   resolution: "@types/ws@npm:8.5.12"
   dependencies:
@@ -8200,7 +8268,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/ws@npm:8.5.13":
+"@types/ws@npm:8.5.13, @types/ws@npm:^8.5.3":
   version: 8.5.13
   resolution: "@types/ws@npm:8.5.13"
   dependencies:
@@ -8402,7 +8470,7 @@ __metadata:
     react: "npm:18.2.0"
   peerDependencies:
     react: 18.2.0
-    react-native: ^0.73.0
+    react-native: ^0.74.0
   languageName: unknown
   linkType: soft
 
@@ -8425,9 +8493,9 @@ __metadata:
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -8446,14 +8514,14 @@ __metadata:
     "@fluentui-react-native/immutable-merge": "workspace:*"
     "@fluentui-react-native/merge-props": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     "@types/jest": "npm:^29.0.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
   peerDependencies:
     react: 18.2.0
-    react-native: ^0.73.0
+    react-native: ^0.74.0
   languageName: unknown
   linkType: soft
 
@@ -8465,19 +8533,21 @@ __metadata:
     "@fluentui-react-native/merge-props": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
     "@fluentui-react-native/tokens": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     "@types/jest": "npm:^29.0.0"
     "@types/react": "npm:^18.2.0"
     "@uifabricshared/foundation-settings": "workspace:*"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-windows: "npm:^0.74.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -8495,14 +8565,14 @@ __metadata:
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/immutable-merge": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     "@types/jest": "npm:^29.0.0"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
   peerDependencies:
     react: 18.2.0
-    react-native: ^0.73.0
+    react-native: ^0.74.0
   languageName: unknown
   linkType: soft
 
@@ -8513,16 +8583,16 @@ __metadata:
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/memo-cache": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     "@types/jest": "npm:^29.0.0"
     "@types/node": "npm:^10.3.5"
     "@uifabricshared/foundation-settings": "workspace:*"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
   peerDependencies:
     react: 18.2.0
-    react-native: ^0.73.0
+    react-native: ^0.74.0
   languageName: unknown
   linkType: soft
 
@@ -8541,7 +8611,7 @@ __metadata:
     react: "npm:18.2.0"
   peerDependencies:
     react: 18.2.0
-    react-native: ^0.73.0
+    react-native: ^0.74.0
   languageName: unknown
   linkType: soft
 
@@ -8553,21 +8623,23 @@ __metadata:
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
     "@fluentui-react-native/win32-theme": "workspace:*"
-    "@react-native/babel-preset": "npm:^0.73.0"
-    "@react-native/metro-config": "npm:^0.73.0"
+    "@react-native/babel-preset": "npm:^0.74.0"
+    "@react-native/metro-config": "npm:^0.74.0"
     "@types/jest": "npm:^29.0.0"
     "@types/react": "npm:^18.2.0"
     "@uifabricshared/theme-registry": "workspace:*"
     "@uifabricshared/theming-ramp": "workspace:*"
     react: "npm:18.2.0"
-    react-native: "npm:^0.73.0"
+    react-native: "npm:^0.74.0"
+    react-native-macos: "npm:^0.74.0"
+    react-native-windows: "npm:^0.74.0"
     typescript: "npm:4.9.4"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
-    react-native: ^0.73.0
-    react-native-macos: ^0.73.0
-    react-native-windows: ^0.73.0
+    react-native: ^0.74.0
+    react-native-macos: ^0.74.0
+    react-native-windows: ^0.74.0
   peerDependenciesMeta:
     "@office-iss/react-native-win32":
       optional: true
@@ -8796,7 +8868,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wdio/globals@npm:8.40.5, @wdio/globals@npm:^8.29.3, @wdio/globals@npm:^8.40.0":
+"@wdio/globals@npm:8.40.5":
   version: 8.40.5
   resolution: "@wdio/globals@npm:8.40.5"
   dependencies:
@@ -8811,7 +8883,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wdio/globals@npm:8.41.0":
+"@wdio/globals@npm:8.41.0, @wdio/globals@npm:^8.29.3, @wdio/globals@npm:^8.40.0":
   version: 8.41.0
   resolution: "@wdio/globals@npm:8.41.0"
   dependencies:
@@ -9050,10 +9122,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmldom/xmldom@npm:^0.8.8, @xmldom/xmldom@npm:^0.x":
+"@xmldom/xmldom@npm:^0.8.8":
   version: 0.8.10
   resolution: "@xmldom/xmldom@npm:0.8.10"
   checksum: 10c0/c7647c442502720182b0d65b17d45d2d95317c1c8c497626fe524bda79b4fb768a9aa4fae2da919f308e7abcff7d67c058b102a9d641097e9a57f0b80187851f
+  languageName: node
+  linkType: hard
+
+"@xmldom/xmldom@npm:^0.x":
+  version: 0.9.3
+  resolution: "@xmldom/xmldom@npm:0.9.3"
+  checksum: 10c0/542bd992839751d6a0ee3f4b944b94ece387288eceebb85258d8ad5206b610c30939a7ce3c58dd9ddef04e23065462571f256f54c4259a702b91e56262ce6048
   languageName: node
   linkType: hard
 
@@ -9146,13 +9225,6 @@ __metadata:
   dependencies:
     debug: "npm:^4.3.4"
   checksum: 10c0/e59ce7bed9c63bf071a30cc471f2933862044c97fd9958967bfe22521d7a0f601ce4ed5a8c011799d0c726ca70312142ae193bbebb60f576b52be19d4a363b50
-  languageName: node
-  linkType: hard
-
-"agent-base@npm:^7.1.2":
-  version: 7.1.3
-  resolution: "agent-base@npm:7.1.3"
-  checksum: 10c0/6192b580c5b1d8fb399b9c62bf8343d76654c2dd62afcb9a52b2cf44a8b6ace1e3b704d3fe3547d91555c857d3df02603341ff2cb961b9cfe2b12f9f3c38ee11
   languageName: node
   linkType: hard
 
@@ -9658,6 +9730,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"applicationinsights@npm:2.9.1":
+  version: 2.9.1
+  resolution: "applicationinsights@npm:2.9.1"
+  dependencies:
+    "@azure/core-auth": "npm:^1.5.0"
+    "@azure/core-rest-pipeline": "npm:1.10.1"
+    "@azure/core-util": "npm:1.2.0"
+    "@azure/opentelemetry-instrumentation-azure-sdk": "npm:^1.0.0-beta.5"
+    "@microsoft/applicationinsights-web-snippet": "npm:^1.0.1"
+    "@opentelemetry/api": "npm:^1.4.1"
+    "@opentelemetry/core": "npm:^1.15.2"
+    "@opentelemetry/sdk-trace-base": "npm:^1.15.2"
+    "@opentelemetry/semantic-conventions": "npm:^1.15.2"
+    cls-hooked: "npm:^4.2.2"
+    continuation-local-storage: "npm:^3.2.1"
+    diagnostic-channel: "npm:1.1.1"
+    diagnostic-channel-publishers: "npm:1.0.7"
+  peerDependencies:
+    applicationinsights-native-metrics: "*"
+  peerDependenciesMeta:
+    applicationinsights-native-metrics:
+      optional: true
+  checksum: 10c0/7549b6f22bb1641b05d4b4e9f83cc5b67e8fb44a828aef6fbf89bf297b22d1cc2b41ef4be8183ace109160b388ebd4e6a3c6180b29ee8b62e18fc031fa3d968d
+  languageName: node
+  linkType: hard
+
 "aproba@npm:^1.0.3 || ^2.0.0":
   version: 2.0.0
   resolution: "aproba@npm:2.0.0"
@@ -10072,9 +10170,9 @@ __metadata:
   linkType: hard
 
 "b4a@npm:^1.6.4":
-  version: 1.6.4
-  resolution: "b4a@npm:1.6.4"
-  checksum: 10c0/a0af707430c3643fd8d9418c732849d3626f1c9281489e021fcad969fb4808fb9f67b224de36b59c9c3b5a13d853482fee0c0eb53f7aec12d540fa67f63648b6
+  version: 1.6.7
+  resolution: "b4a@npm:1.6.7"
+  checksum: 10c0/ec2f004d1daae04be8c5a1f8aeb7fea213c34025e279db4958eb0b82c1729ee25f7c6e89f92a5f65c8a9cf2d017ce27e3dda912403341d1781bd74528a4849d4
   languageName: node
   linkType: hard
 
@@ -10774,21 +10872,34 @@ __metadata:
   linkType: hard
 
 "cheerio@npm:^1.0.0-rc.10":
-  version: 1.0.0-rc.12
-  resolution: "cheerio@npm:1.0.0-rc.12"
+  version: 1.0.0
+  resolution: "cheerio@npm:1.0.0"
   dependencies:
     cheerio-select: "npm:^2.1.0"
     dom-serializer: "npm:^2.0.0"
     domhandler: "npm:^5.0.3"
-    domutils: "npm:^3.0.1"
-    htmlparser2: "npm:^8.0.1"
-    parse5: "npm:^7.0.0"
+    domutils: "npm:^3.1.0"
+    encoding-sniffer: "npm:^0.2.0"
+    htmlparser2: "npm:^9.1.0"
+    parse5: "npm:^7.1.2"
     parse5-htmlparser2-tree-adapter: "npm:^7.0.0"
-  checksum: 10c0/c85d2f2461e3f024345b78e0bb16ad8e41492356210470dd1e7d5a91391da9fcf6c0a7cb48a9ba8820330153f0cedb4d0a60c7af15d96ecdb3092299b9d9c0cc
+    parse5-parser-stream: "npm:^7.1.2"
+    undici: "npm:^6.19.5"
+    whatwg-mimetype: "npm:^4.0.0"
+  checksum: 10c0/d0e16925d9c36c879edfaef1c0244c866375a4c7b8d6ccd7ae0ad42da7d26263ea1a3c17b9a1aa5965918deeff2d40ac2e7223824f8e6eca972df3b81316a09f
   languageName: node
   linkType: hard
 
-"chokidar@npm:*, chokidar@npm:^3.5.2, chokidar@npm:^3.5.3":
+"chokidar@npm:*":
+  version: 4.0.1
+  resolution: "chokidar@npm:4.0.1"
+  dependencies:
+    readdirp: "npm:^4.0.1"
+  checksum: 10c0/4bb7a3adc304059810bb6c420c43261a15bb44f610d77c35547addc84faa0374265c3adc67f25d06f363d9a4571962b02679268c40de07676d260de1986efea9
+  languageName: node
+  linkType: hard
+
+"chokidar@npm:^3.5.2, chokidar@npm:^3.5.3":
   version: 3.6.0
   resolution: "chokidar@npm:3.6.0"
   dependencies:
@@ -11534,9 +11645,9 @@ __metadata:
   linkType: hard
 
 "csstype@npm:^3.0.10, csstype@npm:^3.0.2":
-  version: 3.1.1
-  resolution: "csstype@npm:3.1.1"
-  checksum: 10c0/7c8b8c5923049d84132581c13bae6e1faf999746fe3998ba5f3819a8e1cdc7512ace87b7d0a4a69f0f4b8ba11daf835d4f1390af23e09fc4f0baad52c084753a
+  version: 3.1.3
+  resolution: "csstype@npm:3.1.3"
+  checksum: 10c0/80c089d6f7e0c5b2bd83cf0539ab41474198579584fa10d86d0cafe0642202343cbc119e076a0b1aece191989477081415d66c9fefbf3c957fc2fc4b7009f248
   languageName: node
   linkType: hard
 
@@ -11622,7 +11733,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:4.3.4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4":
+"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4":
+  version: 4.3.7
+  resolution: "debug@npm:4.3.7"
+  dependencies:
+    ms: "npm:^2.1.3"
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 10c0/1471db19c3b06d485a622d62f65947a19a23fbd0dd73f7fd3eafb697eec5360cde447fb075919987899b1a2096e85d35d4eb5a4de09a57600ac9cf7e6c8e768b
+  languageName: node
+  linkType: hard
+
+"debug@npm:4.3.4":
   version: 4.3.4
   resolution: "debug@npm:4.3.4"
   dependencies:
@@ -12043,7 +12166,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"domhandler@npm:^5.0.1, domhandler@npm:^5.0.2, domhandler@npm:^5.0.3":
+"domhandler@npm:^5.0.2, domhandler@npm:^5.0.3":
   version: 5.0.3
   resolution: "domhandler@npm:5.0.3"
   dependencies:
@@ -12052,14 +12175,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"domutils@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "domutils@npm:3.0.1"
+"domutils@npm:^3.0.1, domutils@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "domutils@npm:3.1.0"
   dependencies:
     dom-serializer: "npm:^2.0.0"
     domelementtype: "npm:^2.3.0"
-    domhandler: "npm:^5.0.1"
-  checksum: 10c0/8ec14e7e54f58cae0062fa9aaf97c05a094733ff6df8ede588c57d96799ceb45d1ea46479e8dd285f43af43b3e7618a501b2b41d2c2080078d5947b5fee2b5f9
+    domhandler: "npm:^5.0.3"
+  checksum: 10c0/342d64cf4d07b8a0573fb51e0a6312a88fb520c7fefd751870bf72fa5fc0f2e0cb9a3958a573610b1d608c6e2a69b8e9b4b40f0bfb8f87a71bce4f180cca1887
   languageName: node
   linkType: hard
 
@@ -12226,6 +12349,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"encoding-sniffer@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "encoding-sniffer@npm:0.2.0"
+  dependencies:
+    iconv-lite: "npm:^0.6.3"
+    whatwg-encoding: "npm:^3.1.1"
+  checksum: 10c0/b312e0d67f339bec44e021e5210ee8ee90d7b8f9975eb2c79a36fd467eb07709e88dcf62ee20f62ee0d74a13874307d99557852a2de9b448f1e3fb991fc68257
+  languageName: node
+  linkType: hard
+
 "encoding@npm:^0.1.13":
   version: 0.1.13
   resolution: "encoding@npm:0.1.13"
@@ -12254,10 +12387,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"entities@npm:^4.2.0, entities@npm:^4.3.0, entities@npm:^4.4.0":
-  version: 4.4.0
-  resolution: "entities@npm:4.4.0"
-  checksum: 10c0/b7971419897622d3996bbbff99249e166caaaf3ea95d3841d6dc5d3bf315f133b649fbe932623e3cc527d871112e7563a8284e24f23e472126aa90c4e9c3215b
+"entities@npm:^4.2.0, entities@npm:^4.4.0, entities@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "entities@npm:4.5.0"
+  checksum: 10c0/5b039739f7621f5d1ad996715e53d964035f75ad3b9a4d38c6b3804bb226e282ffeae2443624d8fdd9c47d8e926ae9ac009c54671243f0c3294c26af7cc85250
   languageName: node
   linkType: hard
 
@@ -12530,9 +12663,9 @@ __metadata:
   linkType: hard
 
 "escalade@npm:^3.1.1, escalade@npm:^3.1.2":
-  version: 3.1.2
-  resolution: "escalade@npm:3.1.2"
-  checksum: 10c0/6b4adafecd0682f3aa1cd1106b8fff30e492c7015b178bc81b2d2f75106dabea6c6d6e8508fc491bd58e597c74abb0e8e2368f943ecb9393d4162e3c2f3cf287
+  version: 3.2.0
+  resolution: "escalade@npm:3.2.0"
+  checksum: 10c0/ced4dd3a78e15897ed3be74e635110bbf3b08877b0a41be50dcb325ee0e0b5f65fc2d50e9845194d7c4633f327e2e1c6cce00a71b617c5673df0374201d67f65
   languageName: node
   linkType: hard
 
@@ -13078,23 +13211,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-fifo@npm:^1.1.0, fast-fifo@npm:^1.2.0":
+"fast-fifo@npm:^1.2.0, fast-fifo@npm:^1.3.2":
   version: 1.3.2
   resolution: "fast-fifo@npm:1.3.2"
   checksum: 10c0/d53f6f786875e8b0529f784b59b4b05d4b5c31c651710496440006a398389a579c8dbcd2081311478b5bf77f4b0b21de69109c5a4eabea9d8e8783d1eb864e4c
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.2.7, fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.1":
-  version: 3.3.1
-  resolution: "fast-glob@npm:3.3.1"
+"fast-glob@npm:^3.2.7, fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.1, fast-glob@npm:^3.3.2":
+  version: 3.3.2
+  resolution: "fast-glob@npm:3.3.2"
   dependencies:
     "@nodelib/fs.stat": "npm:^2.0.2"
     "@nodelib/fs.walk": "npm:^1.2.3"
     glob-parent: "npm:^5.1.2"
     merge2: "npm:^1.3.0"
     micromatch: "npm:^4.0.4"
-  checksum: 10c0/b68431128fb6ce4b804c5f9622628426d990b66c75b21c0d16e3d80e2d1398bf33f7e1724e66a2e3f299285dcf5b8d745b122d0304e7dd66f5231081f33ec67c
+  checksum: 10c0/42baad7b9cd40b63e42039132bde27ca2cb3a4950d0a0f9abe4639ea1aa9d3e3b40f98b1fe31cbc0cc17b664c9ea7447d911a152fa34ec5b72977b125a6fc845
   languageName: node
   linkType: hard
 
@@ -13411,7 +13544,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:4.0.0, form-data@npm:^4.0.0":
+"form-data@npm:4.0.0":
   version: 4.0.0
   resolution: "form-data@npm:4.0.0"
   dependencies:
@@ -13422,7 +13555,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:4.0.1":
+"form-data@npm:4.0.1, form-data@npm:^4.0.0":
   version: 4.0.1
   resolution: "form-data@npm:4.0.1"
   dependencies:
@@ -14138,6 +14271,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hermes-estree@npm:0.19.1":
+  version: 0.19.1
+  resolution: "hermes-estree@npm:0.19.1"
+  checksum: 10c0/98c79807c15146c745aca7a9c74b9f1ba20a463c8b9f058caed9b3f2741fc4a8609e7e4c06d163f67d819db35cb6871fc7b25085bb9a084bc53d777f67d9d620
+  languageName: node
+  linkType: hard
+
 "hermes-estree@npm:0.23.1":
   version: 0.23.1
   resolution: "hermes-estree@npm:0.23.1"
@@ -14160,6 +14300,15 @@ __metadata:
   dependencies:
     hermes-estree: "npm:0.15.0"
   checksum: 10c0/3171a52e6a6383a8f9c6289a532a571679905fd54ea64f7b043e9a9e8774629a0c507d1968ca7f7c5238f23e501e511c448ac434b7cc1c5bbf0b5d21e9284c55
+  languageName: node
+  linkType: hard
+
+"hermes-parser@npm:0.19.1":
+  version: 0.19.1
+  resolution: "hermes-parser@npm:0.19.1"
+  dependencies:
+    hermes-estree: "npm:0.19.1"
+  checksum: 10c0/940ccef90673b8e905016332d2660ae00ad747e2d32c694a52dce4ea220835dc1bae299554a7a8eeccb449561065bd97f3690363c087fbf69ad7cbff2deeec35
   languageName: node
   linkType: hard
 
@@ -14243,15 +14392,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"htmlparser2@npm:^8.0.1":
-  version: 8.0.1
-  resolution: "htmlparser2@npm:8.0.1"
+"htmlparser2@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "htmlparser2@npm:9.1.0"
   dependencies:
     domelementtype: "npm:^2.3.0"
-    domhandler: "npm:^5.0.2"
-    domutils: "npm:^3.0.1"
-    entities: "npm:^4.3.0"
-  checksum: 10c0/33942dc6d882f37132fe8e39d5fd860d5abcf52ca769b3742c1b35caae1225db9cfa4486f27ed983db5b6d478944008a515e6ee3a09cfe8fa84af412960e4ca1
+    domhandler: "npm:^5.0.3"
+    domutils: "npm:^3.1.0"
+    entities: "npm:^4.5.0"
+  checksum: 10c0/394f6323efc265bbc791d8c0d96bfe95984e0407565248521ab92e2dc7668e5ceeca7bc6ed18d408b9ee3b25032c5743368a4280d280332d782821d5d467ad8f
   languageName: node
   linkType: hard
 
@@ -14330,17 +14479,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"https-proxy-agent@npm:^7.0.1":
-  version: 7.0.6
-  resolution: "https-proxy-agent@npm:7.0.6"
-  dependencies:
-    agent-base: "npm:^7.1.2"
-    debug: "npm:4"
-  checksum: 10c0/f729219bc735edb621fa30e6e84e60ee5d00802b8247aac0d7b79b0bd6d4b3294737a337b93b86a0bd9e68099d031858a39260c976dc14cdbba238ba1f8779ac
-  languageName: node
-  linkType: hard
-
-"https-proxy-agent@npm:^7.0.2, https-proxy-agent@npm:^7.0.3, https-proxy-agent@npm:^7.0.4, https-proxy-agent@npm:^7.0.5":
+"https-proxy-agent@npm:^7.0.1, https-proxy-agent@npm:^7.0.2, https-proxy-agent@npm:^7.0.3, https-proxy-agent@npm:^7.0.4, https-proxy-agent@npm:^7.0.5":
   version: 7.0.5
   resolution: "https-proxy-agent@npm:7.0.5"
   dependencies:
@@ -16749,7 +16888,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"metro-config@npm:0.80.12, metro-config@npm:^0.80.0, metro-config@npm:^0.80.3":
+"metro-config@npm:0.80.12, metro-config@npm:^0.80.3":
   version: 0.80.12
   resolution: "metro-config@npm:0.80.12"
   dependencies:
@@ -17023,10 +17162,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-db@npm:1.52.0, mime-db@npm:>= 1.43.0 < 2":
+"mime-db@npm:1.52.0":
   version: 1.52.0
   resolution: "mime-db@npm:1.52.0"
   checksum: 10c0/0557a01deebf45ac5f5777fe7740b2a5c309c6d62d40ceab4e23da9f821899ce7a900b7ac8157d4548ddbb7beffe9abc621250e6d182b0397ec7f10c7b91a5aa
+  languageName: node
+  linkType: hard
+
+"mime-db@npm:>= 1.43.0 < 2":
+  version: 1.53.0
+  resolution: "mime-db@npm:1.53.0"
+  checksum: 10c0/1dcc37ba8ed5d1c179f5c6f0837e8db19371d5f2ea3690c3c2f3fa8c3858f976851d3460b172b4dee78ebd606762cbb407aa398545fbacd539e519f858cd7bf4
   languageName: node
   linkType: hard
 
@@ -17524,6 +17670,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-forge@npm:^1":
+  version: 1.3.1
+  resolution: "node-forge@npm:1.3.1"
+  checksum: 10c0/e882819b251a4321f9fc1d67c85d1501d3004b4ee889af822fd07f64de3d1a8e272ff00b689570af0465d65d6bf5074df9c76e900e0aff23e60b847f2a46fbe8
+  languageName: node
+  linkType: hard
+
 "node-gyp@npm:latest":
   version: 9.4.0
   resolution: "node-gyp@npm:9.4.0"
@@ -17721,9 +17874,9 @@ __metadata:
   linkType: hard
 
 "object-inspect@npm:^1.12.0, object-inspect@npm:^1.13.1":
-  version: 1.13.1
-  resolution: "object-inspect@npm:1.13.1"
-  checksum: 10c0/fad603f408e345c82e946abdf4bfd774260a5ed3e5997a0b057c44153ac32c7271ff19e3a5ae39c858da683ba045ccac2f65245c12763ce4e8594f818f4a648d
+  version: 1.13.2
+  resolution: "object-inspect@npm:1.13.2"
+  checksum: 10c0/b97835b4c91ec37b5fd71add84f21c3f1047d1d155d00c0fcd6699516c256d4fcc6ff17a1aced873197fe447f91a3964178fd2a67a1ee2120cdaf60e81a050b4
   languageName: node
   linkType: hard
 
@@ -18237,6 +18390,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parse5-parser-stream@npm:^7.1.2":
+  version: 7.1.2
+  resolution: "parse5-parser-stream@npm:7.1.2"
+  dependencies:
+    parse5: "npm:^7.0.0"
+  checksum: 10c0/e236c61000d38ecad369e725a48506b051cebad8abb00e6d4e8bff7aa85c183820fcb45db1559cc90955bdbbdbd665ea94c41259594e74566fff411478dc7fcb
+  languageName: node
+  linkType: hard
+
 "parse5@npm:^7.0.0, parse5@npm:^7.1.2":
   version: 7.1.2
   resolution: "parse5@npm:7.1.2"
@@ -18333,13 +18495,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:8.1.0":
-  version: 8.1.0
-  resolution: "path-to-regexp@npm:8.1.0"
-  checksum: 10c0/1c46be3806ab081bedc51eb238fcb026b61b15f19e8924b26e7dad88812dda499efe357a780665dc915dcab3be67213f145f5e2921b8fc8c6c497608d4e092ed
-  languageName: node
-  linkType: hard
-
 "path-to-regexp@npm:8.2.0":
   version: 8.2.0
   resolution: "path-to-regexp@npm:8.2.0"
@@ -18378,9 +18533,9 @@ __metadata:
   linkType: hard
 
 "picocolors@npm:^1.0.0, picocolors@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "picocolors@npm:1.0.1"
-  checksum: 10c0/c63cdad2bf812ef0d66c8db29583802355d4ca67b9285d846f390cc15c2f6ccb94e8cb7eb6a6e97fc5990a6d3ad4ae42d86c84d3146e667c739a4234ed50d400
+  version: 1.1.0
+  resolution: "picocolors@npm:1.1.0"
+  checksum: 10c0/86946f6032148801ef09c051c6fb13b5cf942eaf147e30ea79edb91dd32d700934edebe782a1078ff859fb2b816792e97ef4dab03d7f0b804f6b01a0df35e023
   languageName: node
   linkType: hard
 
@@ -18745,6 +18900,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"querystring@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "querystring@npm:0.2.1"
+  checksum: 10c0/6841b32bec4f16ffe7f5b5e4373b47ad451f079cde3a7f45e63e550f0ecfd8f8189ef81fb50079413b3fc1c59b06146e4c98192cb74ed7981aca72090466cd94
+  languageName: node
+  linkType: hard
+
 "queue-microtask@npm:^1.2.2":
   version: 1.2.3
   resolution: "queue-microtask@npm:1.2.3"
@@ -18811,6 +18973,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-devtools-core@npm:^5.0.0":
+  version: 5.3.1
+  resolution: "react-devtools-core@npm:5.3.1"
+  dependencies:
+    shell-quote: "npm:^1.6.1"
+    ws: "npm:^7"
+  checksum: 10c0/da83405f42d2bea641d1bc9dd2a6394f18b9e31201a193463daa6897e0055b1ea4f4727b9847007796b42b5faa9d38883bbc38b67972a179fdf60a25a7325d6c
+  languageName: node
+  linkType: hard
+
 "react-dom@npm:^18.2.0":
   version: 18.3.1
   resolution: "react-dom@npm:18.3.1"
@@ -18844,27 +19016,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-macos@npm:^0.73.0":
-  version: 0.73.35
-  resolution: "react-native-macos@npm:0.73.35"
+"react-native-macos@npm:^0.74.0":
+  version: 0.74.9
+  resolution: "react-native-macos@npm:0.74.9"
   dependencies:
     "@jest/create-cache-key-function": "npm:^29.6.3"
-    "@react-native-community/cli": "npm:12.3.6"
-    "@react-native-community/cli-platform-android": "npm:12.3.6"
-    "@react-native-community/cli-platform-ios": "npm:12.3.6"
-    "@react-native-mac/virtualized-lists": "npm:^0.73.3"
-    "@react-native/assets-registry": "npm:0.73.1"
-    "@react-native/codegen": "npm:0.73.3"
-    "@react-native/community-cli-plugin": "npm:0.73.17"
-    "@react-native/gradle-plugin": "npm:0.73.4"
-    "@react-native/js-polyfills": "npm:0.73.1"
-    "@react-native/normalize-colors": "npm:0.73.2"
+    "@react-native-community/cli": "npm:13.6.9"
+    "@react-native-community/cli-platform-android": "npm:13.6.9"
+    "@react-native-community/cli-platform-ios": "npm:13.6.9"
+    "@react-native-mac/virtualized-lists": "npm:0.74.87"
+    "@react-native/assets-registry": "npm:0.74.87"
+    "@react-native/codegen": "npm:0.74.87"
+    "@react-native/community-cli-plugin": "npm:0.74.87"
+    "@react-native/gradle-plugin": "npm:0.74.87"
+    "@react-native/js-polyfills": "npm:0.74.87"
+    "@react-native/normalize-colors": "npm:0.74.87"
     abort-controller: "npm:^3.0.0"
     anser: "npm:^1.4.9"
     ansi-regex: "npm:^5.0.0"
     base64-js: "npm:^1.5.1"
     chalk: "npm:^4.0.0"
-    deprecated-react-native-prop-types: "npm:^5.0.0"
     event-target-shim: "npm:^5.0.1"
     flow-enums-runtime: "npm:^0.0.6"
     invariant: "npm:^2.2.4"
@@ -18877,7 +19048,7 @@ __metadata:
     nullthrows: "npm:^1.1.1"
     pretty-format: "npm:^26.5.2"
     promise: "npm:^8.3.0"
-    react-devtools-core: "npm:^4.27.7"
+    react-devtools-core: "npm:^5.0.0"
     react-refresh: "npm:^0.14.0"
     react-shallow-renderer: "npm:^16.15.0"
     regenerator-runtime: "npm:^0.13.2"
@@ -18887,10 +19058,14 @@ __metadata:
     ws: "npm:^6.2.2"
     yargs: "npm:^17.6.2"
   peerDependencies:
+    "@types/react": ^18.2.6
     react: 18.2.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   bin:
     react-native-macos: cli.js
-  checksum: 10c0/365b0886e810bbce800a781d4eb186e07d34b8c0daadb25efd4235d3afab4e806b36a44aceef751c586c787ae392ad1c9bee87b3f3475d8769d37de5b8dce4b5
+  checksum: 10c0/fdbb55bef92ce3f739dc93dc6c2b8c6bf474c49a0cc76f7d818e68107ebc8362c532edc4897faaed4c5d021f3b12a01b6f982dd8685386e67f29ea553a1e1026
   languageName: node
   linkType: hard
 
@@ -18922,9 +19097,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-test-app@npm:^3.4.7":
-  version: 3.10.22
-  resolution: "react-native-test-app@npm:3.10.22"
+"react-native-test-app@npm:^3.9.2":
+  version: 3.10.14
+  resolution: "react-native-test-app@npm:3.10.14"
   dependencies:
     "@rnx-kit/react-native-host": "npm:^0.5.0"
     ajv: "npm:^8.0.0"
@@ -18934,12 +19109,12 @@ __metadata:
     semver: "npm:^7.3.5"
     uuid: "npm:^10.0.0"
   peerDependencies:
-    "@callstack/react-native-visionos": 0.73 - 0.76
+    "@callstack/react-native-visionos": 0.73 - 0.75
     "@expo/config-plugins": ">=5.0"
     react: 17.0.1 - 19.0
-    react-native: 0.66 - 0.76 || >=0.77.0-0 <0.77.0
-    react-native-macos: ^0.0.0-0 || 0.66 || 0.68 || 0.71 - 0.76
-    react-native-windows: ^0.0.0-0 || 0.66 - 0.76
+    react-native: 0.66 - 0.75 || >=0.76.0-0 <0.76.0
+    react-native-macos: ^0.0.0-0 || 0.66 || 0.68 || 0.71 - 0.75
+    react-native-windows: ^0.0.0-0 || 0.66 - 0.75
   peerDependenciesMeta:
     "@callstack/react-native-visionos":
       optional: true
@@ -18954,7 +19129,7 @@ __metadata:
     init: scripts/init.mjs
     init-test-app: scripts/init.mjs
     install-windows-test-app: windows/test-app.mjs
-  checksum: 10c0/5d557ec1cc25632069b362f8960c9dc488639d728203431f07d8199cda2d4beb848c7e2888570b044631d8644660f8479b87b10269deb4ea57aaaa50eff53495
+  checksum: 10c0/d90dce9f0d8b8d2f241f9f003dbae5b397b19084bba439fa23a6ecdadf1f119949e82da5431d4b22a33f953b3fc5e335c878997352c8e9c1d00ab6c2f1584d12
   languageName: node
   linkType: hard
 
@@ -19010,6 +19185,59 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-native-windows@npm:^0.74.0":
+  version: 0.74.21
+  resolution: "react-native-windows@npm:0.74.21"
+  dependencies:
+    "@babel/runtime": "npm:^7.0.0"
+    "@jest/create-cache-key-function": "npm:^29.6.3"
+    "@react-native-community/cli": "npm:13.6.9"
+    "@react-native-community/cli-platform-android": "npm:13.6.9"
+    "@react-native-community/cli-platform-ios": "npm:13.6.9"
+    "@react-native-windows/cli": "npm:0.74.5"
+    "@react-native/assets": "npm:1.0.0"
+    "@react-native/assets-registry": "npm:0.74.87"
+    "@react-native/codegen": "npm:0.74.87"
+    "@react-native/community-cli-plugin": "npm:0.74.87"
+    "@react-native/gradle-plugin": "npm:0.74.87"
+    "@react-native/js-polyfills": "npm:0.74.87"
+    "@react-native/normalize-colors": "npm:0.74.87"
+    "@react-native/virtualized-lists": "npm:0.74.87"
+    abort-controller: "npm:^3.0.0"
+    anser: "npm:^1.4.9"
+    ansi-regex: "npm:^5.0.0"
+    base64-js: "npm:^1.5.1"
+    chalk: "npm:^4.0.0"
+    event-target-shim: "npm:^5.0.1"
+    flow-enums-runtime: "npm:^0.0.6"
+    invariant: "npm:^2.2.4"
+    jest-environment-node: "npm:^29.6.3"
+    jsc-android: "npm:^250231.0.0"
+    memoize-one: "npm:^5.0.0"
+    metro-runtime: "npm:^0.80.3"
+    metro-source-map: "npm:^0.80.3"
+    mkdirp: "npm:^0.5.1"
+    nullthrows: "npm:^1.1.1"
+    pretty-format: "npm:^26.5.2"
+    promise: "npm:^8.3.0"
+    react-devtools-core: "npm:^5.0.0"
+    react-refresh: "npm:^0.14.0"
+    react-shallow-renderer: "npm:^16.15.0"
+    regenerator-runtime: "npm:^0.13.2"
+    scheduler: "npm:0.24.0-canary-efb381bbf-20230505"
+    source-map-support: "npm:^0.5.19"
+    stacktrace-parser: "npm:^0.1.10"
+    whatwg-fetch: "npm:^3.0.0"
+    ws: "npm:^6.2.2"
+    yargs: "npm:^17.6.2"
+  peerDependencies:
+    "@types/react": ^18.2.6
+    react: 18.2.0
+    react-native: ^0.74.0
+  checksum: 10c0/2233a31a104058514e032986c2c576c79b36ed46a4794447bf96b571e0c12161a21b13ec78d939ac907ff042cce939416d58ca85cbca3ba83ec2ee7a8f8da9ea
+  languageName: node
+  linkType: hard
+
 "react-native@npm:^0.73.0":
   version: 0.73.9
   resolution: "react-native@npm:0.73.9"
@@ -19057,6 +19285,60 @@ __metadata:
   bin:
     react-native: cli.js
   checksum: 10c0/93a752d155c82ed1e8708c86719ed25a9a6e677534b1f400defcb5c85ef9cb4cd716f645403b959966371a0e49866a9ab0a88515773ae66ae4f36abe5dd78dd1
+  languageName: node
+  linkType: hard
+
+"react-native@npm:^0.74.0":
+  version: 0.74.6
+  resolution: "react-native@npm:0.74.6"
+  dependencies:
+    "@jest/create-cache-key-function": "npm:^29.6.3"
+    "@react-native-community/cli": "npm:13.6.9"
+    "@react-native-community/cli-platform-android": "npm:13.6.9"
+    "@react-native-community/cli-platform-ios": "npm:13.6.9"
+    "@react-native/assets-registry": "npm:0.74.88"
+    "@react-native/codegen": "npm:0.74.88"
+    "@react-native/community-cli-plugin": "npm:0.74.88"
+    "@react-native/gradle-plugin": "npm:0.74.88"
+    "@react-native/js-polyfills": "npm:0.74.88"
+    "@react-native/normalize-colors": "npm:0.74.88"
+    "@react-native/virtualized-lists": "npm:0.74.88"
+    abort-controller: "npm:^3.0.0"
+    anser: "npm:^1.4.9"
+    ansi-regex: "npm:^5.0.0"
+    base64-js: "npm:^1.5.1"
+    chalk: "npm:^4.0.0"
+    event-target-shim: "npm:^5.0.1"
+    flow-enums-runtime: "npm:^0.0.6"
+    glob: "npm:^7.1.1"
+    invariant: "npm:^2.2.4"
+    jest-environment-node: "npm:^29.6.3"
+    jsc-android: "npm:^250231.0.0"
+    memoize-one: "npm:^5.0.0"
+    metro-runtime: "npm:^0.80.3"
+    metro-source-map: "npm:^0.80.3"
+    mkdirp: "npm:^0.5.1"
+    nullthrows: "npm:^1.1.1"
+    pretty-format: "npm:^26.5.2"
+    promise: "npm:^8.3.0"
+    react-devtools-core: "npm:^5.0.0"
+    react-refresh: "npm:^0.14.0"
+    react-shallow-renderer: "npm:^16.15.0"
+    regenerator-runtime: "npm:^0.13.2"
+    scheduler: "npm:0.24.0-canary-efb381bbf-20230505"
+    stacktrace-parser: "npm:^0.1.10"
+    whatwg-fetch: "npm:^3.0.0"
+    ws: "npm:^6.2.2"
+    yargs: "npm:^17.6.2"
+  peerDependencies:
+    "@types/react": ^18.2.6
+    react: 18.2.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  bin:
+    react-native: cli.js
+  checksum: 10c0/af655996b1b09f91f9d9d3f4179d047e67a666fc390cd7b777e9439e55507f80d5939bdab5cb2d4677f21aa41480c4c84ba41aac049a1a1ddd74389764d2088d
   languageName: node
   linkType: hard
 
@@ -19222,6 +19504,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"readdirp@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "readdirp@npm:4.0.2"
+  checksum: 10c0/a16ecd8ef3286dcd90648c3b103e3826db2b766cdb4a988752c43a83f683d01c7059158d623cbcd8bdfb39e65d302d285be2d208e7d9f34d022d912b929217dd
+  languageName: node
+  linkType: hard
+
 "readline@npm:^1.3.0":
   version: 1.3.0
   resolution: "readline@npm:1.3.0"
@@ -19331,14 +19620,14 @@ __metadata:
   linkType: hard
 
 "regexp.prototype.flags@npm:^1.4.3, regexp.prototype.flags@npm:^1.5.2":
-  version: 1.5.2
-  resolution: "regexp.prototype.flags@npm:1.5.2"
+  version: 1.5.3
+  resolution: "regexp.prototype.flags@npm:1.5.3"
   dependencies:
-    call-bind: "npm:^1.0.6"
+    call-bind: "npm:^1.0.7"
     define-properties: "npm:^1.2.1"
     es-errors: "npm:^1.3.0"
-    set-function-name: "npm:^2.0.1"
-  checksum: 10c0/0f3fc4f580d9c349f8b560b012725eb9c002f36daa0041b3fbf6f4238cb05932191a4d7d5db3b5e2caa336d5150ad0402ed2be81f711f9308fe7e1a9bf9bd552
+    set-function-name: "npm:^2.0.2"
+  checksum: 10c0/e1a7c7dc42cc91abf73e47a269c4b3a8f225321b7f617baa25821f6a123a91d23a73b5152f21872c566e699207e1135d075d2251cd3e84cc96d82a910adf6020
   languageName: node
   linkType: hard
 
@@ -19805,6 +20094,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"selfsigned@npm:^2.4.1":
+  version: 2.4.1
+  resolution: "selfsigned@npm:2.4.1"
+  dependencies:
+    "@types/node-forge": "npm:^1.3.0"
+    node-forge: "npm:^1"
+  checksum: 10c0/521829ec36ea042f7e9963bf1da2ed040a815cf774422544b112ec53b7edc0bc50a0f8cc2ae7aa6cc19afa967c641fd96a15de0fc650c68651e41277d2e1df09
+  languageName: node
+  linkType: hard
+
 "semver-compare@npm:^1.0.0":
   version: 1.0.0
   resolution: "semver-compare@npm:1.0.0"
@@ -19906,7 +20205,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"set-function-name@npm:^2.0.1":
+"set-function-name@npm:^2.0.2":
   version: 2.0.2
   resolution: "set-function-name@npm:2.0.2"
   dependencies:
@@ -20042,14 +20341,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:1.8.1, shell-quote@npm:^1.6.1, shell-quote@npm:^1.7.3, shell-quote@npm:^1.8.1":
+"shell-quote@npm:1.8.1":
   version: 1.8.1
   resolution: "shell-quote@npm:1.8.1"
   checksum: 10c0/8cec6fd827bad74d0a49347057d40dfea1e01f12a6123bf82c4649f3ef152fc2bc6d6176e6376bffcd205d9d0ccb4f1f9acae889384d20baff92186f01ea455a
   languageName: node
   linkType: hard
 
-"shell-quote@npm:1.8.2":
+"shell-quote@npm:1.8.2, shell-quote@npm:^1.6.1, shell-quote@npm:^1.7.3, shell-quote@npm:^1.8.1":
   version: 1.8.2
   resolution: "shell-quote@npm:1.8.2"
   checksum: 10c0/85fdd44f2ad76e723d34eb72c753f04d847ab64e9f1f10677e3f518d0e5b0752a176fd805297b30bb8c3a1556ebe6e77d2288dbd7b7b0110c7e941e9e9c20ce1
@@ -20179,30 +20478,30 @@ __metadata:
   linkType: hard
 
 "socks-proxy-agent@npm:^8.0.2":
-  version: 8.0.3
-  resolution: "socks-proxy-agent@npm:8.0.3"
+  version: 8.0.4
+  resolution: "socks-proxy-agent@npm:8.0.4"
   dependencies:
     agent-base: "npm:^7.1.1"
     debug: "npm:^4.3.4"
-    socks: "npm:^2.7.1"
-  checksum: 10c0/4950529affd8ccd6951575e21c1b7be8531b24d924aa4df3ee32df506af34b618c4e50d261f4cc603f1bfd8d426915b7d629966c8ce45b05fb5ad8c8b9a6459d
+    socks: "npm:^2.8.3"
+  checksum: 10c0/345593bb21b95b0508e63e703c84da11549f0a2657d6b4e3ee3612c312cb3a907eac10e53b23ede3557c6601d63252103494caa306b66560f43af7b98f53957a
   languageName: node
   linkType: hard
 
-"socks@npm:^2.6.2, socks@npm:^2.7.1":
-  version: 2.8.1
-  resolution: "socks@npm:2.8.1"
+"socks@npm:^2.6.2, socks@npm:^2.8.3":
+  version: 2.8.3
+  resolution: "socks@npm:2.8.3"
   dependencies:
     ip-address: "npm:^9.0.5"
     smart-buffer: "npm:^4.2.0"
-  checksum: 10c0/ac77b515c260473cc7c4452f09b20939e22510ce3ae48385c516d1d5784374d5cc75be3cb18ff66cc985a7f4f2ef8fef84e984c5ec70aad58355ed59241f40a8
+  checksum: 10c0/d54a52bf9325165770b674a67241143a3d8b4e4c8884560c4e0e078aace2a728dffc7f70150660f51b85797c4e1a3b82f9b7aa25e0a0ceae1a243365da5c51a7
   languageName: node
   linkType: hard
 
 "source-map-js@npm:^1.0.1, source-map-js@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "source-map-js@npm:1.0.2"
-  checksum: 10c0/32f2dfd1e9b7168f9a9715eb1b4e21905850f3b50cf02cf476e47e4eebe8e6b762b63a64357896aa29b37e24922b4282df0f492e0d2ace572b43d15525976ff8
+  version: 1.2.1
+  resolution: "source-map-js@npm:1.2.1"
+  checksum: 10c0/7bda1fc4c197e3c6ff17de1b8b2c20e60af81b63a52cb32ec5a5d67a20a7d42651e2cb34ebe93833c5a2a084377e17455854fee3e21e7925c64a51b6a52b0faf
   languageName: node
   linkType: hard
 
@@ -20432,16 +20731,17 @@ __metadata:
   linkType: hard
 
 "streamx@npm:^2.13.0, streamx@npm:^2.15.0":
-  version: 2.16.1
-  resolution: "streamx@npm:2.16.1"
+  version: 2.20.1
+  resolution: "streamx@npm:2.20.1"
   dependencies:
     bare-events: "npm:^2.2.0"
-    fast-fifo: "npm:^1.1.0"
+    fast-fifo: "npm:^1.3.2"
     queue-tick: "npm:^1.0.1"
+    text-decoder: "npm:^1.1.0"
   dependenciesMeta:
     bare-events:
       optional: true
-  checksum: 10c0/202b1d7cb7ceb36cdc5d5d0e2c27deafcc8670a4934cda7a5e3d3d45b8d3a64dc43f1b982b1c1cb316f01964dd5137b7e26af3151582c7c29ad3cf4072c6dbb9
+  checksum: 10c0/34ffa2ee9465d70e18c7e2ba70189720c166d150ab83eb7700304620fa23ff42a69cb37d712ea4b5fc6234d8e74346a88bb4baceb873c6b05e52ac420f8abb4d
   languageName: node
   linkType: hard
 
@@ -20737,7 +21037,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar-fs@npm:^3.0.4":
+"tar-fs@npm:^3.0.4, tar-fs@npm:^3.0.5":
   version: 3.0.6
   resolution: "tar-fs@npm:3.0.6"
   dependencies:
@@ -20751,23 +21051,6 @@ __metadata:
     bare-path:
       optional: true
   checksum: 10c0/207b7c0f193495668bd9dbad09a0108ce4ffcfec5bce2133f90988cdda5c81fad83c99f963d01e47b565196594f7a17dbd063ae55b97b36268fcc843975278ee
-  languageName: node
-  linkType: hard
-
-"tar-fs@npm:^3.0.5":
-  version: 3.0.5
-  resolution: "tar-fs@npm:3.0.5"
-  dependencies:
-    bare-fs: "npm:^2.1.1"
-    bare-path: "npm:^2.1.0"
-    pump: "npm:^3.0.0"
-    tar-stream: "npm:^3.1.5"
-  dependenciesMeta:
-    bare-fs:
-      optional: true
-    bare-path:
-      optional: true
-  checksum: 10c0/02ad60ab9e7ab4fe2e819a3abc8b8acd8bed49f7eba8ef652f124c1444f2b21da7505af41a4778f0c7c3c60afbe53591b7b6148f6ab12f5d17100a93c8182676
   languageName: node
   linkType: hard
 
@@ -20796,7 +21079,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"teen_process@npm:2.2.0, teen_process@npm:^2.0.0, teen_process@npm:^2.0.1, teen_process@npm:^2.2.0":
+"teen_process@npm:2.2.0":
   version: 2.2.0
   resolution: "teen_process@npm:2.2.0"
   dependencies:
@@ -20808,7 +21091,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"teen_process@npm:2.2.3":
+"teen_process@npm:2.2.3, teen_process@npm:^2.0.0, teen_process@npm:^2.0.1, teen_process@npm:^2.2.0":
   version: 2.2.3
   resolution: "teen_process@npm:2.2.3"
   dependencies:
@@ -20868,6 +21151,15 @@ __metadata:
     glob: "npm:^7.1.4"
     minimatch: "npm:^3.0.4"
   checksum: 10c0/019d33d81adff3f9f1bfcff18125fb2d3c65564f437d9be539270ee74b994986abb8260c7c2ce90e8f30162178b09dbbce33c6389273afac4f36069c48521f57
+  languageName: node
+  linkType: hard
+
+"text-decoder@npm:^1.1.0":
+  version: 1.2.0
+  resolution: "text-decoder@npm:1.2.0"
+  dependencies:
+    b4a: "npm:^1.6.4"
+  checksum: 10c0/398171bef376e06864cd6ba24e0787cc626bebc84a1bbda758d06a6e9b729cc8613f7923dd0d294abd88e8bb5cd7261aad5fda7911fb87253fe71b2b5ac6e507
   languageName: node
   linkType: hard
 
@@ -20954,13 +21246,6 @@ __metadata:
   version: 1.0.5
   resolution: "tmpl@npm:1.0.5"
   checksum: 10c0/f935537799c2d1922cb5d6d3805f594388f75338fe7a4a9dac41504dd539704ca4db45b883b52e7b0aa5b2fd5ddadb1452bf95cd23a69da2f793a843f9451cc9
-  languageName: node
-  linkType: hard
-
-"to-fast-properties@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "to-fast-properties@npm:2.0.0"
-  checksum: 10c0/b214d21dbfb4bce3452b6244b336806ffea9c05297148d32ebb428d5c43ce7545bdfc65a1ceb58c9ef4376a65c0cb2854d645f33961658b3e3b4f84910ddcdd7
   languageName: node
   linkType: hard
 
@@ -21163,14 +21448,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:4.26.1, type-fest@npm:^4.2.0, type-fest@npm:^4.4.0":
+"type-fest@npm:4.26.1":
   version: 4.26.1
   resolution: "type-fest@npm:4.26.1"
   checksum: 10c0/d2719ff8d380befe8a3c61068f37f28d6fa2849fd140c5d2f0f143099e371da6856aad7c97e56b83329d45bfe504afe9fd936a7cff600cc0d46aa9ffb008d6c6
   languageName: node
   linkType: hard
 
-"type-fest@npm:4.31.0":
+"type-fest@npm:4.31.0, type-fest@npm:^4.2.0, type-fest@npm:^4.4.0":
   version: 4.31.0
   resolution: "type-fest@npm:4.31.0"
   checksum: 10c0/a5bb69e3b0f82e068af8c645ac3d50b1fa5c588ebc83735a6add4ef6dacf277bb3605801f66c72c069af20120ee7387a3ae6dd84e12c152f5982784c710b4051
@@ -21291,23 +21576,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.7.2":
+"typescript@npm:5.7.2, typescript@npm:>=4.7.0":
   version: 5.7.2
   resolution: "typescript@npm:5.7.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/a873118b5201b2ef332127ef5c63fb9d9c155e6fdbe211cbd9d8e65877283797cca76546bad742eea36ed7efbe3424a30376818f79c7318512064e8625d61622
-  languageName: node
-  linkType: hard
-
-"typescript@npm:>=4.7.0":
-  version: 5.6.2
-  resolution: "typescript@npm:5.6.2"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/3ed8297a8c7c56b7fec282532503d1ac795239d06e7c4966b42d4330c6cf433a170b53bcf93a130a7f14ccc5235de5560df4f1045eb7f3550b46ebed16d3c5e5
   languageName: node
   linkType: hard
 
@@ -21321,23 +21596,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.7.2#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A5.7.2#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A>=4.7.0#optional!builtin<compat/typescript>":
   version: 5.7.2
   resolution: "typescript@patch:typescript@npm%3A5.7.2#optional!builtin<compat/typescript>::version=5.7.2&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/f3b8082c9d1d1629a215245c9087df56cb784f9fb6f27b5d55577a20e68afe2a889c040aacff6d27e35be165ecf9dca66e694c42eb9a50b3b2c451b36b5675cb
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@npm%3A>=4.7.0#optional!builtin<compat/typescript>":
-  version: 5.6.2
-  resolution: "typescript@patch:typescript@npm%3A5.6.2#optional!builtin<compat/typescript>::version=5.6.2&hash=8c6c40"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/94eb47e130d3edd964b76da85975601dcb3604b0c848a36f63ac448d0104e93819d94c8bdf6b07c00120f2ce9c05256b8b6092d23cf5cf1c6fa911159e4d572f
   languageName: node
   linkType: hard
 
@@ -21396,10 +21661,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici-types@npm:~5.26.4":
+  version: 5.26.5
+  resolution: "undici-types@npm:5.26.5"
+  checksum: 10c0/bb673d7876c2d411b6eb6c560e0c571eef4a01c1c19925175d16e3a30c4c428181fb8d7ae802a261f283e4166a0ac435e2f505743aa9e45d893f9a3df017b501
+  languageName: node
+  linkType: hard
+
 "undici-types@npm:~6.19.2":
   version: 6.19.8
   resolution: "undici-types@npm:6.19.8"
   checksum: 10c0/078afa5990fba110f6824823ace86073b4638f1d5112ee26e790155f481f2a868cc3e0615505b6f4282bdf74a3d8caad715fd809e870c2bb0704e3ea6082f344
+  languageName: node
+  linkType: hard
+
+"undici@npm:^6.19.5":
+  version: 6.19.8
+  resolution: "undici@npm:6.19.8"
+  checksum: 10c0/07fd8520bce7e34ea29c07ef0de27b734183042cdb4e2f1262cd1fb9b755a6b04ff2471040395dfb1770fb7786069a97c5178bcf706b80a34075994f46feb37c
   languageName: node
   linkType: hard
 
@@ -21829,7 +22108,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webdriverio@npm:8.40.6, webdriverio@npm:^8.29.3, webdriverio@npm:^8.40.0":
+"webdriverio@npm:8.40.6":
   version: 8.40.6
   resolution: "webdriverio@npm:8.40.6"
   dependencies:
@@ -21867,7 +22146,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webdriverio@npm:8.41.0":
+"webdriverio@npm:8.41.0, webdriverio@npm:^8.29.3, webdriverio@npm:^8.40.0":
   version: 8.41.0
   resolution: "webdriverio@npm:8.41.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -19070,20 +19070,21 @@ __metadata:
   linkType: hard
 
 "react-native-macos@npm:^0.74.0":
-  version: 0.74.9
-  resolution: "react-native-macos@npm:0.74.9"
+  version: 0.74.26
+  resolution: "react-native-macos@npm:0.74.26"
   dependencies:
     "@jest/create-cache-key-function": "npm:^29.6.3"
     "@react-native-community/cli": "npm:13.6.9"
     "@react-native-community/cli-platform-android": "npm:13.6.9"
+    "@react-native-community/cli-platform-apple": "npm:13.6.9"
     "@react-native-community/cli-platform-ios": "npm:13.6.9"
     "@react-native-mac/virtualized-lists": "npm:0.74.87"
-    "@react-native/assets-registry": "npm:0.74.87"
-    "@react-native/codegen": "npm:0.74.87"
-    "@react-native/community-cli-plugin": "npm:0.74.87"
-    "@react-native/gradle-plugin": "npm:0.74.87"
-    "@react-native/js-polyfills": "npm:0.74.87"
-    "@react-native/normalize-colors": "npm:0.74.87"
+    "@react-native/assets-registry": "npm:0.74.88"
+    "@react-native/codegen": "npm:0.74.88"
+    "@react-native/community-cli-plugin": "npm:0.74.88"
+    "@react-native/gradle-plugin": "npm:0.74.88"
+    "@react-native/js-polyfills": "npm:0.74.88"
+    "@react-native/normalize-colors": "npm:0.74.88"
     abort-controller: "npm:^3.0.0"
     anser: "npm:^1.4.9"
     ansi-regex: "npm:^5.0.0"
@@ -19091,6 +19092,7 @@ __metadata:
     chalk: "npm:^4.0.0"
     event-target-shim: "npm:^5.0.1"
     flow-enums-runtime: "npm:^0.0.6"
+    glob: "npm:^7.1.1"
     invariant: "npm:^2.2.4"
     jest-environment-node: "npm:^29.6.3"
     jsc-android: "npm:^250231.0.0"
@@ -19118,7 +19120,7 @@ __metadata:
       optional: true
   bin:
     react-native-macos: cli.js
-  checksum: 10c0/fdbb55bef92ce3f739dc93dc6c2b8c6bf474c49a0cc76f7d818e68107ebc8362c532edc4897faaed4c5d021f3b12a01b6f982dd8685386e67f29ea553a1e1026
+  checksum: 10c0/d945e24fae29807f4b4d8c864d865f9c7bfba34695db29f0ab1eded51600d1f3c95017999f7d35357ff2f6a7eed6c28736df16d3896c37ff62c6ad24f84a356f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Run rnx-align-deps with the 0.74 requirement and fix as many warnings as we can.

### Verification


### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
