### PR TITLE
Fix ESRP release

### DIFF
--- a/.ado/azure-pipelines.publish.yml
+++ b/.ado/azure-pipelines.publish.yml
@@ -122,8 +122,7 @@ extends:
       - stage: Publish
         displayName: Publish to NPM
         dependsOn: Build
-        # TODO uncomment
-        # condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'), ne('${{ parameters.skipNpmPublish }}', 'true'))
+        condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'), ne('${{ parameters.skipNpmPublish }}', 'true'))
         jobs:
           - job: PublishPackages
             displayName: Publish NPM Packages
@@ -153,17 +152,10 @@ extends:
               - script: |
                   echo "Downloaded tarballs:"
                   ls -laR '$(packagesArtifactPath)'
-                  if ls "$(packagesArtifactPath)/*/*.tgz" > /dev/null 2>&1; then
-                    echo "##vso[task.setvariable variable=hasTarballs]yes"
-                  else
-                    echo "No tarballs found — nothing to publish."
-                    echo "##vso[task.setvariable variable=hasTarballs]no"
-                  fi
                 displayName: 'Check downloaded tarballs'
 
               - task: AzureCLI@2
                 displayName: 'Get credentials for staging blob storage'
-                condition: eq(variables['hasTarballs'], 'yes')
                 inputs:
                   azureSubscription: ogx-esrp-infra-bot
                   scriptType: bash
@@ -176,29 +168,26 @@ extends:
 
               - task: AzureKeyVault@2
                 displayName: 'Get ESRP certificates from Key Vault'
-                condition: eq(variables['hasTarballs'], 'yes')
                 inputs:
                   azureSubscription: ESRP-JSHost3
                   KeyVaultName: OGX-JSHost-KV
                   SecretsFilter: OGX-JSHost-Auth4,OGX-JSHost-Sign3
 
-              # TODO uncomment
-              # - script: node '$(releaseToolArtifactPath)/index.mjs'
-              #   displayName: 'Publish packages using ESRP Release API'
-              #   condition: eq(variables['hasTarballs'], 'yes')
-              #   retryCountOnTaskFailure: 3
-              #   env:
-              #     PACKED_PACKAGES_PATH: $(packagesArtifactPath)
-              #     ESRP_PRODUCT_NAME: fluentui-react-native
-              #     ESRP_NPM_TAG: latest
-              #     # TODO should be somebody else
-              #     ESRP_USER: elcraig@microsoft.com
-              #     ESRP_APPROVERS: dannyvv@microsoft.com
-              #     ESRP_TENANT_ID: cdc5aeea-15c5-4db6-b079-fcadd2505dc2
-              #     ESRP_CLIENT_ID: 0a35e01f-eadf-420a-a2bf-def002ba898d
-              #     ESRP_AUTH_CERT: $(OGX-JSHost-Auth4)
-              #     ESRP_REQUEST_SIGNING_CERT: $(OGX-JSHost-Sign3)
-              #     STAGING_STORAGE_ACCOUNT_NAME: ogxesrptempstorage
-              #     STAGING_CLIENT_ID: $(STAGING_CLIENT_ID)
-              #     STAGING_TENANT_ID: $(STAGING_TENANT_ID)
-              #     STAGING_ID_TOKEN: $(STAGING_ID_TOKEN)
+              - script: node '$(releaseToolArtifactPath)/index.mjs'
+                displayName: 'Publish packages using ESRP Release API'
+                retryCountOnTaskFailure: 3
+                env:
+                  PACKED_PACKAGES_PATH: $(packagesArtifactPath)
+                  ESRP_PRODUCT_NAME: fluentui-react-native
+                  ESRP_NPM_TAG: latest
+                  # TODO should be somebody else
+                  ESRP_USER: elcraig@microsoft.com
+                  ESRP_APPROVERS: dannyvv@microsoft.com
+                  ESRP_TENANT_ID: cdc5aeea-15c5-4db6-b079-fcadd2505dc2
+                  ESRP_CLIENT_ID: 0a35e01f-eadf-420a-a2bf-def002ba898d
+                  ESRP_AUTH_CERT: $(OGX-JSHost-Auth4)
+                  ESRP_REQUEST_SIGNING_CERT: $(OGX-JSHost-Sign3)
+                  STAGING_STORAGE_ACCOUNT_NAME: ogxesrptempstorage
+                  STAGING_CLIENT_ID: $(STAGING_CLIENT_ID)
+                  STAGING_TENANT_ID: $(STAGING_TENANT_ID)
+                  STAGING_ID_TOKEN: $(STAGING_ID_TOKEN)


### PR DESCRIPTION
Uncomment the actual release step which was accidentally left commented after testing...

Also, `ls "$(packagesArtifactPath)/*/*.tgz"` used to set a variable wouldn't have worked (`*` isn't expanded within double quotes), so even if everything was uncommented it would have skipped the release step. The release API tool should be able to directly handle the case where there's nothing to release, so the variable isn't really needed.