### PR TITLE
Updates type signature for memo-cache and fix security issue

### DIFF
--- a/change/@fluentui-react-native-framework-aa92c4c0-877a-4225-80ec-e8f01a0920f8.json
+++ b/change/@fluentui-react-native-framework-aa92c4c0-877a-4225-80ec-e8f01a0920f8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix types in memo-cache as well as a codescan security issue",
+  "packageName": "@fluentui-react-native/framework",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-framework-base-3cfb70a3-c50f-4bec-9311-c804afcede9d.json
+++ b/change/@fluentui-react-native-framework-base-3cfb70a3-c50f-4bec-9311-c804afcede9d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix types in memo-cache as well as a codescan security issue",
+  "packageName": "@fluentui-react-native/framework-base",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-icon-9d54f520-6d46-4184-a951-a58554aeec10.json
+++ b/change/@fluentui-react-native-icon-9d54f520-6d46-4184-a951-a58554aeec10.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix types in memo-cache as well as a codescan security issue",
+  "packageName": "@fluentui-react-native/icon",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-memo-cache-2d7cdae7-7d50-4991-ae97-a8aa939ef0db.json
+++ b/change/@fluentui-react-native-memo-cache-2d7cdae7-7d50-4991-ae97-a8aa939ef0db.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix types in memo-cache as well as a codescan security issue",
+  "packageName": "@fluentui-react-native/memo-cache",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-use-styling-8b71c308-7a1d-4e66-a6d0-3b2d428f2cb7.json
+++ b/change/@fluentui-react-native-use-styling-8b71c308-7a1d-4e66-a6d0-3b2d428f2cb7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix types in memo-cache as well as a codescan security issue",
+  "packageName": "@fluentui-react-native/use-styling",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-use-tokens-2dd48af4-54c2-4486-912e-123d51de181c.json
+++ b/change/@fluentui-react-native-use-tokens-2dd48af4-54c2-4486-912e-123d51de181c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix types in memo-cache as well as a codescan security issue",
+  "packageName": "@fluentui-react-native/use-tokens",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabricshared-foundation-compose-6a0db019-e2f1-4a14-91d0-767e40341f38.json
+++ b/change/@uifabricshared-foundation-compose-6a0db019-e2f1-4a14-91d0-767e40341f38.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix types in memo-cache as well as a codescan security issue",
+  "packageName": "@uifabricshared/foundation-compose",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabricshared-foundation-tokens-4e5a59cb-e9ce-4c31-bad1-d61c036b8708.json
+++ b/change/@uifabricshared-foundation-tokens-4e5a59cb-e9ce-4c31-bad1-d61c036b8708.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix types in memo-cache as well as a codescan security issue",
+  "packageName": "@uifabricshared/foundation-tokens",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabricshared-themed-settings-89e1113f-0bf8-4b41-841a-a6a12fa3c97f.json
+++ b/change/@uifabricshared-themed-settings-89e1113f-0bf8-4b41-841a-a6a12fa3c97f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix types in memo-cache as well as a codescan security issue",
+  "packageName": "@uifabricshared/themed-settings",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Icon/src/SvgIcon/useSvgIcon.ts
+++ b/packages/components/Icon/src/SvgIcon/useSvgIcon.ts
@@ -1,10 +1,8 @@
-import type { ImageStyle } from 'react-native';
-
 import { getMemoCache, mergeStyles } from '@fluentui-react-native/framework';
 
 import type { SvgIconProps } from './SvgIcon.types';
 
