### PR TITLE
Add an engines field with the minimum required version of node

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,9 @@
     "packages/**",
     "scripts"
   ],
+  "engines": {
+    "node": ">=22.12"
+  },
   "resolutions": {
     "@types/react": "^18.2.0",
     "@warren-ms/react-native-icons/react-native-svg": "^15.4.0",


### PR DESCRIPTION
### Platforms Impacted
- all

### Description of changes

For some of the scripts changes, we need at least node 22.12.0, though 23+ is fine too. The engines field now specifies that minimum threshold.

### Verification

Build only change, normal automated tests are sufficient.