### PR TITLE
Set attributes so that autocrlf behavior doesn't turn on

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
 # Set the default line ending behavior for text, in case people don't have core.autocrlf set.
-* text=auto
+* text=auto eol=lf
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
 *.pbxproj -text


### PR DESCRIPTION
### Platforms Impacted

- windows development

### Description of changes

This ensures that autocrlf behavior doesn't turn on in the case that your windows git configuration has that set. The repo should use LF everywhere (except .bat/.cmd/.ps1 files)

