### PR TITLE
fix(multi): Packages using the jsx-runtime should have @fluentui-react-native/framework-base as a dependency

### DIFF
--- a/.changeset/eighty-stamps-stare.md
+++ b/.changeset/eighty-stamps-stare.md
@@ -1,0 +1,31 @@
+---
+"@fluentui-react-native/experimental-activity-indicator": patch
+"@fluentui-react-native/contextual-menu": patch
+"@fluentui-react-native/notification": patch
+"@fluentui-react-native/experimental-menu-button": patch
+"@fluentui-react-native/persona-coin": patch
+"@fluentui-react-native/menu-button": patch
+"@fluentui-react-native/radio-group": patch
+"@fluentui-react-native/experimental-checkbox": patch
+"@fluentui-react-native/dropdown": patch
+"@fluentui-react-native/experimental-expander": patch
+"@fluentui-react-native/separator": patch
+"@fluentui-react-native/popover": patch
+"@fluentui-react-native/experimental-shimmer": patch
+"@fluentui-react-native/spinner": patch
+"@fluentui-react-native/checkbox": patch
+"@fluentui-react-native/experimental-avatar": patch
+"@fluentui-react-native/drawer": patch
+"@fluentui-react-native/divider": patch
+"@fluentui-react-native/persona": patch
+"@fluentui-react-native/tablist": patch
+"@fluentui-react-native/avatar": patch
+"@fluentui-react-native/button": patch
+"@fluentui-react-native/input": patch
+"@fluentui-react-native/stack": patch
+"@fluentui-react-native/chip": patch
+"@fluentui-react-native/link": patch
+"@fluentui-react-native/text": patch
+---
+
+Add missing dependency on framework-base

--- a/.github/scripts/change.mts
+++ b/.github/scripts/change.mts
@@ -2,7 +2,9 @@
 // @ts-ignore
 import { parseArgs, styleText } from 'node:util';
 
