### PR TITLE
Add cooldown period for Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,8 @@ updates:
     schedule:
       interval: daily
       time: '13:00'
+    cooldown:
+      default-days: 7
     labels:
       - 'Type: Dependencies'
     versioning-strategy: lockfile-only


### PR DESCRIPTION
To support internal feed, we need to have 7 day cooldown else noone can build internally

### Verification
N/A


