### PR TITLE
fix(VibrancyView): remove hit test override

### DIFF
--- a/change/@fluentui-react-native-vibrancy-view-0511e685-812d-4174-955f-b2530fe2a8ab.json
+++ b/change/@fluentui-react-native-vibrancy-view-0511e685-812d-4174-955f-b2530fe2a8ab.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix(VibrancyView): remove hit test override",
+  "packageName": "@fluentui-react-native/vibrancy-view",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/VibrancyView/macos/FixedVisualEffectView.swift
+++ b/packages/experimental/VibrancyView/macos/FixedVisualEffectView.swift
@@ -1,7 +1,8 @@
 import AppKit
+
 #if USE_REACT_AS_MODULE
-import React
-#endif // USE_REACT_AS_MODULE
+  import React
+#endif  // USE_REACT_AS_MODULE
 
 /// React Native macOS inherits some assumptions from React Native on iOS / UIKit.
 /// This serves as an issue when we want to write our own native components derived from NSView, as we don't
@@ -9,30 +10,10 @@ import React
 /// so that our native component works as expected.
 internal class FixedVisualEffectView: NSVisualEffectView {
 
-	/// React Native macOS uses a flipped coordinate space by default. to match the other platforms.
-	/// Let's stay consistent and ensure any views hosting React Native views are also flipped.
-	/// This helps RCTTouchHandler register clicks in the right location, and ensures `layer.geometryFlipped` is true.
-	override var isFlipped: Bool {
-		return true
-	}
-
-	/// This subclass is necessary due to differences' in hitTest()'s implementation between iOS and macOS
-	///	On iOS / UIKit, hitTest(_ point:, with event:) takes a point in the receiver's local coordinate system.
-	///	On macOS / AppKit, hitTest(_ point) takes a point in the reciever's superviews' coordinate system.
-	/// RCTView assumes the iOS implementation, so it has  an override of hitTest(_ point). Let's copy the
-	/// implementatation to our  native component, so that clicks for subviews of type RCTView are handled properly.
-	/// Another solution would be to add an RCTView subview that covers the full bounds of our native view
-	open override func hitTest(_ point: NSPoint) -> NSView? {
-		var pointForHitTest = point
-		for subview in subviews {
-			if let subview = subview as? RCTView {
-				pointForHitTest = subview.convert(point, from: superview)
-			}
-			let result = subview.hitTest(pointForHitTest)
-			if (result != nil) {
-				return result
-			}
-		}
-		return nil
-	}
+  /// React Native macOS uses a flipped coordinate space by default. to match the other platforms.
+  /// Let's stay consistent and ensure any views hosting React Native views are also flipped.
+  /// This helps RCTTouchHandler register clicks in the right location, and ensures `layer.geometryFlipped` is true.
+  override var isFlipped: Bool {
+    return true
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -18845,8 +18845,8 @@ __metadata:
   linkType: hard
 
 "react-native-macos@npm:^0.73.0":
-  version: 0.73.35
-  resolution: "react-native-macos@npm:0.73.35"
+  version: 0.73.36
+  resolution: "react-native-macos@npm:0.73.36"
   dependencies:
     "@jest/create-cache-key-function": "npm:^29.6.3"
     "@react-native-community/cli": "npm:12.3.6"
@@ -18890,7 +18890,7 @@ __metadata:
     react: 18.2.0
   bin:
     react-native-macos: cli.js
-  checksum: 10c0/365b0886e810bbce800a781d4eb186e07d34b8c0daadb25efd4235d3afab4e806b36a44aceef751c586c787ae392ad1c9bee87b3f3475d8769d37de5b8dce4b5
+  checksum: 10c0/c58570ab2dd5836a96ccb477e60e8462a89c730d0c4ab3edae780fb0963fc6ca944dcbc321e2e8314e727c41de56a296327b3534fadc6031b62ae53bca54b226
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

https://github.com/microsoft/react-native-macos/pull/2403 has been merged and back ported down to RNM 0.73, so we can safely remove this override after bumping our version of RNM.

### Verification

Tested the test page in Fluent Tester that checks hit testing via child view buttons in a VibrancyView.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
