### PR TITLE
Add named text size/weight lookups to @furn/design and switch Text component to use them

### DIFF
--- a/.changeset/spicy-camels-kick.md
+++ b/.changeset/spicy-camels-kick.md
@@ -1,0 +1,7 @@
+---
+"@fluentui-react-native/dependency-profiles": patch
+"@fluentui-react-native/text": patch
+"@fluentui-react-native/design": patch
+---
+
+Add central font size/weight lookup by name to design package and consume in Text.tsx

--- a/packages/agentic-design/src/concepts/textAttributes.ts
+++ b/packages/agentic-design/src/concepts/textAttributes.ts
@@ -1,0 +1,72 @@
+import {
+  fontSize100,
+  fontSize200,
+  fontSize300,
+  fontSize400,
+  fontSize500,
+  fontSize600,
+  fontSize700,
+  fontSize800,
+  fontSize900,
+  fontSize1000,
+  fontWeightSemibold,
+  fontWeightRegular,
+  fontWeightMedium,
+  fontWeightBold,
+} from '../tokens/global.generated';
+
+/**
+ * Represents the available font sizes for this platform. Available via key lookup
+ */
+export type FontSize = 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | 1000;
+
+/**
+ * Represents the available font weights for this platform. Available via key lookup
+ */
+export type FontWeight = 'bold' | 'medium' | 'regular' | 'semibold';
+
+/**
+ * Get the size value associated with a named font size for this platform
+ * @param size The font size key to retrieve from the FONT_SIZES mapping.
+ * @param defaultSize The default font size key to use if the specified size is not found.
+ * @returns The corresponding font size value from the FONT_SIZES mapping.
+ */
+export const fontSize = (() => {
+  let fontSizes: Record<FontSize, number>;
+  return (size: FontSize, defaultSize: FontSize = 300) => {
+    // initialize fontSizes one time when used
+    fontSizes ??= {
+      100: fontSize100,
+      200: fontSize200,
+      300: fontSize300,
+      400: fontSize400,
+      500: fontSize500,
+      600: fontSize600,
+      700: fontSize700,
+      800: fontSize800,
+      900: fontSize900,
+      1000: fontSize1000,
+    };
+    return fontSizes[size] ?? fontSizes[defaultSize];
+  };
+})();
+
+/**
+ * Get the weight value associated with a named font weight for this platform
+ * @param weight The font weight key to retrieve from the FONT_WEIGHTS mapping.
+ * @param defaultWeight The default font weight key to use if the specified weight is not found.
+ * @returns The corresponding font weight value from the FONT_WEIGHTS mapping.
+ */
+export const fontWeight = (() => {
+  let fontWeights: Record<FontWeight, string>;
+  return (weight: FontWeight, defaultWeight: FontWeight = 'regular') => {
+    // initialize fontWeights one time when used
+    fontWeights ??= {
+      bold: fontWeightBold,
+      medium: fontWeightMedium,
+      regular: fontWeightRegular,
+      semibold: fontWeightSemibold,
+    };
+    return fontWeights[weight] ?? fontWeights[defaultWeight];
+  };
+})();

--- a/packages/agentic-design/src/index.ts
+++ b/packages/agentic-design/src/index.ts
@@ -1,0 +1,2 @@
+export type { FontSize, FontWeight } from './concepts/textAttributes';
+export { fontSize, fontWeight } from './concepts/textAttributes';

--- a/packages/components/Text/package.json
+++ b/packages/components/Text/package.json
@@ -31,10 +31,10 @@
   },
   "dependencies": {
     "@fluentui-react-native/adapters": "workspace:*",
+    "@fluentui-react-native/design": "workspace:*",
     "@fluentui-react-native/framework": "workspace:*",
     "@fluentui-react-native/framework-base": "workspace:*",
     "@fluentui-react-native/interactive-hooks": "workspace:*",
-    "@fluentui-react-native/theme-tokens": "workspace:*",
     "@fluentui-react-native/tokens": "workspace:*",
     "@uifabricshared/foundation-compose": "workspace:*"
   },

--- a/packages/components/Text/src/Text.tsx
+++ b/packages/components/Text/src/Text.tsx
@@ -6,7 +6,7 @@ import type { UseTokens, FontWeightValue } from '@fluentui-react-native/framewor
 import { fontStyles, useFluentTheme, compressible, patchTokens } from '@fluentui-react-native/framework';
 import { mergeStyles } from '@fluentui-react-native/framework-base';
 import { useKeyProps } from '@fluentui-react-native/interactive-hooks';
