### PR TITLE
Remove overflow hidden from Button for Win32/Windows

### DIFF
--- a/.changeset/late-rules-think.md
+++ b/.changeset/late-rules-think.md
@@ -1,0 +1,5 @@
+---
+"@fluentui-react-native/button": patch
+---
+
+Remove overflow hidden from FURN button for windows

--- a/.changeset/small-spiders-pull.md
+++ b/.changeset/small-spiders-pull.md
@@ -1,0 +1,5 @@
+---
+"@fluentui-react-native/tooltip": patch
+---
+
+Update snapshot

--- a/packages/components/Button/src/Button.styling.ts
+++ b/packages/components/Button/src/Button.styling.ts
@@ -33,6 +33,8 @@ export const buttonStates: (keyof ButtonTokens)[] = [
   'disabled',
 ];
 
+const applyOverflowHiddenToRoot = Platform.OS === 'ios' || Platform.OS === 'macos';
+
 export const stylingSettings: UseStylingOptions<ButtonProps, ButtonSlotProps, ButtonTokens> = {
   tokens: [defaultButtonTokens, defaultButtonFontTokens, defaultButtonColorTokens, buttonName],
   states: buttonStates,
@@ -58,7 +60,7 @@ export const stylingSettings: UseStylingOptions<ButtonProps, ButtonSlotProps, Bu
       (tokens: ButtonTokens, theme: Theme) => ({
         style: {
           display: 'flex',
-          overflow: 'hidden',
+          overflow: applyOverflowHiddenToRoot ? 'hidden' : undefined,
           alignItems: 'center',
           flexDirection: 'row',
           alignSelf: 'flex-start',

--- a/packages/experimental/Tooltip/src/__tests__/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/experimental/Tooltip/src/__tests__/__snapshots__/Tooltip.test.tsx.snap
@@ -66,7 +66,7 @@ exports[`Tooltip component tests Tooltip default 1`] = `
         "justifyContent": "center",
         "minHeight": 24,
         "minWidth": 64,
-        "overflow": "hidden",
+        "overflow": undefined,
         "padding": 3,
         "paddingHorizontal": 7,
         "width": undefined,


### PR DESCRIPTION
### Platforms Impacted

- [ ] iOS
- [ ] macOS
- [x] win32 (Office)
- [x] windows
- [x] android

### Description of changes

Turns out adding overflow hidden to all our Buttons is a perf problem for win32. So removing the property from win32 (and windows, in case they have a similar issue).

### Verification

Tested the button in the win32 app. Corners look fine, double focus border also looks fine

### Pull request checklist

This PR has considered (when applicable):

- [ ] Automated Tests
- [ ] Documentation and examples
- [ ] Keyboard Accessibility
- [ ] Voiceover
- [ ] Internationalization and Right-to-left Layouts
