### PR TITLE
fix: Publish stage always skipped due to boolean expression mismatch in publish pipeline

### DIFF
--- a/.ado/azure-pipelines.publish.yml
+++ b/.ado/azure-pipelines.publish.yml
@@ -90,7 +90,7 @@ extends:
       - stage: Publish
         displayName: Publish to NPM
         dependsOn: Build
-        condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'), not(${{ parameters.skipNpmPublish }}), eq(stageDependencies.Build.BuildAndPack.outputs['check.hasTarballs'], 'true'))
+        condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'), ne('${{ parameters.skipNpmPublish }}', 'true'), eq(stageDependencies.Build.BuildAndPack.outputs['check.hasTarballs'], 'true'))
         jobs:
           - job: PublishPackages
             displayName: Publish NPM Packages


### PR DESCRIPTION
## Problem

The **Publish to NPM** stage in `azure-pipelines.publish.yml` is always skipped, even when there are tarballs and `skipNpmPublish` is `false`.

## Root Cause

The stage condition uses:

```yaml
not(${{ parameters.skipNpmPublish }})
```

This mixes **compile-time** template expansion (`${{ }}`) with a **runtime** expression function (`not()`).

At compile time, `${{ parameters.skipNpmPublish }}` expands to the YAML boolean string `False` (capital F). In Azure DevOps **runtime expressions**, `False` is not the boolean keyword `false` — it's a **non-empty string**, which is always **truthy**. So `not(truthy)` → `false`, and the entire `and(...)` short-circuits to `false`.

This happens regardless of the parameter value — both `True` and `False` are non-empty strings, both truthy, both negated to `false`.

## Fix

Replace `not(${{ parameters.skipNpmPublish }})` with:

```yaml
ne('${{ parameters.skipNpmPublish }}', 'true')
```

This uses `ne()` (not-equal) with a **string comparison**. Azure DevOps `ne()` is case-insensitive for strings, so:

| Parameter value | Expansion | Comparison | Result |
|---|---|---|---|
| `false` (default) | `ne('False', 'true')` | not equal | ✅ **true** — stage runs |
| `true` | `ne('True', 'true')` | equal | ✅ **false** — stage skipped |