### PR TITLE
Fix PR gate job to fail when upstream jobs fail

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -385,6 +385,7 @@ jobs:
 
   pr:
     name: PR
+    if: always()
     runs-on: ubuntu-latest
     needs:
       - js
@@ -398,5 +399,10 @@ jobs:
       - publish-dry-run
       - test-links
     steps:
+      - name: Check for failures or cancellations
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "One or more required jobs failed or were cancelled."
+          exit 1
       - name: All required jobs passed
-        run: echo "All required jobs completed."
+        run: echo "All required jobs completed successfully."

--- a/packages/components/Button/src/__snapshots__/Button.test.tsx.snap
+++ b/packages/components/Button/src/__snapshots__/Button.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`Button component tests Button circular 1`] = `
 <View
+  accessibilityLabel="Circular Button"
   accessibilityRole="button"
   accessibilityState={
     {

--- a/packages/components/Button/src/__snapshots__/Button.test.tsx.snap
+++ b/packages/components/Button/src/__snapshots__/Button.test.tsx.snap
@@ -2,7 +2,6 @@
 
 exports[`Button component tests Button circular 1`] = `
 <View
-  accessibilityLabel="Circular Button"
   accessibilityRole="button"
   accessibilityState={
     {


### PR DESCRIPTION
## Summary

- The `pr` gate job is the only required status check in the repo's ruleset for merging to `main`
- Without `if: always()`, when any dependency job (e.g. `JS PR`) fails, the gate job gets **skipped** — and GitHub treats `SKIPPED` as passing for required checks
- This allowed PR #4087 to merge despite `JS PR` failing
- Adds `if: always()` so the gate job always runs, plus an explicit check that fails the job when any dependency failed or was cancelled

## Test plan

- [ ] Verify that when all jobs pass, the `PR` gate job still passes
- [ ] Verify that when any job fails (e.g. `JS PR`), the `PR` gate job now **fails** instead of being skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)