### PR TITLE
[Menu] Update tab navigation on win32

### DIFF
--- a/apps/E2E/src/Menu/specs/Menu.spec.win.ts
+++ b/apps/E2E/src/Menu/specs/Menu.spec.win.ts
@@ -160,15 +160,15 @@ describe('Menu Functional Testing', () => {
       .toBeFalsy();
   });
 
-  it('Press "Tab" to navigate between MenuItems. Validate that focus switches correctly between MenuItems.', async () => {
+  it('Press "Tab" to navigate between MenuGroups. Validate that focus switches correctly between MenuGroups.', async () => {
     await MenuPageObject.openMenu();
 
-    await MenuPageObject.sendKeys(MenuPageObject.getMenuItem('Third'), [Keys.TAB]);
+    await MenuPageObject.sendKeys(MenuPageObject.getMenuItem('First'), [Keys.TAB]);
     expect(
-      await MenuPageObject.compareAttribute(MenuPageObject.getMenuItem('Fourth'), Attribute.IsFocused, AttributeValue.true),
+      await MenuPageObject.compareAttribute(MenuPageObject.getMenuItem('Third'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();
 
-    await MenuPageObject.sendKeys(MenuPageObject.getMenuItem('Fourth'), [Keys.TAB]);
+    await MenuPageObject.sendKeys(MenuPageObject.getMenuItem('Third'), [Keys.TAB]);
     expect(
       await MenuPageObject.compareAttribute(MenuPageObject.getMenuItem('First'), Attribute.IsFocused, AttributeValue.true),
     ).toBeTruthy();

--- a/apps/fluent-tester/src/TestComponents/Menu/E2EMenuTest.tsx
+++ b/apps/fluent-tester/src/TestComponents/Menu/E2EMenuTest.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { View } from 'react-native';
 
 import { ButtonV1 as Button } from '@fluentui-react-native/button';
-import { Menu, MenuItem, MenuList, MenuPopover, MenuTrigger } from '@fluentui-react-native/menu';
+import { Menu, MenuDivider, MenuGroup, MenuItem, MenuList, MenuPopover, MenuTrigger } from '@fluentui-react-native/menu';
 import { Stack } from '@fluentui-react-native/stack';
 import { TextV1 as Text } from '@fluentui-react-native/text';
 
@@ -76,36 +76,41 @@ export const E2EMenuTest: React.FunctionComponent = () => {
             {...testProps(MENUPOPOVER_TEST_COMPONENT)}
           >
             <MenuList>
-              <MenuItem
-                onClick={onItemClick}
-                accessibilityLabel={MENUITEM_ACCESSIBILITY_LABEL}
-                persistOnClick
-                /* For Android E2E testing purposes, testProps must be passed in after accessibilityLabel. */
-                {...testProps(MENUITEM_TEST_COMPONENT)}
-              >
-                A plain MenuItem
-              </MenuItem>
-              <MenuItem
-                onClick={onItemClick}
-                /* For Android E2E testing purposes, testProps must be passed in after accessibilityLabel. */
-                {...testProps(MENUITEM_DISABLED_COMPONENT)}
-                disabled
-                persistOnClick
-              >
-                A second disabled plain MenuItem
-              </MenuItem>
-              <MenuItem
-                /* For Android E2E testing purposes, testProps must be passed in after accessibilityLabel. */
-                {...testProps(MENUITEM_NO_A11Y_LABEL_COMPONENT)}
-              >
-                {MENUITEM_TEST_LABEL}
-              </MenuItem>
-              <MenuItem
-                /* For Android E2E testing purposes, testProps must be passed in after accessibilityLabel. */
-                {...testProps(MENUITEM_FOURTH_COMPONENT)}
-              >
-                A fourth plain MenuItem
-              </MenuItem>
+              <MenuGroup>
+                <MenuItem
+                  onClick={onItemClick}
+                  accessibilityLabel={MENUITEM_ACCESSIBILITY_LABEL}
+                  persistOnClick
+                  /* For Android E2E testing purposes, testProps must be passed in after accessibilityLabel. */
+                  {...testProps(MENUITEM_TEST_COMPONENT)}
+                >
+                  A plain MenuItem
+                </MenuItem>
+                <MenuItem
+                  onClick={onItemClick}
+                  /* For Android E2E testing purposes, testProps must be passed in after accessibilityLabel. */
+                  {...testProps(MENUITEM_DISABLED_COMPONENT)}
+                  disabled
+                  persistOnClick
+                >
+                  A second disabled plain MenuItem
+                </MenuItem>
+              </MenuGroup>
+              <MenuDivider />
+              <MenuGroup>
+                <MenuItem
+                  /* For Android E2E testing purposes, testProps must be passed in after accessibilityLabel. */
+                  {...testProps(MENUITEM_NO_A11Y_LABEL_COMPONENT)}
+                >
+                  {MENUITEM_TEST_LABEL}
+                </MenuItem>
+                <MenuItem
+                  /* For Android E2E testing purposes, testProps must be passed in after accessibilityLabel. */
+                  {...testProps(MENUITEM_FOURTH_COMPONENT)}
+                >
+                  A fourth plain MenuItem
+                </MenuItem>
+              </MenuGroup>
             </MenuList>
           </MenuPopover>
         </Menu>

--- a/change/@fluentui-react-native-e2e-testing-32828e64-4b64-492f-81be-792e3251f3dc.json
+++ b/change/@fluentui-react-native-e2e-testing-32828e64-4b64-492f-81be-792e3251f3dc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "update E2E test for win32",
+  "packageName": "@fluentui-react-native/e2e-testing",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-menu-b17320f8-20c5-4a54-970d-631cdc6f9288.json
+++ b/change/@fluentui-react-native-menu-b17320f8-20c5-4a54-970d-631cdc6f9288.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix Menu tab navigation on win32",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-98ce1cf5-f9a2-4543-8967-482d23186b0e.json
+++ b/change/@fluentui-react-native-tester-98ce1cf5-f9a2-4543-8967-482d23186b0e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "update E2E test for win32",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/MenuList/MenuList.tsx
+++ b/packages/components/Menu/src/MenuList/MenuList.tsx
@@ -87,7 +87,7 @@ export const MenuList = compose<MenuListType>({
         (child) => child && (child as any).type && (child as any).type.displayName === 'MenuGroup',
       );
 
-      // On win32, tab should only navigate between menu groups.
+      // On win32, tab navigation should only be enabled when we have menu groups.
       const hasTabNavigation = Platform.OS === ('win32' as any) && hasMenuGroupChild;
 
       const content = (

--- a/packages/components/Menu/src/MenuList/MenuList.tsx
+++ b/packages/components/Menu/src/MenuList/MenuList.tsx
@@ -37,7 +37,6 @@ MenuStack.displayName = 'MenuStack';
 const shouldHaveFocusZone = ['macos', 'win32'].includes(Platform.OS as string);
 const focusLandsOnContainer = Platform.OS === 'macos';
 const hasCircularNavigation = Platform.OS === ('win32' as any);
-const hasTabNavigation = Platform.OS === ('win32' as any);
 
 export const menuListLookup = (layer: string, state: MenuListState, userProps: MenuListProps): boolean => {
   return state[layer] || userProps[layer] || layer === 'hasMaxHeight';
@@ -83,6 +82,13 @@ export const MenuList = compose<MenuListType>({
 
       const shouldHaveScrollView = Platform.OS === 'macos' || menuList.hasMaxHeight || menuList.hasMaxWidth;
       const ScrollViewWrapper = shouldHaveScrollView ? Slots.scrollView : React.Fragment;
+
+      const hasMenuGroupChild = React.Children.toArray(children).some(
+        (child) => child && (child as any).type && (child as any).type.displayName === 'MenuGroup',
+      );
+
+      // On win32, tab should only navigate between menu groups.
+      const hasTabNavigation = Platform.OS === ('win32' as any) && hasMenuGroupChild;
 
       const content = (
         <Slots.root>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5083,9 +5083,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fluentui-react-native/text@npm:*, @fluentui-react-native/text@workspace:*, @fluentui-react-native/text@workspace:packages/components/Text":
+"@fluentui-react-native/text@npm:*, @fluentui-react-native/text@workspace:*, @fluentui-react-native/text@workspace:packages/components/text":
   version: 0.0.0-use.local
-  resolution: "@fluentui-react-native/text@workspace:packages/components/Text"
+  resolution: "@fluentui-react-native/text@workspace:packages/components/text"
   dependencies:
     "@fluentui-react-native/adapters": "workspace:*"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5083,9 +5083,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fluentui-react-native/text@npm:*, @fluentui-react-native/text@workspace:*, @fluentui-react-native/text@workspace:packages/components/text":
+"@fluentui-react-native/text@npm:*, @fluentui-react-native/text@workspace:*, @fluentui-react-native/text@workspace:packages/components/Text":
   version: 0.0.0-use.local
-  resolution: "@fluentui-react-native/text@workspace:packages/components/text"
+  resolution: "@fluentui-react-native/text@workspace:packages/components/Text"
   dependencies:
     "@fluentui-react-native/adapters": "workspace:*"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

On win32, tab should only navigate between MenuGroups, not to individual MenuItems, for efficient navigation. This change updates the tab navigation for FURN Menu to check if the Menu has any MenuGroups before enabling tab navigation. If there are no MenuGroups present, only arrow keys will navigate to menu items within the Menu.

### Verification

Manually tested by using tab on Menu without MenuGroups. 

Tab would visit every menu item before changes. Tab does not visit additional menu items after placing focus on the first item after changes.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![MenuTabNav_BeforeNoGroups](https://github.com/user-attachments/assets/600180ce-70d0-40c3-9ea6-a81ed9417070) | ![MenuTabNav_AfterNoGroups](https://github.com/user-attachments/assets/1c69fc75-8650-4af9-a42e-1f971e48491f) |


Tab will visit the first/last item in a MenuGroup when MenuGroups are present (depending if user uses Tab/Shift+Tab) which is the same before/after changes:

![MenuTabNav_After](https://github.com/user-attachments/assets/3cd1c5b5-06e7-4ca5-8b7a-a36b025b9518)

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [x] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
