### PR TITLE
Implement TabList CTRL + TAB keyboard shortcut on win32.

### DIFF
--- a/change/@fluentui-react-native-tablist-1728f13f-0b8a-4a97-8107-39f08f25947b.json
+++ b/change/@fluentui-react-native-tablist-1728f13f-0b8a-4a97-8107-39f08f25947b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add native \"Ctrl + Tab\" keyboard shortcut for TabList component.",
+  "packageName": "@fluentui-react-native/tablist",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/TabList/src/TabList/__tests__/TabList.test.tsx
+++ b/packages/components/TabList/src/TabList/__tests__/TabList.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 
-import { checkReRender } from '@fluentui-react-native/test-tools';
 import * as renderer from 'react-test-renderer';
 
 import Tab from '../../Tab/Tab';
@@ -86,17 +85,5 @@ describe('TabList component tests', () => {
       )
       .toJSON();
     expect(tree).toMatchSnapshot();
-  });
-
-  it('TabList re-renders correctly', () => {
-    checkReRender(
-      () => (
-        <TabList>
-          <Tab tabKey="1">Tab 1</Tab>
-          <Tab tabKey="2">Tab 2</Tab>
-        </TabList>
-      ),
-      2,
-    );
   });
 });

--- a/packages/components/TabList/src/TabList/__tests__/__snapshots__/TabList.test.tsx.snap
+++ b/packages/components/TabList/src/TabList/__tests__/__snapshots__/TabList.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`TabList component tests TabList appearance 1`] = `
       "current": null,
     }
   }
+  onKeyDown={[Function]}
   onLayout={[Function]}
   size="medium"
   style={
@@ -463,6 +464,7 @@ exports[`TabList component tests TabList default props 1`] = `
       "current": null,
     }
   }
+  onKeyDown={[Function]}
   onLayout={[Function]}
   size="medium"
   style={
@@ -911,6 +913,7 @@ exports[`TabList component tests TabList disabled list 1`] = `
       "current": null,
     }
   }
+  onKeyDown={[Function]}
   onLayout={[Function]}
   size="medium"
   style={
@@ -1359,6 +1362,7 @@ exports[`TabList component tests TabList orientation 1`] = `
       "current": null,
     }
   }
+  onKeyDown={[Function]}
   onLayout={[Function]}
   size="medium"
   style={
@@ -1804,6 +1808,7 @@ exports[`TabList component tests TabList selected key 1`] = `
       "current": null,
     }
   }
+  onKeyDown={[Function]}
   onLayout={[Function]}
   selectedKey="1"
   size="medium"
@@ -2253,6 +2258,7 @@ exports[`TabList component tests TabList size 1`] = `
       "current": null,
     }
   }
