### PR TITLE
  Add static typing to the FocusZoneNativeComponent defaultTabbableElement type for Fabric usage

### DIFF
--- a/change/@fluentui-react-native-focus-zone-69fa6b84-8c7a-4db8-8a7f-02484425756a.json
+++ b/change/@fluentui-react-native-focus-zone-69fa6b84-8c7a-4db8-8a7f-02484425756a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add static typing to the FocusZoneNativeComponent defaultTabbableElement type for fabric usage of the id/nativeID string type",
+  "packageName": "@fluentui-react-native/focus-zone",
+  "email": "patboyd@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/FocusZone/src/FocusZoneNativeComponent.ts
+++ b/packages/components/FocusZone/src/FocusZoneNativeComponent.ts
@@ -6,12 +6,16 @@
 
 import type { HostComponent, ViewProps } from 'react-native';
 
-import type { Int32, WithDefault } from 'react-native/Libraries/Types/CodegenTypes';
+import type { WithDefault } from 'react-native/Libraries/Types/CodegenTypes';
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+
+import type { UnsafeMixed } from './codegenTypes';
+// Should be:
+// import type { UnsafeObject } from 'react-native/Libraries/Types/CodegenTypes';
 
 export interface NativeProps extends ViewProps {
   navigateAtEnd?: WithDefault<'NavigateStopAtEnds' | 'NavigateWrap' | 'NavigateContinue', 'NavigateStopAtEnds'>;
-  defaultTabbableElement?: Int32;
+  defaultTabbableElement?: UnsafeMixed;
   focusZoneDirection?: WithDefault<'bidirectional' | 'vertical' | 'horizontal' | 'none', 'bidirectional'>;
   use2DNavigation?: boolean;
   tabKeyNavigation?: WithDefault<'None' | 'NavigateWrap' | 'NavigateStopAtEnds' | 'Normal', 'None'>;

--- a/packages/components/FocusZone/src/codegenTypes.d.ts
+++ b/packages/components/FocusZone/src/codegenTypes.d.ts
@@ -1,0 +1,2 @@
+// Separate .d.ts file to fool codegen, since UnsafeMixed does not existing in the TS types of RN currently.
+export type UnsafeMixed = any;


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [x] windows
- [ ] android

### Description of changes

Add static typing to the FocusZoneNativeComponent defaultTabbableElement type for Fabric usage

### Verification

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
