### PR TITLE
[MenuItem][MacOS] Fix "onClick" being called twice when invoking menu item via ENTER / SPACE

### DIFF
--- a/change/@fluentui-react-native-menu-8ba839c0-b982-4c13-ad4d-5abae9240a4e.json
+++ b/change/@fluentui-react-native-menu-8ba839c0-b982-4c13-ad4d-5abae9240a4e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Mark `onInvoke` event as handled for enter / space press to prevent duplicate call",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "winlarry@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/MenuItem/useMenuItem.ts
+++ b/packages/components/Menu/src/MenuItem/useMenuItem.ts
@@ -15,6 +15,8 @@ import { useMenuItemTracking } from '../MenuList/useMenuList';
 export const triggerKeys = [' ', 'Enter'];
 export const submenuTriggerKeys = ['ArrowLeft', 'ArrowRight', ...triggerKeys];
 
+const preventDuplicateKeyDownHandling = Platform.OS === 'macos';
+
 export const useMenuItem = (props: MenuItemProps): MenuItemInfo => {
   // attach the pressable state handlers
   const defaultComponentRef = React.useRef(null);
@@ -38,6 +40,12 @@ export const useMenuItem = (props: MenuItemProps): MenuItemInfo => {
       if (!disabled && (!isArrowKey || isArrowOpen)) {
         componentRef?.current?.blur();
         onClick?.(e);
+
+        // For macOS, the pressable keyDown handler also calls onPress() for 'Enter' / 'Space' keys. This means that
+        // this invoke() callback is called twice on the platform. preventDefault() makes it so that its handled once.
+        if (preventDuplicateKeyDownHandling) {
+          e.preventDefault();
+        }
       }
 
       if (!hasSubmenu && !isArrowKey && !shouldPersist) {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS
- [ ] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

React Native MacOS pressables handle a special case for ENTER / SPACE keys for the `keyDown` / `keyDown` event handlers: these keys should also be interpreted as presses, thus causing the event to be passed to the `onPress` handler. The code for this is found here: https://github.com/microsoft/react-native-macos/blob/48e607706bfcc25b4c28eba1aa352f409c02975e/packages/react-native/Libraries/Pressability/Pressability.js#L580-L617

For the `MenuItem`, we pass `onInvoke`, the handler for clicks and keypresses, into both `press` and `keyDown` / `keyUp` handlers. The code snippet above, then causes `onClick` to be called twice on the platform. We can fix this by simply marking the event as handled, so `onClick` is only called once. 

### Verification

Tested locally, video: 

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [x] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
