### PR TITLE
Manually update the version of packages to match npm

### DIFF
--- a/apps/win32/package.json
+++ b/apps/win32/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/tester-win32",
-  "version": "0.38.43",
+  "version": "0.38.44",
   "main": "src/index.tsx",
   "module": "src/index.tsx",
   "typings": "lib/index.d.ts",

--- a/change/@fluentui-react-native-dependency-profiles-754a7e9a-8dcc-4c8a-97ec-dd3f2ed8ae07.json
+++ b/change/@fluentui-react-native-dependency-profiles-754a7e9a-8dcc-4c8a-97ec-dd3f2ed8ae07.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Manually update version of packages to match npm",
+  "packageName": "@fluentui-react-native/dependency-profiles",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-native-tester-win32-d4b3b44d-be75-4d6a-9234-74e7da3f87b0.json
+++ b/change/@fluentui-react-native-tester-win32-d4b3b44d-be75-4d6a-9234-74e7da3f87b0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Manually update version of packages to match npm",
+  "packageName": "@fluentui-react-native/tester-win32",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/dependency-profiles/package.json
+++ b/packages/dependency-profiles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/dependency-profiles",
-  "version": "0.8.43",
+  "version": "0.8.44",
   "description": "@rnx-kit/align-deps profiles covering packages published from FluentUI-React-Native",
   "license": "MIT",
   "files": [


### PR DESCRIPTION
Last time we published stuff to npmjs, the "update versions of packages in GH" portion failed. Manually updating them here