### PR TITLE
Fix bundling to use typescript files rather than js files

### DIFF
--- a/apps/E2E/package.json
+++ b/apps/E2E/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "typings": "lib/index.d.ts",
   "exports": {
     ".": {

--- a/apps/fluent-tester/package.json
+++ b/apps/fluent-tester/package.json
@@ -7,6 +7,7 @@
   "homepage": "https://github.com/microsoft/fluentui-react-native",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "typings": "lib/index.d.ts",
   "exports": {
     ".": {

--- a/apps/win32/package.json
+++ b/apps/win32/package.json
@@ -3,6 +3,7 @@
   "version": "0.38.47",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "typings": "lib/index.d.ts",
   "exports": {
     ".": {

--- a/change/@fluentui-react-native-a2a54e36-c084-4bec-95c3-2a6dfb0384c0.json
+++ b/change/@fluentui-react-native-a2a54e36-c084-4bec-95c3-2a6dfb0384c0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui/react-native",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-adapters-b6ce4158-a0be-4122-9f7c-4073374be6e2.json
+++ b/change/@fluentui-react-native-adapters-b6ce4158-a0be-4122-9f7c-4073374be6e2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/adapters",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-android-theme-914a20b1-bbfd-4f5b-81fc-0a5db40d258c.json
+++ b/change/@fluentui-react-native-android-theme-914a20b1-bbfd-4f5b-81fc-0a5db40d258c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/android-theme",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-apple-theme-ee3af115-fc91-436a-8fc3-effe7566e399.json
+++ b/change/@fluentui-react-native-apple-theme-ee3af115-fc91-436a-8fc3-effe7566e399.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/apple-theme",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-avatar-cd2ad452-e6f6-4604-a4bc-401320682f19.json
+++ b/change/@fluentui-react-native-avatar-cd2ad452-e6f6-4604-a4bc-401320682f19.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/avatar",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-badge-ee34fe5e-43d3-4790-ba06-d236b0509582.json
+++ b/change/@fluentui-react-native-badge-ee34fe5e-43d3-4790-ba06-d236b0509582.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/badge",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-button-4b1dfeb3-cdb3-4864-b078-2dbc8010e6fc.json
+++ b/change/@fluentui-react-native-button-4b1dfeb3-cdb3-4864-b078-2dbc8010e6fc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/button",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-callout-11650ed3-9e79-4f78-af00-d7ca27a1e817.json
+++ b/change/@fluentui-react-native-callout-11650ed3-9e79-4f78-af00-d7ca27a1e817.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/callout",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-checkbox-f324cc4d-d49e-4b90-8886-7560dd45f4e3.json
+++ b/change/@fluentui-react-native-checkbox-f324cc4d-d49e-4b90-8886-7560dd45f4e3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/checkbox",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-chip-9adc13bb-1354-47e5-95a7-b57b5be3347f.json
+++ b/change/@fluentui-react-native-chip-9adc13bb-1354-47e5-95a7-b57b5be3347f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/chip",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-codemods-e9aead3d-736b-48f8-b220-01a08309e884.json
+++ b/change/@fluentui-react-native-codemods-e9aead3d-736b-48f8-b220-01a08309e884.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/codemods",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-composition-c509945b-10c6-4cf4-bf1d-63c382ec2690.json
+++ b/change/@fluentui-react-native-composition-c509945b-10c6-4cf4-bf1d-63c382ec2690.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/composition",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-contextual-menu-66cef17b-68ea-47e8-acb4-34c278f003e2.json
+++ b/change/@fluentui-react-native-contextual-menu-66cef17b-68ea-47e8-acb4-34c278f003e2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/contextual-menu",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-default-theme-963176f2-c3bb-42aa-8f0e-1c37654b5ddb.json
+++ b/change/@fluentui-react-native-default-theme-963176f2-c3bb-42aa-8f0e-1c37654b5ddb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/default-theme",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-divider-5af46b31-1701-4b31-988a-19dee4bd2f96.json
+++ b/change/@fluentui-react-native-divider-5af46b31-1701-4b31-988a-19dee4bd2f96.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/divider",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-drawer-60a52d07-ca52-42d6-a826-9a1d859eddee.json
+++ b/change/@fluentui-react-native-drawer-60a52d07-ca52-42d6-a826-9a1d859eddee.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/drawer",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-dropdown-2ced80a7-6953-4c86-9f25-789e8c6e58ef.json
+++ b/change/@fluentui-react-native-dropdown-2ced80a7-6953-4c86-9f25-789e8c6e58ef.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/dropdown",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-e2e-testing-21e610cb-3ef4-4b47-a7a0-4e265b00d200.json
+++ b/change/@fluentui-react-native-e2e-testing-21e610cb-3ef4-4b47-a7a0-4e265b00d200.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/e2e-testing",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-activity-indicator-4c996685-6a8e-454e-afcd-a4c693c62017.json
+++ b/change/@fluentui-react-native-experimental-activity-indicator-4c996685-6a8e-454e-afcd-a4c693c62017.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/experimental-activity-indicator",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-appearance-additions-b4a9773a-1e0e-4d4b-9f71-d6bdc1fd3dee.json
+++ b/change/@fluentui-react-native-experimental-appearance-additions-b4a9773a-1e0e-4d4b-9f71-d6bdc1fd3dee.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/experimental-appearance-additions",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-avatar-dfdcd88f-1718-4480-a9d6-c235c54e68ba.json
+++ b/change/@fluentui-react-native-experimental-avatar-dfdcd88f-1718-4480-a9d6-c235c54e68ba.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/experimental-avatar",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-checkbox-2b93e446-32e1-406d-a357-fcb65cc31af9.json
+++ b/change/@fluentui-react-native-experimental-checkbox-2b93e446-32e1-406d-a357-fcb65cc31af9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/experimental-checkbox",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-expander-7a8f9277-24c5-4a87-99fc-f6cd2de54543.json
+++ b/change/@fluentui-react-native-experimental-expander-7a8f9277-24c5-4a87-99fc-f6cd2de54543.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/experimental-expander",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-menu-button-85b238ad-68d9-42ce-8b73-62209826a5fb.json
+++ b/change/@fluentui-react-native-experimental-menu-button-85b238ad-68d9-42ce-8b73-62209826a5fb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/experimental-menu-button",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-native-date-picker-618d7943-f891-4ee2-8143-6c5f23eb1dd8.json
+++ b/change/@fluentui-react-native-experimental-native-date-picker-618d7943-f891-4ee2-8143-6c5f23eb1dd8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/experimental-native-date-picker",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-native-font-metrics-df4bcc4e-56c5-456a-95be-fdd5f716bde2.json
+++ b/change/@fluentui-react-native-experimental-native-font-metrics-df4bcc4e-56c5-456a-95be-fdd5f716bde2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/experimental-native-font-metrics",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-shadow-be004dd6-9077-4172-b721-579b9f260c1d.json
+++ b/change/@fluentui-react-native-experimental-shadow-be004dd6-9077-4172-b721-579b9f260c1d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/experimental-shadow",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-experimental-shimmer-087d82b3-2227-46a9-bde5-bd8f8113d06e.json
+++ b/change/@fluentui-react-native-experimental-shimmer-087d82b3-2227-46a9-bde5-bd8f8113d06e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/experimental-shimmer",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-focus-trap-zone-f5c0f9ba-e730-4616-b7c3-7f94bc5bf71e.json
+++ b/change/@fluentui-react-native-focus-trap-zone-f5c0f9ba-e730-4616-b7c3-7f94bc5bf71e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/focus-trap-zone",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-focus-zone-b2595ab8-daa8-45c7-af04-e82305c44db0.json
+++ b/change/@fluentui-react-native-focus-zone-b2595ab8-daa8-45c7-af04-e82305c44db0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/focus-zone",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-framework-f09281e8-fbf0-4ccf-94ef-46adc70e05e5.json
+++ b/change/@fluentui-react-native-framework-f09281e8-fbf0-4ccf-94ef-46adc70e05e5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/framework",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-icon-d68f5d80-1174-47ba-b1a4-0cbcaabba4fd.json
+++ b/change/@fluentui-react-native-icon-d68f5d80-1174-47ba-b1a4-0cbcaabba4fd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/icon",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-immutable-merge-e97a4028-03ac-481a-8220-a635cc55cead.json
+++ b/change/@fluentui-react-native-immutable-merge-e97a4028-03ac-481a-8220-a635cc55cead.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/immutable-merge",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-input-3fbcf69d-2e64-4912-93f1-0a07b1f189bb.json
+++ b/change/@fluentui-react-native-input-3fbcf69d-2e64-4912-93f1-0a07b1f189bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/input",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-interactive-hooks-8854d4fc-602c-47ac-9a58-7d4e32ea93f9.json
+++ b/change/@fluentui-react-native-interactive-hooks-8854d4fc-602c-47ac-9a58-7d4e32ea93f9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/interactive-hooks",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-link-36d08de3-29b7-4231-961d-e5b39dc7cdbd.json
+++ b/change/@fluentui-react-native-link-36d08de3-29b7-4231-961d-e5b39dc7cdbd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/link",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-memo-cache-3c773a9a-6b1f-4b52-ba0a-a53cc717beda.json
+++ b/change/@fluentui-react-native-memo-cache-3c773a9a-6b1f-4b52-ba0a-a53cc717beda.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/memo-cache",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-menu-98836cc1-92ca-4be7-9471-9b866a64e5e6.json
+++ b/change/@fluentui-react-native-menu-98836cc1-92ca-4be7-9471-9b866a64e5e6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-menu-button-76c287cc-c29e-4027-817d-d6b323505490.json
+++ b/change/@fluentui-react-native-menu-button-76c287cc-c29e-4027-817d-d6b323505490.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/menu-button",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-merge-props-e06ff18c-00ab-4c11-a3a4-8e4226deab10.json
+++ b/change/@fluentui-react-native-merge-props-e06ff18c-00ab-4c11-a3a4-8e4226deab10.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/merge-props",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-notification-bf31cb52-135b-4626-bcf0-306eece7fde1.json
+++ b/change/@fluentui-react-native-notification-bf31cb52-135b-4626-bcf0-306eece7fde1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/notification",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-overflow-c35690eb-62de-4193-bbb3-e11eaa1f05ab.json
+++ b/change/@fluentui-react-native-overflow-c35690eb-62de-4193-bbb3-e11eaa1f05ab.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/overflow",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-persona-coin-ffe49fca-93e5-4c34-9cd7-8950b4804297.json
+++ b/change/@fluentui-react-native-persona-coin-ffe49fca-93e5-4c34-9cd7-8950b4804297.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/persona-coin",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-persona-f7890ce0-a45a-426e-8577-b11484cb341a.json
+++ b/change/@fluentui-react-native-persona-f7890ce0-a45a-426e-8577-b11484cb341a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/persona",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-popover-a55e548a-1a7e-4dc5-82a1-77739a669183.json
+++ b/change/@fluentui-react-native-popover-a55e548a-1a7e-4dc5-82a1-77739a669183.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/popover",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-pressable-466bf716-f0f7-4677-a048-e9274f335acc.json
+++ b/change/@fluentui-react-native-pressable-466bf716-f0f7-4677-a048-e9274f335acc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/pressable",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-radio-group-dc4e6729-b7e3-4f64-beb3-19749a4a0ae7.json
+++ b/change/@fluentui-react-native-radio-group-dc4e6729-b7e3-4f64-beb3-19749a4a0ae7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/radio-group",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-separator-9b62ac5d-0693-41de-ad36-c4c34b6e714c.json
+++ b/change/@fluentui-react-native-separator-9b62ac5d-0693-41de-ad36-c4c34b6e714c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/separator",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-spinner-e88972e5-d096-42e4-a751-dd21aea0cacf.json
+++ b/change/@fluentui-react-native-spinner-e88972e5-d096-42e4-a751-dd21aea0cacf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/spinner",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-stack-eefa120b-d13c-4496-ae7a-1179dd2036fb.json
+++ b/change/@fluentui-react-native-stack-eefa120b-d13c-4496-ae7a-1179dd2036fb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/stack",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-styling-utils-aa3e082a-5bf3-42db-bf0b-4d6e9af4acd4.json
+++ b/change/@fluentui-react-native-styling-utils-aa3e082a-5bf3-42db-bf0b-4d6e9af4acd4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/styling-utils",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-switch-e1f9e94e-d32a-43f8-a85e-7cd91a75e9c8.json
+++ b/change/@fluentui-react-native-switch-e1f9e94e-d32a-43f8-a85e-7cd91a75e9c8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/switch",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tablist-8e3e03af-b8d6-4d00-b068-e132981ccad3.json
+++ b/change/@fluentui-react-native-tablist-8e3e03af-b8d6-4d00-b068-e132981ccad3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/tablist",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-5396b1de-3602-4fbb-a57c-f58b28544891.json
+++ b/change/@fluentui-react-native-tester-5396b1de-3602-4fbb-a57c-f58b28544891.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/tester",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tester-win32-c42a3742-d092-49ea-87d7-4b621b63fbb2.json
+++ b/change/@fluentui-react-native-tester-win32-c42a3742-d092-49ea-87d7-4b621b63fbb2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/tester-win32",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-text-e9927c77-8923-4369-bef4-96703d6e3253.json
+++ b/change/@fluentui-react-native-text-e9927c77-8923-4369-bef4-96703d6e3253.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/text",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-theme-bfd274b6-1ebc-4bb8-82be-5e0a4b8ceafe.json
+++ b/change/@fluentui-react-native-theme-bfd274b6-1ebc-4bb8-82be-5e0a4b8ceafe.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/theme",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-theme-tokens-cd6a4f35-bd52-4b2a-9aea-1726fc75a73a.json
+++ b/change/@fluentui-react-native-theme-tokens-cd6a4f35-bd52-4b2a-9aea-1726fc75a73a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/theme-tokens",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-theme-types-aa50d588-733b-4be2-863a-0e92ce778f73.json
+++ b/change/@fluentui-react-native-theme-types-aa50d588-733b-4be2-863a-0e92ce778f73.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/theme-types",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-themed-stylesheet-970462db-ccda-45c8-804d-5b8ee3729746.json
+++ b/change/@fluentui-react-native-themed-stylesheet-970462db-ccda-45c8-804d-5b8ee3729746.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/themed-stylesheet",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-theming-utils-eb469c2c-4c4b-42d5-b68f-252a87fdd989.json
+++ b/change/@fluentui-react-native-theming-utils-eb469c2c-4c4b-42d5-b68f-252a87fdd989.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/theming-utils",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tokens-3f3b31ff-82cc-419b-a715-e060e604cefe.json
+++ b/change/@fluentui-react-native-tokens-3f3b31ff-82cc-419b-a715-e060e604cefe.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/tokens",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-tooltip-1b6b35f2-17bb-481d-8540-c521f3cb39f0.json
+++ b/change/@fluentui-react-native-tooltip-1b6b35f2-17bb-481d-8540-c521f3cb39f0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/tooltip",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-use-slot-ab435dba-2aa7-46cf-a6f7-468490ec6545.json
+++ b/change/@fluentui-react-native-use-slot-ab435dba-2aa7-46cf-a6f7-468490ec6545.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/use-slot",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-use-slots-bfd40c0e-a33f-4155-b073-02f2b65e2baa.json
+++ b/change/@fluentui-react-native-use-slots-bfd40c0e-a33f-4155-b073-02f2b65e2baa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/use-slots",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-use-styling-ae0b639f-9198-43f6-86ef-2fef1d3fd74b.json
+++ b/change/@fluentui-react-native-use-styling-ae0b639f-9198-43f6-86ef-2fef1d3fd74b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/use-styling",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-use-tokens-11438956-a7c4-44c9-989b-8dc6af6d870a.json
+++ b/change/@fluentui-react-native-use-tokens-11438956-a7c4-44c9-989b-8dc6af6d870a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/use-tokens",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-vibrancy-view-ed118475-7099-4012-b0b1-453d2a617edc.json
+++ b/change/@fluentui-react-native-vibrancy-view-ed118475-7099-4012-b0b1-453d2a617edc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/vibrancy-view",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-win32-theme-40cbf365-7540-42d8-86d0-6763161b5ea2.json
+++ b/change/@fluentui-react-native-win32-theme-40cbf365-7540-42d8-86d0-6763161b5ea2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@fluentui-react-native/win32-theme",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabricshared-foundation-composable-691e9fe5-d52b-4a6b-8bd8-1a0975fe3608.json
+++ b/change/@uifabricshared-foundation-composable-691e9fe5-d52b-4a6b-8bd8-1a0975fe3608.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@uifabricshared/foundation-composable",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabricshared-foundation-compose-f5830663-aa2f-4da1-b4f9-250e7a851ff0.json
+++ b/change/@uifabricshared-foundation-compose-f5830663-aa2f-4da1-b4f9-250e7a851ff0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@uifabricshared/foundation-compose",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabricshared-foundation-settings-8bdb3aa9-6538-42de-8aca-9f27fd4bd187.json
+++ b/change/@uifabricshared-foundation-settings-8bdb3aa9-6538-42de-8aca-9f27fd4bd187.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@uifabricshared/foundation-settings",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabricshared-foundation-tokens-666fcb6e-7d7b-4e2d-9ddd-f47cbd3125fa.json
+++ b/change/@uifabricshared-foundation-tokens-666fcb6e-7d7b-4e2d-9ddd-f47cbd3125fa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@uifabricshared/foundation-tokens",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabricshared-theme-registry-ebe17072-619e-4746-9a7c-487dc3f3e4d5.json
+++ b/change/@uifabricshared-theme-registry-ebe17072-619e-4746-9a7c-487dc3f3e4d5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@uifabricshared/theme-registry",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabricshared-themed-settings-3dbc4a3e-7da2-4b87-81a0-ab54244c8281.json
+++ b/change/@uifabricshared-themed-settings-3dbc4a3e-7da2-4b87-81a0-ab54244c8281.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@uifabricshared/themed-settings",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabricshared-theming-ramp-9890082e-67fc-4f26-a808-3651d148d986.json
+++ b/change/@uifabricshared-theming-ramp-9890082e-67fc-4f26-a808-3651d148d986.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@uifabricshared/theming-ramp",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabricshared-theming-react-native-9ebcd442-61bf-4546-9d91-15b7358b28e6.json
+++ b/change/@uifabricshared-theming-react-native-9ebcd442-61bf-4546-9d91-15b7358b28e6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add react-native entrypoints that ensure metro targets TS files rather than JS files for bundling",
+  "packageName": "@uifabricshared/theming-react-native",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -7,6 +7,7 @@
   "homepage": "https://github.com/microsoft/fluentui-react-native",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "typings": "lib/index.d.ts",
   "exports": {
     ".": {

--- a/packages/components/Avatar/package.json
+++ b/packages/components/Avatar/package.json
@@ -7,6 +7,7 @@
   "homepage": "https://github.com/microsoft/fluentui-react-native",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "typings": "lib/index.d.ts",
   "exports": {
     ".": {

--- a/packages/components/Badge/package.json
+++ b/packages/components/Badge/package.json
@@ -7,6 +7,7 @@
   "homepage": "https://github.com/microsoft/fluentui-react-native",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "typings": "lib/index.d.ts",
   "exports": {
     ".": {

--- a/packages/components/Button/package.json
+++ b/packages/components/Button/package.json
@@ -4,6 +4,7 @@
   "description": "A cross-platform Button component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "typings": "lib/index.d.ts",
   "exports": {
     ".": {

--- a/packages/components/Callout/package.json
+++ b/packages/components/Callout/package.json
@@ -7,6 +7,7 @@
   "homepage": "https://github.com/microsoft/fluentui-react-native",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/components/Checkbox/package.json
+++ b/packages/components/Checkbox/package.json
@@ -4,6 +4,7 @@
   "description": "A cross-platform Checkbox component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "typings": "lib/index.d.ts",
   "exports": {
     ".": {

--- a/packages/components/Chip/package.json
+++ b/packages/components/Chip/package.json
@@ -7,6 +7,7 @@
   "homepage": "https://github.com/microsoft/fluentui-react-native",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/components/ContextualMenu/package.json
+++ b/packages/components/ContextualMenu/package.json
@@ -7,6 +7,7 @@
   "homepage": "https://github.com/microsoft/fluentui-react-native",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/components/Divider/package.json
+++ b/packages/components/Divider/package.json
@@ -4,6 +4,7 @@
   "description": "A cross-platform Divider component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "typings": "lib/index.d.ts",
   "exports": {
     ".": {

--- a/packages/components/FocusTrapZone/package.json
+++ b/packages/components/FocusTrapZone/package.json
@@ -4,6 +4,7 @@
   "description": "A cross-platform FocusTrapZone component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/components/FocusZone/package.json
+++ b/packages/components/FocusZone/package.json
@@ -4,6 +4,7 @@
   "description": "A cross-platform FocusZone component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/components/Icon/package.json
+++ b/packages/components/Icon/package.json
@@ -4,6 +4,7 @@
   "description": "A cross-platform Icon component",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/components/Input/package.json
+++ b/packages/components/Input/package.json
@@ -4,6 +4,7 @@
   "description": "A cross-platform Text input component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/components/Link/package.json
+++ b/packages/components/Link/package.json
@@ -4,6 +4,7 @@
   "description": "A cross-platform Link component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/components/Menu/package.json
+++ b/packages/components/Menu/package.json
@@ -4,6 +4,7 @@
   "description": "A cross-platform Menu component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/components/MenuButton/package.json
+++ b/packages/components/MenuButton/package.json
@@ -7,6 +7,7 @@
   "homepage": "https://github.com/microsoft/fluentui-react-native",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/components/Notification/package.json
+++ b/packages/components/Notification/package.json
@@ -4,6 +4,7 @@
   "description": "add component-description",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/components/Persona/package.json
+++ b/packages/components/Persona/package.json
@@ -4,6 +4,7 @@
   "description": "A cross-platform Persona component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/components/PersonaCoin/package.json
+++ b/packages/components/PersonaCoin/package.json
@@ -4,6 +4,7 @@
   "description": "A cross-platform PersonaCoin component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/components/Pressable/package.json
+++ b/packages/components/Pressable/package.json
@@ -4,6 +4,7 @@
   "description": "A cross-platform Pressable component",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/components/RadioGroup/package.json
+++ b/packages/components/RadioGroup/package.json
@@ -4,6 +4,7 @@
   "description": "A cross-platform Radio Group component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/components/Separator/package.json
+++ b/packages/components/Separator/package.json
@@ -4,6 +4,7 @@
   "description": "A cross-platform Separator component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/components/Stack/package.json
+++ b/packages/components/Stack/package.json
@@ -4,6 +4,7 @@
   "description": "A cross-platform opinionated Fluent Text component",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/components/Switch/package.json
+++ b/packages/components/Switch/package.json
@@ -4,6 +4,7 @@
   "description": "A cross-platform Switch component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/components/TabList/package.json
+++ b/packages/components/TabList/package.json
@@ -4,6 +4,7 @@
   "description": "A cross-platform TabList component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/components/Text/package.json
+++ b/packages/components/Text/package.json
@@ -4,6 +4,7 @@
   "description": "A cross-platform Text component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/deprecated/foundation-composable/package.json
+++ b/packages/deprecated/foundation-composable/package.json
@@ -7,8 +7,9 @@
     "url": "https://github.com/microsoft/fluentui-react-native.git",
     "directory": "packages/deprecated/foundation-composable"
   },
-  "module": "lib-commonjs/index.js",
-  "main": "lib/index.js",
+  "main": "lib-commonjs/index.js",
+  "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "typings": "lib/index.d.ts",
   "exports": {
     ".": {

--- a/packages/deprecated/foundation-compose/package.json
+++ b/packages/deprecated/foundation-compose/package.json
@@ -9,6 +9,7 @@
   },
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "typings": "lib/index.d.ts",
   "exports": {
     ".": {

--- a/packages/deprecated/foundation-settings/package.json
+++ b/packages/deprecated/foundation-settings/package.json
@@ -9,6 +9,7 @@
   },
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "typings": "lib/index.d.ts",
   "exports": {
     ".": {

--- a/packages/deprecated/foundation-tokens/package.json
+++ b/packages/deprecated/foundation-tokens/package.json
@@ -9,6 +9,7 @@
   },
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "typings": "lib/index.d.ts",
   "exports": {
     ".": {

--- a/packages/deprecated/theme-registry/package.json
+++ b/packages/deprecated/theme-registry/package.json
@@ -9,6 +9,7 @@
   },
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "typings": "lib/index.d.ts",
   "exports": {
     ".": {

--- a/packages/deprecated/themed-settings/package.json
+++ b/packages/deprecated/themed-settings/package.json
@@ -9,6 +9,7 @@
   },
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "typings": "lib/index.d.ts",
   "exports": {
     ".": {

--- a/packages/deprecated/theming-ramp/package.json
+++ b/packages/deprecated/theming-ramp/package.json
@@ -9,6 +9,7 @@
   },
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "typings": "lib/index.d.ts",
   "exports": {
     ".": {

--- a/packages/deprecated/theming-react-native/package.json
+++ b/packages/deprecated/theming-react-native/package.json
@@ -4,6 +4,7 @@
   "description": "A library of functions which produce React Native styles from a Theme",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "typings": "lib/index.d.ts",
   "exports": {
     ".": {

--- a/packages/experimental/ActivityIndicator/package.json
+++ b/packages/experimental/ActivityIndicator/package.json
@@ -4,6 +4,7 @@
   "description": "A cross-platform Fluent Activity Indicator component",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/experimental/AppearanceAdditions/package.json
+++ b/packages/experimental/AppearanceAdditions/package.json
@@ -7,6 +7,7 @@
   "homepage": "https://github.com/microsoft/fluentui-react-native",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/experimental/Avatar/package.json
+++ b/packages/experimental/Avatar/package.json
@@ -7,6 +7,7 @@
   "homepage": "https://github.com/microsoft/fluentui-react-native",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/experimental/Checkbox/package.json
+++ b/packages/experimental/Checkbox/package.json
@@ -4,6 +4,7 @@
   "description": "A cross-platform Checkbox component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/experimental/Drawer/package.json
+++ b/packages/experimental/Drawer/package.json
@@ -4,6 +4,7 @@
   "description": "A cross-platform Drawer component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/experimental/Dropdown/package.json
+++ b/packages/experimental/Dropdown/package.json
@@ -4,6 +4,7 @@
   "description": "A cross-platform Dropdown component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/experimental/Expander/package.json
+++ b/packages/experimental/Expander/package.json
@@ -7,6 +7,7 @@
   "homepage": "https://github.com/microsoft/fluentui-react-native",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/experimental/MenuButton/package.json
+++ b/packages/experimental/MenuButton/package.json
@@ -4,6 +4,7 @@
   "description": "A cross-platform MenuButton component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/experimental/NativeDatePicker/package.json
+++ b/packages/experimental/NativeDatePicker/package.json
@@ -7,6 +7,7 @@
   "homepage": "https://github.com/microsoft/fluentui-react-native",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/experimental/NativeFontMetrics/package.json
+++ b/packages/experimental/NativeFontMetrics/package.json
@@ -7,6 +7,7 @@
   "homepage": "https://github.com/microsoft/fluentui-react-native",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/experimental/Overflow/package.json
+++ b/packages/experimental/Overflow/package.json
@@ -4,6 +4,7 @@
   "description": "A cross-platform Overflow component for React Native.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/experimental/Popover/package.json
+++ b/packages/experimental/Popover/package.json
@@ -4,6 +4,7 @@
   "description": "A cross-platform Popover component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/experimental/Shadow/package.json
+++ b/packages/experimental/Shadow/package.json
@@ -4,6 +4,7 @@
   "description": "A cross-platform Shadow component using the Fluent Design System",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/experimental/Shimmer/package.json
+++ b/packages/experimental/Shimmer/package.json
@@ -4,6 +4,7 @@
   "description": "A cross-platform Fluent Shimmer component",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/experimental/Spinner/package.json
+++ b/packages/experimental/Spinner/package.json
@@ -4,6 +4,7 @@
   "description": "A cross-platform Fluent spinner component",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/experimental/Stack/package.json
+++ b/packages/experimental/Stack/package.json
@@ -4,6 +4,7 @@
   "description": "A cross-platform opinionated Fluent Text component",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/experimental/Tooltip/package.json
+++ b/packages/experimental/Tooltip/package.json
@@ -4,6 +4,7 @@
   "description": "A cross-platform Tooltip component for React Native.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/experimental/VibrancyView/package.json
+++ b/packages/experimental/VibrancyView/package.json
@@ -4,6 +4,7 @@
   "description": "A native wrapper for NSVisualEffectView on macOS",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/framework/composition/package.json
+++ b/packages/framework/composition/package.json
@@ -9,6 +9,7 @@
   },
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/framework/framework/package.json
+++ b/packages/framework/framework/package.json
@@ -4,6 +4,7 @@
   "description": "Component framework used by fluentui react native controls",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "typings": "lib/index.d.ts",
   "exports": {
     ".": {

--- a/packages/framework/immutable-merge/package.json
+++ b/packages/framework/immutable-merge/package.json
@@ -9,6 +9,7 @@
   },
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/framework/memo-cache/package.json
+++ b/packages/framework/memo-cache/package.json
@@ -9,6 +9,7 @@
   },
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/framework/merge-props/package.json
+++ b/packages/framework/merge-props/package.json
@@ -9,6 +9,7 @@
   },
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/framework/theme/package.json
+++ b/packages/framework/theme/package.json
@@ -9,6 +9,7 @@
   },
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/framework/themed-stylesheet/package.json
+++ b/packages/framework/themed-stylesheet/package.json
@@ -9,6 +9,7 @@
   },
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/framework/use-slot/package.json
+++ b/packages/framework/use-slot/package.json
@@ -9,6 +9,7 @@
   },
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "typings": "lib/index.d.ts",
   "exports": {
     ".": {

--- a/packages/framework/use-slots/package.json
+++ b/packages/framework/use-slots/package.json
@@ -9,6 +9,7 @@
   },
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/framework/use-styling/package.json
+++ b/packages/framework/use-styling/package.json
@@ -9,6 +9,7 @@
   },
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/framework/use-tokens/package.json
+++ b/packages/framework/use-tokens/package.json
@@ -9,6 +9,7 @@
   },
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/libraries/core/package.json
+++ b/packages/libraries/core/package.json
@@ -10,6 +10,7 @@
   },
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/theming/android-theme/package.json
+++ b/packages/theming/android-theme/package.json
@@ -9,6 +9,7 @@
   },
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/theming/apple-theme/package.json
+++ b/packages/theming/apple-theme/package.json
@@ -7,6 +7,7 @@
   "homepage": "https://github.com/microsoft/fluentui-react-native",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/theming/default-theme/package.json
+++ b/packages/theming/default-theme/package.json
@@ -9,6 +9,7 @@
   },
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/theming/theme-tokens/package.json
+++ b/packages/theming/theme-tokens/package.json
@@ -9,6 +9,7 @@
   },
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/theming/theme-types/package.json
+++ b/packages/theming/theme-types/package.json
@@ -9,6 +9,7 @@
   },
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/theming/theming-utils/package.json
+++ b/packages/theming/theming-utils/package.json
@@ -9,6 +9,7 @@
   },
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/theming/win32-theme/package.json
+++ b/packages/theming/win32-theme/package.json
@@ -9,6 +9,7 @@
   },
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/utils/adapters/package.json
+++ b/packages/utils/adapters/package.json
@@ -4,6 +4,7 @@
   "description": "Adapters for working with react-native types",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/utils/interactive-hooks/package.json
+++ b/packages/utils/interactive-hooks/package.json
@@ -4,6 +4,7 @@
   "description": "Hooks for adding focus, hover, and press semantics to view based components",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/utils/styling/package.json
+++ b/packages/utils/styling/package.json
@@ -4,6 +4,7 @@
   "description": "Utility functions for styling components in FURN",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/utils/test-tools/package.json
+++ b/packages/utils/test-tools/package.json
@@ -5,6 +5,7 @@
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/packages/utils/tokens/package.json
+++ b/packages/utils/tokens/package.json
@@ -4,6 +4,7 @@
   "description": "Token interface parts and helpers",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "react-native": "src/index.ts",
   "exports": {
     ".": {
       "import": "./lib/index.js",


### PR DESCRIPTION
### Platforms Impacted
- all

### Description of changes

We used to have the package.json main field pointing at src/index.ts, then we would change it to point to lib-commonjs/index.js on publish. This served to ensure that metro bundling used the typescript files directly when bundling. This avoids the need to build, while also ensuring fast-refresh worked correctly when changes were made. This was changed as part of modernizing the way modules were defined and referenced in the repo (which was previously hiding bugs) but had the downside of breaking fast-refresh in the repo.

Instead of the old system (with the custom publishing hook) instead I added "react-native": "src/index.ts" references to the packages. This will cause the metro bundler to use the typescript entry-point and causes fast-refresh to work again. This will also cause downstream consumers to use the typescript entry points in their builds as well which is good for type-checking, good for avoiding intermediate helpers being added as part of JS build targeting, and eventually good for allowing static hermes to better optimize the code.

### Verification

Normal build & pipeline checks, also checked that bundling runs without building the repo first.
