### PR TITLE
fix: Publish stage skipped due to broken stageDependencies output variable in 1ES template

### DIFF
--- a/.ado/azure-pipelines.publish.yml
+++ b/.ado/azure-pipelines.publish.yml
@@ -79,18 +79,12 @@ extends:
 
               - script: |
                   ls -la $(System.DefaultWorkingDirectory)/_packed/
-                  if ls $(System.DefaultWorkingDirectory)/_packed/*.tgz > /dev/null 2>&1; then
-                    echo "##vso[task.setvariable variable=hasTarballs;isOutput=true]true"
-                  else
-                    echo "##vso[task.setvariable variable=hasTarballs;isOutput=true]false"
-                  fi
-                name: check
                 displayName: 'List packed tarballs'
 
       - stage: Publish
         displayName: Publish to NPM
         dependsOn: Build
-        condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'), ne('${{ parameters.skipNpmPublish }}', 'true'), eq(stageDependencies.Build.BuildAndPack.outputs['check.hasTarballs'], 'true'))
+        condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'), ne('${{ parameters.skipNpmPublish }}', 'true'))
         jobs:
           - job: PublishPackages
             displayName: Publish NPM Packages
@@ -113,11 +107,18 @@ extends:
               - script: |
                   echo "Downloaded tarballs:"
                   ls -la $(System.DefaultWorkingDirectory)/_packed/
-                displayName: 'List downloaded tarballs'
+                  if ls $(System.DefaultWorkingDirectory)/_packed/*.tgz > /dev/null 2>&1; then
+                    echo "##vso[task.setvariable variable=hasTarballs]true"
+                  else
+                    echo "No tarballs found — nothing to publish."
+                    echo "##vso[task.setvariable variable=hasTarballs]false"
+                  fi
+                displayName: 'Check downloaded tarballs'
 
               - script: |
                   yarn
                 displayName: 'yarn install'
+                condition: eq(variables['hasTarballs'], 'true')
 
               - script: |
                   yarn config set npmPublishAccess public
@@ -125,12 +126,14 @@ extends:
                   yarn config set npmAuthToken $(npmAuth)
                   npm config set //registry.npmjs.org/:_authToken $(npmAuth)
                 displayName: 'Configure npm publishing auth'
+                condition: eq(variables['hasTarballs'], 'true')
 
               - script: |
                   # https://github.com/changesets/changesets/issues/432
                   # We can't use `changeset publish` because it doesn't support workspaces, so we have to publish each package individually
                   yarn lage publish --verbose --grouped --reporter azureDevops
                 displayName: 'Publish NPM Packages'
+                condition: eq(variables['hasTarballs'], 'true')
 
               - script: |
                   yarn config unset npmPublishAccess


### PR DESCRIPTION
## Follow-up to #4093

PR #4093 fixed the `not(${{ parameters.skipNpmPublish }})` compile-time/runtime boolean mismatch, but the Publish stage is still being skipped.

## Root Cause

The remaining issue is the `stageDependencies` output variable reference:

```yaml
eq(stageDependencies.Build.BuildAndPack.outputs['check.hasTarballs'], 'true')
```

Under **1ES Pipeline Templates**, `templateContext.outputs` restructures the job internally. This breaks the `stageDependencies` reference path — the output variable resolves to empty, so `eq('', 'true')` → `false`, and the stage is always skipped.

## Fix

1. **Remove the cross-stage output variable dependency** from the stage condition. The simplified condition is now:

    ```yaml
    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'), ne('${{ parameters.skipNpmPublish }}', 'true'))
    ```

2. **Move the tarball check into the Publish job** — after downloading the artifact, verify tarballs exist and fail early with a clear error if they don't:

    ```yaml
    - script: |
        echo "Downloaded tarballs:"
        ls -la $(System.DefaultWorkingDirectory)/_packed/
        if ! ls $(System.DefaultWorkingDirectory)/_packed/*.tgz > /dev/null 2>&1; then
          echo "##vso[task.logissue type=error]No tarballs found in _packed/"
          exit 1
        fi
      displayName: 'Verify downloaded tarballs'
    ```

This is more robust than relying on cross-stage output variables through the 1ES template layer.