### PR TITLE
feat: Introduce script to sync package versions with NPM registry

### DIFF
--- a/apps/E2E/package.json
+++ b/apps/E2E/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/e2e-testing",
-  "version": "1.40.9",
+  "version": "1.41.0",
   "description": "Package containing E2E testing specs",
   "license": "MIT",
   "main": "lib-commonjs/index.js",

--- a/apps/fluent-tester/package.json
+++ b/apps/fluent-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/tester",
-  "version": "0.170.27",
+  "version": "0.170.28",
   "description": "A test app to test FluentUI React Native Components during development",
   "license": "MIT",
   "author": "Microsoft <fluentuinativeowners@microsoft.com>",

--- a/apps/win32/package.json
+++ b/apps/win32/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/tester-win32",
-  "version": "0.38.46",
+  "version": "0.38.47",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/codemods",
-  "version": "0.5.15",
+  "version": "0.5.16",
   "description": "Transform files to make refactoring FURN code easier",
   "license": "MIT",
   "author": "Microsoft <fluentuinativeowners@microsoft.com>",

--- a/packages/components/Avatar/package.json
+++ b/packages/components/Avatar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/avatar",
-  "version": "1.12.9",
+  "version": "1.12.10",
   "description": "A cross-platform Avatar component using the Fluent Design System",
   "license": "MIT",
   "author": "Microsoft <fluentuinativeowners@microsoft.com>",

--- a/packages/components/Badge/package.json
+++ b/packages/components/Badge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/badge",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "A cross-platform Badge component using the Fluent Design System. A badge is an additional visual descriptor for UI elements.",
   "license": "MIT",
   "author": "Microsoft <fluentuinativeowners@microsoft.com>",

--- a/packages/components/Button/package.json
+++ b/packages/components/Button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/button",
-  "version": "0.39.5",
+  "version": "0.39.6",
   "description": "A cross-platform Button component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/components/Callout/package.json
+++ b/packages/components/Callout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/callout",
-  "version": "0.27.3",
+  "version": "0.27.4",
   "description": "A cross-platform Callout component using the Fluent Design System",
   "license": "MIT",
   "author": "",

--- a/packages/components/Checkbox/package.json
+++ b/packages/components/Checkbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/checkbox",
-  "version": "0.23.9",
+  "version": "0.23.10",
   "description": "A cross-platform Checkbox component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/components/Chip/package.json
+++ b/packages/components/Chip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/chip",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "A cross-platform Chip component using the Fluent Design System. A chip is a compact representations of entities (most commonly, people) that can be typed in, deleted or dragged easily.",
   "license": "MIT",
   "author": "Microsoft <fluentuinativeowners@microsoft.com>",

--- a/packages/components/ContextualMenu/package.json
+++ b/packages/components/ContextualMenu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/contextual-menu",
-  "version": "0.24.17",
+  "version": "0.24.18",
   "description": "A cross-platform ContextualMenu component using the Fluent Design System",
   "license": "MIT",
   "author": "",

--- a/packages/components/Divider/package.json
+++ b/packages/components/Divider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/divider",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "A cross-platform Divider component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/components/FocusTrapZone/package.json
+++ b/packages/components/FocusTrapZone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/focus-trap-zone",
-  "version": "0.12.6",
+  "version": "0.12.7",
   "description": "A cross-platform FocusTrapZone component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/components/FocusZone/package.json
+++ b/packages/components/FocusZone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/focus-zone",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "A cross-platform FocusZone component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/components/Icon/package.json
+++ b/packages/components/Icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/icon",
-  "version": "0.21.9",
+  "version": "0.21.10",
   "description": "A cross-platform Icon component",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/components/Input/package.json
+++ b/packages/components/Input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/input",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "A cross-platform Text input component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/components/Link/package.json
+++ b/packages/components/Link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/link",
-  "version": "0.23.9",
+  "version": "0.23.10",
   "description": "A cross-platform Link component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/components/Menu/package.json
+++ b/packages/components/Menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/menu",
-  "version": "1.14.23",
+  "version": "1.14.24",
   "description": "A cross-platform Menu component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/components/MenuButton/package.json
+++ b/packages/components/MenuButton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/menu-button",
-  "version": "0.13.20",
+  "version": "0.13.21",
   "description": "A cross-platform MenuButton component using the Fluent Design System",
   "license": "MIT",
   "author": "Microsoft <fluentuinativeowners@microsoft.com>",

