### PR TITLE
Remove bkg ctl subtle selection highlight

### DIFF
--- a/change/@fluentui-react-native-theme-types-232938d2-8f40-43bc-b262-c993de210fda.json
+++ b/change/@fluentui-react-native-theme-types-232938d2-8f40-43bc-b262-c993de210fda.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Remove BkgCtlSubtleSelectionHighlight from palette",
+  "packageName": "@fluentui-react-native/theme-types",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-native-win32-theme-78f7053b-dc87-4616-9c52-f7d912787d14.json
+++ b/change/@fluentui-react-native-win32-theme-78f7053b-dc87-4616-9c52-f7d912787d14.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Remove BkgCtlSubtleSelectionHighlight from palette",
+  "packageName": "@fluentui-react-native/win32-theme",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/theming/theme-types/src/palette.types.ts
+++ b/packages/theming/theme-types/src/palette.types.ts
@@ -117,7 +117,6 @@ export interface OfficePalette {
   BkgCtlSubtleHover: ColorValue;
   BkgCtlSubtlePressed: ColorValue;
   BkgCtlSubtleDisabled: ColorValue;
-  BkgCtlSubtleSelectionHighlight: ColorValue;
 
   // text
   TextCtlSubtle: ColorValue;

--- a/packages/theming/win32-theme/src/NativeModule/fallbackOfficeModule.ts
+++ b/packages/theming/win32-theme/src/NativeModule/fallbackOfficeModule.ts
@@ -67,7 +67,6 @@ const whiteColorsPalette: OfficePalette = {
   BkgCtlSubtleHover: '#FFFFFF',
   BkgCtlSubtlePressed: '#FFFFFF',
   BkgCtlSubtleDisabled: '#F3F3F3',
-  BkgCtlSubtleSelectionHighlight: '#7DA3C6',
   TextCtlSubtle: '#262626',
   TextCtlSubtlePlaceholder: '#666666',
   TextCtlSubtleHover: '#262626',


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [ ] windows
- [ ] android

### Description of changes

Swatch is being removed from palette. Remove from our own def.

### Verification

Swatch is not used in any partner codebases.