### PR TITLE
chore: fix <package> doesn't provide @babel/core

### DIFF
--- a/apps/fluent-tester/package.json
+++ b/apps/fluent-tester/package.json
@@ -96,8 +96,8 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@babel/core": "^7.8.0",
-    "@babel/runtime": "^7.8.0",
+    "@babel/core": "^7.20.0",
+    "@babel/runtime": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/focus-zone": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",

--- a/apps/win32/package.json
+++ b/apps/win32/package.json
@@ -37,6 +37,7 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",

--- a/change/@fluentui-react-native-474a6bed-9cbe-4fa0-bac5-66325c11ccdc.json
+++ b/change/@fluentui-react-native-474a6bed-9cbe-4fa0-bac5-66325c11ccdc.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui/react-native",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-adapters-d1117d4e-d9d5-4ccf-8eda-022eedd3609d.json
+++ b/change/@fluentui-react-native-adapters-d1117d4e-d9d5-4ccf-8eda-022eedd3609d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/adapters",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-android-theme-f5212796-a031-4c55-a65e-cf57f736e877.json
+++ b/change/@fluentui-react-native-android-theme-f5212796-a031-4c55-a65e-cf57f736e877.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/android-theme",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-apple-theme-d4df0b61-0ced-4a6c-a687-b2db4fca4e02.json
+++ b/change/@fluentui-react-native-apple-theme-d4df0b61-0ced-4a6c-a687-b2db4fca4e02.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/apple-theme",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-avatar-f39246d4-6c10-4c64-8112-ed2f010ddfdf.json
+++ b/change/@fluentui-react-native-avatar-f39246d4-6c10-4c64-8112-ed2f010ddfdf.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/avatar",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-badge-8172c80c-989a-4417-b811-cede6da666cc.json
+++ b/change/@fluentui-react-native-badge-8172c80c-989a-4417-b811-cede6da666cc.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/badge",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-button-9064aad2-2ac9-4437-be46-354b99581c47.json
+++ b/change/@fluentui-react-native-button-9064aad2-2ac9-4437-be46-354b99581c47.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/button",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-callout-1a561c7d-db91-4a62-a30d-5c609ab33297.json
+++ b/change/@fluentui-react-native-callout-1a561c7d-db91-4a62-a30d-5c609ab33297.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/callout",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-checkbox-bf0b47ca-d05a-4e59-9cde-473c7b73be6c.json
+++ b/change/@fluentui-react-native-checkbox-bf0b47ca-d05a-4e59-9cde-473c7b73be6c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/checkbox",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-chip-6b881c4c-7ae7-46b3-ac91-e7b0a7399dbb.json
+++ b/change/@fluentui-react-native-chip-6b881c4c-7ae7-46b3-ac91-e7b0a7399dbb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/chip",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-composition-1c977c52-7177-4b9d-a54f-dd932ed9002d.json
+++ b/change/@fluentui-react-native-composition-1c977c52-7177-4b9d-a54f-dd932ed9002d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/composition",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-contextual-menu-e1ce6a88-71a1-41d0-b705-ad0bead7544b.json
+++ b/change/@fluentui-react-native-contextual-menu-e1ce6a88-71a1-41d0-b705-ad0bead7544b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/contextual-menu",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-default-theme-77d80ba6-edc2-4fe2-8e63-b9117200ba51.json
+++ b/change/@fluentui-react-native-default-theme-77d80ba6-edc2-4fe2-8e63-b9117200ba51.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/default-theme",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-divider-77487db6-8f21-4d69-b013-b9aaa0e41869.json
+++ b/change/@fluentui-react-native-divider-77487db6-8f21-4d69-b013-b9aaa0e41869.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/divider",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-drawer-285823a7-95ff-4019-9ab7-abe68b230fbb.json
+++ b/change/@fluentui-react-native-drawer-285823a7-95ff-4019-9ab7-abe68b230fbb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/drawer",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-dropdown-677f06f9-1c78-41ad-8eb3-3779db779b59.json
+++ b/change/@fluentui-react-native-dropdown-677f06f9-1c78-41ad-8eb3-3779db779b59.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/dropdown",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-activity-indicator-3cf3081a-f542-49e5-aa87-aa48a828bde0.json
+++ b/change/@fluentui-react-native-experimental-activity-indicator-3cf3081a-f542-49e5-aa87-aa48a828bde0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/experimental-activity-indicator",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-appearance-additions-fb17df5a-5dc3-485f-b8a3-1be01ba4b5d7.json
+++ b/change/@fluentui-react-native-experimental-appearance-additions-fb17df5a-5dc3-485f-b8a3-1be01ba4b5d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/experimental-appearance-additions",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-avatar-e2afa50b-54ae-434c-851f-7d7deeeb3ef8.json
+++ b/change/@fluentui-react-native-experimental-avatar-e2afa50b-54ae-434c-851f-7d7deeeb3ef8.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/experimental-avatar",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-checkbox-fa152af6-3fa1-47ea-8425-9116637498fa.json
+++ b/change/@fluentui-react-native-experimental-checkbox-fa152af6-3fa1-47ea-8425-9116637498fa.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/experimental-checkbox",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-expander-9b8be649-293d-4259-a892-647c2f5ca5d3.json
+++ b/change/@fluentui-react-native-experimental-expander-9b8be649-293d-4259-a892-647c2f5ca5d3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/experimental-expander",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-menu-button-3a31f2f8-f2aa-4d32-a255-89f14ea7b30f.json
+++ b/change/@fluentui-react-native-experimental-menu-button-3a31f2f8-f2aa-4d32-a255-89f14ea7b30f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/experimental-menu-button",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-native-date-picker-8b382e73-9553-4624-99b2-a4f260c97a54.json
+++ b/change/@fluentui-react-native-experimental-native-date-picker-8b382e73-9553-4624-99b2-a4f260c97a54.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/experimental-native-date-picker",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-native-font-metrics-2575a074-23ab-4864-89d3-201465b06dea.json
+++ b/change/@fluentui-react-native-experimental-native-font-metrics-2575a074-23ab-4864-89d3-201465b06dea.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/experimental-native-font-metrics",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-shadow-70972193-f41a-420d-9fcb-ab6e931bf364.json
+++ b/change/@fluentui-react-native-experimental-shadow-70972193-f41a-420d-9fcb-ab6e931bf364.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/experimental-shadow",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-experimental-shimmer-6c16e978-d2fb-48b3-9eec-3bb9fe96c354.json
+++ b/change/@fluentui-react-native-experimental-shimmer-6c16e978-d2fb-48b3-9eec-3bb9fe96c354.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/experimental-shimmer",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-focus-trap-zone-879fcc3e-1e63-403a-ae1a-64734bb89390.json
+++ b/change/@fluentui-react-native-focus-trap-zone-879fcc3e-1e63-403a-ae1a-64734bb89390.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/focus-trap-zone",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-focus-zone-61fedb8f-426e-457e-9834-05fbff62480f.json
+++ b/change/@fluentui-react-native-focus-zone-61fedb8f-426e-457e-9834-05fbff62480f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/focus-zone",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-framework-1f200b83-2a8f-4cd9-ad92-c09b2f97e273.json
+++ b/change/@fluentui-react-native-framework-1f200b83-2a8f-4cd9-ad92-c09b2f97e273.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/framework",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-icon-e143d629-271e-44fb-93b4-1ea41125ae46.json
+++ b/change/@fluentui-react-native-icon-e143d629-271e-44fb-93b4-1ea41125ae46.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/icon",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-input-896726bd-424d-4231-81d7-21122774fa92.json
+++ b/change/@fluentui-react-native-input-896726bd-424d-4231-81d7-21122774fa92.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/input",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-interactive-hooks-4955b813-ac7f-4507-91f7-1daa4392a785.json
+++ b/change/@fluentui-react-native-interactive-hooks-4955b813-ac7f-4507-91f7-1daa4392a785.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/interactive-hooks",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-link-e56e5d73-92f1-455e-a2c0-c067f3223a0d.json
+++ b/change/@fluentui-react-native-link-e56e5d73-92f1-455e-a2c0-c067f3223a0d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/link",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-menu-0d9f0905-3ab1-4f57-a3d0-a7c2fa851eb5.json
+++ b/change/@fluentui-react-native-menu-0d9f0905-3ab1-4f57-a3d0-a7c2fa851eb5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-menu-button-2caafe55-8677-414f-856c-c5b64b396844.json
+++ b/change/@fluentui-react-native-menu-button-2caafe55-8677-414f-856c-c5b64b396844.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/menu-button",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-merge-props-0ac6dae2-eb94-46d7-8379-8a7ffeef709d.json
+++ b/change/@fluentui-react-native-merge-props-0ac6dae2-eb94-46d7-8379-8a7ffeef709d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/merge-props",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-notification-7d8878a2-4bda-4593-85a0-31a9e517adcf.json
+++ b/change/@fluentui-react-native-notification-7d8878a2-4bda-4593-85a0-31a9e517adcf.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/notification",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-overflow-ef41b6fe-464f-47ff-97d4-cb719b4ee431.json
+++ b/change/@fluentui-react-native-overflow-ef41b6fe-464f-47ff-97d4-cb719b4ee431.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/overflow",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-persona-53a71506-8a2c-43a8-ae45-17ac46268123.json
+++ b/change/@fluentui-react-native-persona-53a71506-8a2c-43a8-ae45-17ac46268123.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/persona",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-persona-coin-86826ced-2135-43f4-9d24-0ad3d3935004.json
+++ b/change/@fluentui-react-native-persona-coin-86826ced-2135-43f4-9d24-0ad3d3935004.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/persona-coin",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-popover-2dbe9bba-1781-47d9-84b6-a3ad098f9652.json
+++ b/change/@fluentui-react-native-popover-2dbe9bba-1781-47d9-84b6-a3ad098f9652.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/popover",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-pressable-9f3c6de7-9e48-4160-87f7-6facc7924c5e.json
+++ b/change/@fluentui-react-native-pressable-9f3c6de7-9e48-4160-87f7-6facc7924c5e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/pressable",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-radio-group-a1845c06-d4bf-4d29-8a5b-7c7d5c94797d.json
+++ b/change/@fluentui-react-native-radio-group-a1845c06-d4bf-4d29-8a5b-7c7d5c94797d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/radio-group",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-separator-43640f2b-a8fe-416d-a5ec-1742afeb6eeb.json
+++ b/change/@fluentui-react-native-separator-43640f2b-a8fe-416d-a5ec-1742afeb6eeb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/separator",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-spinner-bb270b1f-4117-42a7-aa03-6c66ccccd7cf.json
+++ b/change/@fluentui-react-native-spinner-bb270b1f-4117-42a7-aa03-6c66ccccd7cf.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/spinner",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-stack-2399e59e-9810-416c-ba56-98f45e669bb6.json
+++ b/change/@fluentui-react-native-stack-2399e59e-9810-416c-ba56-98f45e669bb6.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/stack",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-styling-utils-f68ab20c-402e-4c15-8f71-92fd00b97bad.json
+++ b/change/@fluentui-react-native-styling-utils-f68ab20c-402e-4c15-8f71-92fd00b97bad.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/styling-utils",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-switch-9829dcec-a692-4c06-a8cd-eb9b4f539919.json
+++ b/change/@fluentui-react-native-switch-9829dcec-a692-4c06-a8cd-eb9b4f539919.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/switch",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-tablist-f5571fa8-3735-45ec-86b0-b19053d0a8c2.json
+++ b/change/@fluentui-react-native-tablist-f5571fa8-3735-45ec-86b0-b19053d0a8c2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/tablist",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-tester-99d19e7d-0c08-4502-a26d-fa6b859bcc5a.json
+++ b/change/@fluentui-react-native-tester-99d19e7d-0c08-4502-a26d-fa6b859bcc5a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-tester-win32-99b156d5-04e1-4bf0-b093-bf57dc58fe6a.json
+++ b/change/@fluentui-react-native-tester-win32-99b156d5-04e1-4bf0-b093-bf57dc58fe6a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/tester-win32",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-text-2241da8d-e41a-47a6-8a4f-e5442ea6b2a3.json
+++ b/change/@fluentui-react-native-text-2241da8d-e41a-47a6-8a4f-e5442ea6b2a3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/text",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-theme-29603a70-6943-4035-9b10-2bee92b37f45.json
+++ b/change/@fluentui-react-native-theme-29603a70-6943-4035-9b10-2bee92b37f45.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/theme",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-theme-tokens-5e55380d-a1bc-4319-90f3-ff3600a21020.json
+++ b/change/@fluentui-react-native-theme-tokens-5e55380d-a1bc-4319-90f3-ff3600a21020.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/theme-tokens",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-theme-types-f4eade56-af25-4c15-a475-044d48260c0b.json
+++ b/change/@fluentui-react-native-theme-types-f4eade56-af25-4c15-a475-044d48260c0b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/theme-types",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-themed-stylesheet-278e5c02-78c8-4c88-84d5-4ceeabf24c9e.json
+++ b/change/@fluentui-react-native-themed-stylesheet-278e5c02-78c8-4c88-84d5-4ceeabf24c9e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/themed-stylesheet",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-theming-utils-c7649b6b-ffa6-4ba3-bb9b-a701d0a8e874.json
+++ b/change/@fluentui-react-native-theming-utils-c7649b6b-ffa6-4ba3-bb9b-a701d0a8e874.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/theming-utils",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-tokens-47f2e859-ca11-4d55-88cf-84110c36cdca.json
+++ b/change/@fluentui-react-native-tokens-47f2e859-ca11-4d55-88cf-84110c36cdca.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/tokens",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-tooltip-c8dd6d9e-49f3-4a2c-8e4c-e3eda615ab20.json
+++ b/change/@fluentui-react-native-tooltip-c8dd6d9e-49f3-4a2c-8e4c-e3eda615ab20.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/tooltip",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-use-slot-493148e4-70df-4b36-aaf5-c9f28342a813.json
+++ b/change/@fluentui-react-native-use-slot-493148e4-70df-4b36-aaf5-c9f28342a813.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/use-slot",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-use-slots-4a18f04d-629a-435f-8065-1d4cf5eec5f0.json
+++ b/change/@fluentui-react-native-use-slots-4a18f04d-629a-435f-8065-1d4cf5eec5f0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/use-slots",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-use-styling-87d87833-0d6c-45fb-80d0-aac6079c7e9c.json
+++ b/change/@fluentui-react-native-use-styling-87d87833-0d6c-45fb-80d0-aac6079c7e9c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/use-styling",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-use-tokens-37c9e452-e2ae-444c-92a5-deb46464320f.json
+++ b/change/@fluentui-react-native-use-tokens-37c9e452-e2ae-444c-92a5-deb46464320f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/use-tokens",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-vibrancy-view-467b29e5-1efb-4948-8172-62ebd56140b1.json
+++ b/change/@fluentui-react-native-vibrancy-view-467b29e5-1efb-4948-8172-62ebd56140b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/vibrancy-view",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-win32-theme-925ae793-631e-40b3-ac13-5526085fe3ca.json
+++ b/change/@fluentui-react-native-win32-theme-925ae793-631e-40b3-ac13-5526085fe3ca.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@fluentui-react-native/win32-theme",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@uifabricshared-foundation-compose-982df06d-d7ba-424d-9672-9c46eda5039b.json
+++ b/change/@uifabricshared-foundation-compose-982df06d-d7ba-424d-9672-9c46eda5039b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@uifabricshared/foundation-compose",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@uifabricshared-foundation-settings-7a632b63-acc5-40a2-a4ca-86e7c47906a2.json
+++ b/change/@uifabricshared-foundation-settings-7a632b63-acc5-40a2-a4ca-86e7c47906a2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@uifabricshared/foundation-settings",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@uifabricshared-foundation-tokens-6426c661-3e09-43e6-abb8-c7d5dd96572b.json
+++ b/change/@uifabricshared-foundation-tokens-6426c661-3e09-43e6-abb8-c7d5dd96572b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@uifabricshared/foundation-tokens",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@uifabricshared-theme-registry-dedcd33e-ef65-413f-ad3e-055dbb4560cb.json
+++ b/change/@uifabricshared-theme-registry-dedcd33e-ef65-413f-ad3e-055dbb4560cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@uifabricshared/theme-registry",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@uifabricshared-themed-settings-4fb98051-de2f-4ba8-bebb-0337181f52cf.json
+++ b/change/@uifabricshared-themed-settings-4fb98051-de2f-4ba8-bebb-0337181f52cf.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@uifabricshared/themed-settings",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@uifabricshared-theming-react-native-a605efed-386d-4df8-abe0-12649f85bff3.json
+++ b/change/@uifabricshared-theming-react-native-a605efed-386d-4df8-abe0-12649f85bff3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added missing dev dependencies",
+  "packageName": "@uifabricshared/theming-react-native",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test-links": "markdown-link-check"
   },
   "devDependencies": {
-    "@babel/core": "^7.8.0",
+    "@babel/core": "^7.20.0",
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@babel/preset-env": "^7.8.0",
     "@babel/preset-react": "^7.8.0",

--- a/packages/components/Avatar/package.json
+++ b/packages/components/Avatar/package.json
@@ -39,6 +39,7 @@
     "@fluentui-react-native/use-styling": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",

--- a/packages/components/Badge/package.json
+++ b/packages/components/Badge/package.json
@@ -36,6 +36,7 @@
     "@fluentui-react-native/use-styling": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",

--- a/packages/components/Button/package.json
+++ b/packages/components/Button/package.json
@@ -46,6 +46,7 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",

--- a/packages/components/Callout/package.json
+++ b/packages/components/Callout/package.json
@@ -36,6 +36,7 @@
     "@uifabricshared/foundation-settings": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",

--- a/packages/components/Checkbox/package.json
+++ b/packages/components/Checkbox/package.json
@@ -42,6 +42,7 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",

--- a/packages/components/Chip/package.json
+++ b/packages/components/Chip/package.json
@@ -34,6 +34,7 @@
     "@fluentui-react-native/use-styling": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",

--- a/packages/components/ContextualMenu/package.json
+++ b/packages/components/ContextualMenu/package.json
@@ -41,6 +41,7 @@
     "@uifabricshared/foundation-settings": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/pressable": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",

--- a/packages/components/Divider/package.json
+++ b/packages/components/Divider/package.json
@@ -33,6 +33,7 @@
     "@fluentui-react-native/tokens": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",

--- a/packages/components/FocusTrapZone/package.json
+++ b/packages/components/FocusTrapZone/package.json
@@ -32,6 +32,7 @@
     "@uifabricshared/foundation-settings": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",

--- a/packages/components/FocusZone/package.json
+++ b/packages/components/FocusZone/package.json
@@ -32,6 +32,7 @@
     "@uifabricshared/foundation-settings": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",

--- a/packages/components/Icon/package.json
+++ b/packages/components/Icon/package.json
@@ -31,6 +31,7 @@
     "@fluentui-react-native/text": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",

--- a/packages/components/Input/package.json
+++ b/packages/components/Input/package.json
@@ -36,6 +36,7 @@
     "@fluentui-react-native/use-styling": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",

--- a/packages/components/Link/package.json
+++ b/packages/components/Link/package.json
@@ -38,6 +38,7 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",

--- a/packages/components/Menu/package.json
+++ b/packages/components/Menu/package.json
@@ -40,6 +40,7 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/button": "workspace:*",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",

--- a/packages/components/MenuButton/package.json
+++ b/packages/components/MenuButton/package.json
@@ -38,6 +38,7 @@
     "@uifabricshared/foundation-settings": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",

--- a/packages/components/Notification/package.json
+++ b/packages/components/Notification/package.json
@@ -41,6 +41,7 @@
     "@fluentui-react-native/use-styling": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",

--- a/packages/components/Persona/package.json
+++ b/packages/components/Persona/package.json
@@ -36,6 +36,7 @@
     "@uifabricshared/foundation-tokens": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native/babel-preset": "^0.73.0",

--- a/packages/components/PersonaCoin/package.json
+++ b/packages/components/PersonaCoin/package.json
@@ -36,6 +36,7 @@
     "@uifabricshared/foundation-tokens": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",

--- a/packages/components/Pressable/package.json
+++ b/packages/components/Pressable/package.json
@@ -32,6 +32,7 @@
     "@uifabricshared/foundation-settings": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native/babel-preset": "^0.73.0",

--- a/packages/components/RadioGroup/package.json
+++ b/packages/components/RadioGroup/package.json
@@ -41,6 +41,7 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",

--- a/packages/components/Separator/package.json
+++ b/packages/components/Separator/package.json
@@ -31,6 +31,7 @@
     "@fluentui-react-native/use-styling": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",

--- a/packages/components/Stack/package.json
+++ b/packages/components/Stack/package.json
@@ -35,6 +35,7 @@
     "@uifabricshared/foundation-tokens": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/text": "workspace:*",

--- a/packages/components/Switch/package.json
+++ b/packages/components/Switch/package.json
@@ -36,6 +36,7 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",

--- a/packages/components/TabList/package.json
+++ b/packages/components/TabList/package.json
@@ -38,6 +38,7 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",

--- a/packages/components/Text/package.json
+++ b/packages/components/Text/package.json
@@ -35,6 +35,7 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",

--- a/packages/deprecated/foundation-compose/package.json
+++ b/packages/deprecated/foundation-compose/package.json
@@ -44,7 +44,8 @@
   "devDependencies": {
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
-    "react": "18.2.0"
+    "react": "18.2.0",
+    "react-native": "^0.73.0"
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.73.0",

--- a/packages/deprecated/foundation-settings/package.json
+++ b/packages/deprecated/foundation-settings/package.json
@@ -35,6 +35,7 @@
     "@fluentui-react-native/merge-props": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native/babel-preset": "^0.73.0",

--- a/packages/deprecated/foundation-tokens/package.json
+++ b/packages/deprecated/foundation-tokens/package.json
@@ -36,6 +36,7 @@
     "@uifabricshared/foundation-settings": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/memo-cache": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native/babel-preset": "^0.73.0",

--- a/packages/deprecated/theme-registry/package.json
+++ b/packages/deprecated/theme-registry/package.json
@@ -31,6 +31,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/immutable-merge": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",

--- a/packages/deprecated/themed-settings/package.json
+++ b/packages/deprecated/themed-settings/package.json
@@ -34,6 +34,7 @@
     "@uifabricshared/foundation-settings": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/memo-cache": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",

--- a/packages/deprecated/theming-react-native/package.json
+++ b/packages/deprecated/theming-react-native/package.json
@@ -37,6 +37,7 @@
     "@uifabricshared/theming-ramp": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native/babel-preset": "^0.73.0",

--- a/packages/experimental/ActivityIndicator/package.json
+++ b/packages/experimental/ActivityIndicator/package.json
@@ -30,6 +30,7 @@
     "assert-never": "^1.2.1"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native/babel-preset": "^0.73.0",

--- a/packages/experimental/AppearanceAdditions/package.json
+++ b/packages/experimental/AppearanceAdditions/package.json
@@ -33,6 +33,7 @@
     "use-subscription": ">=1.0.0 <1.6.0"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/framework": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",

--- a/packages/experimental/Avatar/package.json
+++ b/packages/experimental/Avatar/package.json
@@ -32,6 +32,7 @@
     "@fluentui-react-native/framework": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native/babel-preset": "^0.73.0",

--- a/packages/experimental/Checkbox/package.json
+++ b/packages/experimental/Checkbox/package.json
@@ -32,6 +32,7 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",

--- a/packages/experimental/Drawer/package.json
+++ b/packages/experimental/Drawer/package.json
@@ -32,6 +32,7 @@
     "@fluentui-react-native/use-styling": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native/babel-preset": "^0.73.0",

--- a/packages/experimental/Dropdown/package.json
+++ b/packages/experimental/Dropdown/package.json
@@ -35,6 +35,7 @@
     "@fluentui-react-native/theme-tokens": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",

--- a/packages/experimental/Expander/package.json
+++ b/packages/experimental/Expander/package.json
@@ -33,6 +33,7 @@
     "@fluentui-react-native/framework": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native/babel-preset": "^0.73.0",

--- a/packages/experimental/MenuButton/package.json
+++ b/packages/experimental/MenuButton/package.json
@@ -32,6 +32,7 @@
     "@fluentui-react-native/tokens": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",

--- a/packages/experimental/NativeDatePicker/package.json
+++ b/packages/experimental/NativeDatePicker/package.json
@@ -29,6 +29,7 @@
     "directory": "packages/experimental/NativeDatePicker"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native/babel-preset": "^0.73.0",

--- a/packages/experimental/NativeFontMetrics/package.json
+++ b/packages/experimental/NativeFontMetrics/package.json
@@ -32,6 +32,7 @@
     "use-subscription": ">=1.0.0 <1.6.0"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native/babel-preset": "^0.73.0",

--- a/packages/experimental/Overflow/package.json
+++ b/packages/experimental/Overflow/package.json
@@ -30,6 +30,7 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/button": "workspace:*",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/menu": "workspace:*",

--- a/packages/experimental/Popover/package.json
+++ b/packages/experimental/Popover/package.json
@@ -31,6 +31,7 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native/babel-preset": "^0.73.0",

--- a/packages/experimental/Shadow/package.json
+++ b/packages/experimental/Shadow/package.json
@@ -31,6 +31,7 @@
     "@fluentui-react-native/theme-types": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",

--- a/packages/experimental/Shimmer/package.json
+++ b/packages/experimental/Shimmer/package.json
@@ -33,6 +33,7 @@
     "assert-never": "^1.2.1"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native/babel-preset": "^0.73.0",

--- a/packages/experimental/Spinner/package.json
+++ b/packages/experimental/Spinner/package.json
@@ -32,6 +32,7 @@
     "@fluentui-react-native/use-styling": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native/babel-preset": "^0.73.0",

--- a/packages/experimental/Stack/package.json
+++ b/packages/experimental/Stack/package.json
@@ -32,6 +32,7 @@
     "@fluentui-react-native/tokens": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/text": "workspace:*",

--- a/packages/experimental/Tooltip/package.json
+++ b/packages/experimental/Tooltip/package.json
@@ -31,6 +31,7 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/button": "workspace:*",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",

--- a/packages/experimental/VibrancyView/package.json
+++ b/packages/experimental/VibrancyView/package.json
@@ -31,6 +31,7 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native/babel-preset": "^0.73.0",

--- a/packages/framework/composition/package.json
+++ b/packages/framework/composition/package.json
@@ -37,6 +37,7 @@
     "@fluentui-react-native/use-styling": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native/babel-preset": "^0.73.0",
     "@react-native/metro-config": "^0.73.0",

--- a/packages/framework/framework/package.json
+++ b/packages/framework/framework/package.json
@@ -42,6 +42,7 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native/babel-preset": "^0.73.0",

--- a/packages/framework/merge-props/package.json
+++ b/packages/framework/merge-props/package.json
@@ -36,6 +36,7 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native/babel-preset": "^0.73.0",

--- a/packages/framework/theme/package.json
+++ b/packages/framework/theme/package.json
@@ -35,6 +35,7 @@
     "@fluentui-react-native/theme-types": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",
     "@react-native/babel-preset": "^0.73.0",

--- a/packages/framework/themed-stylesheet/package.json
+++ b/packages/framework/themed-stylesheet/package.json
@@ -34,6 +34,7 @@
     "@fluentui-react-native/memo-cache": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native/babel-preset": "^0.73.0",

--- a/packages/framework/use-slot/package.json
+++ b/packages/framework/use-slot/package.json
@@ -35,6 +35,7 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native/babel-preset": "^0.73.0",
     "@react-native/metro-config": "^0.73.0",

--- a/packages/framework/use-slots/package.json
+++ b/packages/framework/use-slots/package.json
@@ -34,6 +34,7 @@
     "@fluentui-react-native/use-slot": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/merge-props": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native/babel-preset": "^0.73.0",

--- a/packages/framework/use-styling/package.json
+++ b/packages/framework/use-styling/package.json
@@ -36,6 +36,7 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native/babel-preset": "^0.73.0",
     "@react-native/metro-config": "^0.73.0",

--- a/packages/framework/use-tokens/package.json
+++ b/packages/framework/use-tokens/package.json
@@ -36,6 +36,7 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/merge-props": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native/babel-preset": "^0.73.0",

--- a/packages/libraries/core/package.json
+++ b/packages/libraries/core/package.json
@@ -62,12 +62,14 @@
     }
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native/babel-preset": "^0.73.0",
     "@react-native/metro-config": "^0.73.0",
     "react": "18.2.0",
-    "react-native": "^0.73.0"
+    "react-native": "^0.73.0",
+    "react-native-svg": "^15.0.0"
   },
   "onPublish": {
     "main": "lib-commonjs/index.js",

--- a/packages/theming/android-theme/package.json
+++ b/packages/theming/android-theme/package.json
@@ -38,6 +38,7 @@
     "@fluentui-react-native/theming-utils": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native/babel-preset": "^0.73.0",

--- a/packages/theming/apple-theme/package.json
+++ b/packages/theming/apple-theme/package.json
@@ -43,6 +43,7 @@
     "assert-never": "^1.2.1"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native/babel-preset": "^0.73.0",

--- a/packages/theming/default-theme/package.json
+++ b/packages/theming/default-theme/package.json
@@ -39,6 +39,7 @@
     "assert-never": "^1.2.1"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",

--- a/packages/theming/theme-tokens/package.json
+++ b/packages/theming/theme-tokens/package.json
@@ -39,6 +39,7 @@
     "assert-never": "^1.2.1"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native/babel-preset": "^0.73.0",

--- a/packages/theming/theme-types/package.json
+++ b/packages/theming/theme-types/package.json
@@ -31,6 +31,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native/babel-preset": "^0.73.0",

--- a/packages/theming/theming-utils/package.json
+++ b/packages/theming/theming-utils/package.json
@@ -30,6 +30,7 @@
     "@fluentui-react-native/tokens": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/design-tokens-win32": "^0.53.0",
     "@fluentui-react-native/design-tokens-windows": "^0.53.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",

--- a/packages/theming/win32-theme/package.json
+++ b/packages/theming/win32-theme/package.json
@@ -41,6 +41,7 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@office-iss/react-native-win32": "^0.73.0",

--- a/packages/utils/adapters/package.json
+++ b/packages/utils/adapters/package.json
@@ -26,6 +26,7 @@
     "directory": "packages/utils/adapters"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native/babel-preset": "^0.73.0",

--- a/packages/utils/interactive-hooks/package.json
+++ b/packages/utils/interactive-hooks/package.json
@@ -33,6 +33,7 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",

--- a/packages/utils/styling/package.json
+++ b/packages/utils/styling/package.json
@@ -26,6 +26,7 @@
     "directory": "packages/utils/styling"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native/babel-preset": "^0.73.0",

--- a/packages/utils/tokens/package.json
+++ b/packages/utils/tokens/package.json
@@ -31,6 +31,7 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@fluentui-react-native/eslint-config-rules": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native/babel-preset": "^0.73.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2702,7 +2702,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.25.0, @babel/runtime@npm:^7.8.0, @babel/runtime@npm:^7.8.4":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.20.0, @babel/runtime@npm:^7.25.0, @babel/runtime@npm:^7.8.0, @babel/runtime@npm:^7.8.4":
   version: 7.26.10
   resolution: "@babel/runtime@npm:7.26.10"
   dependencies:
@@ -3098,6 +3098,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/adapters@workspace:packages/utils/adapters"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
     "@react-native/babel-preset": "npm:^0.73.0"
@@ -3127,6 +3128,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/android-theme@workspace:packages/theming/android-theme"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/memo-cache": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
@@ -3158,6 +3160,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/apple-theme@workspace:packages/theming/apple-theme"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/default-theme": "workspace:*"
     "@fluentui-react-native/design-tokens-ios": "npm:^0.53.0"
     "@fluentui-react-native/design-tokens-macos": "npm:^0.53.0"
@@ -3196,6 +3199,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/avatar@workspace:packages/components/Avatar"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/adapters": "workspace:*"
     "@fluentui-react-native/badge": "workspace:*"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
@@ -3233,6 +3237,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/badge@workspace:packages/components/Badge"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/adapters": "workspace:*"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/experimental-shadow": "workspace:*"
@@ -3273,6 +3278,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/button@workspace:packages/components/Button"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/adapters": "workspace:*"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/experimental-activity-indicator": "workspace:*"
@@ -3320,6 +3326,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/callout@workspace:packages/components/Callout"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/adapters": "workspace:*"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
@@ -3352,6 +3359,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/checkbox@workspace:packages/components/Checkbox"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/adapters": "workspace:*"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/framework": "workspace:*"
@@ -3396,6 +3404,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/chip@workspace:packages/components/Chip"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/adapters": "workspace:*"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/framework": "workspace:*"
@@ -3451,6 +3460,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/composition@workspace:packages/framework/composition"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/immutable-merge": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
     "@fluentui-react-native/use-slot": "workspace:*"
@@ -3470,6 +3480,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/contextual-menu@workspace:packages/components/ContextualMenu"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/adapters": "workspace:*"
     "@fluentui-react-native/callout": "workspace:*"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
@@ -3511,6 +3522,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/default-theme@workspace:packages/theming/default-theme"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/memo-cache": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
@@ -3666,6 +3678,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/divider@workspace:packages/components/Divider"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/framework": "workspace:*"
     "@fluentui-react-native/icon": "workspace:*"
@@ -3700,6 +3713,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/drawer@workspace:packages/experimental/Drawer"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/framework": "workspace:*"
     "@fluentui-react-native/interactive-hooks": "workspace:*"
@@ -3730,6 +3744,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/dropdown@workspace:packages/experimental/Dropdown"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/adapters": "workspace:*"
     "@fluentui-react-native/button": "workspace:*"
     "@fluentui-react-native/callout": "workspace:*"
@@ -3815,6 +3830,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/experimental-activity-indicator@workspace:packages/experimental/ActivityIndicator"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/framework": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
@@ -3845,6 +3861,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/experimental-appearance-additions@workspace:packages/experimental/AppearanceAdditions"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/framework": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
@@ -3874,6 +3891,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/experimental-avatar@workspace:packages/experimental/Avatar"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/framework": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
@@ -3901,6 +3919,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/experimental-checkbox@workspace:packages/experimental/Checkbox"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/adapters": "workspace:*"
     "@fluentui-react-native/checkbox": "workspace:*"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
@@ -3933,6 +3952,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/experimental-expander@workspace:packages/experimental/Expander"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/framework": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
@@ -3961,6 +3981,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/experimental-menu-button@workspace:packages/experimental/MenuButton"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/button": "workspace:*"
     "@fluentui-react-native/contextual-menu": "workspace:*"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
@@ -3994,6 +4015,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/experimental-native-date-picker@workspace:packages/experimental/NativeDatePicker"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
     "@react-native/babel-preset": "npm:^0.73.0"
@@ -4010,6 +4032,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/experimental-native-font-metrics@workspace:packages/experimental/NativeFontMetrics"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
     "@react-native/babel-preset": "npm:^0.73.0"
@@ -4028,6 +4051,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/experimental-shadow@workspace:packages/experimental/Shadow"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/framework": "workspace:*"
     "@fluentui-react-native/pressable": "workspace:*"
@@ -4058,6 +4082,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/experimental-shimmer@workspace:packages/experimental/Shimmer"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/framework": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
@@ -4091,6 +4116,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/experimental-stack@workspace:packages/experimental/Stack"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/adapters": "workspace:*"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/framework": "workspace:*"
@@ -4122,6 +4148,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/focus-trap-zone@workspace:packages/components/FocusTrapZone"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/adapters": "workspace:*"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/interactive-hooks": "workspace:*"
@@ -4153,6 +4180,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/focus-zone@workspace:packages/components/FocusZone"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/adapters": "workspace:*"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/interactive-hooks": "workspace:*"
@@ -4184,6 +4212,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/framework@workspace:packages/framework/framework"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/composition": "workspace:*"
     "@fluentui-react-native/default-theme": "workspace:*"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
@@ -4223,6 +4252,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/icon@workspace:packages/components/Icon"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/adapters": "workspace:*"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/framework": "workspace:*"
@@ -4268,6 +4298,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/input@workspace:packages/components/Input"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/framework": "workspace:*"
     "@fluentui-react-native/icon": "workspace:*"
@@ -4305,6 +4336,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/interactive-hooks@workspace:packages/utils/interactive-hooks"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/adapters": "workspace:*"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/framework": "workspace:*"
@@ -4343,6 +4375,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/link@workspace:packages/components/Link"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/adapters": "workspace:*"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/framework": "workspace:*"
@@ -4392,6 +4425,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/menu-button@workspace:packages/components/MenuButton"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/button": "workspace:*"
     "@fluentui-react-native/contextual-menu": "workspace:*"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
@@ -4428,6 +4462,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/menu@workspace:packages/components/Menu"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/adapters": "workspace:*"
     "@fluentui-react-native/button": "workspace:*"
     "@fluentui-react-native/callout": "workspace:*"
@@ -4471,6 +4506,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/merge-props@workspace:packages/framework/merge-props"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/immutable-merge": "workspace:*"
     "@fluentui-react-native/memo-cache": "workspace:*"
@@ -4491,6 +4527,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/notification@workspace:packages/components/Notification"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/adapters": "workspace:*"
     "@fluentui-react-native/button": "workspace:*"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
@@ -4534,6 +4571,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/overflow@workspace:packages/experimental/Overflow"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/button": "workspace:*"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/framework": "workspace:*"
@@ -4567,6 +4605,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/persona-coin@workspace:packages/components/PersonaCoin"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/adapters": "workspace:*"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/framework": "workspace:*"
@@ -4602,6 +4641,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/persona@workspace:packages/components/Persona"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/adapters": "workspace:*"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/framework": "workspace:*"
@@ -4636,6 +4676,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/popover@workspace:packages/experimental/Popover"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/adapters": "workspace:*"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/framework": "workspace:*"
@@ -4665,6 +4706,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/pressable@workspace:packages/components/Pressable"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/adapters": "workspace:*"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/interactive-hooks": "workspace:*"
@@ -4695,6 +4737,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/radio-group@workspace:packages/components/RadioGroup"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/adapters": "workspace:*"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/focus-zone": "workspace:*"
@@ -4738,7 +4781,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/repo@workspace:."
   dependencies:
-    "@babel/core": "npm:^7.8.0"
+    "@babel/core": "npm:^7.20.0"
     "@babel/plugin-proposal-private-property-in-object": "npm:^7.21.11"
     "@babel/preset-env": "npm:^7.8.0"
     "@babel/preset-react": "npm:^7.8.0"
@@ -4810,6 +4853,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/separator@workspace:packages/components/Separator"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/framework": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
@@ -4840,6 +4884,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/spinner@workspace:packages/experimental/Spinner"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/framework": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
@@ -4872,6 +4917,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/stack@workspace:packages/components/Stack"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/adapters": "workspace:*"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/framework": "workspace:*"
@@ -4906,6 +4952,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/styling-utils@workspace:packages/utils/styling"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
     "@react-native/babel-preset": "npm:^0.73.0"
@@ -4922,6 +4969,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/switch@workspace:packages/components/Switch"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/adapters": "workspace:*"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/framework": "workspace:*"
@@ -4958,6 +5006,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/tablist@workspace:packages/components/TabList"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/adapters": "workspace:*"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/focus-zone": "workspace:*"
@@ -5013,6 +5062,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/tester-win32@workspace:apps/win32"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
     "@fluentui-react-native/tester": "workspace:*"
@@ -5046,8 +5096,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/tester@workspace:apps/fluent-tester"
   dependencies:
-    "@babel/core": "npm:^7.8.0"
-    "@babel/runtime": "npm:^7.8.0"
+    "@babel/core": "npm:^7.20.0"
+    "@babel/runtime": "npm:^7.20.0"
     "@fluentui-react-native/android-theme": "workspace:*"
     "@fluentui-react-native/apple-theme": "workspace:*"
     "@fluentui-react-native/avatar": "workspace:*"
@@ -5135,6 +5185,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/text@workspace:packages/components/Text"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/adapters": "workspace:*"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/framework": "workspace:*"
@@ -5169,6 +5220,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/theme-tokens@workspace:packages/theming/theme-tokens"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/design-tokens-android": "npm:^0.53.0"
     "@fluentui-react-native/design-tokens-ios": "npm:^0.53.0"
     "@fluentui-react-native/design-tokens-win32": "npm:^0.53.0"
@@ -5191,6 +5243,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/theme-types@workspace:packages/theming/theme-types"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
     "@react-native/babel-preset": "npm:^0.73.0"
@@ -5208,6 +5261,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/theme@workspace:packages/framework/theme"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/immutable-merge": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
     "@fluentui-react-native/test-tools": "workspace:*"
@@ -5226,6 +5280,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/themed-stylesheet@workspace:packages/framework/themed-stylesheet"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/memo-cache": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
@@ -5243,6 +5298,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/theming-utils@workspace:packages/theming/theming-utils"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/design-tokens-win32": "npm:^0.53.0"
     "@fluentui-react-native/design-tokens-windows": "npm:^0.53.0"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
@@ -5274,6 +5330,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/tokens@workspace:packages/utils/tokens"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/adapters": "workspace:*"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
@@ -5303,6 +5360,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/tooltip@workspace:packages/experimental/Tooltip"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/button": "workspace:*"
     "@fluentui-react-native/callout": "workspace:*"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
@@ -5336,6 +5394,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/use-slot@workspace:packages/framework/use-slot"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/merge-props": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
     "@react-native/babel-preset": "npm:^0.73.0"
@@ -5353,6 +5412,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/use-slots@workspace:packages/framework/use-slots"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/merge-props": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
     "@fluentui-react-native/use-slot": "workspace:*"
@@ -5370,6 +5430,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/use-styling@workspace:packages/framework/use-styling"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/memo-cache": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
     "@fluentui-react-native/use-tokens": "workspace:*"
@@ -5389,6 +5450,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/use-tokens@workspace:packages/framework/use-tokens"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/immutable-merge": "workspace:*"
     "@fluentui-react-native/memo-cache": "workspace:*"
     "@fluentui-react-native/merge-props": "workspace:*"
@@ -5409,6 +5471,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/vibrancy-view@workspace:packages/experimental/VibrancyView"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/adapters": "workspace:*"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
@@ -5437,6 +5500,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui-react-native/win32-theme@workspace:packages/theming/win32-theme"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/default-theme": "workspace:*"
     "@fluentui-react-native/design-tokens-win32": "npm:^0.53.0"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
@@ -5473,6 +5537,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui/react-native@workspace:packages/libraries/core"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/button": "workspace:*"
     "@fluentui-react-native/callout": "workspace:*"
     "@fluentui-react-native/checkbox": "workspace:*"
@@ -5495,6 +5560,7 @@ __metadata:
     "@react-native/metro-config": "npm:^0.73.0"
     react: "npm:18.2.0"
     react-native: "npm:^0.73.0"
+    react-native-svg: "npm:^15.0.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
@@ -8619,6 +8685,7 @@ __metadata:
     "@uifabricshared/themed-settings": "workspace:*"
     "@uifabricshared/theming-ramp": "workspace:*"
     react: "npm:18.2.0"
+    react-native: "npm:^0.73.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.73.0
     react: 18.2.0
@@ -8639,6 +8706,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@uifabricshared/foundation-settings@workspace:packages/deprecated/foundation-settings"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/immutable-merge": "workspace:*"
     "@fluentui-react-native/merge-props": "workspace:*"
@@ -8658,6 +8726,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@uifabricshared/foundation-tokens@workspace:packages/deprecated/foundation-tokens"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/memo-cache": "workspace:*"
     "@fluentui-react-native/merge-props": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
@@ -8689,6 +8758,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@uifabricshared/theme-registry@workspace:packages/deprecated/theme-registry"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/immutable-merge": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
@@ -8707,6 +8777,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@uifabricshared/themed-settings@workspace:packages/deprecated/themed-settings"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/memo-cache": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
@@ -8746,6 +8817,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@uifabricshared/theming-react-native@workspace:packages/deprecated/theming-react-native"
   dependencies:
+    "@babel/core": "npm:^7.20.0"
     "@fluentui-react-native/default-theme": "workspace:*"
     "@fluentui-react-native/eslint-config-rules": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"


### PR DESCRIPTION
### Platforms Impacted

- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

`yarn install` currently outputs a \*lot\* of warnings. Cleaned up some of these warnings to make it easier to see the important ones.

```
➤ YN0002: │ @fluentui-react-native/framework@workspace:packages/framework/framework doesn't provide @babel/core (p0c182), requested by @react-native/babel-preset.
➤ YN0002: │ @fluentui-react-native/icon@workspace:packages/components/Icon doesn't provide @babel/core (p5d5c5), requested by @react-native/babel-preset.
➤ YN0002: │ @fluentui-react-native/input@workspace:packages/components/Input doesn't provide @babel/core (p83275), requested by @react-native/babel-preset.
➤ YN0002: │ @fluentui-react-native/interactive-hooks@workspace:packages/utils/interactive-hooks doesn't provide @babel/core (p99d31), requested by @react-native/babel-preset.
➤ YN0002: │ @fluentui-react-native/link@workspace:packages/components/Link doesn't provide @babel/core (p2b39c), requested by @react-native/babel-preset.
➤ YN0002: │ @fluentui-react-native/menu-button@workspace:packages/components/MenuButton doesn't provide @babel/core (p600c7), requested by @react-native/babel-preset.
➤ YN0002: │ @fluentui-react-native/menu@workspace:packages/components/Menu doesn't provide @babel/core (p5d2f4), requested by @react-native/babel-preset.
```

### Verification

n/a

### Pull request checklist

n/a