-import { $, echo, fs } from 'zx';
+import { $, echo, fs, quote } from 'zx';
+
+$.quote = quote;
 
 /**
  * Wrapper around `changeset add` (default) and `changeset status` validation (--check).

--- a/packages/components/Avatar/package.json
+++ b/packages/components/Avatar/package.json
@@ -35,6 +35,7 @@
     "@fluentui-react-native/adapters": "workspace:*",
     "@fluentui-react-native/badge": "workspace:*",
     "@fluentui-react-native/framework": "workspace:*",
+    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/icon": "workspace:*",
     "@fluentui-react-native/theme-tokens": "workspace:*",
     "@fluentui-react-native/theming-utils": "workspace:*",
@@ -44,7 +45,6 @@
   },
   "devDependencies": {
     "@babel/core": "catalog:",
-    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@office-iss/react-native-win32": "^0.81.8",
     "@react-native-community/cli": "^20.0.0",

--- a/packages/components/Button/package.json
+++ b/packages/components/Button/package.json
@@ -36,6 +36,7 @@
     "@fluentui-react-native/experimental-activity-indicator": "workspace:*",
     "@fluentui-react-native/experimental-shadow": "workspace:*",
     "@fluentui-react-native/framework": "workspace:*",
+    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/icon": "workspace:*",
     "@fluentui-react-native/interactive-hooks": "workspace:*",
     "@fluentui-react-native/pressable": "workspace:*",
@@ -52,7 +53,6 @@
   },
   "devDependencies": {
     "@babel/core": "catalog:",
-    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",
     "@office-iss/react-native-win32": "^0.81.8",

--- a/packages/components/Checkbox/package.json
+++ b/packages/components/Checkbox/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@fluentui-react-native/adapters": "workspace:*",
     "@fluentui-react-native/framework": "workspace:*",
+    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/interactive-hooks": "workspace:*",
     "@fluentui-react-native/pressable": "workspace:*",
     "@fluentui-react-native/styling-utils": "workspace:*",
@@ -48,7 +49,6 @@
   },
   "devDependencies": {
     "@babel/core": "catalog:",
-    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",
     "@office-iss/react-native-win32": "^0.81.8",

--- a/packages/components/Chip/package.json
+++ b/packages/components/Chip/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@fluentui-react-native/adapters": "workspace:*",
     "@fluentui-react-native/framework": "workspace:*",
+    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/icon": "workspace:*",
     "@fluentui-react-native/interactive-hooks": "workspace:*",
     "@fluentui-react-native/text": "workspace:*",
@@ -37,7 +38,6 @@
   },
   "devDependencies": {
     "@babel/core": "catalog:",
-    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",
     "@fluentui-react-native/use-styling": "workspace:*",

--- a/packages/components/ContextualMenu/package.json
+++ b/packages/components/ContextualMenu/package.json
@@ -35,6 +35,7 @@
     "@fluentui-react-native/adapters": "workspace:*",
     "@fluentui-react-native/callout": "workspace:*",
     "@fluentui-react-native/focus-zone": "workspace:*",
+    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/icon": "workspace:*",
     "@fluentui-react-native/interactive-hooks": "workspace:*",
     "@fluentui-react-native/text": "workspace:*",
@@ -45,7 +46,6 @@
   },
   "devDependencies": {
     "@babel/core": "catalog:",
-    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/pressable": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@office-iss/react-native-win32": "^0.81.8",

--- a/packages/components/Divider/package.json
+++ b/packages/components/Divider/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@fluentui-react-native/framework": "workspace:*",
+    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/icon": "workspace:*",
     "@fluentui-react-native/text": "workspace:*",
     "@fluentui-react-native/theme-tokens": "workspace:*",
@@ -39,7 +40,6 @@
   },
   "devDependencies": {
     "@babel/core": "catalog:",
-    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",
     "@office-iss/react-native-win32": "^0.81.8",

--- a/packages/components/Input/package.json
+++ b/packages/components/Input/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@fluentui-react-native/framework": "workspace:*",
+    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/icon": "workspace:*",
     "@fluentui-react-native/interactive-hooks": "workspace:*",
     "@fluentui-react-native/styling-utils": "workspace:*",
@@ -42,7 +43,6 @@
   },
   "devDependencies": {
     "@babel/core": "catalog:",
-    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",
     "@react-native-community/cli": "^20.0.0",

--- a/packages/components/Link/package.json
+++ b/packages/components/Link/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@fluentui-react-native/adapters": "workspace:*",
     "@fluentui-react-native/framework": "workspace:*",
+    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/interactive-hooks": "workspace:*",
     "@fluentui-react-native/text": "workspace:*",
     "@fluentui-react-native/tokens": "workspace:*",
@@ -43,7 +44,6 @@
   },
   "devDependencies": {
     "@babel/core": "catalog:",
-    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",
     "@react-native-community/cli": "^20.0.0",

--- a/packages/components/MenuButton/package.json
+++ b/packages/components/MenuButton/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@fluentui-react-native/button": "workspace:*",
     "@fluentui-react-native/contextual-menu": "workspace:*",
+    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/icon": "workspace:*",
     "@fluentui-react-native/tokens": "workspace:*",
     "@uifabricshared/foundation-composable": "workspace:*",
@@ -42,7 +43,6 @@
   },
   "devDependencies": {
     "@babel/core": "catalog:",
-    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@office-iss/react-native-win32": "^0.81.8",
     "@react-native-community/cli": "^20.0.0",

--- a/packages/components/Notification/package.json
+++ b/packages/components/Notification/package.json
@@ -36,6 +36,7 @@
     "@fluentui-react-native/experimental-appearance-additions": "workspace:*",
     "@fluentui-react-native/experimental-shadow": "workspace:*",
     "@fluentui-react-native/framework": "workspace:*",
+    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/icon": "workspace:*",
     "@fluentui-react-native/interactive-hooks": "workspace:*",
     "@fluentui-react-native/pressable": "workspace:*",
@@ -47,7 +48,6 @@
   },
   "devDependencies": {
     "@babel/core": "catalog:",
-    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",
     "@office-iss/react-native-win32": "^0.81.8",

--- a/packages/components/Persona/package.json
+++ b/packages/components/Persona/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@fluentui-react-native/adapters": "workspace:*",
     "@fluentui-react-native/framework": "workspace:*",
+    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/persona-coin": "workspace:*",
     "@fluentui-react-native/tokens": "workspace:*",
     "@uifabricshared/foundation-composable": "workspace:*",
@@ -42,7 +43,6 @@
   },
   "devDependencies": {
     "@babel/core": "catalog:",
-    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native-community/cli": "^20.0.0",
     "@react-native-community/cli-platform-android": "^20.0.0",

--- a/packages/components/PersonaCoin/package.json
+++ b/packages/components/PersonaCoin/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@fluentui-react-native/adapters": "workspace:*",
     "@fluentui-react-native/framework": "workspace:*",
+    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/theme-tokens": "workspace:*",
     "@fluentui-react-native/tokens": "workspace:*",
     "@uifabricshared/foundation-composable": "workspace:*",
@@ -42,7 +43,6 @@
   },
   "devDependencies": {
     "@babel/core": "catalog:",
-    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@office-iss/react-native-win32": "^0.81.8",
     "@react-native-community/cli": "^20.0.0",

--- a/packages/components/RadioGroup/package.json
+++ b/packages/components/RadioGroup/package.json
@@ -35,6 +35,7 @@
     "@fluentui-react-native/adapters": "workspace:*",
     "@fluentui-react-native/focus-zone": "workspace:*",
     "@fluentui-react-native/framework": "workspace:*",
+    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/interactive-hooks": "workspace:*",
     "@fluentui-react-native/pressable": "workspace:*",
     "@fluentui-react-native/text": "workspace:*",
@@ -47,7 +48,6 @@
   },
   "devDependencies": {
     "@babel/core": "catalog:",
-    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",
     "@office-iss/react-native-win32": "^0.81.8",

--- a/packages/components/Separator/package.json
+++ b/packages/components/Separator/package.json
@@ -32,12 +32,12 @@
   },
   "dependencies": {
     "@fluentui-react-native/framework": "workspace:*",
+    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/theme-tokens": "workspace:*",
     "@fluentui-react-native/use-styling": "workspace:*"
   },
   "devDependencies": {
     "@babel/core": "catalog:",
-    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@office-iss/react-native-win32": "^0.81.8",
     "@react-native-community/cli": "^20.0.0",

--- a/packages/components/Stack/package.json
+++ b/packages/components/Stack/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@fluentui-react-native/adapters": "workspace:*",
     "@fluentui-react-native/framework": "workspace:*",
+    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/tokens": "workspace:*",
     "@uifabricshared/foundation-composable": "workspace:*",
     "@uifabricshared/foundation-compose": "workspace:*",
@@ -41,7 +42,6 @@
   },
   "devDependencies": {
     "@babel/core": "catalog:",
-    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/text": "workspace:*",
     "@react-native-community/cli": "^20.0.0",

--- a/packages/components/TabList/package.json
+++ b/packages/components/TabList/package.json
@@ -34,6 +34,7 @@
     "@fluentui-react-native/adapters": "workspace:*",
     "@fluentui-react-native/focus-zone": "workspace:*",
     "@fluentui-react-native/framework": "workspace:*",
+    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/icon": "workspace:*",
     "@fluentui-react-native/interactive-hooks": "workspace:*",
     "@fluentui-react-native/text": "workspace:*",
@@ -43,7 +44,6 @@
   },
   "devDependencies": {
     "@babel/core": "catalog:",
-    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",
     "@office-iss/react-native-win32": "^0.81.8",

--- a/packages/components/Text/package.json
+++ b/packages/components/Text/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@fluentui-react-native/adapters": "workspace:*",
     "@fluentui-react-native/framework": "workspace:*",
+    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/interactive-hooks": "workspace:*",
     "@fluentui-react-native/theme-tokens": "workspace:*",
     "@fluentui-react-native/tokens": "workspace:*",
@@ -40,7 +41,6 @@
   },
   "devDependencies": {
     "@babel/core": "catalog:",
-    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",
     "@react-native-community/cli": "^20.0.0",

--- a/packages/experimental/ActivityIndicator/package.json
+++ b/packages/experimental/ActivityIndicator/package.json
@@ -32,11 +32,11 @@
   },
   "dependencies": {
     "@fluentui-react-native/framework": "workspace:*",
+    "@fluentui-react-native/framework-base": "workspace:*",
     "assert-never": "^1.2.1"
   },
   "devDependencies": {
     "@babel/core": "catalog:",
-    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native-community/cli": "^20.0.0",
     "@react-native-community/cli-platform-android": "^20.0.0",

--- a/packages/experimental/Avatar/package.json
+++ b/packages/experimental/Avatar/package.json
@@ -32,11 +32,11 @@
     "update-snapshots": "fluentui-scripts jest -u"
   },
   "dependencies": {
-    "@fluentui-react-native/framework": "workspace:*"
+    "@fluentui-react-native/framework": "workspace:*",
+    "@fluentui-react-native/framework-base": "workspace:*"
   },
   "devDependencies": {
     "@babel/core": "catalog:",
-    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native-community/cli": "^20.0.0",
     "@react-native-community/cli-platform-android": "^20.0.0",

--- a/packages/experimental/Checkbox/package.json
+++ b/packages/experimental/Checkbox/package.json
@@ -32,11 +32,11 @@
   },
   "dependencies": {
     "@fluentui-react-native/checkbox": "workspace:*",
-    "@fluentui-react-native/framework": "workspace:*"
+    "@fluentui-react-native/framework": "workspace:*",
+    "@fluentui-react-native/framework-base": "workspace:*"
   },
   "devDependencies": {
     "@babel/core": "catalog:",
-    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@office-iss/react-native-win32": "^0.81.8",
     "@react-native-community/cli": "^20.0.0",

--- a/packages/experimental/Drawer/package.json
+++ b/packages/experimental/Drawer/package.json
@@ -32,13 +32,13 @@
   },
   "dependencies": {
     "@fluentui-react-native/framework": "workspace:*",
+    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/interactive-hooks": "workspace:*",
     "@fluentui-react-native/theme-tokens": "workspace:*",
     "@fluentui-react-native/use-styling": "workspace:*"
   },
   "devDependencies": {
     "@babel/core": "catalog:",
-    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native-community/cli": "^20.0.0",
     "@react-native-community/cli-platform-android": "^20.0.0",

--- a/packages/experimental/Dropdown/package.json
+++ b/packages/experimental/Dropdown/package.json
@@ -35,13 +35,13 @@
     "@fluentui-react-native/button": "workspace:*",
     "@fluentui-react-native/callout": "workspace:*",
     "@fluentui-react-native/framework": "workspace:*",
+    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/interactive-hooks": "workspace:*",
     "@fluentui-react-native/text": "workspace:*",
     "@fluentui-react-native/theme-tokens": "workspace:*"
   },
   "devDependencies": {
     "@babel/core": "catalog:",
-    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@fluentui-react-native/test-tools": "workspace:*",
     "@react-native-community/cli": "^20.0.0",

--- a/packages/experimental/Expander/package.json
+++ b/packages/experimental/Expander/package.json
@@ -34,11 +34,11 @@
     "windows": "react-native run-windows"
   },
   "dependencies": {
-    "@fluentui-react-native/framework": "workspace:*"
+    "@fluentui-react-native/framework": "workspace:*",
+    "@fluentui-react-native/framework-base": "workspace:*"
   },
   "devDependencies": {
     "@babel/core": "catalog:",
-    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native-community/cli": "^20.0.0",
     "@react-native-community/cli-platform-android": "^20.0.0",

--- a/packages/experimental/MenuButton/package.json
+++ b/packages/experimental/MenuButton/package.json
@@ -34,11 +34,11 @@
     "@fluentui-react-native/button": "workspace:*",
     "@fluentui-react-native/contextual-menu": "workspace:*",
     "@fluentui-react-native/framework": "workspace:*",
+    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/tokens": "workspace:*"
   },
   "devDependencies": {
     "@babel/core": "catalog:",
-    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@office-iss/react-native-win32": "^0.81.8",
     "@react-native-community/cli": "^20.0.0",

--- a/packages/experimental/Popover/package.json
+++ b/packages/experimental/Popover/package.json
@@ -32,11 +32,11 @@
   },
   "dependencies": {
     "@fluentui-react-native/adapters": "workspace:*",
-    "@fluentui-react-native/framework": "workspace:*"
+    "@fluentui-react-native/framework": "workspace:*",
+    "@fluentui-react-native/framework-base": "workspace:*"
   },
   "devDependencies": {
     "@babel/core": "catalog:",
-    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native-community/cli": "^20.0.0",
     "@react-native-community/cli-platform-android": "^20.0.0",

--- a/packages/experimental/Shimmer/package.json
+++ b/packages/experimental/Shimmer/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@fluentui-react-native/framework": "workspace:*",
+    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/theming-utils": "workspace:*",
     "@fluentui-react-native/tokens": "workspace:*",
     "@fluentui-react-native/use-styling": "workspace:*",
@@ -39,7 +40,6 @@
   },
   "devDependencies": {
     "@babel/core": "catalog:",
-    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native-community/cli": "^20.0.0",
     "@react-native-community/cli-platform-android": "^20.0.0",

--- a/packages/experimental/Spinner/package.json
+++ b/packages/experimental/Spinner/package.json
@@ -32,13 +32,13 @@
   },
   "dependencies": {
     "@fluentui-react-native/framework": "workspace:*",
+    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/text": "workspace:*",
     "@fluentui-react-native/theme-tokens": "workspace:*",
     "@fluentui-react-native/use-styling": "workspace:*"
   },
   "devDependencies": {
     "@babel/core": "catalog:",
-    "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/scripts": "workspace:*",
     "@react-native-community/cli": "^20.0.0",
     "@react-native-community/cli-platform-android": "^20.0.0",


### PR DESCRIPTION
### Platforms Impacted

- all

### Description of changes

Packages using the jsx-runtime are referencing framework-base but that was only included as a devDependency. It is in the dependency chain but in many cases that is not sufficient to resolve it correctly.

This updates the dependencies to be correct.

There was also an issue with the change command where it wasn't working correctly on windows. I fixed that as part of this change.

### Verification

Tests