-const rasterImageStyleCache = getMemoCache<ImageStyle>();
+const rasterImageStyleCache = getMemoCache();
 
 export const useSvgIcon = (props: SvgIconProps): SvgIconProps => {
   const { accessible, style, height, width, ...rest } = props;

--- a/packages/components/Icon/src/legacy/Icon.tsx
+++ b/packages/components/Icon/src/legacy/Icon.tsx
@@ -3,14 +3,14 @@ import { Image, Platform, View } from 'react-native';
 import type { ImageStyle, TextStyle } from 'react-native';
 
 import { mergeStyles, useFluentTheme } from '@fluentui-react-native/framework';
-import { stagedComponent, mergeProps, getMemoCache } from '@fluentui-react-native/framework';
+import { stagedComponent, mergeProps, getMemoCache, getTypedMemoCache } from '@fluentui-react-native/framework';
 import { Text } from '@fluentui-react-native/text';
 import type { SvgProps } from 'react-native-svg';
 import { SvgUri } from 'react-native-svg';
 
 import type { IconProps, SvgIconProps, FontIconProps } from './Icon.types';
 
-const rasterImageStyleCache = getMemoCache<ImageStyle>();
+const rasterImageStyleCache = getTypedMemoCache<ImageStyle>();
 
 function renderRasterImage(iconProps: IconProps) {
   const { width, height, color } = iconProps;

--- a/packages/deprecated/foundation-compose/src/useStyling.ts
+++ b/packages/deprecated/foundation-compose/src/useStyling.ts
@@ -38,7 +38,7 @@ function _getHasToken<TProps, TSlotProps extends ISlotProps, TTokens extends obj
 function useStylingCore<TProps, TSlotProps extends ISlotProps, TTokens extends object>(
   props: TProps,
   options: IStylingSettings<TSlotProps, TTokens>,
-  instanceMemoCache: GetMemoValue<TSlotProps, TSlotProps>,
+  instanceMemoCache: GetMemoValue,
   lookupOverride?: IOverrideLookup,
 ): IWithTokens<TSlotProps, TTokens> {
   // get the theme value from the context (or the default theme if it is not set)
@@ -50,20 +50,14 @@ function useStylingCore<TProps, TSlotProps extends ISlotProps, TTokens extends o
   const { settings, getMemoValue } = getThemedSettings<ILocalSettings, ITheme>(
     options.settings,
     theme,
-    instanceMemoCache as GetMemoValue<any>,
+    instanceMemoCache as GetMemoValue,
     lookupOverride,
     _getSettingsFromTheme as any,
   );
 
   // finish by processing the tokens and turning IComponentSettings into ISlotProps (this removes things like _overrides)
   return returnAsSlotProps(
-    processTokens<TSlotProps, TTokens, ITheme>(
-      props as unknown as TTokens,
-      theme,
-      settings as any,
-      options.resolvedTokens,
-      getMemoValue as GetMemoValue<any>,
-    ),
+    processTokens<TSlotProps, TTokens, ITheme>(props as unknown as TTokens, theme, settings as any, options.resolvedTokens, getMemoValue),
   ) as IWithTokens<TSlotProps, TTokens>;
 }
 
@@ -86,7 +80,7 @@ export function initializeStyling<
   options.resolvedTokens = buildComponentTokens<TSlotProps, TTokens, ITheme>(styles, _getHasToken(slots));
 
   // memo cache root for this component, keyed on options
-  const getMemoValue = getMemoCache<TSlotProps>(options);
+  const getMemoValue = getMemoCache(options);
 
   // create a useStyling implementation for this component type (per type, not per instance)
   return (props: TProps, lookupOverride?: IOverrideLookup) => {

--- a/packages/deprecated/foundation-tokens/src/MockComponent.ts
+++ b/packages/deprecated/foundation-tokens/src/MockComponent.ts
@@ -17,7 +17,7 @@ export type IMockComponentFn<TProps, TSlotProps extends ISlotProps, TTokens> = (
   props: TProps,
   settings: IComponentSettings<TSlotProps> & { tokens?: TTokens },
   theme: IMockTheme,
-  cache: GetMemoValue<any>,
+  cache: GetMemoValue,
   recurse?: boolean,
 ) => TSlotProps | TProps;
 
@@ -36,7 +36,7 @@ export function stockFakeComponent(
   props: IMockBaseProps,
   _settings: ISlotProps,
   _theme: IMockTheme,
-  _cache: GetMemoValue<any>,
+  _cache: GetMemoValue,
   _recurse: boolean,
 ): IMockBaseProps {
   return props;
@@ -56,13 +56,7 @@ export function mockCreate<TProps extends object, TSlotProps extends ISlotProps,
     options.styles,
     hasTokens,
   );
-  const fn = (
-    props: TProps,
-    settings: TSlotProps & { tokens?: TTokens },
-    theme: IMockTheme,
-    cache: GetMemoValue<any>,
-    recurse?: boolean,
-  ) => {
+  const fn = (props: TProps, settings: TSlotProps & { tokens?: TTokens }, theme: IMockTheme, cache: GetMemoValue, recurse?: boolean) => {
     let newSettings = processTokens(props as any, theme, settings as any, resolvedTokens, cache);
     if (recurse) {
       Object.keys(slots).forEach((slotName: string) => {

--- a/packages/deprecated/foundation-tokens/src/Token.function.ts
+++ b/packages/deprecated/foundation-tokens/src/Token.function.ts
@@ -1,4 +1,4 @@
-import type { GetMemoValue } from '@fluentui-react-native/framework-base';
+import type { GetTypedMemoValue } from '@fluentui-react-native/framework-base';
 import { mergeProps } from '@fluentui-react-native/framework-base';
 import type { ISlotProps } from '@uifabricshared/foundation-settings';
 
@@ -82,7 +82,7 @@ function _getCachedPropsForSlot<TProps, TTokens, TTheme>(
   tokenProps: ITokenPropInfo<TTokens>,
   theme: TTheme,
   slotName: string,
-  getMemoValue: GetMemoValue<TProps>,
+  getMemoValue: GetTypedMemoValue<TProps>,
   keys: string[],
   mappings: ITokensForSlot<TProps, TTokens, TTheme>,
   finalizer?: IStyleFinalizer<TProps>,
@@ -160,7 +160,7 @@ export function buildComponentTokens<TSlotProps extends ISlotProps, TTokens, TTh
       tokenProps: ITokenPropInfo<TTokens>,
       theme: TTheme,
       slotName: string,
-      getValue: GetMemoValue<IPropsForSlot>,
+      getValue: GetTypedMemoValue<IPropsForSlot>,
     ) => {
       const keys = Object.getOwnPropertyNames(slotKeys);
       return _getCachedPropsForSlot<IPropsForSlot, TTokens, TTheme>(props, tokenProps, theme, slotName, getValue, keys, mappings);

--- a/packages/deprecated/foundation-tokens/src/Token.internal.ts
+++ b/packages/deprecated/foundation-tokens/src/Token.internal.ts
@@ -16,7 +16,7 @@ export type IGetCachedPropsForSlot<TProps, TTokens, TTheme> = (
   tokenProps: ITokenPropInfo<TTokens>,
   theme: TTheme,
   slotName: string,
-  getMemoValue: GetMemoValue<TProps>,
+  getMemoValue: GetMemoValue,
 ) => TProps;
 
 export type ICachedPropHandlers<TSlotProps extends object, TTokens, TTheme> = {

--- a/packages/deprecated/foundation-tokens/src/Token.ts
+++ b/packages/deprecated/foundation-tokens/src/Token.ts
@@ -42,7 +42,7 @@ export function processTokens<TSlotProps extends ISlotProps, TTokens extends obj
   theme: TTheme,
   slotProps: IComponentSettings<TSlotProps & { tokens?: TTokens }>,
   tokenInfo: IComponentTokens<TSlotProps, TTokens, TTheme>,
-  cache: GetMemoValue<TSlotProps>,
+  cache: GetMemoValue,
 ): ISlotProps {
   // merge in tokens and build up the cache key which are the tokens overridden by the user
   slotProps = slotProps || {};

--- a/packages/deprecated/themed-settings/src/CustomSettings.ts
+++ b/packages/deprecated/themed-settings/src/CustomSettings.ts
@@ -42,10 +42,10 @@ export function mergeBaseSettings<TSettings extends IComponentSettings, TTheme>(
 export function getThemedSettings<TSettings extends IComponentSettings, TTheme>(
   customSettings: ISettingsEntry<TSettings, TTheme>[],
   theme: TTheme,
-  memoValue: GetMemoValue<TSettings, TSettings>,
+  memoValue: GetMemoValue,
   hasOverride?: IOverrideLookup,
   getFromTheme?: IGetSettingsFromTheme<TSettings, TTheme>,
-): { settings: TSettings | undefined; getMemoValue: GetMemoValue<TSettings, TSettings> } {
+): { settings: TSettings | undefined; getMemoValue: GetMemoValue } {
   // resolve the settings for this component, keyed on the theme
   let [settings, getMemoValue] = memoValue(() => mergeBaseSettings(customSettings, theme, getFromTheme), [theme]);
 

--- a/packages/experimental/Stack/src/Stack.styling.ts
+++ b/packages/experimental/Stack/src/Stack.styling.ts
@@ -44,7 +44,7 @@ const tokensThatAreAlsoProps: (keyof StackTokenProps)[] = [
 
 const nowrapProps: ViewProps = {};
 
-const buildInnerProps = (tokenProps: StackTokens, theme: Theme, cache: GetMemoValue<ViewProps>) => {
+const buildInnerProps = (tokenProps: StackTokens, theme: Theme, cache: GetMemoValue) => {
   // if wrapping is disabled just return a fixed empty object without doing any additional work
   if (!tokenProps.wrap) {
     return nowrapProps;
@@ -54,7 +54,7 @@ const buildInnerProps = (tokenProps: StackTokens, theme: Theme, cache: GetMemoVa
   const { horizontal, horizontalAlign, verticalAlign, padding } = tokenProps;
   return !tokenProps.wrap
     ? nowrapProps
-    : cache(() => {
+    : cache<ViewProps>(() => {
         const childrenGap = tokenProps.childrenGap || tokenProps.gap;
         const { rowGap, columnGap } = parseGap(childrenGap, theme);
 

--- a/packages/experimental/Stack/src/Stack.tsx
+++ b/packages/experimental/Stack/src/Stack.tsx
@@ -6,7 +6,7 @@ import type { ViewProps } from 'react-native';
 
 import { filterViewProps } from '@fluentui-react-native/adapters';
 import type { UseSlots } from '@fluentui-react-native/framework';
-import { compose, withSlots, mergeProps, getMemoCache } from '@fluentui-react-native/framework';
+import { compose, withSlots, mergeProps, getTypedMemoCache } from '@fluentui-react-native/framework';
 
 import { stylingSettings } from './Stack.styling';
 import { stackName } from './Stack.types';
@@ -23,7 +23,7 @@ declare global {
   }
 }
 
-const mixinCache = getMemoCache<ViewProps>();
+const mixinCache = getTypedMemoCache<ViewProps>();
 
 /**
  * ensures that the object reference of the ViewProps is the same if the values of horizontal and gap are the same, this

--- a/packages/experimental/Stack/src/StackItem/StackItem.styles.ts
+++ b/packages/experimental/Stack/src/StackItem/StackItem.styles.ts
@@ -1,13 +1,13 @@
 import type { ViewStyle, ViewProps } from 'react-native';
 
 import type { UseStylingOptions } from '@fluentui-react-native/framework';
-import { getMemoCache } from '@fluentui-react-native/framework';
+import { getTypedMemoCache } from '@fluentui-react-native/framework';
 
 import { stackItemName } from './StackItem.types';
 import type { StackItemTokens, StackItemProps, StackItemSlotProps } from './StackItem.types';
 
 // styles are keyed on token values and are independent of themes or variants so just use a common cache
-const localCache = getMemoCache<ViewProps>();
+const localCache = getTypedMemoCache<ViewProps>();
 
 const alignMap: { [key: string]: ViewStyle['alignSelf'] } = {
   start: 'flex-start',

--- a/packages/framework-base/package.json
+++ b/packages/framework-base/package.json
@@ -16,21 +16,6 @@
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js",
       "types": "./lib/index.d.ts"
-    },
-    "./immutable-merge": {
-      "import": "./lib/immutable-merge/Merge.js",
-      "require": "./lib-commonjs/immutable-merge/Merge.js",
-      "types": "./lib/immutable-merge/Merge.d.ts"
-    },
-    "./memo-cache": {
-      "import": "./lib/memo-cache/index.js",
-      "require": "./lib-commonjs/memo-cache/index.js",
-      "types": "./lib/memo-cache/index.d.ts"
-    },
-    "./merge-props": {
-      "import": "./lib/merge-props/index.js",
-      "require": "./lib-commonjs/merge-props/index.js",
-      "types": "./lib/merge-props/lib/index.d.ts"
     }
   },
   "scripts": {

--- a/packages/framework-base/src/index.ts
+++ b/packages/framework-base/src/index.ts
@@ -10,8 +10,8 @@ export type {
 } from './immutable-merge/Merge';
 
 // memo-cache exports
-export type { GetMemoValue } from './memo-cache/getMemoCache';
-export { getMemoCache } from './memo-cache/getMemoCache';
+export type { GetMemoValue, GetTypedMemoValue } from './memo-cache/getMemoCache';
+export { getMemoCache, getTypedMemoCache } from './memo-cache/getMemoCache';
 export { memoize } from './memo-cache/memoize';
 
 // merge-props exports

--- a/packages/framework-base/src/memo-cache/getCacheEntry.ts
+++ b/packages/framework-base/src/memo-cache/getCacheEntry.ts
@@ -1,31 +1,23 @@
-export type CacheEntry<T, TGet = any> = {
+/** signature for the object/function key values, used for memoization */
+// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+export type MemoObjectKey = object | Function;
+
+export type CacheEntry<T = unknown> = {
   /** stores the cached value if any */
   value?: T;
 
   /** entry used for undefined and null values, these both collapse to the same type */
-  empty?: CacheEntry<TGet>;
+  empty?: CacheEntry<T>;
 
   /** entry used for the case where the array of args is null or length 0 */
-  noargs?: CacheEntry<TGet>;
+  noargs?: CacheEntry<T>;
 
   /** all remaining non-object types are keyed as strings for lookups */
-  str?: { [key: string]: CacheEntry<TGet> };
+  str?: { [key: string]: CacheEntry<T> };
 
   /** object types are keyed in a weak map on object identity */
-  obj?: WeakMap<object, TGet>;
+  obj?: WeakMap<MemoObjectKey, CacheEntry<T>>;
 };
-
-/**
- * just wraps the common entry.foo = entry.foo || {} pattern
- * @param entry - entry to ensure a key value for
- * @param key - which key of that entry to ensure the value for
- */
-function ensureAndReturn(entry: CacheEntry<any>, key: keyof CacheEntry<any>): CacheEntry<any> | { [key: string]: CacheEntry<any> } {
-  if ((key as string) === '__proto__' || (key as string) === 'constructor' || (key as string) === 'prototype') {
-    throw new Error('Invalid key');
-  }
-  return (entry[key] = entry[key] || {});
-}
 
 /**
  * Step one level deeper in the cache, based on the key value from the current location
@@ -33,22 +25,22 @@ function ensureAndReturn(entry: CacheEntry<any>, key: keyof CacheEntry<any>): Ca
  * @param entry - base entry to work from
  * @param val - value to use as the key for progressing to the next level of the cache
  */
-function jumpToCacheEntry(entry: CacheEntry<any>, val: any): CacheEntry<any> {
+function jumpToCacheEntry(entry: CacheEntry, val: any): CacheEntry {
   if (val === undefined || val === null) {
     // undefined or null just routes directly to the empty object.  This avoids the issues of string collisions with 'null' or 'undefined'
     // when using the string key map, it also avoids creating the WeakMap (since null is technically typoef object), particularly in cases
     // where null is just being set on non-object types.
-    return ensureAndReturn(entry, 'empty');
+    return (entry.empty ??= {});
   }
   if (typeof val === 'object' || typeof val === 'function') {
     // objects and functions will be treated as key values in a WeakMap
-    const byObj = (entry.obj = entry.obj || new WeakMap<object, CacheEntry<any>>());
+    const byObj = (entry.obj ??= new WeakMap<MemoObjectKey, CacheEntry>());
     return byObj.get(val) || byObj.set(val, {}).get(val);
   }
   // otherwise convert everything to a string and store it in the str object (using it as a map)
   const key = val + '';
-  const byString = ensureAndReturn(entry, 'str');
-  return (byString[key] = byString[key] || {});
+  const byString = (entry.str ??= {});
+  return (byString[key] ??= {});
 }
 
 /**
@@ -57,11 +49,11 @@ function jumpToCacheEntry(entry: CacheEntry<any>, val: any): CacheEntry<any> {
  * @param entry - entry to use as the base of the cache walk
  * @param args - array of arguments to use to progress deeper into the cache
  */
-export function getCacheEntry<T, TGet = any>(entry: CacheEntry<T>, args: any[]): CacheEntry<TGet> {
+export function getCacheEntry(entry: CacheEntry, args: unknown[]): CacheEntry {
   // in the case where the args array exists and is > 0 length:
   // - walk the cache from entry, like a linked list, jumping to the next entry by key, building it up as you go
   // - otherwise if there are no args just use the noargs branch
   return args && args.length > 0
-    ? (args.reduce((previous: CacheEntry<any>, arg: any) => jumpToCacheEntry(previous, arg), entry) as CacheEntry<TGet>)
-    : ensureAndReturn(entry, 'noargs');
+    ? (args.reduce((previous: CacheEntry, arg: unknown) => jumpToCacheEntry(previous, arg), entry) as CacheEntry)
+    : (entry.noargs ??= {});
 }

--- a/packages/framework-base/src/memo-cache/getMemoCache.test.ts
+++ b/packages/framework-base/src/memo-cache/getMemoCache.test.ts
@@ -1,4 +1,4 @@
-import { getMemoCache } from './getMemoCache';
+import { getMemoCache, getTypedMemoCache } from './getMemoCache';
 
 interface TestObj {
   id: number;
@@ -38,7 +38,7 @@ describe('getMemoCache unit tests', () => {
   });
 
   test('memoValue executes function', () => {
-    const memoValue = getMemoCache();
+    const memoValue = getTypedMemoCache<TestObj>();
     const fn = getObjFactory();
     const v1 = fn();
     const [v2] = memoValue(fn, ['bar', 'baz']);

--- a/packages/framework-base/src/memo-cache/getMemoCache.ts
+++ b/packages/framework-base/src/memo-cache/getMemoCache.ts
@@ -3,11 +3,16 @@ import { getCacheEntry } from './getCacheEntry';
 
 export type ValueFactory<T> = () => T;
 
-/** signature for the cache function */
-export type GetMemoValue<T, TGet = any> = (factory: T | ValueFactory<T>, keys: any[]) => [T, GetMemoValue<TGet>];
+/**
+ * Signature for the cache function. While the implementation is generic, it can run in two modes:
+ * - Typed: the cache will enforce the type of both the factory and returned value
+ * - Untyped: the cache will infer the type on each call from the factory return value
+ */
+export type GetTypedMemoValue<T> = (factory: T | ValueFactory<T>, keys: unknown[]) => [T, GetTypedMemoValue<T>];
+export type GetMemoValue = <T>(factory: T | ValueFactory<T>, keys: unknown[]) => [T, GetMemoValue];
 
 /** base node used to remember references when a globalKey is set */
-const _baseEntry: CacheEntry<any> = {};
+const _baseEntry: CacheEntry = {};
 
 /**
  * Primary functional worker used to implement the caching pattern
@@ -16,13 +21,13 @@ const _baseEntry: CacheEntry<any> = {};
  * @param factory - generally a function who's results will be cached, and returned via the set of keys
  * @param keys - an ordered array of values of any type, used as keys to look up the entry
  */
-function getMemoValueWorker<T, TGet = any>(entry: CacheEntry<any>, factory: T | ValueFactory<T>, keys: any[]): [T, GetMemoValue<TGet>] {
+function getMemoValueWorker<T>(entry: CacheEntry, factory: T | ValueFactory<T>, keys: unknown[]): [T, GetMemoValue] {
   const foundEntry = getCacheEntry(entry, keys);
   // check the key being set, not the value to disambiguate an undefined factory result/value from never having run the factory
-  if (!foundEntry.hasOwnProperty('value')) {
+  if (!Object.prototype.hasOwnProperty.call(foundEntry, 'value')) {
     foundEntry.value = typeof factory === 'function' ? (factory as ValueFactory<T>)() : factory;
   }
-  return [foundEntry.value, (fact: TGet | ValueFactory<TGet>, args: any[]) => getMemoValueWorker<TGet>(foundEntry, fact, args)];
+  return [foundEntry.value as T, <U>(fact: U | ValueFactory<U>, args: unknown[]) => getMemoValueWorker<U>(foundEntry, fact, args)];
 }
 
 /**
@@ -31,7 +36,18 @@ function getMemoValueWorker<T, TGet = any>(entry: CacheEntry<any>, factory: T | 
  * @param globalKey - optional object reference to use as a key for this cache.  If specified it can be used
  * to retrieve the same cache from the global call.  If not specified the returned cache will be completely isolated.
  */
-export function getMemoCache<T = any>(globalKey?: object): GetMemoValue<T> {
+export function getMemoCache(globalKey?: object): GetMemoValue {
   const entry = globalKey ? getCacheEntry(_baseEntry, [globalKey]) : {};
-  return (fact: T | ValueFactory<T>, args: any[]) => getMemoValueWorker<T>(entry, fact, args);
+  return (fact, args) => getMemoValueWorker(entry, fact, args);
+}
+
+/**
+ * Get a typed memo cache instance, this can either be completely self-contained or associated with a global key
+ *
+ * @param globalKey - optional object reference to use as a key for this cache.  If specified it can be used
+ * to retrieve the same cache from the global call.  If not specified the returned cache will be completely isolated.
+ */
+export function getTypedMemoCache<T>(globalKey?: object): GetTypedMemoValue<T> {
+  const entry = globalKey ? getCacheEntry(_baseEntry, [globalKey]) : {};
+  return (fact, args) => getMemoValueWorker(entry, fact, args);
 }

--- a/packages/framework-base/src/memo-cache/index.ts
+++ b/packages/framework-base/src/memo-cache/index.ts
@@ -1,3 +1,0 @@
-export type { GetMemoValue } from './getMemoCache';
-export { getMemoCache } from './getMemoCache';
-export { memoize } from './memoize';

--- a/packages/framework-base/src/memo-cache/memoize.ts
+++ b/packages/framework-base/src/memo-cache/memoize.ts
@@ -7,9 +7,9 @@ import { getMemoCache } from './getMemoCache';
 // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
 export function memoize<T extends Function>(fn: T): T {
   // create a unique cache that will be captured in the closure
-  const cache = getMemoCache<any>();
+  const cache = getMemoCache();
   // create the closure which wraps the calling function
-  const closure = (...args: any[]) => {
+  const closure = (...args: unknown[]) => {
     return cache(() => fn(...(args || [])), args)[0];
   };
   // now return that closure strongly typed as the function.

--- a/packages/framework/framework/src/index.ts
+++ b/packages/framework/framework/src/index.ts
@@ -1,5 +1,5 @@
-export type { GetMemoValue } from '@fluentui-react-native/framework-base';
-export { getMemoCache, memoize } from '@fluentui-react-native/framework-base';
+export type { GetMemoValue, GetTypedMemoValue } from '@fluentui-react-native/framework-base';
+export { getMemoCache, getTypedMemoCache, memoize } from '@fluentui-react-native/framework-base';
 
 export type { StyleProp } from '@fluentui-react-native/framework-base';
 export { mergeProps, mergeStyles } from '@fluentui-react-native/framework-base';

--- a/packages/framework/memo-cache/src/index.ts
+++ b/packages/framework/memo-cache/src/index.ts
@@ -1,2 +1,2 @@
-export type { GetMemoValue } from '@fluentui-react-native/framework-base';
-export { getMemoCache, memoize } from '@fluentui-react-native/framework-base';
+export type { GetMemoValue, GetTypedMemoValue } from '@fluentui-react-native/framework-base';
+export { getMemoCache, getTypedMemoCache, memoize } from '@fluentui-react-native/framework-base';

--- a/packages/framework/use-styling/src/buildProps.ts
+++ b/packages/framework/use-styling/src/buildProps.ts
@@ -18,7 +18,7 @@ export type TokensThatAreAlsoProps<TTokens> = (keyof TTokens)[] | 'all' | 'none'
  * The provided
  * cache will be scoped to the theme, slot, and tokens that are coming out of the theme.
  */
-export type BuildPropsBase<TProps, TTokens, TTheme> = (tokens: TTokens, theme: TTheme, cache: GetMemoValue<any>) => Partial<TProps>;
+export type BuildPropsBase<TProps, TTokens, TTheme> = (tokens: TTokens, theme: TTheme, cache: GetMemoValue) => Partial<TProps>;
 
 /**
  * A refine function allows style functions to be updated based on tokens that are also props. Only those tokens that are also
@@ -46,7 +46,7 @@ function cacheStyleClosure<TProps, TTokens, TTheme>(
   fn: (tokens: TTokens, theme: TTheme) => TProps,
   keys?: (keyof TTokens)[],
 ): RefinableBuildPropsBase<TProps, TTokens, TTheme> {
-  return (tokens: TTokens, theme: TTheme, cache: GetMemoValue<TProps>) =>
+  return (tokens: TTokens, theme: TTheme, cache: GetMemoValue) =>
     cache(
       () => fn(tokens, theme),
       (keys || []).map((key) => tokens[key]),

--- a/packages/framework/use-styling/src/buildUseStyling.ts
+++ b/packages/framework/use-styling/src/buildUseStyling.ts
@@ -1,4 +1,4 @@
-import type { GetMemoValue } from '@fluentui-react-native/framework-base';
+import type { GetTypedMemoValue } from '@fluentui-react-native/framework-base';
 import type { HasLayer, TokenSettings } from '@fluentui-react-native/use-tokens';
 import { applyPropsToTokens, applyTokenLayers, buildUseTokens } from '@fluentui-react-native/use-tokens';
 
@@ -64,7 +64,7 @@ function resolveToSlotProps<TSlotProps, TTokens, TTheme>(
   styles: BuildSlotProps<TSlotProps, TTokens, TTheme>,
   tokens: TTokens,
   theme: TTheme,
-  cache: GetMemoValue<TTokens>,
+  cache: GetTypedMemoValue<TTokens>,
 ): TSlotProps {
   const slotProps = {};
   Object.keys(styles).forEach((key) => {

--- a/packages/framework/use-tokens/src/applyPropsToTokens.test.ts
+++ b/packages/framework/use-tokens/src/applyPropsToTokens.test.ts
@@ -1,4 +1,4 @@
-import { getMemoCache } from '@fluentui-react-native/framework-base';
+import { getTypedMemoCache } from '@fluentui-react-native/framework-base';
 
 import { applyPropsToTokens } from './applyPropsToTokens';
 
@@ -32,7 +32,7 @@ const props1: Props = { dos: 'two', quatro: 'four', cinco: false, foo: 'foo', ba
 
 describe('applyPropsToTokens tests', () => {
   test('props get copied', () => {
-    const cache = getMemoCache();
+    const cache = getTypedMemoCache<Tokens>();
     const [tokens] = applyPropsToTokens(props1, themeTokens, cache, tokenProps);
     expect(tokens).not.toBe(themeTokens);
     for (const key of tokenProps) {
@@ -41,7 +41,7 @@ describe('applyPropsToTokens tests', () => {
   });
 
   test('no copied props does not change tokens', () => {
-    const cache = getMemoCache();
+    const cache = getTypedMemoCache<Tokens>();
     const [tokens] = applyPropsToTokens({}, themeTokens, cache, tokenProps);
     expect(tokens).toBe(themeTokens);
   });

--- a/packages/framework/use-tokens/src/applyPropsToTokens.ts
+++ b/packages/framework/use-tokens/src/applyPropsToTokens.ts
@@ -1,11 +1,11 @@
-import type { GetMemoValue } from '@fluentui-react-native/framework-base';
+import type { GetTypedMemoValue } from '@fluentui-react-native/framework-base';
 
 export function applyPropsToTokens<TProps, TTokens>(
   props: TProps,
   tokens: TTokens,
-  cache: GetMemoValue<TTokens>,
+  cache: GetTypedMemoValue<TTokens>,
   keys: (keyof TTokens)[],
-): [TTokens, GetMemoValue<TTokens>] {
+): [TTokens, GetTypedMemoValue<TTokens>] {
   for (const key of keys) {
     const sourceValue = props[key as string];
     const setValue = sourceValue === tokens[key] ? undefined : sourceValue;

--- a/packages/framework/use-tokens/src/applyTokenLayers.ts
+++ b/packages/framework/use-tokens/src/applyTokenLayers.ts
@@ -1,5 +1,5 @@
 import { immutableMerge } from '@fluentui-react-native/framework-base';
-import type { GetMemoValue } from '@fluentui-react-native/framework-base';
+import type { GetTypedMemoValue } from '@fluentui-react-native/framework-base';
 
 /**
  * alternatively look them up with a passed in function
@@ -18,10 +18,10 @@ export type HasLayer = (name: string) => boolean;
 export function applyTokenLayers<TTokens>(
   tokens: TTokens,
   states: string[],
-  subCache: GetMemoValue<TTokens>,
+  subCache: GetTypedMemoValue<TTokens>,
   hasLayer: HasLayer,
-): [TTokens, GetMemoValue<TTokens>] {
-  type TokensAndCache = { tokens: TTokens; subCache: GetMemoValue<TTokens> };
+): [TTokens, GetTypedMemoValue<TTokens>] {
+  type TokensAndCache = { tokens: TTokens; subCache: GetTypedMemoValue<TTokens> };
   let final: TokensAndCache = { tokens, subCache };
   if (states && states.length > 0) {
     // now walk the overrides that are set, merging in props, caching results, and getting a new sub cache

--- a/packages/framework/use-tokens/src/buildUseTokens.ts
+++ b/packages/framework/use-tokens/src/buildUseTokens.ts
@@ -1,5 +1,5 @@
 import { immutableMerge } from '@fluentui-react-native/framework-base';
-import type { GetMemoValue } from '@fluentui-react-native/framework-base';
+import type { GetTypedMemoValue } from '@fluentui-react-native/framework-base';
 import { getMemoCache } from '@fluentui-react-native/framework-base';
 
 /** A function to generate tokens based on a theme */
@@ -18,7 +18,7 @@ export type TokenSettings<TTokens, TTheme> = string | TTokens | TokensFromTheme<
  * as well as a sub-cache, specific to this particular theme, that can be used for caching various styles
  * or values that are theme specific
  */
-export type UseTokensCore<TTokens, TTheme> = (theme: TTheme) => [TTokens, GetMemoValue<TTokens>];
+export type UseTokensCore<TTokens, TTheme> = (theme: TTheme) => [TTokens, GetTypedMemoValue<TTokens>];
 
 /**
  * The full signature also includes a customize function that returns an updated version of useTokens
@@ -50,14 +50,14 @@ function mapToTokens<TTokens, TTheme>(
   tokenEntry: TTokens | string | TokensFromTheme<TTokens, TTheme>,
   theme: TTheme,
   getComponentInfo: GetComponentInfo<TTokens, TTheme> | undefined,
-): object {
+): TTokens {
   if (typeof tokenEntry === 'string') {
     tokenEntry = (getComponentInfo && (getComponentInfo(theme, tokenEntry) as TTokens)) || ({} as TTokens);
   }
   if (typeof tokenEntry === 'function') {
     tokenEntry = (tokenEntry as TokensFromTheme<TTokens, TTheme>)(theme);
   }
-  return tokenEntry as unknown as object;
+  return tokenEntry;
 }
 
 /**
@@ -77,7 +77,7 @@ export function buildUseTokens<TTokens, TTheme>(
   // theme functions. This turns the tokens into an array of token objects that then get merged together
   const useTokensCore = (theme: TTheme) => {
     // get the base styles all merged together, these will only depend on internal tokens and theme
-    return cache(() => immutableMerge(...tokens.map((value) => mapToTokens(value, theme, getComponentInfo))), [theme]);
+    return cache(() => immutableMerge<TTokens>(...tokens.map((value) => mapToTokens(value, theme, getComponentInfo))), [theme]);
   };
 
   // attach a customize function to generate a new use

--- a/packages/framework/use-tokens/src/patchTokens.ts
+++ b/packages/framework/use-tokens/src/patchTokens.ts
@@ -1,4 +1,4 @@
-import type { GetMemoValue } from '@fluentui-react-native/framework-base';
+import type { GetTypedMemoValue } from '@fluentui-react-native/framework-base';
 
 /**
  * Take a set of tokens (and a memo-cache) and apply changes to those tokens from an additional set of tokens. Only keys which are
@@ -11,9 +11,9 @@ import type { GetMemoValue } from '@fluentui-react-native/framework-base';
  */
 export function patchTokens<TTokens>(
   tokens: TTokens,
-  cache: GetMemoValue<TTokens>,
+  cache: GetTypedMemoValue<TTokens>,
   patchValues: TTokens,
-): [TTokens, GetMemoValue<TTokens>] {
+): [TTokens, GetTypedMemoValue<TTokens>] {
   // reduce the patch values to the set of keys that are defined, and sort them to ensure consistent ordering
   const keys = Object.keys(patchValues)
     .filter((v) => patchValues[v] !== undefined)


### PR DESCRIPTION
### Platforms Impacted
- All

### Description of changes

#### Type Updates
This updates the types in the memo-cache package to split the untyped and typed usage. Previously it used any in ways would make it look like it was typed, when in fact it had lost the type inferences. Now there are two patterns:

- Typed - this is equivalent to `GetMemoValue<MyType>` and `getMemoCache<MyType>()` except things are more explicitly typed here. The previous utilities are replaced by `GetTypedMemoValue<T>` and `getTypedMemoCache<T>`
- Untyped - this replaces what happens when the above were used untyped. In this case the returned signature is a function that inferences its type from the parameters (or it can be specified). This is what we want in this case, not any behavior.

The previous usage was type unsafe, fails a bunch of more advanced lint rules and TS 5+ compilations, and at times would break inferencing in the project.

#### Security Fix
This fix addresses the code scanning issue: https://github.com/microsoft/fluentui-react-native/security/code-scanning/4 by making the calls to ensure entries in the underlying cache explicit rather than using the helper function.

#### Export entry removals
This also removes the export map entries for immutable-merge, memo-cache, and merge-props from framework base. These would require special handling in metro bundling to use and I don't want to tempt people into using something that breaks their bundling. It also eliminates another place where additional exports would need to be added.

### Verification
Builds work, tests run, the changes should be almost entirely type only.