### PR TITLE
Fix `gap` token on `MenuList`

### DIFF
--- a/change/@fluentui-react-native-menu-81acb56e-ab1f-46a9-bce0-dc440e0aa15e.json
+++ b/change/@fluentui-react-native-menu-81acb56e-ab1f-46a9-bce0-dc440e0aa15e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix gap tokens on MenuList",
+  "packageName": "@fluentui-react-native/menu",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Menu/src/MenuList/MenuList.styling.ts
+++ b/packages/components/Menu/src/MenuList/MenuList.styling.ts
@@ -15,16 +15,29 @@ export const stylingSettings: UseStylingOptions<MenuListProps, MenuListSlotProps
   states: menuListStates,
   slotProps: {
     root: buildProps(
-      (tokens: MenuListTokens, theme: Theme) => ({
+      (tokens: MenuListTokens, theme: Theme) => {
+        console.log(tokens);
+        return {
+          style: {
+            backgroundColor: tokens.backgroundColor,
+            display: 'flex',
+            gap: tokens.gap,
+            ...layoutStyles.from(tokens, theme),
+            ...(Platform.OS === 'android' && { borderRadius: tokens.borderRadius }),
+          },
+        };
+      },
+      ['backgroundColor', 'borderRadius', 'gap', ...layoutStyles.keys],
+    ),
+    focusZone: buildProps(
+      (tokens: MenuListTokens) => ({
         style: {
-          backgroundColor: tokens.backgroundColor,
           display: 'flex',
-          ...layoutStyles.from(tokens, theme),
-          ...(Platform.OS === 'android' && { borderRadius: tokens.borderRadius }),
+          flexDirection: 'column',
+          gap: tokens.gap,
         },
-        gap: tokens.gap,
       }),
-      ['backgroundColor', 'gap', ...layoutStyles.keys],
+      ['gap'],
     ),
   },
 };

--- a/packages/components/Menu/src/MenuList/MenuList.styling.ts
+++ b/packages/components/Menu/src/MenuList/MenuList.styling.ts
@@ -15,18 +15,15 @@ export const stylingSettings: UseStylingOptions<MenuListProps, MenuListSlotProps
   states: menuListStates,
   slotProps: {
     root: buildProps(
-      (tokens: MenuListTokens, theme: Theme) => {
-        console.log(tokens);
-        return {
-          style: {
-            backgroundColor: tokens.backgroundColor,
-            display: 'flex',
-            gap: tokens.gap,
-            ...layoutStyles.from(tokens, theme),
-            ...(Platform.OS === 'android' && { borderRadius: tokens.borderRadius }),
-          },
-        };
-      },
+      (tokens: MenuListTokens, theme: Theme) => ({
+        style: {
+          backgroundColor: tokens.backgroundColor,
+          display: 'flex',
+          gap: tokens.gap,
+          ...layoutStyles.from(tokens, theme),
+          ...(Platform.OS === 'android' && { borderRadius: tokens.borderRadius }),
+        },
+      }),
       ['backgroundColor', 'borderRadius', 'gap', ...layoutStyles.keys],
     ),
     focusZone: buildProps(

--- a/packages/components/Menu/src/MenuList/MenuList.tsx
+++ b/packages/components/Menu/src/MenuList/MenuList.tsx
@@ -3,10 +3,9 @@
 import React from 'react';
 import { Platform, ScrollView, View } from 'react-native';
 
-import type { IViewProps } from '@fluentui-react-native/adapters';
 import { FocusZone } from '@fluentui-react-native/focus-zone';
 import type { UseSlots } from '@fluentui-react-native/framework';
-import { compose, mergeProps, stagedComponent, withSlots } from '@fluentui-react-native/framework';
+import { compose, withSlots } from '@fluentui-react-native/framework';
 
 import { stylingSettings } from './MenuList.styling';
 import type { MenuListProps, MenuListState, MenuListType } from './MenuList.types';
@@ -14,25 +13,6 @@ import { menuListName } from './MenuList.types';
 import { useMenuList } from './useMenuList';
 import { useMenuListContextValue } from './useMenuListContextValue';
 import { MenuListProvider } from '../context/menuListContext';
-
-const MenuStack = stagedComponent((props: React.PropsWithRef<IViewProps> & { gap?: number }) => {
-  const { gap, ...rest } = props;
-  return (final: React.PropsWithRef<IViewProps> & { gap?: number }, children: React.ReactNode) => {
-    if (gap && gap > 0 && children) {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore - GH:1684, fix typing error
-      children = React.Children.map(children, (child: React.ReactChild, index: number) => {
-        if (React.isValidElement(child) && index > 0) {
-          return React.cloneElement(child, mergeProps(child.props, { style: { marginTop: gap } }));
-        }
-        return child;
-      });
-    }
-
-    return <View {...mergeProps(rest, final)}>{children}</View>;
-  };
-});
-MenuStack.displayName = 'MenuStack';
 
 const shouldHaveFocusZone = ['macos', 'win32'].includes(Platform.OS as string);
 const focusLandsOnContainer = Platform.OS === 'macos';
@@ -46,9 +26,9 @@ export const MenuList = compose<MenuListType>({
   displayName: menuListName,
   ...stylingSettings,
   slots: {
-    root: MenuStack,
+    root: View,
     scrollView: ScrollView,
-    focusZone: shouldHaveFocusZone ? FocusZone : React.Fragment,
+    focusZone: shouldHaveFocusZone ? FocusZone : View,
   },
   useRender: (userProps: MenuListProps, useSlots: UseSlots<MenuListType>) => {
     const menuList = useMenuList(userProps);


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

`gap` token wasn't working on MenuList component. Turns out it was being applied to the wrong component, the outer root View which only has one child, instead of the focusZone slot which actually wraps the menu items.

Apply the gap token to the focus zone instead. If no focus zone is present then make it a View.

### Verification

Used the customized Menu test which applies a noticeable gap to the MenuList

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="172" height="133" alt="image" src="https://github.com/user-attachments/assets/657f4fd2-f9bf-4fd0-96d7-bb0a32070ddf" /> | <img width="172" height="148" alt="image" src="https://github.com/user-attachments/assets/00a0a084-5d46-4c1c-966c-55b7de2f5727" /> |

### Pull request checklist

This PR has considered (when applicable):
- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
