### PR TITLE
Potential fix for code scanning alert no. 3: Prototype-polluting assignment

### DIFF
--- a/change/@fluentui-react-native-memo-cache-0c1ce6d7-722e-4518-9cf5-bc2fe0e0ced9.json
+++ b/change/@fluentui-react-native-memo-cache-0c1ce6d7-722e-4518-9cf5-bc2fe0e0ced9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Potential fix for code scanning alert no. 3: Prototype-polluting assignment",
+  "packageName": "@fluentui-react-native/memo-cache",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/framework/memo-cache/src/getCacheEntry.ts
+++ b/packages/framework/memo-cache/src/getCacheEntry.ts
@@ -22,7 +22,7 @@ export type CacheEntry<T, TGet = any> = {
  * @param key - which key of that entry to ensure the value for
  */
 function ensureAndReturn(entry: CacheEntry<any>, key: keyof CacheEntry<any>): CacheEntry<any> | { [key: string]: CacheEntry<any> } {
-  if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+  if ((key as string) === '__proto__' || (key as string) === 'constructor' || (key as string) === 'prototype') {
     throw new Error('Invalid key');
   }
   return (entry[key] = entry[key] || {});

--- a/packages/framework/memo-cache/src/getCacheEntry.ts
+++ b/packages/framework/memo-cache/src/getCacheEntry.ts
@@ -22,6 +22,9 @@ export type CacheEntry<T, TGet = any> = {
  * @param key - which key of that entry to ensure the value for
  */
 function ensureAndReturn(entry: CacheEntry<any>, key: keyof CacheEntry<any>): CacheEntry<any> | { [key: string]: CacheEntry<any> } {
+  if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+    throw new Error('Invalid key');
+  }
   return (entry[key] = entry[key] || {});
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/fluentui-react-native/security/code-scanning/3](https://github.com/microsoft/fluentui-react-native/security/code-scanning/3)

To fix the prototype pollution issue, we need to ensure that the `key` value used in the `ensureAndReturn` function is validated and does not include dangerous property names like `__proto__`, `constructor`, or `prototype`. We can achieve this by adding a check to reject these keys before performing the assignment.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


From Ruriko: I have checked the code and it's in line with the suggestions attached to the CodeQL alert for how to fix the issue.