### PR TITLE
Fix build error by exporting a missing type from the framework package

### DIFF
--- a/change/@fluentui-react-native-framework-aafca808-a718-4bae-aa2e-92db63b904dd.json
+++ b/change/@fluentui-react-native-framework-aafca808-a718-4bae-aa2e-92db63b904dd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "export missing type from framework to fix build error in Popover",
+  "packageName": "@fluentui-react-native/framework",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/framework/framework/src/index.ts
+++ b/packages/framework/framework/src/index.ts
@@ -96,4 +96,4 @@ export type { HasLayer, TokensThatAreAlsoProps, UseStyling } from './useStyling'
 export { buildProps, buildUseStyling } from './useStyling';
 export type { BuildProps, TokenSettings, TokensFromTheme, UseStylingOptions } from './useStyling';
 export { applyPropsToTokens, applyTokenLayers, buildUseTokens, customizable, patchTokens } from './useTokens';
-export type { UseTokens } from './useTokens';
+export type { UseTokens, CustomizableComponent } from './useTokens';

--- a/packages/framework/framework/src/useTokens.ts
+++ b/packages/framework/framework/src/useTokens.ts
@@ -9,6 +9,7 @@ export { applyTokenLayers, applyPropsToTokens, customizable, patchTokens } from 
 
 // A hook function to build a set of tokens from a passed in theme as well as a cache object
 export type UseTokens<TTokens> = UseTokensCore<TTokens, Theme>;
+export type { CustomizableComponent } from '@fluentui-react-native/use-tokens';
 
 export function buildUseTokens<TTokens>(...tokens: TokenSettings<TTokens>[]): UseTokens<TTokens> {
   return buildUseTokensCore(themeHelper.getComponentInfo, ...tokens);


### PR DESCRIPTION
### Platforms Impacted
- all

### Description of changes

Typescript was complaining about code portability issues because of a missing type. The type was being inferred correctly but only by referencing the type by relative path. With the type exported correctly the error goes away.

### Verification

Just normal build runs. It is a type only change.