### PR TITLE
Fix tablist test perf to fix Nuget pipeline

### DIFF
--- a/change/@fluentui-react-native-tablist-23579e14-31ed-42c5-8a13-db58d77dc611.json
+++ b/change/@fluentui-react-native-tablist-23579e14-31ed-42c5-8a13-db58d77dc611.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Make tablist test not async so that it runs faster",
+  "packageName": "@fluentui-react-native/tablist",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/TabList/src/TabList/__tests__/TabList.test.tsx
+++ b/packages/components/TabList/src/TabList/__tests__/TabList.test.tsx
@@ -21,11 +21,9 @@ describe('TabList component tests', () => {
       )
       .toJSON();
     expect(tree).toMatchSnapshot();
-    // Each test needs this, again having to do with tests failing during the second render.
-    await renderer.act(async () => null);
   });
 
-  it('TabList selected key', async () => {
+  it('TabList selected key', () => {
     const tree = renderer
       .create(
         <TabList selectedKey="1">
@@ -36,10 +34,9 @@ describe('TabList component tests', () => {
       )
       .toJSON();
     expect(tree).toMatchSnapshot();
-    await renderer.act(async () => null);
   });
 
-  it('TabList disabled list', async () => {
+  it('TabList disabled list', () => {
     const tree = renderer
       .create(
         <TabList disabled>
@@ -50,10 +47,9 @@ describe('TabList component tests', () => {
       )
       .toJSON();
     expect(tree).toMatchSnapshot();
-    await renderer.act(async () => null);
   });
 
-  it('TabList appearance', async () => {
+  it('TabList appearance', () => {
     const tree = renderer
       .create(
         <TabList appearance="subtle">
@@ -64,10 +60,9 @@ describe('TabList component tests', () => {
       )
       .toJSON();
     expect(tree).toMatchSnapshot();
-    await renderer.act(async () => null);
   });
 
-  it('TabList size', async () => {
+  it('TabList size', () => {
     const tree = renderer
       .create(
         <TabList size="large">
@@ -78,10 +73,9 @@ describe('TabList component tests', () => {
       )
       .toJSON();
     expect(tree).toMatchSnapshot();
-    await renderer.act(async () => null);
   });
 
-  it('TabList orientation', async () => {
+  it('TabList orientation', () => {
     const tree = renderer
       .create(
         <TabList vertical>
@@ -92,20 +86,17 @@ describe('TabList component tests', () => {
       )
       .toJSON();
     expect(tree).toMatchSnapshot();
-    await renderer.act(async () => null);
   });
 
-  it('TabList re-renders correctly', async () => {
+  it('TabList re-renders correctly', () => {
     checkReRender(
       () => (
         <TabList>
           <Tab tabKey="1">Tab 1</Tab>
           <Tab tabKey="2">Tab 2</Tab>
-          <Tab tabKey="3">Tab 3</Tab>
         </TabList>
       ),
       2,
     );
-    await renderer.act(async () => null);
   });
 });

--- a/packages/components/TabList/src/TabList/__tests__/__snapshots__/TabList.test.tsx.snap
+++ b/packages/components/TabList/src/TabList/__tests__/__snapshots__/TabList.test.tsx.snap
@@ -47,9 +47,9 @@ exports[`TabList component tests TabList appearance 1`] = `
           ]
         }
         accessibilityLabel="Tab 1"
-        accessibilityPositionInSet={0}
+        accessibilityPositionInSet={1}
         accessibilityRole="tab"
-        accessibilitySetSize={0}
+        accessibilitySetSize={3}
         accessibilityState={
           {
             "busy": undefined,
@@ -182,9 +182,9 @@ exports[`TabList component tests TabList appearance 1`] = `
           ]
         }
         accessibilityLabel="Tab 2"
-        accessibilityPositionInSet={0}
+        accessibilityPositionInSet={2}
         accessibilityRole="tab"
-        accessibilitySetSize={0}
+        accessibilitySetSize={3}
         accessibilityState={
           {
             "busy": undefined,
@@ -317,9 +317,9 @@ exports[`TabList component tests TabList appearance 1`] = `
           ]
         }
         accessibilityLabel="Tab 3"
-        accessibilityPositionInSet={0}
+        accessibilityPositionInSet={3}
         accessibilityRole="tab"
-        accessibilitySetSize={0}
+        accessibilitySetSize={3}
         accessibilityState={
           {
             "busy": undefined,
@@ -1391,9 +1391,9 @@ exports[`TabList component tests TabList orientation 1`] = `
           ]
         }
         accessibilityLabel="Tab 1"
-        accessibilityPositionInSet={0}
+        accessibilityPositionInSet={1}
         accessibilityRole="tab"
-        accessibilitySetSize={0}
+        accessibilitySetSize={3}
         accessibilityState={
           {
             "busy": undefined,
@@ -1525,9 +1525,9 @@ exports[`TabList component tests TabList orientation 1`] = `
           ]
         }
         accessibilityLabel="Tab 2"
-        accessibilityPositionInSet={0}
+        accessibilityPositionInSet={2}
         accessibilityRole="tab"
-        accessibilitySetSize={0}
+        accessibilitySetSize={3}
         accessibilityState={
           {
             "busy": undefined,
@@ -1659,9 +1659,9 @@ exports[`TabList component tests TabList orientation 1`] = `
           ]
         }
         accessibilityLabel="Tab 3"
-        accessibilityPositionInSet={0}
+        accessibilityPositionInSet={3}
         accessibilityRole="tab"
-        accessibilitySetSize={0}
+        accessibilitySetSize={3}
         accessibilityState={
           {
             "busy": undefined,
@@ -1837,9 +1837,9 @@ exports[`TabList component tests TabList selected key 1`] = `
           ]
         }
         accessibilityLabel="Tab 1"
-        accessibilityPositionInSet={0}
+        accessibilityPositionInSet={1}
         accessibilityRole="tab"
-        accessibilitySetSize={0}
+        accessibilitySetSize={3}
         accessibilityState={
           {
             "busy": undefined,
@@ -1972,9 +1972,9 @@ exports[`TabList component tests TabList selected key 1`] = `
           ]
         }
         accessibilityLabel="Tab 2"
-        accessibilityPositionInSet={0}
+        accessibilityPositionInSet={2}
         accessibilityRole="tab"
-        accessibilitySetSize={0}
+        accessibilitySetSize={3}
         accessibilityState={
           {
             "busy": undefined,
@@ -2107,9 +2107,9 @@ exports[`TabList component tests TabList selected key 1`] = `
           ]
         }
         accessibilityLabel="Tab 3"
-        accessibilityPositionInSet={0}
+        accessibilityPositionInSet={3}
         accessibilityRole="tab"
-        accessibilitySetSize={0}
+        accessibilitySetSize={3}
         accessibilityState={
           {
             "busy": undefined,


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

The `TabList selected key` test frequently times out when trying to publish the win32 Nuget after committing. Trying to fix that timeout by making the test not async.

### Verification

CI will verify

### Pull request checklist

This PR has considered (when applicable):
- [x] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
