### PR TITLE
[LinkV1] Simplify code to find child string of LinkV1 when setting a11yLabel

### DIFF
--- a/change/@fluentui-react-native-link-c18251d2-05a6-485f-a6bc-f471efef105e.json
+++ b/change/@fluentui-react-native-link-c18251d2-05a6-485f-a6bc-f471efef105e.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Check if we find a string as a child before calling .toString()",
+  "comment": "Simplify code to find child string of LinkV1",
   "packageName": "@fluentui-react-native/link",
   "email": "krsiler@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-native-link-c18251d2-05a6-485f-a6bc-f471efef105e.json
+++ b/change/@fluentui-react-native-link-c18251d2-05a6-485f-a6bc-f471efef105e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Check if we find a string as a child before calling .toString()",
+  "packageName": "@fluentui-react-native/link",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Link/src/Link.tsx
+++ b/packages/components/Link/src/Link.tsx
@@ -49,15 +49,9 @@ export const Link = compose<LinkType>({
       // Views in Text, we use that to handle interactions instead.
       const supportsInteractionOnText = Platform.OS !== 'macos';
 
-      // Find the first child that's a string and save it to set as the link's
+      // Find the first child that's a string (if it exists) and save it to set as the link's
       // accessibilityLabel if one isn't defined.
-      let linkA11yLabel = '';
-
-      const textChild = React.Children.toArray(children).find((child) => typeof child === 'string');
-
-      if (textChild != undefined) {
-        linkA11yLabel = textChild.toString();
-      }
+      const linkA11yLabel = React.Children.toArray(children).find((child) => typeof child === 'string');
 
       return supportsA11yTextInText && supportsInteractionOnText && (inline || mergedProps.selectable) ? (
         <Slots.content {...mergedProps}>{children}</Slots.content>

--- a/packages/components/Link/src/Link.tsx
+++ b/packages/components/Link/src/Link.tsx
@@ -52,9 +52,12 @@ export const Link = compose<LinkType>({
       // Find the first child that's a string and save it to set as the link's
       // accessibilityLabel if one isn't defined.
       let linkA11yLabel = '';
-      linkA11yLabel = React.Children.toArray(children)
-        .find((child) => typeof child === 'string')
-        .toString();
+
+      const textChild = React.Children.toArray(children).find((child) => typeof child === 'string');
+
+      if (textChild != undefined) {
+        linkA11yLabel = textChild.toString();
+      }
 
       return supportsA11yTextInText && supportsInteractionOnText && (inline || mergedProps.selectable) ? (
         <Slots.content {...mergedProps}>{children}</Slots.content>


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Previously, if we didn't find a string as a child of LinkV1 and called .toString(), we ran into an error. This fixes it by simplyfing the code to just return the first child that's a string (if it exists) instead of calling .toString() on the result. We use this to set the a11yLabel if one isn't defined.

### Verification

Tested by creating a Link without any children. Verified FURN test app no longer runs into an error.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