--- a/packages/components/Notification/package.json
+++ b/packages/components/Notification/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/notification",
-  "version": "0.25.12",
+  "version": "0.25.13",
   "description": "add component-description",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/components/Persona/package.json
+++ b/packages/components/Persona/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/persona",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "description": "A cross-platform Persona component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/components/PersonaCoin/package.json
+++ b/packages/components/PersonaCoin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/persona-coin",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "description": "A cross-platform PersonaCoin component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/components/Pressable/package.json
+++ b/packages/components/Pressable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/pressable",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "description": "A cross-platform Pressable component",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/components/RadioGroup/package.json
+++ b/packages/components/RadioGroup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/radio-group",
-  "version": "0.21.17",
+  "version": "0.21.18",
   "description": "A cross-platform Radio Group component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/components/Separator/package.json
+++ b/packages/components/Separator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/separator",
-  "version": "0.18.3",
+  "version": "0.18.4",
   "description": "A cross-platform Separator component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/components/Stack/package.json
+++ b/packages/components/Stack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/stack",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "description": "A cross-platform opinionated Fluent Text component",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/components/Switch/package.json
+++ b/packages/components/Switch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/switch",
-  "version": "0.13.8",
+  "version": "0.13.9",
   "description": "A cross-platform Switch component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/components/TabList/package.json
+++ b/packages/components/TabList/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/tablist",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "A cross-platform TabList component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/components/Text/package.json
+++ b/packages/components/Text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/text",
-  "version": "0.24.7",
+  "version": "0.24.8",
   "description": "A cross-platform Text component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/dependency-profiles/package.json
