### PR TITLE
Export stuff that Button should export

### DIFF
--- a/change/@fluentui-react-native-9e7fcb38-d267-4761-af0a-f5abea037199.json
+++ b/change/@fluentui-react-native-9e7fcb38-d267-4761-af0a-f5abea037199.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Export stuff that Button should export",
+  "packageName": "@fluentui/react-native",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-button-5518c923-49c4-4183-885d-57da9b947083.json
+++ b/change/@fluentui-react-native-button-5518c923-49c4-4183-885d-57da9b947083.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Export stuff that Button should export",
+  "packageName": "@fluentui-react-native/button",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/components/Button/src/index.ts
+++ b/packages/components/Button/src/index.ts
@@ -24,7 +24,7 @@ export type {
   ButtonType,
 } from './Button.types';
 export { buttonName as buttonNameV1 } from './Button.types';
-export { Button as ButtonV1 } from './Button';
+export { Button as ButtonV1, buttonLookup, getFocusBorderStyle } from './Button';
 export { useButton } from './useButton';
 export { CompoundButton, compoundButtonName } from './CompoundButton';
 export type { CompoundButtonProps, CompoundButtonSlotProps, CompoundButtonTokens, CompoundButtonType } from './CompoundButton';

--- a/packages/libraries/core/src/index.ts
+++ b/packages/libraries/core/src/index.ts
@@ -13,6 +13,8 @@ export {
   toggleButtonName,
   useButton,
   useToggleButton,
+  buttonLookup,
+  getFocusBorderStyle,
 } from '@fluentui-react-native/button';
 export type {
   ButtonAppearance,


### PR DESCRIPTION
Fixes #3959

### Description of changes

buttonLookup and getFocusBorderStyles should be exported so that if people decide to customize buttons, they are able to use pieces of the existing FURN logic.