### PR TITLE
MenuButton Narrator A11y Bug Fix

### DIFF
--- a/change/@fluentui-react-native-experimental-menu-button-c9b218b6-9745-435f-bf0c-2aa3325fafd7.json
+++ b/change/@fluentui-react-native-experimental-menu-button-c9b218b6-9745-435f-bf0c-2aa3325fafd7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "expand collapse",
+  "packageName": "@fluentui-react-native/experimental-menu-button",
+  "email": "gulnazsayed@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/experimental/MenuButton/src/MenuButton.tsx
+++ b/packages/experimental/MenuButton/src/MenuButton.tsx
@@ -50,22 +50,25 @@ export const MenuButton = compose<MenuButtonType>({
       return [];
     }, []);
 
-    const onAccessibilityAction = useCallback((event) => {
-      if (Platform.OS === ('win32' as any)) {
-        switch (event.nativeEvent.actionName) {
-          case 'Expand':
-            if (!showContextualMenu) {
-              setShowContextualMenu(true);
-            }
-            break;
-          case 'Collapse':
-            if (showContextualMenu) {
-              setShowContextualMenu(false);
-            }
-            break;
+    const onAccessibilityAction = useCallback(
+      (event) => {
+        if (Platform.OS === ('win32' as any)) {
+          switch (event.nativeEvent.actionName) {
+            case 'Expand':
+              if (!showContextualMenu) {
+                setShowContextualMenu(true);
+              }
+              break;
+            case 'Collapse':
+              if (showContextualMenu) {
+                setShowContextualMenu(false);
+              }
+              break;
+          }
         }
-      }
-    }, [showContextualMenu]);
+      },
+      [showContextualMenu],
+    );
 
     const buttonProps = {
       disabled,

--- a/packages/experimental/MenuButton/src/MenuButton.tsx
+++ b/packages/experimental/MenuButton/src/MenuButton.tsx
@@ -1,6 +1,7 @@
 /** @jsxRuntime classic */
 /** @jsx withSlots */
-import React, { useRef, useState, useCallback } from 'react';
+import React, { useRef, useState, useCallback, useMemo } from 'react';
+import { Platform } from 'react-native';
 
 import { ButtonV1 as Button } from '@fluentui-react-native/button';
 import type { UseSlots } from '@fluentui-react-native/framework';
@@ -37,6 +38,35 @@ export const MenuButton = compose<MenuButtonType>({
       setShowContextualMenu(!showContextualMenu);
     }, [showContextualMenu, setShowContextualMenu]);
 
+    // Default accessibility actions to help screen readers announce expanded/collapsed state
+    // Only provide on win32 to follow platform-specific accessibility patterns
+    const defaultAccessibilityActions = useMemo(() => {
+      if (Platform.OS === ('win32' as any)) {
+        return [
+          { name: 'Expand', label: 'Expand menu' },
+          { name: 'Collapse', label: 'Collapse menu' },
+        ];
+      }
+      return [];
+    }, []);
+
+    const onAccessibilityAction = useCallback((event) => {
+      if (Platform.OS === ('win32' as any)) {
+        switch (event.nativeEvent.actionName) {
+          case 'Expand':
+            if (!showContextualMenu) {
+              setShowContextualMenu(true);
+            }
+            break;
+          case 'Collapse':
+            if (showContextualMenu) {
+              setShowContextualMenu(false);
+            }
+            break;
+        }
+      }
+    }, [showContextualMenu]);
+
     const buttonProps = {
       disabled,
       appearance,
@@ -45,6 +75,9 @@ export const MenuButton = compose<MenuButtonType>({
       componentRef: stdBtnRef,
       onClick: toggleShowContextualMenu,
       iconOnly: content ? false : true,
+      accessibilityState: { expanded: showContextualMenu },
+      accessibilityActions: defaultAccessibilityActions,
+      onAccessibilityAction,
       ...rest,
     };
 

--- a/packages/experimental/MenuButton/src/__tests__/__snapshots__/MenuButton.test.tsx.snap
+++ b/packages/experimental/MenuButton/src/__tests__/__snapshots__/MenuButton.test.tsx.snap
@@ -2,6 +2,18 @@
 
 exports[`ContextualMenu default 1`] = `
 <View
+  accessibilityActions={
+    [
+      {
+        "label": "Expand menu",
+        "name": "Expand",
+      },
+      {
+        "label": "Collapse menu",
+        "name": "Collapse",
+      },
+    ]
+  }
   accessibilityLabel="Press for Nested MenuButton"
   accessibilityRole="button"
   accessibilityState={
@@ -9,7 +21,7 @@ exports[`ContextualMenu default 1`] = `
       "busy": undefined,
       "checked": undefined,
       "disabled": false,
-      "expanded": undefined,
+      "expanded": false,
       "multiselectable": undefined,
       "required": undefined,
       "selected": undefined,
@@ -36,6 +48,7 @@ exports[`ContextualMenu default 1`] = `
       },
     ]
   }
+  onAccessibilityAction={[Function]}
   onAccessibilityTap={[Function]}
   onBlur={[Function]}
   onClick={[Function]}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Narrator wasn't announcing a description indicative of a MenuButton being able to toggle. We fixed this by setting the expand/collapse state. Now, Narrator announces if the menu is expanded or collapsed.

### Verification

Manually verified that Narrator is announcing the expand/collapse state in the FURN tester.

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [x] Voiceover
- [ ] Internationalization and Right-to-left Layouts