+++ b/packages/dependency-profiles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/dependency-profiles",
-  "version": "0.8.46",
+  "version": "0.8.47",
   "description": "@rnx-kit/align-deps profiles covering packages published from FluentUI-React-Native",
   "license": "MIT",
   "files": [

--- a/packages/deprecated/foundation-composable/package.json
+++ b/packages/deprecated/foundation-composable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uifabricshared/foundation-composable",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "description": "Composable component building blocks",
   "repository": {
     "type": "git",

--- a/packages/deprecated/foundation-compose/package.json
+++ b/packages/deprecated/foundation-compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uifabricshared/foundation-compose",
-  "version": "1.15.3",
+  "version": "1.15.4",
   "description": "Compose infrastructure",
   "repository": {
     "type": "git",

--- a/packages/deprecated/foundation-settings/package.json
+++ b/packages/deprecated/foundation-settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uifabricshared/foundation-settings",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "Settings and style definitions and helpers",
   "repository": {
     "type": "git",

--- a/packages/deprecated/foundation-tokens/package.json
+++ b/packages/deprecated/foundation-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uifabricshared/foundation-tokens",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "description": "Core tokens package",
   "repository": {
     "type": "git",

--- a/packages/deprecated/theme-registry/package.json
+++ b/packages/deprecated/theme-registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uifabricshared/theme-registry",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Implementation of the theme graph",
   "repository": {
     "type": "git",

--- a/packages/deprecated/themed-settings/package.json
+++ b/packages/deprecated/themed-settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uifabricshared/themed-settings",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "Package which drives custom cacheable settings for a component",
   "repository": {
     "type": "git",

--- a/packages/deprecated/theming-ramp/package.json
+++ b/packages/deprecated/theming-ramp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uifabricshared/theming-ramp",
-  "version": "0.20.3",
+  "version": "0.20.4",
   "description": "Theming Library",
   "repository": {
     "type": "git",

--- a/packages/deprecated/theming-react-native/package.json
+++ b/packages/deprecated/theming-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uifabricshared/theming-react-native",
-  "version": "0.20.6",
+  "version": "0.20.7",
   "description": "A library of functions which produce React Native styles from a Theme",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/experimental/ActivityIndicator/package.json
+++ b/packages/experimental/ActivityIndicator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/experimental-activity-indicator",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "A cross-platform Fluent Activity Indicator component",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/experimental/AppearanceAdditions/package.json
+++ b/packages/experimental/AppearanceAdditions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/experimental-appearance-additions",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "A module to expose callbacks for additional traitCollection changes.",
   "license": "MIT",
   "author": "Microsoft <fluentuinativeowners@microsoft.com>",

--- a/packages/experimental/Avatar/package.json
+++ b/packages/experimental/Avatar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/experimental-avatar",
-  "version": "0.21.5",
+  "version": "0.21.6",
   "description": "A cross-platform Avatar component using the Fluent Design System. Currently only implemented on iOS",
   "license": "MIT",
   "author": "Microsoft <fluentuinativeowners@microsoft.com>",

--- a/packages/experimental/Checkbox/package.json
+++ b/packages/experimental/Checkbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/experimental-checkbox",
-  "version": "0.17.10",
+  "version": "0.17.11",
   "description": "A cross-platform Checkbox component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/experimental/Drawer/package.json
+++ b/packages/experimental/Drawer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/drawer",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "A cross-platform Drawer component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/experimental/Dropdown/package.json
+++ b/packages/experimental/Dropdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/dropdown",
-  "version": "0.10.14",
+  "version": "0.10.15",
   "description": "A cross-platform Dropdown component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/experimental/Expander/package.json
+++ b/packages/experimental/Expander/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/experimental-expander",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "A cross-platform Native Expander component using the Fluent Design System. Currently only implemented on windows",
   "license": "MIT",
   "author": "Microsoft <fluentuinativeowners@microsoft.com>",

--- a/packages/experimental/MenuButton/package.json
+++ b/packages/experimental/MenuButton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/experimental-menu-button",
-  "version": "0.10.20",
+  "version": "0.10.21",
   "description": "A cross-platform MenuButton component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/experimental/NativeDatePicker/package.json
+++ b/packages/experimental/NativeDatePicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/experimental-native-date-picker",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "A Native date picker component using the Fluent Design System.  Currently only implemented on iOS.",
   "license": "MIT",
   "author": "Microsoft <fluentuinativeowners@microsoft.com>",

--- a/packages/experimental/NativeFontMetrics/package.json
+++ b/packages/experimental/NativeFontMetrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/experimental-native-font-metrics",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "A temporary partial wrapper for UIFontMetrics.",
   "license": "MIT",
   "author": "Microsoft <fluentuinativeowners@microsoft.com>",

--- a/packages/experimental/Overflow/package.json
+++ b/packages/experimental/Overflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/overflow",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "description": "A cross-platform Overflow component for React Native.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/experimental/Popover/package.json
+++ b/packages/experimental/Popover/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/popover",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "A cross-platform Popover component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/experimental/Shadow/package.json
+++ b/packages/experimental/Shadow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/experimental-shadow",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "A cross-platform Shadow component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/experimental/Shimmer/package.json
+++ b/packages/experimental/Shimmer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/experimental-shimmer",
-  "version": "0.13.6",
+  "version": "0.13.7",
   "description": "A cross-platform Fluent Shimmer component",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/experimental/Spinner/package.json
+++ b/packages/experimental/Spinner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/spinner",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "A cross-platform Fluent spinner component",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/experimental/Tooltip/package.json
+++ b/packages/experimental/Tooltip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/tooltip",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "A cross-platform Tooltip component for React Native.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/experimental/VibrancyView/package.json
+++ b/packages/experimental/VibrancyView/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/vibrancy-view",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A native wrapper for NSVisualEffectView on macOS",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/framework/composition/package.json
+++ b/packages/framework/composition/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/composition",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "Composition factories for building HOCs",
   "repository": {
     "type": "git",

--- a/packages/framework/framework/package.json
+++ b/packages/framework/framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/framework",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "description": "Component framework used by fluentui react native controls",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/framework/immutable-merge/package.json
+++ b/packages/framework/immutable-merge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/immutable-merge",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Immutable merge routines for deep customizable merging",
   "repository": {
     "type": "git",

--- a/packages/framework/memo-cache/package.json
+++ b/packages/framework/memo-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/memo-cache",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Layered memoization style cache helper",
   "repository": {
     "type": "git",

--- a/packages/framework/merge-props/package.json
+++ b/packages/framework/merge-props/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/merge-props",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Utility for merging props with styles and caching style combinations",
   "repository": {
     "type": "git",

--- a/packages/framework/theme/package.json
+++ b/packages/framework/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/theme",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Experimental version of fluentui-react-native theme framework",
   "repository": {
     "type": "git",

--- a/packages/framework/themed-stylesheet/package.json
+++ b/packages/framework/themed-stylesheet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/themed-stylesheet",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Helper for using react-native StyleSheets with themes",
   "repository": {
     "type": "git",

--- a/packages/framework/use-slot/package.json
+++ b/packages/framework/use-slot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/use-slot",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Hook function to use a component as a pluggable slot",
   "repository": {
     "type": "git",

--- a/packages/framework/use-slots/package.json
+++ b/packages/framework/use-slots/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/use-slots",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Hook function to return styled slots",
   "repository": {
     "type": "git",

--- a/packages/framework/use-styling/package.json
+++ b/packages/framework/use-styling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/use-styling",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "description": "Opinionated use styling hook implementation",
   "repository": {
     "type": "git",

--- a/packages/framework/use-tokens/package.json
+++ b/packages/framework/use-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/use-tokens",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Utilities and hook function for getting themed tokens for a component",
   "repository": {
     "type": "git",

--- a/packages/libraries/core/package.json
+++ b/packages/libraries/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/react-native",
-  "version": "0.42.14",
+  "version": "0.42.15",
   "description": "A react-native component library that implements the Fluent Design System.",
   "license": "MIT",
   "repository": {

--- a/packages/theming/android-theme/package.json
+++ b/packages/theming/android-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/android-theme",
-  "version": "0.25.3",
+  "version": "0.25.4",
   "description": "A FluentUI React Native theme that pulls constants from FluentUI Android",
   "repository": {
     "type": "git",

--- a/packages/theming/apple-theme/package.json
+++ b/packages/theming/apple-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/apple-theme",
-  "version": "0.28.3",
+  "version": "0.28.4",
   "description": "A FluentUI React Native theme that pulls constants from FluentUI Apple",
   "license": "MIT",
   "author": "Microsoft <fluentuinativeowners@microsoft.com>",

--- a/packages/theming/default-theme/package.json
+++ b/packages/theming/default-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/default-theme",
-  "version": "0.26.3",
+  "version": "0.26.4",
   "description": "Typing only package for fluentui-react-native theme types",
   "repository": {
     "type": "git",

--- a/packages/theming/theme-tokens/package.json
+++ b/packages/theming/theme-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/theme-tokens",
-  "version": "0.27.2",
+  "version": "0.27.3",
   "description": "Defines values for tokens used to fill out themes.",
   "repository": {
     "type": "git",

--- a/packages/theming/theme-types/package.json
+++ b/packages/theming/theme-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/theme-types",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Typing only package for fluentui-react-native theme types",
   "repository": {
     "type": "git",

--- a/packages/theming/theming-utils/package.json
+++ b/packages/theming/theming-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/theming-utils",
-  "version": "0.26.2",
+  "version": "0.26.3",
   "description": "Utils for dealing with theming",
   "repository": {
     "type": "git",

--- a/packages/theming/win32-theme/package.json
+++ b/packages/theming/win32-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/win32-theme",
-  "version": "0.34.6",
+  "version": "0.34.7",
   "description": "Win32 office theme that works with the theming native module",
   "repository": {
     "type": "git",

--- a/packages/utils/adapters/package.json
+++ b/packages/utils/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/adapters",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Adapters for working with react-native types",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/utils/interactive-hooks/package.json
+++ b/packages/utils/interactive-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/interactive-hooks",
-  "version": "0.27.5",
+  "version": "0.27.6",
   "description": "Hooks for adding focus, hover, and press semantics to view based components",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/utils/styling/package.json
+++ b/packages/utils/styling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/styling-utils",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Utility functions for styling components in FURN",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/utils/tokens/package.json
+++ b/packages/utils/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui-react-native/tokens",
-  "version": "0.23.2",
+  "version": "0.23.3",
   "description": "Token interface parts and helpers",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

We often have NPM publish issues where the pacakge version numbers are behind what was published to NPM. So.. I asked AI: "Could we write a script in the scripts/ folder that goes through every package.json, checks NPM for the latest package, and if they don't match, updates the local package.json version to match NPM?"

This is the output of GitHub Copilot with Claude Sonnet 4. I want to fix this up to not be the straight AI generated script, but I also want to unblock FURN. So publishing this PR with its output in a separate PR.  

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