-import { globalTokens } from '@fluentui-react-native/theme-tokens';
+import { fontSize, fontWeight } from '@fluentui-react-native/design';
 
 import type { TextProps, TextTokens } from './Text.types';
 import { textName } from './Text.types';
@@ -84,8 +84,8 @@ export const Text = compressible<TextProps, TextTokens>((props: TextProps, useTo
     variant,
     fontFamily: font == 'base' ? 'primary' : font,
     fontMaximumSize: tokens.maximumFontSize,
-    fontSize: globalTokens.font['size' + size],
-    fontWeight: globalTokens.font.weight[weight] as FontWeightValue,
+    fontSize: size !== undefined ? fontSize(size) : undefined,
+    fontWeight: weight !== undefined ? (fontWeight(weight) as FontWeightValue) : undefined,
     // leave it undefined for tokens to be set by user
     fontStyle: italic ? 'italic' : undefined,
     textAlign: textAlign,

--- a/packages/components/Text/src/Text.types.ts
+++ b/packages/components/Text/src/Text.types.ts
@@ -1,6 +1,7 @@
 import type { ColorValue, Text, TextStyle } from 'react-native';
 
 import type { ITextProps } from '@fluentui-react-native/adapters';
+import type { FontSize, FontWeight } from '@fluentui-react-native/design';
 import type { FontTokens, FontVariantTokens, IForegroundColorTokens } from '@fluentui-react-native/framework';
 
 export const textName = 'Text';
@@ -27,8 +28,8 @@ export type TextTokens = Omit<FontTokens, 'fontFamily'> &
 
 export type TextAlign = 'start' | 'center' | 'end' | 'justify';
 export type TextFont = 'base' | 'monospace' | 'numeric';
-export type TextSize = 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | 1000;
-export type TextWeight = 'regular' | 'medium' | 'semibold' | 'bold';
+export type TextSize = FontSize;
+export type TextWeight = FontWeight;
 
 /**
  * Text props, based off of the standard react-native TextProps with some new extensions

--- a/packages/components/Text/tsconfig.json
+++ b/packages/components/Text/tsconfig.json
@@ -12,6 +12,9 @@
       "path": "../../utils/adapters/tsconfig.json"
     },
     {
+      "path": "../../agentic-design/tsconfig.json"
+    },
+    {
       "path": "../../framework-base/tsconfig.json"
     },
     {
@@ -25,9 +28,6 @@
     },
     {
       "path": "../../utils/test-tools/tsconfig.json"
-    },
-    {
-      "path": "../../theming/theme-tokens/tsconfig.json"
     },
     {
       "path": "../../utils/tokens/tsconfig.json"

--- a/packages/dependency-profiles/src/index.js
+++ b/packages/dependency-profiles/src/index.js
@@ -6,6 +6,10 @@ module.exports = {
       "name": "@fluentui-react-native/tester",
       "version": "0.170.53"
     },
+    "@fluentui-react-native/design": {
+      "name": "@fluentui-react-native/design",
+      "version": "0.1.0"
+    },
     "@fluentui-react-native/avatar": {
       "name": "@fluentui-react-native/avatar",
       "version": "1.13.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5392,12 +5392,12 @@ __metadata:
   dependencies:
     "@babel/core": "catalog:"
     "@fluentui-react-native/adapters": "workspace:*"
+    "@fluentui-react-native/design": "workspace:*"
     "@fluentui-react-native/framework": "workspace:*"
     "@fluentui-react-native/framework-base": "workspace:*"
     "@fluentui-react-native/interactive-hooks": "workspace:*"
     "@fluentui-react-native/scripts": "workspace:*"
     "@fluentui-react-native/test-tools": "workspace:*"
-    "@fluentui-react-native/theme-tokens": "workspace:*"
     "@fluentui-react-native/tokens": "workspace:*"
     "@react-native-community/cli": "npm:^20.0.0"
     "@react-native-community/cli-platform-android": "npm:^20.0.0"


### PR DESCRIPTION
### Platforms Impacted

- all (though shouldn't have any runtime impact)

### Description of changes

This gets rid of globalTokens usage in `Text`, switching to use new named text attribute lookup in `@fluentui-react-native/design`.

This also updates the dependency profiles as the graph changed.

