### PR TITLE
Fix peer dep warnings when running yarn

### DIFF
--- a/change/@fluentui-react-native-experimental-appearance-additions-cd83f7e7-9794-4e07-810d-5e809945b6e0.json
+++ b/change/@fluentui-react-native-experimental-appearance-additions-cd83f7e7-9794-4e07-810d-5e809945b6e0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bump our version of use-subscription",
+  "packageName": "@fluentui-react-native/experimental-appearance-additions",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-native-font-metrics-05b03532-e1ea-4a9b-881c-b60d0277c65c.json
+++ b/change/@fluentui-react-native-experimental-native-font-metrics-05b03532-e1ea-4a9b-881c-b60d0277c65c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bump our version of use-subscription",
+  "packageName": "@fluentui-react-native/experimental-native-font-metrics",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/AppearanceAdditions/package.json
+++ b/packages/experimental/AppearanceAdditions/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@fluentui-react-native/framework": "workspace:*",
-    "use-subscription": ">=1.0.0 <1.6.0"
+    "use-subscription": "^1.11.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
@@ -39,7 +39,7 @@
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native/babel-preset": "^0.74.0",
     "@react-native/metro-config": "^0.74.0",
-    "@types/use-subscription": "1.0.0",
+    "@types/use-subscription": "^1.0.0",
     "react": "18.2.0",
     "react-native": "^0.74.0"
   },

--- a/packages/experimental/NativeFontMetrics/package.json
+++ b/packages/experimental/NativeFontMetrics/package.json
@@ -29,7 +29,7 @@
     "directory": "packages/experimental/NativeFontMetrics"
   },
   "dependencies": {
-    "use-subscription": ">=1.0.0 <1.6.0"
+    "use-subscription": "^1.11.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
@@ -37,7 +37,7 @@
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native/babel-preset": "^0.74.0",
     "@react-native/metro-config": "^0.74.0",
-    "@types/use-subscription": "1.0.0",
+    "@types/use-subscription": "^1.0.0",
     "react": "18.2.0",
     "react-native": "^0.74.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -18010,19 +18010,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:^18.2.0":
-  version: 18.3.1
-  resolution: "react-dom@npm:18.3.1"
-  dependencies:
-    loose-envify: "npm:^1.1.0"
-    scheduler: "npm:^0.23.2"
-  peerDependencies:
-    react: ^18.3.1
-  checksum: 10c0/a752496c1941f958f2e8ac56239172296fcddce1365ce45222d04a1947e0cc5547df3e8447f855a81d6d39f008d7c32eab43db3712077f09e3f67c4874973e85
-  languageName: node
-  linkType: hard
-
-"react-dom@npm:~18.2.0":
+"react-dom@npm:^18.2.0, react-dom@npm:~18.2.0":
   version: 18.2.0
   resolution: "react-dom@npm:18.2.0"
   dependencies:
@@ -19067,7 +19055,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scheduler@npm:^0.23.0, scheduler@npm:^0.23.2":
+"scheduler@npm:^0.23.0":
   version: 0.23.2
   resolution: "scheduler@npm:0.23.2"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3088,10 +3088,10 @@ __metadata:
     "@fluentui-react-native/scripts": "workspace:*"
     "@react-native/babel-preset": "npm:^0.74.0"
     "@react-native/metro-config": "npm:^0.74.0"
-    "@types/use-subscription": "npm:1.0.0"
+    "@types/use-subscription": "npm:^1.0.0"
     react: "npm:18.2.0"
     react-native: "npm:^0.74.0"
-    use-subscription: "npm:>=1.0.0 <1.6.0"
+    use-subscription: "npm:^1.11.0"
   peerDependencies:
     "@office-iss/react-native-win32": ^0.74.0
     react: 18.2.0
@@ -3261,10 +3261,10 @@ __metadata:
     "@fluentui-react-native/scripts": "workspace:*"
     "@react-native/babel-preset": "npm:^0.74.0"
     "@react-native/metro-config": "npm:^0.74.0"
-    "@types/use-subscription": "npm:1.0.0"
+    "@types/use-subscription": "npm:^1.0.0"
     react: "npm:18.2.0"
     react-native: "npm:^0.74.0"
-    use-subscription: "npm:>=1.0.0 <1.6.0"
+    use-subscription: "npm:^1.11.0"
   peerDependencies:
     react: 18.2.0
     react-native: ^0.73.0 || ^0.74.0
@@ -7448,10 +7448,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/use-subscription@npm:1.0.0":
-  version: 1.0.0
-  resolution: "@types/use-subscription@npm:1.0.0"
-  checksum: 10c0/887e204c47b7c9cf9f6497f9db65c406a729ca48fc6bbaf09cf24662f099e4d71b67693b31fa5795454d122a000db5e514ddcbe9a776be4ac5263ed7f6cb234c
+"@types/use-subscription@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "@types/use-subscription@npm:1.0.2"
+  checksum: 10c0/4fa4af6f4a86d6a5d3dfd5e2ee08db41761b8f6f41d95f3b472893f1b55374df89a0f62634abeb70b8ed16d316285b1ece1b57dffa43011c430c14374ff12d4a
   languageName: node
   linkType: hard
 
@@ -20784,14 +20784,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-subscription@npm:>=1.0.0 <1.6.0":
-  version: 1.5.1
-  resolution: "use-subscription@npm:1.5.1"
+"use-subscription@npm:^1.11.0":
+  version: 1.11.0
+  resolution: "use-subscription@npm:1.11.0"
   dependencies:
-    object-assign: "npm:^4.1.1"
+    use-sync-external-store: "npm:^1.5.0"
   peerDependencies:
-    react: ^16.8.0 || ^17.0.0
-  checksum: 10c0/0de6185cd5890a0640cd08b616f9de7875c41d51e6570894eb2bb83fa48c6137eaa56c360edb8fb9f7f253b9705e103bca52fbcd9f86b03d07c6467d282758fc
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/6aa31e134d56e90a37f0f8232ece5ab5b74f35224e52bfd5b9a9e1af668423bba37715ee0f932f9e40dd9f8825d2efb90a1d254a7014b55a470b033acfadf4a3
+  languageName: node
+  linkType: hard
+
+"use-sync-external-store@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "use-sync-external-store@npm:1.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/1b8663515c0be34fa653feb724fdcce3984037c78dd4a18f68b2c8be55cc1a1084c578d5b75f158d41b5ddffc2bf5600766d1af3c19c8e329bb20af2ec6f52f4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixing the last peer dep warnings that appear when running yarn:
- Update version of use-subscription
- Change our react-dom version to 18.2.0 to align with react version of RN. We do this via yarn.lock so that we can look into changing the depdencies of FURN to allow multiple RN versions, at which point we couldnt restrict react that tightly