+  onKeyDown={[Function]}
   onLayout={[Function]}
   size="large"
   style={

--- a/packages/components/TabList/src/TabList/useTabList.ts
+++ b/packages/components/TabList/src/TabList/useTabList.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { type View, type AccessibilityState, type LayoutRectangle, Platform } from 'react-native';
+import { Platform } from 'react-native';
+import type { View, AccessibilityState, LayoutRectangle } from 'react-native';
 
 import { memoize, mergeStyles } from '@fluentui-react-native/framework';
 import type { LayoutEvent } from '@fluentui-react-native/interactive-hooks';
@@ -81,17 +82,13 @@ export const useTabList = (props: TabListProps): TabListInfo => {
 
       const currentIndex = tabKeys.indexOf(selectedTabKey);
 
-      if (currentIndex === -1 && __DEV__) {
-        console.error(`Selected tab key does not exist in tab key array. Tab Key: ${selectedTabKey}. Keys: ${tabKeys}`);
-      }
-
       // We want to only switch selection to non-disabled tabs. This skips over disabled ones.
       const direction = increment > 0 ? 1 : -1;
-      increment = increment / direction; // abs
+      const magnitude = increment * direction;
       let newTabKey: string;
       let retries = 0;
       while (retries < tabKeys.length) {
-        let newIndex = (currentIndex + direction * (increment + retries)) % tabKeys.length;
+        let newIndex = (currentIndex + direction * (magnitude + retries)) % tabKeys.length;
 
         if (newIndex < 0) {
           newIndex = tabKeys.length + newIndex;

--- a/packages/components/TabList/src/TabList/useTabList.ts
+++ b/packages/components/TabList/src/TabList/useTabList.ts
@@ -167,7 +167,7 @@ export const useTabList = (props: TabListProps): TabListInfo => {
   // win32 only prop used to implemement CTRL + TAB shortcut native to windows tab components
   const onRootKeyDown = React.useCallback(
     (e: IKeyboardEvent) => {
-      if (e.nativeEvent.key === 'Tab' && e.nativeEvent.ctrlKey) {
+      if ((Platform.OS as string) === 'win32' && e.nativeEvent.key === 'Tab' && e.nativeEvent.ctrlKey) {
         incrementSelectedTab(e.nativeEvent.shiftKey);
         setInvoked(true); // on win32, set focus on the new tab without triggering narration twice
       }
@@ -187,7 +187,7 @@ export const useTabList = (props: TabListProps): TabListInfo => {
       componentRef: componentRef,
       defaultTabbableElement: focusedTabRef,
       isCircularNavigation: isCircularNavigation ?? false,
-      onKeyDown: (Platform.OS as string) === 'win32' ? onRootKeyDown : undefined,
+      onKeyDown: onRootKeyDown,
       onLayout: onTabListLayout,
       size: size,
       vertical: vertical,

--- a/packages/components/TabList/src/TabList/useTabList.ts
+++ b/packages/components/TabList/src/TabList/useTabList.ts
@@ -74,21 +74,17 @@ export const useTabList = (props: TabListProps): TabListInfo => {
     [setTabKeys],
   );
 
-  const incrementTabKey = React.useCallback(
-    (increment: number) => {
-      if (increment === 0) {
-        return;
-      }
-
+  const incrementSelectedTab = React.useCallback(
+    (goBackward: boolean) => {
       const currentIndex = tabKeys.indexOf(selectedTabKey);
 
-      // We want to only switch selection to non-disabled tabs. This skips over disabled ones.
-      const direction = increment > 0 ? 1 : -1;
-      const magnitude = increment * direction;
+      const direction = goBackward ? -1 : 1;
+      let increment = 1;
       let newTabKey: string;
-      let retries = 0;
-      while (retries < tabKeys.length) {
-        let newIndex = (currentIndex + direction * (magnitude + retries)) % tabKeys.length;
+
+      // We want to only switch selection to non-disabled tabs. This loop allows us to skip over disabled ones.
+      while (increment <= tabKeys.length) {
+        let newIndex = (currentIndex + direction * increment) % tabKeys.length;
 
         if (newIndex < 0) {
           newIndex = tabKeys.length + newIndex;
@@ -97,14 +93,14 @@ export const useTabList = (props: TabListProps): TabListInfo => {
         newTabKey = tabKeys[newIndex];
 
         if (disabledStateMap[newTabKey]) {
-          retries += 1;
+          increment += 1;
         } else {
           break;
         }
       }
 
       // Unable to find a non-disabled next tab, early return
-      if (retries === tabKeys.length) {
+      if (increment > tabKeys.length) {
         return;
       }
 
@@ -172,13 +168,13 @@ export const useTabList = (props: TabListProps): TabListInfo => {
   const onRootKeyDown = React.useCallback(
     (e: IKeyboardEvent) => {
       if (e.nativeEvent.key === 'Tab' && e.nativeEvent.ctrlKey) {
-        incrementTabKey(e.nativeEvent.shiftKey ? -1 : 1);
+        incrementSelectedTab(e.nativeEvent.shiftKey);
         setInvoked(true); // on win32, set focus on the new tab without triggering narration twice
       }
 
       props.onKeyDown?.(e);
     },
-    [incrementTabKey, props],
+    [incrementSelectedTab, props],
   );
 
   return {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Native Windows TabList / Pivot implement a CTRL + TAB keyboard shortcut to switch tab selection for the entire tablist. This keyboard shortcut was missing on the FURN TabList, and this PR implements this. 

### Verification

Tested locally in FURN app. Verified narration and announcements do not break - no repro of old double narration bug. 

https://github.com/user-attachments/assets/c7705bc9-4f9c-4832-920f-a60f8008a2a8

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [x] Keyboard Accessibility
- [x] Voiceover
- [ ] Internationalization and Right-to-left Layouts
