### PR TITLE
Add themed Text component and make the component skills more flexible

### DIFF
--- a/.changeset/quiet-text-inherits.md
+++ b/.changeset/quiet-text-inherits.md
@@ -1,0 +1,5 @@
+---
+"@fluentui-react-native/components": minor
+---
+
+Add a theme-aware Text primitive and use it for component text content.

--- a/.github/skills/agentic-component-authoring/SKILL.md
+++ b/.github/skills/agentic-component-authoring/SKILL.md
@@ -25,32 +25,29 @@ authoring rule in one always-loaded instruction file.
 
 ## Load focused references
 
-| Work                                                                                           | Reference                                                                          |
-| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| Flex component source resolution, React Native contract adaptation, provenance, or divergences | [Flex source adaptation](references/spec-source-adaptation.md)                     |
-| Public props, slots, state types, native prop exposure, or exports                             | [Types and slots](references/types-and-slots.md)                                   |
-| Defaults, derived state, interaction hooks, accessibility, or slot construction                | [State and accessibility](references/state-and-accessibility.md)                   |
-| Tokens, style factories, theme caching, state precedence, or slot style application            | [Styles and tokens](references/styles-and-tokens.md)                               |
-| Pure slot rendering, component assembly, or display names                                      | [Rendering and assembly](references/rendering.md)                                  |
-| Runtime tests, type tests, snapshots, Storybook stories, or validation                         | [Tests and stories](references/tests-and-stories.md)                               |
-| Native React Native Windows Fabric components, codegen, registration, or UIA                   | [Windows Fabric native components](references/windows-fabric-native-components.md) |
-| Cross-component duplication, shared helper extraction, or dependency hygiene                   | [Package optimization](../agentic-component-optimization/SKILL.md)                 |
+| Work                                                                         | Reference                                                                          |
+| ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Source interpretation, provenance, contract drafting, review, or divergences | [Contract authoring](../agentic-component-contract-authoring/SKILL.md)             |
+| Public props, slots, state types, native prop exposure, or exports           | [Types and slots](references/types-and-slots.md)                                   |
+| Defaults, derived state, interaction hooks, accessibility, or slots          | [State and accessibility](references/state-and-accessibility.md)                   |
+| Tokens, theme caching, state precedence, or slot style application           | [Styles and tokens](references/styles-and-tokens.md)                               |
+| Pure slot rendering, component assembly, or display names                    | [Rendering and assembly](references/rendering.md)                                  |
+| Runtime tests, type tests, snapshots, Storybook stories, or validation       | [Tests and stories](references/tests-and-stories.md)                               |
+| Native React Native Windows Fabric components, codegen, registration, or UIA | [Windows Fabric native components](references/windows-fabric-native-components.md) |
+| Cross-component duplication, shared extraction, or dependency hygiene        | [Package optimization](../agentic-component-optimization/SKILL.md)                 |
 
 A new higher-order component normally needs every reference. A focused fix should load only the affected reference and
 its immediate neighbors. Keep the component's colocated `SPEC.md` and companion files authoritative for its contract.
 
 ## Workflow
 
-1. For a higher-order component, start Agency with the repository's
-   `flex-authoring` profile, invoke `flex-components:<name>`, and follow the
-   [Flex source adaptation](references/spec-source-adaptation.md) reference.
-   Record source identities without copying source bodies.
-2. Read the repository and package instructions, the component `SPEC.md`,
-   `spec/source.json`, and every React Native companion referenced by the
-   spec. For a new component, draft and review those local contract files
-   before implementation. Use the package-wide optimization guidance only when
-   the change clearly involves repeated patterns or shared dependency
-   boundaries.
+1. Read the repository and package instructions, the component `SPEC.md`,
+   `spec/source.json`, and every React Native companion referenced by the spec.
+2. Use an existing reviewed contract directly when its source evidence and
+   requested behavior are unchanged. If the contract is absent, stale, still a
+   draft, or accompanied by new source evidence, run the
+   [contract authoring workflow](../agentic-component-contract-authoring/SKILL.md)
+   and complete its pre-code review gate first.
 3. Inspect the closest canonical implementation. Use
    [`components/button`](../../../packages/agentic/components/src/components/button) for a styled higher-order component
    and [`primitives/icon`](../../../packages/agentic/components/src/primitives/icon) for a direct primitive.

--- a/.github/skills/agentic-component-authoring/references/spec-source-adaptation.md
+++ b/.github/skills/agentic-component-authoring/references/spec-source-adaptation.md
@@ -1,81 +1,9 @@
 # Flex source adaptation
 
-Use this reference when creating or revising a higher-order component contract.
-Flex skills provide design evidence; local React Native documents define FURN
-behavior.
+Contract creation now belongs to the
+[agentic component contract authoring skill](../../agentic-component-contract-authoring/SKILL.md).
+For pinned Flex component skills and X3 lineage, use its
+[Flex and X3 source adapter](../../agentic-component-contract-authoring/references/sources/flex-x3.md).
 
-## Resolve one immutable source set
-
-Start Agency with the repository's `flex-authoring` profile and invoke
-`flex-components:<name>`. Confirm that `flex-components`, `flex-system`, and
-`flex-tokens` resolve to the release in
-`packages/agentic/components/spec-source-lock.json`.
-
-Read the component's shared skill and usage material plus its web companions.
-Read mobile companions only when that component provides them. A platform never
-falls back to another platform's files, and files from different revisions must
-not be combined.
-
-Do not copy source prose or token tables into the public repository. Record
-only identifiers and digests in `spec/source.json`.
-
-## Draft the React Native contract
-
-Before implementation, classify every relevant axis, slot, behavior, and token
-along two dimensions:
-
-1. Source surface: shared, web, mobile, Flex system, or an existing FURN
-   implementation.
-2. Disposition: adopted, adapted, intentional divergence, not applicable, or
-   deferred.
-
-Consult the local Flex token map and the closest Win32, macOS, or Windows V1
-implementation. Do not use iOS as the desktop compatibility reference.
-
-Write an original local contract:
-
-- public props, slots, defaults, and state ownership in `SPEC.md`;
-- actual FURN token bindings in `spec/tokens.yaml`;
-- React Native accessibility and UIA/AX behavior in
-  `spec/accessibility.md`;
-- keyboard, pointer, focus, and motion behavior in `spec/interaction.md`;
-- FURN usage and examples in `spec/usage.md`.
-
-Give contract requirements stable IDs and map each one to existing or planned
-types, tests, stories, or platform evidence in the Conformance table. Record
-every divergence in `SPEC.md` with a stable ID, disposition, rationale, status,
-and issue when follow-up work is required.
-
-Translate platform concepts deliberately:
-
-| Flex evidence                        | React Native contract                                                              |
-| ------------------------------------ | ---------------------------------------------------------------------------------- |
-| ARIA attributes or native elements   | `accessibilityRole`, `accessibilityState`, labels, and UIA/AX expectations         |
-| CSS pseudo-classes                   | explicit interaction state and precedence                                          |
-| browser focus selectors and outlines | persistent `FocusVisual`; never conditional `outline*` or native RNW focus visuals |
-| CSS pixel or layout rules            | React Native layout units, minimum targets, and platform behavior                  |
-| unsupported browser capability       | explicit divergence, dependency, or blocker                                        |
-
-Review the draft contract before writing code.
-
-Use `contract-draft` with `review-required` while authoring. A pre-code review
-moves the lifecycle to `contract-reviewed`, records only the source surfaces
-the reviewer actually consulted, and adds the review date. Planned evidence
-paths may remain unrealized at this stage.
-
-## Implement and ratify
-
-Implement the component through the normal types, state, styles, render, and
-assembly stages. Derive tests and stories from the requirement IDs. After
-validation, reconcile the draft against the realized public types and native
-output. Change the contract only through an explicit review; do not make an
-accidental implementation choice authoritative after the fact.
-
-Generating or repinning `spec/source.json` requires access to the private
-Marketplace and x3 repositories. Set lifecycle to `implemented` and
-conformance to `reviewed` only when the contract, implementation, and declared
-evidence agree. Updating
-the immutable source lock or its recorded file identities clears that review
-until each delta is adopted, adapted, rejected, or deferred. Drift at mutable
-Marketplace or x3 HEAD is a candidate proposal and does not invalidate a
-contract ratified against the pinned release.
+This compatibility reference remains so existing links continue to resolve.
+Implementation guidance stays in the agentic component authoring skill.

--- a/.github/skills/agentic-component-contract-authoring/SKILL.md
+++ b/.github/skills/agentic-component-contract-authoring/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: agentic-component-contract-authoring
+description: Create or revise reviewed React Native component contracts in packages/agentic/components from Flex/X3, Fluent v9, HTML/CSS, images, local platform foundations, or composite evidence.
+license: MIT
+---
+
+# Agentic component contract authoring
+
+Turn source material into an original, reviewable Fluent UI React Native
+contract. This skill owns source interpretation, authority, provenance,
+uncertainty, React Native adaptation, divergences, and requirement planning. It
+does not own component implementation.
+
+Use this skill directly for contract-only, feasibility, or implementation-plan
+requests. The [component authoring skill](../agentic-component-authoring/SKILL.md)
+invokes this workflow before code when a contract is missing, stale, still a
+draft, or accompanied by new source evidence.
+
+## Choose the request mode
+
+- **Feasibility or plan only:** inspect the evidence, identify blockers and
+  unknowns, and describe the contract work without changing implementation.
+  Commit contract files only when the user requested a contract.
+- **Contract only:** create or revise the local contract and stop after its
+  review state accurately reflects the evidence.
+- **Contract plus implementation:** complete this workflow, then return to the
+  component authoring skill without splitting the implementation into separate
+  source-specific phases.
+
+## Select source adapters
+
+Load every adapter represented by the supplied evidence, but no others.
+
+| Evidence                                      | Adapter                                                        |
+| --------------------------------------------- | -------------------------------------------------------------- |
+| Pinned Flex component skill and X3 lineage    | [Flex and X3](references/sources/flex-x3.md)                   |
+| Fluent UI v9 source or specification          | [Fluent v9](references/sources/fluent-v9.md)                   |
+| HTML, CSS, computed styles, or browser output | [HTML and CSS](references/sources/html-css.md)                 |
+| Images, screenshots, or design renders        | [Visual reference](references/sources/visual-reference.md)     |
+| Public native API plus repository precedent   | [Local foundation](references/sources/local-foundation.md)     |
+| More than one of the preceding source sets    | [Composite evidence](references/sources/composite-evidence.md) |
+
+## Workflow
+
+1. Read the package instructions, the existing `SPEC.md`, all companions under
+   `spec/`, and `SPEC-SOURCE.md`. Preserve a reviewed contract unless new
+   evidence or an explicit requested behavior change requires re-review.
+2. Inventory the source sets. Give each source a stable kebab-case ID, classify
+   its authority, pin immutable identities where possible, and record only
+   public or redistributable evidence.
+3. Separate observations from inferences. A source governs only what it can
+   establish: images do not prove semantics, CSS does not prove native
+   interaction, and a web implementation does not define React Native
+   platform behavior.
+4. Resolve authority per requirement. For multiple sources, record sorted
+   source IDs on every requirement and document conflicts explicitly; never
+   choose one source as globally authoritative merely for convenience.
+5. Draft the original React Native contract:
+   - public API, slots, defaults, state ownership, and requirement IDs in
+     `SPEC.md`;
+   - FURN token bindings and gaps in `spec/tokens.yaml`;
+   - native accessibility in `spec/accessibility.md`;
+   - keyboard, pointer, focus, and motion behavior in
+     `spec/interaction.md`;
+   - FURN examples and constraints in `spec/usage.md`;
+   - lifecycle, provenance, divergences, and requirement evidence in
+     `spec/source.json`.
+6. Classify every relevant source claim as adopted, adapted, intentionally
+   divergent, not applicable, deferred, or unknown. Do not turn missing
+   evidence into an inferred guarantee.
+7. Review the contract before code. Keep `contract-draft`,
+   `review-required`, and a null review date until the source interpretation,
+   native adaptation, authority decisions, and planned evidence are coherent.
+   Move to `contract-reviewed` only after that explicit review.
+8. Run the package contract checker. Source refresh tools may update provenance
+   but never approve a contract or populate reviewed surfaces automatically.
+
+## Contract rules
+
+- `spec/source.json` uses schema version 2 and a sorted, non-empty `sources[]`.
+  Source IDs are unique. Keep this generated, digest-heavy metadata in JSON;
+  `spec/tokens.yaml` remains YAML because token mappings are human-authored.
+- Supported source kinds are `flex-skill`, `git-files`, `html-css`,
+  `visual-reference`, and `local-foundation`.
+- A source's `authority` describes how it may govern requirements. Requirement
+  `sources` identify the actual source set used for that decision.
+- `git-files` records a repository, full commit SHA, and sorted file paths with
+  SHA-256 digests. `html-css` and `visual-reference` record immutable artifact
+  digests; repository-relative artifacts are verified locally.
+- A `local-foundation` source is valid only when no Flex catalog component
+  exists and must be the contract's sole source.
+- Only `flex-skill` has automated release and candidate drift reporting.
+  Other immutable sources report Flex drift as `not-applicable`; refresh their
+  identities through an explicit source review.
+- A reviewed local contract is normative for FURN. New upstream evidence is a
+  change proposal, not an automatic rewrite.
+- Do not copy or lightly transform private source bodies into this public
+  repository. Record identities and write original React Native documentation.

--- a/.github/skills/agentic-component-contract-authoring/references/sources/composite-evidence.md
+++ b/.github/skills/agentic-component-contract-authoring/references/sources/composite-evidence.md
@@ -1,0 +1,36 @@
+# Composite evidence adapter
+
+Use multiple `sources[]` entries when no single source can establish the full
+React Native contract. Composite evidence is a resolution method, not a source
+kind.
+
+## Resolve authority per requirement
+
+For every requirement, list the sorted source IDs that govern or support it.
+Do not assign one global precedence order to an entire component. A common
+division is:
+
+| Requirement area         | Likely authority                                     |
+| ------------------------ | ---------------------------------------------------- |
+| design intent and tokens | normative design source plus token reference         |
+| public API and state     | product specification or reviewed behavior reference |
+| native semantics         | React Native/platform contract                       |
+| visual fidelity          | normative design source plus visual evidence         |
+| compatibility            | existing FURN implementation                         |
+
+One source may be authoritative for one requirement and merely corroborating
+for another. If sources disagree, record the conflicting claims, chosen
+resolution, rationale, and divergence or follow-up issue. If evidence is
+insufficient, keep the behavior unknown or deferred.
+
+## Keep the contract reviewable
+
+- Give each source a stable ID and use the source-specific adapter schema.
+- Keep `sources[]` sorted and unique.
+- Require every requirement to identify at least one source when more than one
+  source is present.
+- Do not duplicate one artifact across source entries to manufacture
+  corroboration.
+- Re-review only the requirements affected by changed evidence, but keep the
+  document-level conformance state at `review-required` until the combined
+  contract is coherent again.

--- a/.github/skills/agentic-component-contract-authoring/references/sources/flex-x3.md
+++ b/.github/skills/agentic-component-contract-authoring/references/sources/flex-x3.md
@@ -1,0 +1,46 @@
+# Flex and X3 source adapter
+
+Use this adapter for a component in the pinned Flex catalog. Flex skills are
+authoring inputs; the immutable X3 lineage identifies their original design
+source, and the reviewed local contract defines FURN behavior.
+
+## Resolve the source
+
+Start Agency with the repository's `flex-authoring` profile and invoke
+`flex-components:<name>`. Confirm that the profile and
+`packages/agentic/components/spec-source-lock.json` identify the same release.
+Read shared and usage material plus the relevant platform companions. Do not
+combine files from different releases or use one platform as an implicit
+fallback for another.
+
+Generate or refresh the `flex-skill` entry with:
+
+```sh
+yarn workspace @fluentui-react-native/components report:spec-source-drift --write --update-sources --component <name>
+```
+
+The entry records `authority: normative`, the skill ID, source-lock identity,
+available and consulted surfaces, immutable Marketplace/X3 file identities,
+and release differences. Availability is generated; consultation is a
+reviewer's assertion and remains empty after a source identity changes.
+
+## Adapt to React Native
+
+Classify source guidance as adopted, adapted, intentionally divergent, not
+applicable, or deferred. Consult the Flex token map and the closest Win32,
+macOS, or Windows FURN implementation for compatibility; do not use iOS as the
+cross-platform canonical reference unless the work targets iOS.
+
+Translate web concepts deliberately:
+
+| Flex evidence                        | React Native contract                                                              |
+| ------------------------------------ | ---------------------------------------------------------------------------------- |
+| ARIA attributes or native elements   | `accessibilityRole`, `accessibilityState`, labels, and UIA/AX expectations         |
+| CSS pseudo-classes                   | explicit interaction state and precedence                                          |
+| browser focus selectors and outlines | persistent `FocusVisual`; never conditional `outline*` or RNW native focus visuals |
+| CSS pixel or layout rules            | React Native units, minimum targets, and platform behavior                         |
+| unsupported browser capability       | explicit divergence, dependency, or blocker                                        |
+
+Do not copy Flex prose or token tables into the public package. A mutable
+Marketplace or X3 HEAD change is candidate drift and does not invalidate a
+contract ratified against the pinned release.

--- a/.github/skills/agentic-component-contract-authoring/references/sources/fluent-v9.md
+++ b/.github/skills/agentic-component-contract-authoring/references/sources/fluent-v9.md
@@ -1,0 +1,30 @@
+# Fluent v9 source adapter
+
+Use Fluent UI v9 as API, behavior, and design precedent, not as a DOM contract
+for React Native.
+
+## Record provenance
+
+Pin the exact repository and full commit SHA. Record a `git-files` source with
+sorted source/spec paths, semantic roles, and SHA-256 digests. Use an authority
+such as `behavior-reference`, `compatibility-reference`, `token-reference`, or
+`implementation-evidence` that describes what the selected files can govern.
+Do not cite a mutable branch or package version without its immutable commit.
+
+## Interpret the source
+
+Inspect public types, state hooks, render structure, styles, tests, stories, and
+published specifications as separate evidence surfaces. Distinguish intended
+public behavior from incidental implementation details.
+
+- Preserve portable API names and state ownership when they fit native usage.
+- Translate DOM elements and ARIA to React Native roles, states, labels, and
+  platform accessibility expectations.
+- Translate CSS inheritance, selectors, and pseudo-classes into explicit
+  tokens, state precedence, and native layout.
+- Treat browser focus, keyboard, pointer, and hover behavior as evidence to
+  adapt, not behavior to copy mechanically.
+- Record unsupported or intentionally different behavior as a divergence.
+
+When Fluent v9 is combined with another design source, assign its source ID
+only to the requirements for which it is authoritative or informative.

--- a/.github/skills/agentic-component-contract-authoring/references/sources/html-css.md
+++ b/.github/skills/agentic-component-contract-authoring/references/sources/html-css.md
@@ -1,0 +1,35 @@
+# HTML and CSS source adapter
+
+Use HTML/CSS evidence to recover observable anatomy, content flow, layout,
+computed values, and visual state differences. It does not by itself establish
+native semantics, controlled-state ownership, event contracts, or platform
+accessibility.
+
+## Capture reproducible evidence
+
+Record an `html-css` source with its origin and sorted immutable artifacts.
+Supported artifacts are HTML, CSS, computed-style captures, accessibility-tree
+captures, and screenshots. Each artifact needs a stable ID, kind, location,
+and SHA-256 digest. Store only evidence that may be redistributed; otherwise
+use an HTTPS identity and retain restricted material outside the public
+repository.
+
+Capture the relevant matrix when available:
+
+- variants, sizes, appearances, and interaction states;
+- viewport, zoom or scale, color scheme, direction, and locale;
+- inherited versus explicitly assigned typography and color;
+- computed dimensions, spacing, wrapping, truncation, and overflow;
+- browser accessibility output separately from visual output.
+
+## Adapt the evidence
+
+Map element anatomy to typed React Native slots only when consumers need the
+slot. Convert CSS inheritance into explicit theme/token defaults at the owning
+native boundary. Translate pseudo-classes to component state and precedence.
+Treat layout values as observations, then choose the appropriate React Native
+layout and minimum-target behavior.
+
+Mark semantics, keyboard behavior, motion, state ownership, and inaccessible
+states as unknown unless another source establishes them. Never infer an API
+solely from class names, data attributes, or a single rendered DOM snapshot.

--- a/.github/skills/agentic-component-contract-authoring/references/sources/local-foundation.md
+++ b/.github/skills/agentic-component-contract-authoring/references/sources/local-foundation.md
@@ -1,0 +1,22 @@
+# Local foundation source adapter
+
+Use `local-foundation` only for a theme-aware foundational component that has
+no entry in the locked Flex component catalog. This is not a bypass for missing
+Flex access or an alternative way to author a catalog component.
+
+The source entry is the contract's sole source and uses
+`authority: normative`. Its sorted references identify the public native
+platform contract and repository precedents used during review. Give each
+reference its own authority, such as `platform-contract`,
+`compatibility-reference`, or `token-reference`.
+
+Inspect the current React Native API for the package's supported version,
+relevant native behavior, existing FURN components, and token mappings. Define
+the smallest theme-aware primitive contract needed by other components. Keep
+web inheritance or browser behavior out of the contract unless React Native
+provides an equivalent.
+
+Local-foundation contracts still require lifecycle, review, divergence,
+requirement, implementation, test, story, and platform evidence. Flex release
+and candidate drift are `not-applicable`. The checker rejects this source kind
+if the locked Flex catalog contains the component.

--- a/.github/skills/agentic-component-contract-authoring/references/sources/visual-reference.md
+++ b/.github/skills/agentic-component-contract-authoring/references/sources/visual-reference.md
@@ -1,0 +1,35 @@
+# Visual reference source adapter
+
+Use screenshots, design renders, and other images as visual evidence only.
+They can establish observable anatomy, geometry, typography, color,
+iconography, and differences among captured states. They cannot prove invisible
+semantics, accessibility, events, keyboard behavior, motion, or controlled
+state ownership.
+
+## Record the evidence
+
+Record a `visual-reference` source with `authority: visual-evidence`. Give each
+artifact a stable ID, location, and SHA-256 digest. Add appearance, state,
+platform, scale, viewport, and locale metadata when known. Repository-relative
+artifacts are digest-verified by the contract checker; do not commit images
+without redistribution permission.
+
+Inventory the capture matrix before interpreting it. A missing state is
+unknown, not equivalent to the nearest visible state. Note cropping,
+compression, scaling, overlays, device chrome, and any dimensions that prevent
+reliable measurement.
+
+## Derive a contract conservatively
+
+- Describe anatomy and spatial relationships before choosing implementation
+  slots or layout primitives.
+- Map visible values to the nearest established FURN tokens; record genuine
+  token gaps rather than inventing exact literals from noisy pixels.
+- Require non-visual sources for public APIs, semantics, interactions,
+  accessibility, motion, and platform behavior.
+- Express uncertain conclusions as open questions, deferred divergences, or
+  explicitly scoped requirements.
+
+When visual evidence conflicts with normative design or platform evidence,
+record the conflict and resolve authority for the affected requirement rather
+than silently selecting the image.

--- a/packages/agentic/components/AGENTS.md
+++ b/packages/agentic/components/AGENTS.md
@@ -19,9 +19,13 @@ invariants; detailed authoring recipes live in the
 
 ## Package invariants
 
-- For a higher-order component contract, start Agency with the
+- For a source-backed higher-order component contract, start Agency with the
   `flex-authoring` profile, invoke `flex-components:<name>`, and follow the
   [Flex source adaptation reference](../../../.github/skills/agentic-component-authoring/references/spec-source-adaptation.md).
+- A theme-aware foundational component that has no Flex catalog entry must use
+  the validator-backed `local-foundation` source kind. Cite its public platform
+  contract and repository evidence; never invent a `flex-components:<name>`
+  skill or bypass the component contract gate.
 - Follow [SPEC-SOURCE.md](./SPEC-SOURCE.md) for provenance fields, contract
   lifecycle, review state, and drift commands.
 - Read the component `SPEC.md`, `spec/source.json`, and all referenced React

--- a/packages/agentic/components/AGENTS.md
+++ b/packages/agentic/components/AGENTS.md
@@ -19,13 +19,17 @@ invariants; detailed authoring recipes live in the
 
 ## Package invariants
 
-- For a source-backed higher-order component contract, start Agency with the
-  `flex-authoring` profile, invoke `flex-components:<name>`, and follow the
-  [Flex source adaptation reference](../../../.github/skills/agentic-component-authoring/references/spec-source-adaptation.md).
+- Create or revise source-backed contracts through the
+  [agentic component contract authoring skill](../../../.github/skills/agentic-component-contract-authoring/SKILL.md).
+  It routes Flex/X3, Fluent v9, HTML/CSS, visual, local-foundation, and
+  composite evidence before implementation.
+- Use the repository's `flex-authoring` profile and `flex-components:<name>`
+  only for a pinned Flex/X3 source. It is not a prerequisite for other source
+  adapters.
 - A theme-aware foundational component that has no Flex catalog entry must use
-  the validator-backed `local-foundation` source kind. Cite its public platform
-  contract and repository evidence; never invent a `flex-components:<name>`
-  skill or bypass the component contract gate.
+  a sole validator-backed `local-foundation` entry in `sources[]`. Cite its
+  public platform contract and repository evidence; never invent a
+  `flex-components:<name>` skill or bypass the component contract gate.
 - Follow [SPEC-SOURCE.md](./SPEC-SOURCE.md) for provenance fields, contract
   lifecycle, review state, and drift commands.
 - Read the component `SPEC.md`, `spec/source.json`, and all referenced React
@@ -42,6 +46,6 @@ invariants; detailed authoring recipes live in the
   behind variables, spreads, functions, or computed values.
 - Use package scripts for format, lint, build, tests, and snapshots.
 - Do not copy web-only APIs, CSS behavior, or DOM assumptions into React Native.
-- Do not copy or mechanically transform private Flex skill bodies into this
-  public package. Record source identifiers and digests, then author the local
-  React Native contract.
+- Do not copy or mechanically transform private source bodies into this public
+  package. Record source identifiers and digests, then author the local React
+  Native contract.

--- a/packages/agentic/components/SPEC-SOURCE.md
+++ b/packages/agentic/components/SPEC-SOURCE.md
@@ -1,127 +1,240 @@
-# Flex source and React Native component contracts
+# React Native component contract sources
 
-Flex component skills are authoring references, not files to ingest into this
-package. Start an authoring session with:
+Each higher-order component owns an original React Native contract in
+`src/components/<name>/SPEC.md` and companion files under `spec/`. Source
+material is evidence for authoring that contract; it is never promoted
+mechanically into this public package.
 
-```sh
-agency copilot --profile flex-authoring
+Use the
+[agentic component contract authoring skill](../../../.github/skills/agentic-component-contract-authoring/SKILL.md)
+to interpret Flex/X3, Fluent v9, HTML/CSS, visual, local-foundation, or
+composite evidence. Use the component authoring skill after the contract has
+passed its pre-code review.
+
+## Why provenance stays JSON
+
+`spec/source.json` is generated, digest-heavy, strictly validated metadata.
+JSON provides unambiguous scalars, built-in Node parsing, deterministic atomic
+rewrites, and no additional parser dependency. Generator rewrites would also
+discard the main benefit of YAML comments. Keep this provenance in JSON.
+
+`spec/tokens.yaml` remains YAML because it is concise, human-authored token
+mapping data rather than a generated identity record.
+
+## Schema version 2
+
+Every source document has the following document-level shape:
+
+```json
+{
+  "schemaVersion": 2,
+  "component": "example",
+  "lifecycle": "contract-reviewed",
+  "conformance": "reviewed",
+  "reviewedAt": "2026-09-01",
+  "sources": [],
+  "divergences": [],
+  "requirements": []
+}
 ```
 
-The profile in the repository root pins `flex-components`, `flex-system`, and
-`flex-tokens` to the same self-consistent Marketplace commit. The package lock
-records the Marketplace release and its immutable x3 source lineage. Plugin
-versions are descriptive only; content identity comes from commits and file
-digests. The canonical lock fingerprint binds all release commits, plugin
-trees, and catalog entries so a repin cannot retain a stale component review.
+`sources[]` is non-empty, sorted by source ID, and contains unique IDs.
+Lifecycle, conformance, divergences, and requirements apply to the combined
+local contract rather than to one upstream source.
 
-For one component:
+When a contract has multiple sources, every requirement must list the sorted
+source IDs that govern or support it:
 
-1. Invoke `flex-components:<name>` in the pinned session.
-2. Draft the local `SPEC.md` and React Native companions under
-   `src/components/<name>/`; classify source guidance as adopted, adapted,
-   divergent, not applicable, or deferred.
-3. Record immutable file identities with
-   `yarn workspace @fluentui-react-native/components report:spec-source-drift --write --update-sources --component <name>`.
-   This operation requires a GitHub token authorized for both private source
-   repositories. Contributors without that access can work on an existing
-   contract, but cannot create or repin source provenance.
-4. Keep `status: contract-draft`, `conformance: review-required`, and
-   `reviewedAt: null` while drafting. After an explicit pre-code review, use
-   `status: contract-reviewed`, record the source surfaces actually consulted,
-   and set the review date.
-5. Build through the normal component pipeline, then set `status: implemented`
-   only after ratifying the local contract against realized types, tests,
-   stories, and platform evidence.
+```json
+{
+  "id": "EXM-001",
+  "sources": ["fluent-v9", "x3-component"],
+  "plannedEvidence": ["example.types.ts", "example.types.test.tsx"]
+}
+```
 
-## Local foundational components
+This resolves authority per requirement. It does not declare one source
+globally authoritative for the whole component.
 
-A theme-aware foundational component may have no entry in the Flex component
-catalog. Keep it under `src/components`, retain the complete local contract and
-evidence structure, and set `sourceKind` in `spec/source.json` to
-`local-foundation`. Its sorted references identify the public platform contract
-and repository evidence consulted during review.
+## Source kinds
 
-Local-foundation contracts do not claim a `flex-components:<name>` skill,
-source-lock identity, release differences, or candidate source drift. The
-contract checker still enforces lifecycle, review date, divergences,
-requirements, and realized evidence. Live and offline source reports include
-the component with candidate status `not-applicable`.
+Every source has an `id`, `kind`, and `authority`. Supported authorities are
+`normative`, `behavior-reference`, `compatibility-reference`,
+`implementation-evidence`, `platform-contract`, `token-reference`, and
+`visual-evidence`.
 
-There is intentionally no operation that copies a Flex skill into `specs/` and
-no promotion step that moves a web-authored draft into production. The pinned
-plugin is the session input; the first committed document is the independently
-authored React Native contract.
+### Pinned Flex/X3
+
+A `flex-skill` entry records the exact skill payload and X3 lineage:
+
+```json
+{
+  "id": "flex-component",
+  "kind": "flex-skill",
+  "authority": "normative",
+  "skill": "flex-components:example",
+  "sourceLock": "flex-...",
+  "sourceLockFingerprint": "...",
+  "availableSurfaces": ["shared", "web"],
+  "surfacesConsulted": ["shared", "web"],
+  "sourceFiles": [],
+  "releaseDifferences": []
+}
+```
+
+The repository's `flex-authoring` Agency profile pins `flex-components`,
+`flex-system`, and `flex-tokens` to one self-consistent Marketplace commit.
+`spec-source-lock.json` records that release and its immutable X3 source
+lineage. Plugin versions are descriptive; commits, trees, files, and digests
+define content identity.
+
+`availableSurfaces` is generated from the source inventory.
+`surfacesConsulted` is a review assertion and is never populated merely because
+a surface exists. `releaseDifferences` records normalized-content differences
+between the Marketplace authoring input and its X3 lineage; each difference
+requires an explicit disposition before review.
+
+### Versioned repository files
+
+A `git-files` entry records a repository, full commit SHA, and sorted files:
+
+```json
+{
+  "id": "fluent-v9",
+  "kind": "git-files",
+  "authority": "behavior-reference",
+  "repository": "microsoft/fluentui",
+  "commit": "0000000000000000000000000000000000000000",
+  "files": [
+    {
+      "role": "implementation",
+      "path": "packages/react-components/react-example/library/src/example.ts",
+      "sha256": "..."
+    }
+  ]
+}
+```
+
+Use this for Fluent v9 and other immutable repository evidence. The local
+checker validates shape and identities; an explicit source review is
+responsible for refreshing remote file digests.
+
+### HTML and CSS artifacts
+
+An `html-css` entry records an origin plus sorted HTML, CSS, computed-style,
+accessibility-tree, or screenshot artifacts. Each artifact has a stable ID,
+kind, location, and SHA-256 digest. Repository-relative artifacts are checked
+against their recorded raw-byte digest. HTTPS artifacts retain an immutable
+identity but require explicit source review because the credential-free checker
+does not fetch them.
+
+HTML/CSS can establish observable anatomy, content flow, computed values, and
+captured browser behavior. It does not by itself establish native semantics,
+state ownership, events, or platform accessibility.
+
+### Visual references
+
+A `visual-reference` entry uses `authority: visual-evidence` and records sorted
+artifacts with stable IDs, locations, and raw-byte SHA-256 digests. Appearance,
+state, platform, scale, viewport, and locale metadata may be recorded when
+known.
+
+Images can establish visible anatomy, geometry, typography, color, iconography,
+and captured state differences. They cannot establish invisible semantics,
+accessibility, events, keyboard behavior, motion, or controlled-state
+ownership.
+
+### Local foundations
+
+A theme-aware foundation with no locked Flex catalog entry may use one
+`local-foundation` source as its sole source:
+
+```json
+{
+  "id": "local-foundation",
+  "kind": "local-foundation",
+  "authority": "normative",
+  "references": [
+    {
+      "id": "react-native-api",
+      "type": "external",
+      "authority": "platform-contract",
+      "location": "https://reactnative.dev/docs/0.81/example"
+    }
+  ]
+}
+```
+
+References must be sorted and identify public platform contracts or repository
+evidence. The checker rejects `local-foundation` for a component present in the
+locked Flex catalog. It is not a way to bypass private source access.
+
+## Composite evidence
+
+Composite evidence is multiple source entries, not another source kind. Record
+conflicts and uncertainty explicitly. Assign source IDs per requirement, and
+use divergences or follow-up issues when evidence is contradictory,
+unsupported, or incomplete.
+
+New source evidence is a change proposal. It never rewrites a reviewed local
+contract automatically.
 
 ## Contract lifecycle
 
-| `status` / lifecycle | Conformance                                             | Evidence                                                                                          |
-| -------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| `contract-draft`     | `review-required`; no review date                       | Requirement IDs may name planned files.                                                           |
-| `contract-reviewed`  | `reviewed`; review date and consulted surfaces required | The pre-code contract is approved; evidence may still be planned.                                 |
-| `implemented`        | `reviewed`                                              | Every requirement names an existing type, implementation, test, story, or platform-evidence file. |
+| Lifecycle           | Conformance       | Evidence                                                                                          |
+| ------------------- | ----------------- | ------------------------------------------------------------------------------------------------- |
+| `contract-draft`    | `review-required` | Requirement IDs may name planned files.                                                           |
+| `contract-reviewed` | `reviewed`        | The pre-code contract is approved; evidence may still be planned.                                 |
+| `implemented`       | `reviewed`        | Every requirement names an existing type, implementation, test, story, or platform-evidence file. |
 
-`availableSurfaces` is generated from the pinned source inventory.
-`surfacesConsulted` is the reviewer's explicit assertion of what was opened; it
-is never populated from availability by the generator. It may equal
-`availableSurfaces` when every surface was reviewed. Source sidecars accept
-only provenance, lifecycle, source-difference dispositions, divergence IDs,
-and requirement evidence; upstream prose does not belong there.
-
-`releaseDifferences` is non-empty when the Marketplace payload and its x3
-lineage have different normalized content for the same role. Each difference
-must be reviewed explicitly. `marketplace-authoring-input` means the pinned
-plugin payload governs what the authoring session saw while the x3 digest
-remains recorded for lineage.
+A changed source identity resets document conformance to `review-required` and
+clears the review date until the affected requirements and divergences are
+reviewed again.
 
 ## Authority
 
-1. The pinned x3 commit identifies the original Flex design source for the
-   release.
-2. The pinned Marketplace commit identifies the exact skills presented to an
-   Agency authoring session.
+1. Immutable source identities establish exactly what evidence was consulted.
+2. Source authority and requirement source IDs establish what each source may
+   govern.
 3. A reviewed local `SPEC.md` and its React Native companions define FURN
    behavior.
 4. Public types, implementation, tests, stories, and platform evidence prove
    conformance to the local contract.
 
-A newer Marketplace or x3 revision is a change proposal. It never rewrites a
-local component automatically.
-
 ## Public content boundary
 
-Commit source identifiers, paths, versions, dates, and digests. Write original
-documentation for the public React Native API and behavior. Do not copy or
-lightly rewrite Flex skill prose, rationale, tables, or token files without an
-explicit redistribution decision from the source and repository owners.
+Commit source identifiers, paths, versions, dates, and digests. Commit source
+artifacts only when redistribution is allowed. Write original documentation
+for the public React Native API and behavior. Do not copy or lightly rewrite
+private skill prose, rationale, tables, token files, or source bodies without
+an explicit redistribution decision.
 
-## Source review
+## Validation and drift
 
-Run the credential-free check in any environment:
+Run the credential-free local check in any environment:
 
 ```sh
 yarn workspace @fluentui-react-native/components check:spec-contracts
 ```
 
-It validates local schemas, references, requirement evidence, and review state.
-It does not claim that a private source is current.
+It validates schema version 2, local references and artifact digests,
+requirement evidence, lifecycle, and review state. It does not claim that a
+remote source is current.
 
-With `GH_TOKEN` or `GITHUB_TOKEN` authorized for the curated Marketplace and
-x3 source, generate a digest-only report:
+With `GH_TOKEN` or `GITHUB_TOKEN` authorized for the curated Marketplace and X3
+source, generate the Flex-only digest report:
 
 ```sh
 yarn workspace @fluentui-react-native/components report:spec-source-drift --write
 ```
 
-Use `--update-sources` during a deliberate release review to refresh file
-identities, optionally scoped with `--component <name>`. Review source changes
-before accepting the new metadata. Changing locked source identities clears
-the prior review and intentionally makes `check:spec-contracts` fail for an
-implemented component. Resolve every Marketplace/origin content difference,
-review the new source, and then restore `conformance: reviewed`,
-`surfacesConsulted`, and `reviewedAt`. A difference at mutable Marketplace or
-x3 HEAD is reported as candidate drift and does not invalidate ratification
-against the pin.
+Use `--update-sources` during deliberate Flex release review to refresh the
+nested `flex-skill` entry, optionally with `--component <name>`. Other source
+entries and document-level contract fields are preserved. A changed Flex
+identity clears the prior review; resolve release differences and review the
+affected contract before restoring conformance.
 
-`--offline` prints a credential-free diagnostic with external state marked
-`unchecked`. Add `--write` to refresh only locally derived lifecycle and
-conformance fields while preserving the last committed live source evidence.
+Only `flex-skill` currently has automated release and candidate drift. Contract
+entries without a Flex source report candidate status `not-applicable`.
+`--offline --write` refreshes locally derived lifecycle and conformance fields
+while preserving the last committed live Flex evidence.

--- a/packages/agentic/components/SPEC-SOURCE.md
+++ b/packages/agentic/components/SPEC-SOURCE.md
@@ -33,6 +33,20 @@ For one component:
    only after ratifying the local contract against realized types, tests,
    stories, and platform evidence.
 
+## Local foundational components
+
+A theme-aware foundational component may have no entry in the Flex component
+catalog. Keep it under `src/components`, retain the complete local contract and
+evidence structure, and set `sourceKind` in `spec/source.json` to
+`local-foundation`. Its sorted references identify the public platform contract
+and repository evidence consulted during review.
+
+Local-foundation contracts do not claim a `flex-components:<name>` skill,
+source-lock identity, release differences, or candidate source drift. The
+contract checker still enforces lifecycle, review date, divergences,
+requirements, and realized evidence. Live and offline source reports include
+the component with candidate status `not-applicable`.
+
 There is intentionally no operation that copies a Flex skill into `specs/` and
 no promotion step that moves a web-authored draft into production. The pinned
 plugin is the session input; the first committed document is the independently

--- a/packages/agentic/components/scripts/spec-contracts/check-spec-contracts.cjs
+++ b/packages/agentic/components/scripts/spec-contracts/check-spec-contracts.cjs
@@ -1,3 +1,4 @@
+const crypto = require('node:crypto');
 const fs = require('node:fs');
 const path = require('node:path');
 
@@ -87,21 +88,36 @@ function validateDivergences(component, spec, source) {
   }
 }
 
-function validateRequirements(component, spec, source, componentRoot) {
-  invariant(Array.isArray(source.requirements) && source.requirements.length > 0, `${component} must declare contract requirements.`);
+function validateRequirements(component, spec, contract, componentRoot) {
+  invariant(Array.isArray(contract.requirements) && contract.requirements.length > 0, `${component} must declare contract requirements.`);
   const requirementIds = new Set();
-  for (const requirement of source.requirements) {
-    validateExactKeys(requirement, ['id'], ['evidence', 'plannedEvidence'], `${component} requirement`);
+  const sourceIds = new Set(contract.sources.map((source) => source.id));
+  for (const requirement of contract.requirements) {
+    validateExactKeys(requirement, ['id'], ['sources', 'evidence', 'plannedEvidence'], `${component} requirement`);
     invariant(/^[A-Z][A-Z0-9]{1,9}-\d{3}$/.test(requirement.id), `${component} has an invalid requirement id.`);
     invariant(!requirementIds.has(requirement.id), `${component} repeats requirement ${requirement.id}.`);
     requirementIds.add(requirement.id);
     invariant(spec.includes(requirement.id), `${component} SPEC.md must describe requirement ${requirement.id}.`);
+    if (contract.sources.length > 1) {
+      invariant(
+        isSortedUnique(requirement.sources) && requirement.sources.length > 0,
+        `${requirement.id} must identify its governing sources when a contract has multiple sources.`,
+      );
+    } else if (Object.hasOwn(requirement, 'sources')) {
+      invariant(
+        isSortedUnique(requirement.sources) && requirement.sources.length > 0,
+        `${requirement.id} sources must be sorted and unique.`,
+      );
+    }
+    for (const sourceId of requirement.sources || []) {
+      invariant(sourceIds.has(sourceId), `${requirement.id} references unknown source ${sourceId}.`);
+    }
     const evidence = requirement.evidence || [];
     const plannedEvidence = requirement.plannedEvidence || [];
     invariant(Array.isArray(evidence), `${requirement.id} evidence must be an array.`);
     invariant(Array.isArray(plannedEvidence), `${requirement.id} plannedEvidence must be an array.`);
     invariant(evidence.length + plannedEvidence.length > 0, `${requirement.id} must name actual or planned evidence.`);
-    if (source.lifecycle === 'implemented') {
+    if (contract.lifecycle === 'implemented') {
       invariant(evidence.length > 0, `${requirement.id} must name realized evidence for an implemented component.`);
     }
     for (const evidencePathValue of evidence) {
@@ -124,116 +140,62 @@ function validateRequirements(component, spec, source, componentRoot) {
   }
 }
 
-function validateLocalFoundationSource(component, spec, source, componentRoot, lock) {
-  validateExactKeys(
-    source,
-    ['schemaVersion', 'component', 'sourceKind', 'lifecycle', 'conformance', 'reviewedAt', 'references', 'divergences', 'requirements'],
-    [],
-    `${component}/spec/source.json`,
-  );
-  invariant(source.schemaVersion === 1, `${component}/spec/source.json must use schemaVersion 1.`);
-  invariant(source.component === component, `${component}/spec/source.json has the wrong component.`);
-  invariant(source.sourceKind === 'local-foundation', `${component}/spec/source.json has an invalid local source kind.`);
-  invariant(!lock.catalog.entries.includes(component), `${component} has a Flex catalog entry and cannot use a local-foundation source.`);
-  invariant(['contract-draft', 'contract-reviewed', 'implemented'].includes(source.lifecycle), `${component} has an invalid lifecycle.`);
-  invariant(['review-required', 'reviewed'].includes(source.conformance), `${component} has an invalid conformance value.`);
-  if (source.lifecycle === 'contract-draft') {
-    invariant(source.conformance === 'review-required', `${component} draft contracts must require review.`);
-  }
-  if (source.conformance === 'review-required') {
-    invariant(source.reviewedAt === null, `${component} cannot have reviewedAt while review is required.`);
-  } else {
-    invariant(/^\d{4}-\d{2}-\d{2}$/.test(source.reviewedAt), `${component} reviewedAt must be YYYY-MM-DD.`);
-  }
+const sourceAuthorities = [
+  'behavior-reference',
+  'compatibility-reference',
+  'implementation-evidence',
+  'normative',
+  'platform-contract',
+  'token-reference',
+  'visual-evidence',
+];
 
-  invariant(Array.isArray(source.references) && source.references.length > 0, `${component} must record local-foundation references.`);
-  invariant(
-    JSON.stringify(source.references.map((reference) => reference.id)) ===
-      JSON.stringify(source.references.map((reference) => reference.id).sort()),
-    `${component} local-foundation references must be sorted by id.`,
-  );
-  const referenceIds = new Set();
-  for (const reference of source.references) {
-    validateExactKeys(reference, ['id', 'type', 'location'], [], `${component} local-foundation reference`);
-    invariant(/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(reference.id), `${component} has an invalid reference id.`);
-    invariant(!referenceIds.has(reference.id), `${component} repeats reference ${reference.id}.`);
-    referenceIds.add(reference.id);
-    invariant(['external', 'repository'].includes(reference.type), `${component}:${reference.id} has an invalid reference type.`);
-    if (reference.type === 'external') {
-      invariant(reference.location.startsWith('https://'), `${component}:${reference.id} must use an HTTPS reference.`);
-    } else {
-      const referencePath = path.resolve(repositoryRoot, reference.location);
-      invariant(
-        !path.isAbsolute(reference.location) && referencePath.startsWith(`${repositoryRoot}${path.sep}`) && fs.existsSync(referencePath),
-        `${component}:${reference.id} references missing repository content ${reference.location}.`,
-      );
-    }
-  }
-
-  validateDivergences(component, spec, source);
-  validateRequirements(component, spec, source, componentRoot);
-  return source;
+function validateSourceIdentity(component, source) {
+  invariant(/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(source.id), `${component} has an invalid source id.`);
+  invariant(sourceAuthorities.includes(source.authority), `${component}:${source.id} has an invalid source authority.`);
 }
 
-function validateSource(component, spec, lock) {
-  const componentRoot = path.join(componentsRoot, component);
-  const sourcePath = sourcePathFor(component);
-  const source = readJson(sourcePath);
-  if (source.sourceKind === 'local-foundation') {
-    return validateLocalFoundationSource(component, spec, source, componentRoot, lock);
-  }
-
+function validateFlexSource(component, contract, source, lock) {
   validateExactKeys(
     source,
     [
-      'schemaVersion',
-      'component',
+      'id',
+      'kind',
+      'authority',
       'skill',
       'sourceLock',
       'sourceLockFingerprint',
-      'lifecycle',
-      'conformance',
-      'reviewedAt',
       'availableSurfaces',
       'surfacesConsulted',
       'sourceFiles',
       'releaseDifferences',
-      'divergences',
-      'requirements',
     ],
     [],
-    `${component}/spec/source.json`,
+    `${component}:${source.id}`,
   );
-  invariant(source.schemaVersion === 1, `${component}/spec/source.json must use schemaVersion 1.`);
-  invariant(source.component === component, `${component}/spec/source.json has the wrong component.`);
-  invariant(source.sourceLock === lock.id, `${component}/spec/source.json must reference ${lock.id}.`);
+  validateSourceIdentity(component, source);
+  invariant(source.kind === 'flex-skill', `${component}:${source.id} has the wrong source kind.`);
+  invariant(source.authority === 'normative', `${component}:${source.id} must be normative.`);
+  invariant(source.sourceLock === lock.id, `${component}:${source.id} must reference ${lock.id}.`);
   invariant(
     source.sourceLockFingerprint === lock.fingerprint,
-    `${component}/spec/source.json must reference the active source-lock fingerprint.`,
+    `${component}:${source.id} must reference the active source-lock fingerprint.`,
   );
-  invariant(source.skill === `flex-components:${component}`, `${component}/spec/source.json has the wrong skill.`);
-  invariant(['contract-draft', 'contract-reviewed', 'implemented'].includes(source.lifecycle), `${component} has an invalid lifecycle.`);
-  invariant(['review-required', 'reviewed'].includes(source.conformance), `${component} has an invalid conformance value.`);
-  if (source.lifecycle === 'contract-draft') {
-    invariant(source.conformance === 'review-required', `${component} draft contracts must require review.`);
-  }
-  if (source.conformance === 'review-required') {
-    invariant(source.reviewedAt === null, `${component} cannot have reviewedAt while review is required.`);
-  } else {
-    invariant(/^\d{4}-\d{2}-\d{2}$/.test(source.reviewedAt), `${component} reviewedAt must be YYYY-MM-DD.`);
-    invariant(source.surfacesConsulted.length > 0, `${component} reviewed contracts must record consulted surfaces.`);
-  }
-  invariant(isSortedUnique(source.availableSurfaces), `${component} must record sorted availableSurfaces.`);
-  invariant(isSortedUnique(source.surfacesConsulted), `${component} must record sorted surfacesConsulted.`);
+  invariant(source.skill === `flex-components:${component}`, `${component}:${source.id} has the wrong skill.`);
+  invariant(isSortedUnique(source.availableSurfaces), `${component}:${source.id} must record sorted availableSurfaces.`);
+  invariant(isSortedUnique(source.surfacesConsulted), `${component}:${source.id} must record sorted surfacesConsulted.`);
   invariant(
     source.surfacesConsulted.every((surface) => source.availableSurfaces.includes(surface)),
-    `${component} consulted a source surface that is not available.`,
+    `${component}:${source.id} consulted a source surface that is not available.`,
   );
-  invariant(Array.isArray(source.sourceFiles) && source.sourceFiles.length > 0, `${component} must record source files.`);
+  if (contract.conformance === 'reviewed') {
+    invariant(source.surfacesConsulted.length > 0, `${component}:${source.id} reviewed contracts must record consulted surfaces.`);
+  }
+  invariant(Array.isArray(source.sourceFiles) && source.sourceFiles.length > 0, `${component}:${source.id} must record source files.`);
   invariant(
     JSON.stringify(source.sourceFiles.map((file) => file.marketplacePath)) ===
       JSON.stringify(source.sourceFiles.map((file) => file.marketplacePath).sort((left, right) => left.localeCompare(right))),
-    `${component} source files must be sorted by Marketplace path.`,
+    `${component}:${source.id} source files must be sorted by Marketplace path.`,
   );
 
   const sourceRoles = new Set();
@@ -251,31 +213,31 @@ function validateSource(component, spec, lock) {
         'contentDiffers',
       ],
       [],
-      `${component} source file`,
+      `${component}:${source.id} source file`,
     );
-    invariant(/^[a-z0-9]+(?::[a-z0-9-]+)*$/.test(file.role), `${component} has an invalid source role.`);
-    invariant(!sourceRoles.has(file.role), `${component} repeats source role ${file.role}.`);
+    invariant(/^[a-z0-9]+(?::[a-z0-9-]+)*$/.test(file.role), `${component}:${source.id} has an invalid source role.`);
+    invariant(!sourceRoles.has(file.role), `${component}:${source.id} repeats source role ${file.role}.`);
     sourceRoles.add(file.role);
     invariant(
       file.marketplacePath.startsWith(`catalogs/flex/plugins/components/skills/${component}/`),
-      `${component}:${file.role} has a Marketplace path outside its skill.`,
+      `${component}:${source.id}:${file.role} has a Marketplace path outside its skill.`,
     );
     invariant(
       file.originPath.startsWith(`plugins/components/skills/${component}/`),
-      `${component}:${file.role} has an origin path outside its skill.`,
+      `${component}:${source.id}:${file.role} has an origin path outside its skill.`,
     );
     invariant(
       file.marketplacePath.slice(`catalogs/flex/plugins/components/skills/${component}/`.length) ===
         file.originPath.slice(`plugins/components/skills/${component}/`.length),
-      `${component}:${file.role} does not identify the same Marketplace and origin path.`,
+      `${component}:${source.id}:${file.role} does not identify the same Marketplace and origin path.`,
     );
-    invariant(isFullSha(file.marketplaceBlobSha), `${component}:${file.role} has an invalid Marketplace blob SHA.`);
-    invariant(isFullSha(file.originBlobSha), `${component}:${file.role} has an invalid origin blob SHA.`);
-    invariant(/^[0-9a-f]{64}$/.test(file.marketplaceSha256), `${component}:${file.role} has an invalid Marketplace SHA-256.`);
-    invariant(/^[0-9a-f]{64}$/.test(file.originSha256), `${component}:${file.role} has an invalid origin SHA-256.`);
+    invariant(isFullSha(file.marketplaceBlobSha), `${component}:${source.id}:${file.role} has an invalid Marketplace blob SHA.`);
+    invariant(isFullSha(file.originBlobSha), `${component}:${source.id}:${file.role} has an invalid origin blob SHA.`);
+    invariant(/^[0-9a-f]{64}$/.test(file.marketplaceSha256), `${component}:${source.id}:${file.role} has an invalid Marketplace SHA-256.`);
+    invariant(/^[0-9a-f]{64}$/.test(file.originSha256), `${component}:${source.id}:${file.role} has an invalid origin SHA-256.`);
     invariant(
       file.contentDiffers === (file.marketplaceSha256 !== file.originSha256),
-      `${component}:${file.role} has an inconsistent contentDiffers value.`,
+      `${component}:${source.id}:${file.role} has an inconsistent contentDiffers value.`,
     );
   }
   const expectedAvailableSurfaces = [
@@ -288,45 +250,257 @@ function validateSource(component, spec, lock) {
   ].sort();
   invariant(
     JSON.stringify(source.availableSurfaces) === JSON.stringify(expectedAvailableSurfaces),
-    `${component} availableSurfaces do not match its source inventory.`,
+    `${component}:${source.id} availableSurfaces do not match its source inventory.`,
   );
 
-  invariant(Array.isArray(source.releaseDifferences), `${component} must declare releaseDifferences.`);
+  invariant(Array.isArray(source.releaseDifferences), `${component}:${source.id} must declare releaseDifferences.`);
   const differingRoles = source.sourceFiles.filter((file) => file.contentDiffers).map((file) => file.role);
   invariant(
     JSON.stringify(source.releaseDifferences.map((difference) => difference.role)) === JSON.stringify(differingRoles),
-    `${component} releaseDifferences do not match its Marketplace and origin digests.`,
+    `${component}:${source.id} releaseDifferences do not match its Marketplace and origin digests.`,
   );
   for (const difference of source.releaseDifferences) {
-    validateExactKeys(difference, ['role', 'status', 'resolution', 'note'], [], `${component} release difference`);
+    validateExactKeys(difference, ['role', 'status', 'resolution', 'note'], [], `${component}:${source.id} release difference`);
     invariant(
       ['review-required', 'reviewed'].includes(difference.status),
-      `${component}:${difference.role} has an invalid release-difference status.`,
+      `${component}:${source.id}:${difference.role} has an invalid release-difference status.`,
     );
     if (difference.status === 'review-required') {
-      invariant(difference.resolution === null, `${component}:${difference.role} requires review and cannot have a resolution.`);
-      invariant(difference.note === null, `${component}:${difference.role} requires review and cannot have a review note.`);
+      invariant(
+        difference.resolution === null,
+        `${component}:${source.id}:${difference.role} requires review and cannot have a resolution.`,
+      );
+      invariant(difference.note === null, `${component}:${source.id}:${difference.role} requires review and cannot have a review note.`);
     } else {
       invariant(
         ['marketplace-authoring-input', 'origin-lineage-reviewed', 'not-material'].includes(difference.resolution),
-        `${component}:${difference.role} has an invalid release-difference resolution.`,
+        `${component}:${source.id}:${difference.role} has an invalid release-difference resolution.`,
       );
       invariant(
         typeof difference.note === 'string' && difference.note.length > 0,
-        `${component}:${difference.role} must explain its reviewed release difference.`,
+        `${component}:${source.id}:${difference.role} must explain its reviewed release difference.`,
       );
     }
   }
-  if (source.conformance === 'reviewed') {
+  if (contract.conformance === 'reviewed') {
     invariant(
       source.releaseDifferences.every((difference) => difference.status === 'reviewed'),
-      `${component} cannot be reviewed while a release-content difference is unresolved.`,
+      `${component}:${source.id} cannot be reviewed while a release-content difference is unresolved.`,
     );
   }
+}
 
-  validateDivergences(component, spec, source);
-  validateRequirements(component, spec, source, componentRoot);
-  return source;
+function validateLocalFoundationSource(component, source, lock) {
+  validateExactKeys(source, ['id', 'kind', 'authority', 'references'], [], `${component}:${source.id}`);
+  validateSourceIdentity(component, source);
+  invariant(source.kind === 'local-foundation', `${component}:${source.id} has the wrong source kind.`);
+  invariant(source.authority === 'normative', `${component}:${source.id} must be normative.`);
+  invariant(!lock.catalog.entries.includes(component), `${component} has a Flex catalog entry and cannot use a local-foundation source.`);
+  invariant(Array.isArray(source.references) && source.references.length > 0, `${component}:${source.id} must record references.`);
+  invariant(
+    JSON.stringify(source.references.map((reference) => reference.id)) ===
+      JSON.stringify(source.references.map((reference) => reference.id).sort()),
+    `${component}:${source.id} references must be sorted by id.`,
+  );
+  const referenceIds = new Set();
+  for (const reference of source.references) {
+    validateExactKeys(reference, ['id', 'type', 'authority', 'location'], [], `${component}:${source.id} reference`);
+    invariant(/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(reference.id), `${component}:${source.id} has an invalid reference id.`);
+    invariant(!referenceIds.has(reference.id), `${component}:${source.id} repeats reference ${reference.id}.`);
+    referenceIds.add(reference.id);
+    invariant(sourceAuthorities.includes(reference.authority), `${component}:${source.id}:${reference.id} has an invalid authority.`);
+    invariant(
+      ['external', 'repository'].includes(reference.type),
+      `${component}:${source.id}:${reference.id} has an invalid reference type.`,
+    );
+    if (reference.type === 'external') {
+      invariant(reference.location.startsWith('https://'), `${component}:${source.id}:${reference.id} must use an HTTPS reference.`);
+    } else {
+      const referencePath = path.resolve(repositoryRoot, reference.location);
+      invariant(
+        !path.isAbsolute(reference.location) && referencePath.startsWith(`${repositoryRoot}${path.sep}`) && fs.existsSync(referencePath),
+        `${component}:${source.id}:${reference.id} references missing repository content ${reference.location}.`,
+      );
+    }
+  }
+}
+
+function validateArtifactLocation(component, source, artifact) {
+  invariant(
+    typeof artifact.location === 'string' && artifact.location.length > 0,
+    `${component}:${source.id}:${artifact.id} needs a location.`,
+  );
+  invariant(/^[0-9a-f]{64}$/.test(artifact.sha256), `${component}:${source.id}:${artifact.id} has an invalid SHA-256.`);
+  if (!artifact.location.startsWith('https://')) {
+    const artifactPath = path.resolve(repositoryRoot, artifact.location);
+    invariant(
+      !path.isAbsolute(artifact.location) && artifactPath.startsWith(`${repositoryRoot}${path.sep}`) && fs.existsSync(artifactPath),
+      `${component}:${source.id}:${artifact.id} references missing repository content ${artifact.location}.`,
+    );
+    const digest = crypto.createHash('sha256').update(fs.readFileSync(artifactPath)).digest('hex');
+    invariant(digest === artifact.sha256, `${component}:${source.id}:${artifact.id} has a stale SHA-256.`);
+  }
+}
+
+function validateGitFilesSource(component, source) {
+  validateExactKeys(source, ['id', 'kind', 'authority', 'repository', 'commit', 'files'], [], `${component}:${source.id}`);
+  validateSourceIdentity(component, source);
+  invariant(source.kind === 'git-files', `${component}:${source.id} has the wrong source kind.`);
+  invariant(
+    /^(?:https:\/\/\S+|[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)$/.test(source.repository),
+    `${component}:${source.id} has an invalid repository.`,
+  );
+  invariant(isFullSha(source.commit), `${component}:${source.id} must identify an immutable commit.`);
+  invariant(Array.isArray(source.files) && source.files.length > 0, `${component}:${source.id} must record files.`);
+  invariant(
+    JSON.stringify(source.files.map((file) => file.path)) === JSON.stringify(source.files.map((file) => file.path).sort()),
+    `${component}:${source.id} files must be sorted by path.`,
+  );
+  const paths = new Set();
+  for (const file of source.files) {
+    validateExactKeys(file, ['role', 'path', 'sha256'], [], `${component}:${source.id} file`);
+    invariant(/^[a-z0-9]+(?::[a-z0-9-]+)*$/.test(file.role), `${component}:${source.id} has an invalid file role.`);
+    invariant(
+      typeof file.path === 'string' &&
+        file.path.length > 0 &&
+        !path.isAbsolute(file.path) &&
+        !file.path.includes('\\') &&
+        !file.path.split('/').includes('..'),
+      `${component}:${source.id} has an invalid file path.`,
+    );
+    invariant(!paths.has(file.path), `${component}:${source.id} repeats file ${file.path}.`);
+    paths.add(file.path);
+    invariant(/^[0-9a-f]{64}$/.test(file.sha256), `${component}:${source.id}:${file.path} has an invalid SHA-256.`);
+  }
+}
+
+function validateHtmlCssSource(component, source) {
+  validateExactKeys(source, ['id', 'kind', 'authority', 'origin', 'artifacts'], [], `${component}:${source.id}`);
+  validateSourceIdentity(component, source);
+  invariant(source.kind === 'html-css', `${component}:${source.id} has the wrong source kind.`);
+  invariant(typeof source.origin === 'string' && source.origin.length > 0, `${component}:${source.id} must identify its origin.`);
+  invariant(Array.isArray(source.artifacts) && source.artifacts.length > 0, `${component}:${source.id} must record artifacts.`);
+  invariant(
+    JSON.stringify(source.artifacts.map((artifact) => artifact.id)) ===
+      JSON.stringify(source.artifacts.map((artifact) => artifact.id).sort()),
+    `${component}:${source.id} artifacts must be sorted by id.`,
+  );
+  const artifactIds = new Set();
+  for (const artifact of source.artifacts) {
+    validateExactKeys(artifact, ['id', 'kind', 'location', 'sha256'], [], `${component}:${source.id} artifact`);
+    invariant(/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(artifact.id), `${component}:${source.id} has an invalid artifact id.`);
+    invariant(!artifactIds.has(artifact.id), `${component}:${source.id} repeats artifact ${artifact.id}.`);
+    artifactIds.add(artifact.id);
+    invariant(
+      ['accessibility-tree', 'computed-styles', 'css', 'html', 'screenshot'].includes(artifact.kind),
+      `${component}:${source.id}:${artifact.id} has an invalid artifact kind.`,
+    );
+    validateArtifactLocation(component, source, artifact);
+  }
+}
+
+function validateVisualReferenceSource(component, source) {
+  validateExactKeys(source, ['id', 'kind', 'authority', 'artifacts'], [], `${component}:${source.id}`);
+  validateSourceIdentity(component, source);
+  invariant(source.kind === 'visual-reference', `${component}:${source.id} has the wrong source kind.`);
+  invariant(source.authority === 'visual-evidence', `${component}:${source.id} must use visual-evidence authority.`);
+  invariant(Array.isArray(source.artifacts) && source.artifacts.length > 0, `${component}:${source.id} must record artifacts.`);
+  invariant(
+    JSON.stringify(source.artifacts.map((artifact) => artifact.id)) ===
+      JSON.stringify(source.artifacts.map((artifact) => artifact.id).sort()),
+    `${component}:${source.id} artifacts must be sorted by id.`,
+  );
+  const artifactIds = new Set();
+  for (const artifact of source.artifacts) {
+    validateExactKeys(
+      artifact,
+      ['id', 'location', 'sha256'],
+      ['appearance', 'state', 'platform', 'scale', 'viewport', 'locale'],
+      `${component}:${source.id} artifact`,
+    );
+    invariant(/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(artifact.id), `${component}:${source.id} has an invalid artifact id.`);
+    invariant(!artifactIds.has(artifact.id), `${component}:${source.id} repeats artifact ${artifact.id}.`);
+    artifactIds.add(artifact.id);
+    validateArtifactLocation(component, source, artifact);
+    for (const field of ['appearance', 'state', 'platform', 'viewport', 'locale']) {
+      if (Object.hasOwn(artifact, field)) {
+        invariant(
+          typeof artifact[field] === 'string' && artifact[field].length > 0,
+          `${component}:${source.id}:${artifact.id} has invalid ${field}.`,
+        );
+      }
+      if (Object.hasOwn(artifact, 'scale')) {
+        invariant(
+          typeof artifact.scale === 'number' && artifact.scale > 0,
+          `${component}:${source.id}:${artifact.id} has an invalid scale.`,
+        );
+      }
+    }
+  }
+}
+
+function validateSource(component, spec, lock) {
+  const componentRoot = path.join(componentsRoot, component);
+  const sourcePath = sourcePathFor(component);
+  const contract = readJson(sourcePath);
+
+  validateExactKeys(
+    contract,
+    ['schemaVersion', 'component', 'lifecycle', 'conformance', 'reviewedAt', 'sources', 'divergences', 'requirements'],
+    [],
+    `${component}/spec/source.json`,
+  );
+  invariant(contract.schemaVersion === 2, `${component}/spec/source.json must use schemaVersion 2.`);
+  invariant(contract.component === component, `${component}/spec/source.json has the wrong component.`);
+  invariant(['contract-draft', 'contract-reviewed', 'implemented'].includes(contract.lifecycle), `${component} has an invalid lifecycle.`);
+  invariant(['review-required', 'reviewed'].includes(contract.conformance), `${component} has an invalid conformance value.`);
+  if (contract.lifecycle === 'contract-draft') {
+    invariant(contract.conformance === 'review-required', `${component} draft contracts must require review.`);
+  } else {
+    invariant(contract.conformance === 'reviewed', `${component} ${contract.lifecycle} contracts must be reviewed.`);
+  }
+  if (contract.conformance === 'review-required') {
+    invariant(contract.reviewedAt === null, `${component} cannot have reviewedAt while review is required.`);
+  } else {
+    invariant(/^\d{4}-\d{2}-\d{2}$/.test(contract.reviewedAt), `${component} reviewedAt must be YYYY-MM-DD.`);
+  }
+
+  invariant(Array.isArray(contract.sources) && contract.sources.length > 0, `${component} must declare sources.`);
+  invariant(
+    JSON.stringify(contract.sources.map((source) => source.id)) === JSON.stringify(contract.sources.map((source) => source.id).sort()),
+    `${component} sources must be sorted by id.`,
+  );
+  const sourceIds = new Set();
+  for (const source of contract.sources) {
+    invariant(!sourceIds.has(source.id), `${component} repeats source ${source.id}.`);
+    sourceIds.add(source.id);
+    if (source.kind === 'flex-skill') {
+      validateFlexSource(component, contract, source, lock);
+    } else if (source.kind === 'local-foundation') {
+      validateLocalFoundationSource(component, source, lock);
+    } else if (source.kind === 'git-files') {
+      validateGitFilesSource(component, source);
+    } else if (source.kind === 'html-css') {
+      validateHtmlCssSource(component, source);
+    } else if (source.kind === 'visual-reference') {
+      validateVisualReferenceSource(component, source);
+    } else {
+      throw new Error(`${component}:${source.id} has unsupported source kind ${source.kind}.`);
+    }
+  }
+  const localFoundationSources = contract.sources.filter((source) => source.kind === 'local-foundation');
+  invariant(
+    localFoundationSources.length === 0 || (localFoundationSources.length === 1 && contract.sources.length === 1),
+    `${component} local-foundation must be the only source.`,
+  );
+  invariant(
+    contract.sources.filter((source) => source.kind === 'flex-skill').length <= 1,
+    `${component} cannot declare more than one Flex skill source.`,
+  );
+
+  validateDivergences(component, spec, contract);
+  validateRequirements(component, spec, contract, componentRoot);
+  return contract;
 }
 
 function validateComponent(component, lock) {
@@ -348,9 +522,13 @@ function validateComponent(component, lock) {
   invariant(frontMatter.interaction === './spec/interaction.md', `${component}/SPEC.md must reference ./spec/interaction.md.`);
   invariant(frontMatter.usage === './spec/usage.md', `${component}/SPEC.md must reference ./spec/usage.md.`);
 
-  for (const heading of ['## Scope', '## Public contract', '## Platform behavior', '## Divergences from Flex', '## Conformance']) {
+  for (const heading of ['## Scope', '## Public contract', '## Platform behavior', '## Conformance']) {
     invariant(spec.includes(heading), `${component}/SPEC.md is missing ${heading}.`);
   }
+  invariant(
+    spec.includes('## Divergences') || spec.includes('## Divergences from Flex'),
+    `${component}/SPEC.md is missing its divergences section.`,
+  );
 
   for (const companion of ['tokens.yaml', 'accessibility.md', 'interaction.md', 'usage.md']) {
     const companionPath = path.join(componentRoot, 'spec', companion);
@@ -434,24 +612,25 @@ function validateReport(lock, components) {
     'The report component details are stale.',
   );
   for (const entry of report.components) {
-    const source = readJson(sourcePathFor(entry.component));
+    const contract = readJson(sourcePathFor(entry.component));
+    const flexSource = contract.sources.find((source) => source.kind === 'flex-skill');
     validateExactKeys(
       entry,
       ['component', 'lifecycle', 'conformance', 'releaseDifferences', 'marketplaceDrift', 'originDrift', 'candidateStatus'],
       [],
       `${entry.component} report entry`,
     );
-    invariant(entry.lifecycle === source.lifecycle, `${entry.component} has stale lifecycle reporting.`);
-    invariant(entry.conformance === source.conformance, `${entry.component} has stale conformance reporting.`);
+    invariant(entry.lifecycle === contract.lifecycle, `${entry.component} has stale lifecycle reporting.`);
+    invariant(entry.conformance === contract.conformance, `${entry.component} has stale conformance reporting.`);
     invariant(
-      JSON.stringify(entry.releaseDifferences) === JSON.stringify(source.releaseDifferences || []),
+      JSON.stringify(entry.releaseDifferences) === JSON.stringify(flexSource?.releaseDifferences || []),
       `${entry.component} has stale release-content difference reporting.`,
     );
-    if (source.sourceKind === 'local-foundation') {
+    if (!flexSource) {
       invariant(entry.candidateStatus === 'not-applicable', `${entry.component} must omit Flex candidate drift.`);
       invariant(
         entry.marketplaceDrift === null && entry.originDrift === null,
-        `${entry.component} local-foundation source cannot report Flex drift.`,
+        `${entry.component} without a Flex source cannot report Flex drift.`,
       );
     } else if (entry.candidateStatus === 'unchecked') {
       invariant(

--- a/packages/agentic/components/scripts/spec-contracts/check-spec-contracts.cjs
+++ b/packages/agentic/components/scripts/spec-contracts/check-spec-contracts.cjs
@@ -74,10 +74,114 @@ function validateAgencyProfile(lock) {
   }
 }
 
+function validateDivergences(component, spec, source) {
+  invariant(Array.isArray(source.divergences), `${component} must declare divergences.`);
+  for (const divergence of source.divergences) {
+    validateExactKeys(divergence, ['id', 'status'], [], `${component} divergence`);
+    invariant(/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(divergence.id), `${component} has an invalid divergence id.`);
+    invariant(
+      ['accepted', 'deferred', 'aligning', 'not-applicable', 'resolved'].includes(divergence.status),
+      `${component}:${divergence.id} has an invalid divergence status.`,
+    );
+    invariant(spec.includes(`\`${divergence.id}\``), `${component} SPEC.md must describe divergence ${divergence.id}.`);
+  }
+}
+
+function validateRequirements(component, spec, source, componentRoot) {
+  invariant(Array.isArray(source.requirements) && source.requirements.length > 0, `${component} must declare contract requirements.`);
+  const requirementIds = new Set();
+  for (const requirement of source.requirements) {
+    validateExactKeys(requirement, ['id'], ['evidence', 'plannedEvidence'], `${component} requirement`);
+    invariant(/^[A-Z][A-Z0-9]{1,9}-\d{3}$/.test(requirement.id), `${component} has an invalid requirement id.`);
+    invariant(!requirementIds.has(requirement.id), `${component} repeats requirement ${requirement.id}.`);
+    requirementIds.add(requirement.id);
+    invariant(spec.includes(requirement.id), `${component} SPEC.md must describe requirement ${requirement.id}.`);
+    const evidence = requirement.evidence || [];
+    const plannedEvidence = requirement.plannedEvidence || [];
+    invariant(Array.isArray(evidence), `${requirement.id} evidence must be an array.`);
+    invariant(Array.isArray(plannedEvidence), `${requirement.id} plannedEvidence must be an array.`);
+    invariant(evidence.length + plannedEvidence.length > 0, `${requirement.id} must name actual or planned evidence.`);
+    if (source.lifecycle === 'implemented') {
+      invariant(evidence.length > 0, `${requirement.id} must name realized evidence for an implemented component.`);
+    }
+    for (const evidencePathValue of evidence) {
+      const evidencePath = typeof evidencePathValue === 'string' ? path.resolve(componentRoot, evidencePathValue) : '';
+      invariant(
+        typeof evidencePathValue === 'string' &&
+          !path.isAbsolute(evidencePathValue) &&
+          evidencePath.startsWith(`${componentRoot}${path.sep}`) &&
+          fs.existsSync(evidencePath),
+        `${requirement.id} references missing evidence ${evidencePathValue}.`,
+      );
+    }
+    for (const plannedPathValue of plannedEvidence) {
+      const plannedPath = typeof plannedPathValue === 'string' ? path.resolve(componentRoot, plannedPathValue) : '';
+      invariant(
+        typeof plannedPathValue === 'string' && !path.isAbsolute(plannedPathValue) && plannedPath.startsWith(`${componentRoot}${path.sep}`),
+        `${requirement.id} has invalid planned evidence ${plannedPathValue}.`,
+      );
+    }
+  }
+}
+
+function validateLocalFoundationSource(component, spec, source, componentRoot, lock) {
+  validateExactKeys(
+    source,
+    ['schemaVersion', 'component', 'sourceKind', 'lifecycle', 'conformance', 'reviewedAt', 'references', 'divergences', 'requirements'],
+    [],
+    `${component}/spec/source.json`,
+  );
+  invariant(source.schemaVersion === 1, `${component}/spec/source.json must use schemaVersion 1.`);
+  invariant(source.component === component, `${component}/spec/source.json has the wrong component.`);
+  invariant(source.sourceKind === 'local-foundation', `${component}/spec/source.json has an invalid local source kind.`);
+  invariant(!lock.catalog.entries.includes(component), `${component} has a Flex catalog entry and cannot use a local-foundation source.`);
+  invariant(['contract-draft', 'contract-reviewed', 'implemented'].includes(source.lifecycle), `${component} has an invalid lifecycle.`);
+  invariant(['review-required', 'reviewed'].includes(source.conformance), `${component} has an invalid conformance value.`);
+  if (source.lifecycle === 'contract-draft') {
+    invariant(source.conformance === 'review-required', `${component} draft contracts must require review.`);
+  }
+  if (source.conformance === 'review-required') {
+    invariant(source.reviewedAt === null, `${component} cannot have reviewedAt while review is required.`);
+  } else {
+    invariant(/^\d{4}-\d{2}-\d{2}$/.test(source.reviewedAt), `${component} reviewedAt must be YYYY-MM-DD.`);
+  }
+
+  invariant(Array.isArray(source.references) && source.references.length > 0, `${component} must record local-foundation references.`);
+  invariant(
+    JSON.stringify(source.references.map((reference) => reference.id)) ===
+      JSON.stringify(source.references.map((reference) => reference.id).sort()),
+    `${component} local-foundation references must be sorted by id.`,
+  );
+  const referenceIds = new Set();
+  for (const reference of source.references) {
+    validateExactKeys(reference, ['id', 'type', 'location'], [], `${component} local-foundation reference`);
+    invariant(/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(reference.id), `${component} has an invalid reference id.`);
+    invariant(!referenceIds.has(reference.id), `${component} repeats reference ${reference.id}.`);
+    referenceIds.add(reference.id);
+    invariant(['external', 'repository'].includes(reference.type), `${component}:${reference.id} has an invalid reference type.`);
+    if (reference.type === 'external') {
+      invariant(reference.location.startsWith('https://'), `${component}:${reference.id} must use an HTTPS reference.`);
+    } else {
+      const referencePath = path.resolve(repositoryRoot, reference.location);
+      invariant(
+        !path.isAbsolute(reference.location) && referencePath.startsWith(`${repositoryRoot}${path.sep}`) && fs.existsSync(referencePath),
+        `${component}:${reference.id} references missing repository content ${reference.location}.`,
+      );
+    }
+  }
+
+  validateDivergences(component, spec, source);
+  validateRequirements(component, spec, source, componentRoot);
+  return source;
+}
+
 function validateSource(component, spec, lock) {
   const componentRoot = path.join(componentsRoot, component);
   const sourcePath = sourcePathFor(component);
   const source = readJson(sourcePath);
+  if (source.sourceKind === 'local-foundation') {
+    return validateLocalFoundationSource(component, spec, source, componentRoot, lock);
+  }
 
   validateExactKeys(
     source,
@@ -220,51 +324,8 @@ function validateSource(component, spec, lock) {
     );
   }
 
-  invariant(Array.isArray(source.divergences), `${component} must declare divergences.`);
-  for (const divergence of source.divergences) {
-    validateExactKeys(divergence, ['id', 'status'], [], `${component} divergence`);
-    invariant(/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(divergence.id), `${component} has an invalid divergence id.`);
-    invariant(
-      ['accepted', 'deferred', 'aligning', 'not-applicable', 'resolved'].includes(divergence.status),
-      `${component}:${divergence.id} has an invalid divergence status.`,
-    );
-    invariant(spec.includes(`\`${divergence.id}\``), `${component} SPEC.md must describe divergence ${divergence.id}.`);
-  }
-
-  invariant(Array.isArray(source.requirements) && source.requirements.length > 0, `${component} must declare contract requirements.`);
-  const requirementIds = new Set();
-  for (const requirement of source.requirements) {
-    validateExactKeys(requirement, ['id'], ['evidence', 'plannedEvidence'], `${component} requirement`);
-    invariant(/^[A-Z][A-Z0-9]{1,9}-\d{3}$/.test(requirement.id), `${component} has an invalid requirement id.`);
-    invariant(!requirementIds.has(requirement.id), `${component} repeats requirement ${requirement.id}.`);
-    requirementIds.add(requirement.id);
-    invariant(spec.includes(requirement.id), `${component} SPEC.md must describe requirement ${requirement.id}.`);
-    const evidence = requirement.evidence || [];
-    const plannedEvidence = requirement.plannedEvidence || [];
-    invariant(Array.isArray(evidence), `${requirement.id} evidence must be an array.`);
-    invariant(Array.isArray(plannedEvidence), `${requirement.id} plannedEvidence must be an array.`);
-    invariant(evidence.length + plannedEvidence.length > 0, `${requirement.id} must name actual or planned evidence.`);
-    if (source.lifecycle === 'implemented') {
-      invariant(evidence.length > 0, `${requirement.id} must name realized evidence for an implemented component.`);
-    }
-    for (const evidencePathValue of evidence) {
-      const evidencePath = typeof evidencePathValue === 'string' ? path.resolve(componentRoot, evidencePathValue) : '';
-      invariant(
-        typeof evidencePathValue === 'string' &&
-          !path.isAbsolute(evidencePathValue) &&
-          evidencePath.startsWith(`${componentRoot}${path.sep}`) &&
-          fs.existsSync(evidencePath),
-        `${requirement.id} references missing evidence ${evidencePathValue}.`,
-      );
-    }
-    for (const plannedPathValue of plannedEvidence) {
-      const plannedPath = typeof plannedPathValue === 'string' ? path.resolve(componentRoot, plannedPathValue) : '';
-      invariant(
-        typeof plannedPathValue === 'string' && !path.isAbsolute(plannedPathValue) && plannedPath.startsWith(`${componentRoot}${path.sep}`),
-        `${requirement.id} has invalid planned evidence ${plannedPathValue}.`,
-      );
-    }
-  }
+  validateDivergences(component, spec, source);
+  validateRequirements(component, spec, source, componentRoot);
   return source;
 }
 
@@ -383,10 +444,16 @@ function validateReport(lock, components) {
     invariant(entry.lifecycle === source.lifecycle, `${entry.component} has stale lifecycle reporting.`);
     invariant(entry.conformance === source.conformance, `${entry.component} has stale conformance reporting.`);
     invariant(
-      JSON.stringify(entry.releaseDifferences) === JSON.stringify(source.releaseDifferences),
+      JSON.stringify(entry.releaseDifferences) === JSON.stringify(source.releaseDifferences || []),
       `${entry.component} has stale release-content difference reporting.`,
     );
-    if (entry.candidateStatus === 'unchecked') {
+    if (source.sourceKind === 'local-foundation') {
+      invariant(entry.candidateStatus === 'not-applicable', `${entry.component} must omit Flex candidate drift.`);
+      invariant(
+        entry.marketplaceDrift === null && entry.originDrift === null,
+        `${entry.component} local-foundation source cannot report Flex drift.`,
+      );
+    } else if (entry.candidateStatus === 'unchecked') {
       invariant(
         entry.marketplaceDrift === null && entry.originDrift === null,
         `${entry.component} cannot claim unchecked source drift details.`,

--- a/packages/agentic/components/scripts/spec-contracts/report-spec-source-drift.cjs
+++ b/packages/agentic/components/scripts/spec-contracts/report-spec-source-drift.cjs
@@ -137,8 +137,16 @@ function sourceIdentityMatches(existingFiles, sourceFiles) {
   return JSON.stringify(normalize(existingFiles)) === JSON.stringify(normalize(sourceFiles));
 }
 
-function isLocalFoundationSource(source) {
-  return source.sourceKind === 'local-foundation';
+function flexSourceFor(contract) {
+  return contract.sources?.find((source) => source.kind === 'flex-skill');
+}
+
+function localFoundationSourceFor(contract) {
+  return contract.sources?.find((source) => source.kind === 'local-foundation');
+}
+
+function hasNonFlexContract(contract) {
+  return Array.isArray(contract.sources) && contract.sources.length > 0 && !flexSourceFor(contract);
 }
 
 async function updateComponentSources(lock, marketplaceTree, originTree, token) {
@@ -148,9 +156,11 @@ async function updateComponentSources(lock, marketplaceTree, originTree, token) 
     invariant(contractDirectories().includes(target), `${target} must have a local SPEC.md before source metadata is generated.`);
     const existingSourcePath = sourcePathFor(target);
     const existing = fs.existsSync(existingSourcePath) ? readJson(existingSourcePath) : {};
-    if (isLocalFoundationSource(existing)) {
+    const existingFlexSource = flexSourceFor(existing);
+    if (hasNonFlexContract(existing) && !component) {
       continue;
     }
+    invariant(!localFoundationSourceFor(existing), `${target} uses local-foundation references and cannot add a Flex source.`);
     const marketplacePrefix = `catalogs/flex/plugins/components/skills/${target}/`;
     const originPrefix = `plugins/components/skills/${target}/`;
     const marketplaceEntries = componentSourceEntries(marketplaceTree, marketplacePrefix);
@@ -190,12 +200,12 @@ async function updateComponentSources(lock, marketplaceTree, originTree, token) 
       ),
     ].sort();
     const sameSource =
-      existing.sourceLock === lock.id &&
-      existing.sourceLockFingerprint === lock.fingerprint &&
-      sourceIdentityMatches(existing.sourceFiles, sourceFiles);
+      existingFlexSource?.sourceLock === lock.id &&
+      existingFlexSource.sourceLockFingerprint === lock.fingerprint &&
+      sourceIdentityMatches(existingFlexSource.sourceFiles, sourceFiles);
     const conformance = sameSource ? existing.conformance || 'review-required' : 'review-required';
     const existingDifferences = new Map(
-      (sameSource ? existing.releaseDifferences || [] : []).map((difference) => [difference.role, difference]),
+      (sameSource ? existingFlexSource.releaseDifferences || [] : []).map((difference) => [difference.role, difference]),
     );
     const releaseDifferences = sourceFiles
       .filter((file) => file.contentDiffers)
@@ -208,25 +218,33 @@ async function updateComponentSources(lock, marketplaceTree, originTree, token) 
             note: null,
           },
       );
-    const source = {
-      schemaVersion: 1,
-      component: target,
+    const flexSource = {
+      id: existingFlexSource?.id || 'flex-component',
+      kind: 'flex-skill',
+      authority: existingFlexSource?.authority || 'normative',
       skill: `flex-components:${target}`,
       sourceLock: lock.id,
       sourceLockFingerprint: lock.fingerprint,
-      lifecycle: existing.lifecycle || 'contract-draft',
-      conformance,
-      reviewedAt: conformance === 'review-required' ? null : existing.reviewedAt,
       availableSurfaces,
       surfacesConsulted: sameSource
-        ? (existing.surfacesConsulted || []).filter((surface) => availableSurfaces.includes(surface)).sort()
+        ? (existingFlexSource.surfacesConsulted || []).filter((surface) => availableSurfaces.includes(surface)).sort()
         : [],
       sourceFiles,
       releaseDifferences,
+    };
+    const contract = {
+      schemaVersion: 2,
+      component: target,
+      lifecycle: existing.lifecycle || 'contract-draft',
+      conformance,
+      reviewedAt: conformance === 'review-required' ? null : existing.reviewedAt,
+      sources: [...(existing.sources || []).filter((source) => source.kind !== 'flex-skill'), flexSource].sort((left, right) =>
+        left.id.localeCompare(right.id),
+      ),
       divergences: existing.divergences || [],
       requirements: existing.requirements || [],
     };
-    updates.set(target, source);
+    updates.set(target, contract);
   }
   return updates;
 }
@@ -269,8 +287,9 @@ async function verifyComponentSourceIntegrity(lock, marketplaceTree, originTree,
   }
 
   for (const target of contractDirectories()) {
-    const source = proposedSources.get(target) || readJson(sourcePathFor(target));
-    if (isLocalFoundationSource(source)) {
+    const contract = proposedSources.get(target) || readJson(sourcePathFor(target));
+    const source = flexSourceFor(contract);
+    if (!source) {
       continue;
     }
     invariant(source.sourceLock === lock.id, `${target} does not reference the active source lock.`);
@@ -315,13 +334,11 @@ async function verifyComponentSourceIntegrity(lock, marketplaceTree, originTree,
   }
 }
 
-function sourceDrift(source, tree, channel) {
+function sourceDrift(componentName, source, tree, channel) {
   const pathField = channel === 'marketplace' ? 'marketplacePath' : 'originPath';
   const shaField = channel === 'marketplace' ? 'marketplaceBlobSha' : 'originBlobSha';
   const prefix =
-    channel === 'marketplace'
-      ? `catalogs/flex/plugins/components/skills/${source.component}/`
-      : `plugins/components/skills/${source.component}/`;
+    channel === 'marketplace' ? `catalogs/flex/plugins/components/skills/${componentName}/` : `plugins/components/skills/${componentName}/`;
   const baseline = new Map(source.sourceFiles.map((file) => [relativeSourcePath(file[pathField], prefix), file[shaField]]));
   const candidate = new Map(componentSourceEntries(tree, prefix).map((entry) => [relativeSourcePath(entry.path, prefix), entry.sha]));
   return {
@@ -335,28 +352,29 @@ function sourceDrift(source, tree, channel) {
 
 function localComponentReport(marketplaceTree, originTree) {
   return contractDirectories().map((target) => {
-    const source = readJson(sourcePathFor(target));
-    if (isLocalFoundationSource(source)) {
+    const contract = readJson(sourcePathFor(target));
+    const source = flexSourceFor(contract);
+    if (!source) {
       return {
         component: target,
-        lifecycle: source.lifecycle,
-        conformance: source.conformance,
+        lifecycle: contract.lifecycle,
+        conformance: contract.conformance,
         releaseDifferences: [],
         marketplaceDrift: null,
         originDrift: null,
         candidateStatus: 'not-applicable',
       };
     }
-    const marketplaceDrift = marketplaceTree ? sourceDrift(source, marketplaceTree, 'marketplace') : null;
-    const originDrift = originTree ? sourceDrift(source, originTree, 'origin') : null;
+    const marketplaceDrift = marketplaceTree ? sourceDrift(target, source, marketplaceTree, 'marketplace') : null;
+    const originDrift = originTree ? sourceDrift(target, source, originTree, 'origin') : null;
     const hasCandidateDrift =
       marketplaceDrift &&
       originDrift &&
       [marketplaceDrift, originDrift].some((drift) => drift.added.length > 0 || drift.removed.length > 0 || drift.modified.length > 0);
     return {
       component: target,
-      lifecycle: source.lifecycle,
-      conformance: source.conformance,
+      lifecycle: contract.lifecycle,
+      conformance: contract.conformance,
       releaseDifferences: source.releaseDifferences,
       marketplaceDrift,
       originDrift,
@@ -474,12 +492,13 @@ function offlineRefresh(lock) {
   invariant(existing.external?.mode === 'live', 'Offline refresh requires prior live source evidence.');
   const existingComponents = new Map(existing.components.map((entry) => [entry.component, entry]));
   const components = contractDirectories().map((target) => {
-    const source = readJson(sourcePathFor(target));
-    if (isLocalFoundationSource(source)) {
+    const contract = readJson(sourcePathFor(target));
+    const source = flexSourceFor(contract);
+    if (!source) {
       return {
         component: target,
-        lifecycle: source.lifecycle,
-        conformance: source.conformance,
+        lifecycle: contract.lifecycle,
+        conformance: contract.conformance,
         releaseDifferences: [],
         marketplaceDrift: null,
         originDrift: null,
@@ -489,8 +508,8 @@ function offlineRefresh(lock) {
     const previous = existingComponents.get(target);
     return {
       component: target,
-      lifecycle: source.lifecycle,
-      conformance: source.conformance,
+      lifecycle: contract.lifecycle,
+      conformance: contract.conformance,
       releaseDifferences: source.releaseDifferences,
       marketplaceDrift: previous?.marketplaceDrift ?? null,
       originDrift: previous?.originDrift ?? null,
@@ -508,9 +527,9 @@ async function main() {
   const lock = loadLock();
   if (component) {
     const sourcePath = sourcePathFor(component);
-    const source = fs.existsSync(sourcePath) ? readJson(sourcePath) : {};
+    const contract = fs.existsSync(sourcePath) ? readJson(sourcePath) : {};
     invariant(
-      !isLocalFoundationSource(source),
+      !localFoundationSourceFor(contract),
       `${component} uses local-foundation references and cannot update from the Flex component catalog.`,
     );
     invariant(lock.catalog.entries.includes(component), `${component} is not in the locked Flex component catalog.`);

--- a/packages/agentic/components/scripts/spec-contracts/report-spec-source-drift.cjs
+++ b/packages/agentic/components/scripts/spec-contracts/report-spec-source-drift.cjs
@@ -137,11 +137,20 @@ function sourceIdentityMatches(existingFiles, sourceFiles) {
   return JSON.stringify(normalize(existingFiles)) === JSON.stringify(normalize(sourceFiles));
 }
 
+function isLocalFoundationSource(source) {
+  return source.sourceKind === 'local-foundation';
+}
+
 async function updateComponentSources(lock, marketplaceTree, originTree, token) {
   const targets = component ? [component] : contractDirectories();
   const updates = new Map();
   for (const target of targets) {
     invariant(contractDirectories().includes(target), `${target} must have a local SPEC.md before source metadata is generated.`);
+    const existingSourcePath = sourcePathFor(target);
+    const existing = fs.existsSync(existingSourcePath) ? readJson(existingSourcePath) : {};
+    if (isLocalFoundationSource(existing)) {
+      continue;
+    }
     const marketplacePrefix = `catalogs/flex/plugins/components/skills/${target}/`;
     const originPrefix = `plugins/components/skills/${target}/`;
     const marketplaceEntries = componentSourceEntries(marketplaceTree, marketplacePrefix);
@@ -172,8 +181,6 @@ async function updateComponentSources(lock, marketplaceTree, originTree, token) 
       });
     }
 
-    const sourcePath = sourcePathFor(target);
-    const existing = fs.existsSync(sourcePath) ? readJson(sourcePath) : {};
     const availableSurfaces = [
       ...new Set(
         sourceFiles.map((file) => {
@@ -263,6 +270,9 @@ async function verifyComponentSourceIntegrity(lock, marketplaceTree, originTree,
 
   for (const target of contractDirectories()) {
     const source = proposedSources.get(target) || readJson(sourcePathFor(target));
+    if (isLocalFoundationSource(source)) {
+      continue;
+    }
     invariant(source.sourceLock === lock.id, `${target} does not reference the active source lock.`);
     invariant(source.sourceLockFingerprint === lock.fingerprint, `${target} does not reference the active source-lock fingerprint.`);
     const marketplacePrefix = `catalogs/flex/plugins/components/skills/${target}/`;
@@ -326,6 +336,17 @@ function sourceDrift(source, tree, channel) {
 function localComponentReport(marketplaceTree, originTree) {
   return contractDirectories().map((target) => {
     const source = readJson(sourcePathFor(target));
+    if (isLocalFoundationSource(source)) {
+      return {
+        component: target,
+        lifecycle: source.lifecycle,
+        conformance: source.conformance,
+        releaseDifferences: [],
+        marketplaceDrift: null,
+        originDrift: null,
+        candidateStatus: 'not-applicable',
+      };
+    }
     const marketplaceDrift = marketplaceTree ? sourceDrift(source, marketplaceTree, 'marketplace') : null;
     const originDrift = originTree ? sourceDrift(source, originTree, 'origin') : null;
     const hasCandidateDrift =
@@ -454,6 +475,17 @@ function offlineRefresh(lock) {
   const existingComponents = new Map(existing.components.map((entry) => [entry.component, entry]));
   const components = contractDirectories().map((target) => {
     const source = readJson(sourcePathFor(target));
+    if (isLocalFoundationSource(source)) {
+      return {
+        component: target,
+        lifecycle: source.lifecycle,
+        conformance: source.conformance,
+        releaseDifferences: [],
+        marketplaceDrift: null,
+        originDrift: null,
+        candidateStatus: 'not-applicable',
+      };
+    }
     const previous = existingComponents.get(target);
     return {
       component: target,
@@ -475,6 +507,12 @@ function offlineRefresh(lock) {
 async function main() {
   const lock = loadLock();
   if (component) {
+    const sourcePath = sourcePathFor(component);
+    const source = fs.existsSync(sourcePath) ? readJson(sourcePath) : {};
+    invariant(
+      !isLocalFoundationSource(source),
+      `${component} uses local-foundation references and cannot update from the Flex component catalog.`,
+    );
     invariant(lock.catalog.entries.includes(component), `${component} is not in the locked Flex component catalog.`);
   }
   const report = offline ? (write ? offlineRefresh(lock) : offlineReport(lock)) : await liveReport(lock);

--- a/packages/agentic/components/spec-source-report.json
+++ b/packages/agentic/components/spec-source-report.json
@@ -142,7 +142,8 @@
       "switch",
       "tab",
       "tablist",
-      "tag"
+      "tag",
+      "text"
     ],
     "adaptedDrafts": [],
     "implemented": [
@@ -164,7 +165,8 @@
       "switch",
       "tab",
       "tablist",
-      "tag"
+      "tag",
+      "text"
     ],
     "implementationGap": [
       "avatar-group",
@@ -761,6 +763,15 @@
         "modified": ["web/accessibility.md", "web/interaction.md"]
       },
       "candidateStatus": "review-required"
+    },
+    {
+      "component": "text",
+      "lifecycle": "implemented",
+      "conformance": "reviewed",
+      "releaseDifferences": [],
+      "marketplaceDrift": null,
+      "originDrift": null,
+      "candidateStatus": "not-applicable"
     }
   ]
 }

--- a/packages/agentic/components/src/components/AGENTS.md
+++ b/packages/agentic/components/src/components/AGENTS.md
@@ -7,12 +7,13 @@ Higher-order components own design-token styling, interaction state, layout, and
 components without a Flex catalog entry remain in this directory and use the
 validator-backed `local-foundation` contract source.
 
-Draft and review a source-backed component's React Native contract from the
-pinned `flex-components:<name>` reference before implementation. For a
-`local-foundation` component, review the cited public platform behavior and
-repository token evidence instead. Ratify either contract after types, tests,
-stories, and platform evidence agree; never mechanically promote a web-authored
-spec.
+Draft and review a source-backed React Native contract through the
+[agentic component contract authoring skill](../../../../../.github/skills/agentic-component-contract-authoring/SKILL.md)
+before implementation. Select only the adapters represented by the evidence,
+resolve authority per requirement, and use the pinned
+`flex-components:<name>` reference only when a `flex-skill` source applies.
+Ratify the local contract after types, tests, stories, and platform evidence
+agree; never mechanically promote a web-authored spec.
 
 For package-wide dependency or extraction reviews, also read
 [`packages/agentic/components/src/AGENTS.md`](../AGENTS.md) and the
@@ -61,7 +62,7 @@ audit.
 
 ## Focused references
 
-- [Flex source adaptation](../../../../../.github/skills/agentic-component-authoring/references/spec-source-adaptation.md)
+- [Contract and source adaptation](../../../../../.github/skills/agentic-component-contract-authoring/SKILL.md)
 - [Types and slots](../../../../../.github/skills/agentic-component-authoring/references/types-and-slots.md)
 - [State and accessibility](../../../../../.github/skills/agentic-component-authoring/references/state-and-accessibility.md)
 - [Styles and tokens](../../../../../.github/skills/agentic-component-authoring/references/styles-and-tokens.md)

--- a/packages/agentic/components/src/components/AGENTS.md
+++ b/packages/agentic/components/src/components/AGENTS.md
@@ -3,12 +3,16 @@
 These instructions apply to `packages/agentic/components/src/components` and its descendants.
 
 Higher-order components own design-token styling, interaction state, layout, and component-level accessibility. Use
-`components/button` as the canonical implementation.
+`components/button` as the canonical implementation. Theme-aware foundational
+components without a Flex catalog entry remain in this directory and use the
+validator-backed `local-foundation` contract source.
 
-Draft and review the component's React Native contract from the pinned
-`flex-components:<name>` reference before implementation. Ratify the contract
-after types, tests, stories, and platform evidence agree; never mechanically
-promote a web-authored spec.
+Draft and review a source-backed component's React Native contract from the
+pinned `flex-components:<name>` reference before implementation. For a
+`local-foundation` component, review the cited public platform behavior and
+repository token evidence instead. Ratify either contract after types, tests,
+stories, and platform evidence agree; never mechanically promote a web-authored
+spec.
 
 For package-wide dependency or extraction reviews, also read
 [`packages/agentic/components/src/AGENTS.md`](../AGENTS.md) and the

--- a/packages/agentic/components/src/components/accordion/accordion.types.ts
+++ b/packages/agentic/components/src/components/accordion/accordion.types.ts
@@ -1,4 +1,4 @@
-import type { AccessibilityState, Pressable, StyleProp, Text, View, ViewStyle } from 'react-native';
+import type { AccessibilityState, Pressable, StyleProp, View, ViewStyle } from 'react-native';
 import type {
   ComponentProps,
   ComponentState,
@@ -11,6 +11,7 @@ import type {
 import type { ThemeState } from '@fluentui-react-native/design';
 import type { Icon } from '../../primitives/icon/icon';
 import type { FocusVisualProps } from '../../primitives/focus-visual/focus-visual.types';
+import type { Text } from '../text/text';
 
 export type AccordionLayout = 'chevronStart' | 'chevronEnd';
 export type AccordionSize = 'small';

--- a/packages/agentic/components/src/components/accordion/renderAccordion.tsx
+++ b/packages/agentic/components/src/components/accordion/renderAccordion.tsx
@@ -1,9 +1,9 @@
 /** @jsxImportSource @fluentui-react-native/framework-base */
 import type { ReactNode } from 'react';
-import { Text } from 'react-native';
 import type { StyleProp, TextStyle } from 'react-native';
 
 import { FocusVisual } from '../../primitives/focus-visual/focus-visual';
+import { Text } from '../text/text';
 import type { AccordionState } from './accordion.types';
 
 type AccordionRenderStyles = {

--- a/packages/agentic/components/src/components/accordion/spec/source.json
+++ b/packages/agentic/components/src/components/accordion/spec/source.json
@@ -1,67 +1,74 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "component": "accordion",
-  "skill": "flex-components:accordion",
-  "sourceLock": "flex-1.5.0-206c4996",
-  "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
   "lifecycle": "implemented",
   "conformance": "reviewed",
   "reviewedAt": "2026-08-28",
-  "availableSurfaces": ["shared", "web"],
-  "surfacesConsulted": ["shared", "web"],
-  "sourceFiles": [
+  "sources": [
     {
-      "role": "skill",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/accordion/SKILL.md",
-      "marketplaceBlobSha": "2b18787639ff817789e36ba1e318c86f65e59929",
-      "marketplaceSha256": "c1ea94d075eaf931903f7df8d4767aefc4c741227ca4318f34cdb64436aa1320",
-      "originPath": "plugins/components/skills/accordion/SKILL.md",
-      "originBlobSha": "2b18787639ff817789e36ba1e318c86f65e59929",
-      "originSha256": "c1ea94d075eaf931903f7df8d4767aefc4c741227ca4318f34cdb64436aa1320",
-      "contentDiffers": false
-    },
-    {
-      "role": "usage",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/accordion/usage.md",
-      "marketplaceBlobSha": "cd263e7897b28545a6f61c7e1a8162b95ce4687d",
-      "marketplaceSha256": "ee8cb81565a6ebc612231a57440301605dac65155f068cd3afa6b974ea668e75",
-      "originPath": "plugins/components/skills/accordion/usage.md",
-      "originBlobSha": "cd263e7897b28545a6f61c7e1a8162b95ce4687d",
-      "originSha256": "ee8cb81565a6ebc612231a57440301605dac65155f068cd3afa6b974ea668e75",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:accessibility",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/accordion/web/accessibility.md",
-      "marketplaceBlobSha": "28ed0f0b8a04dafa52bff9145c14b4eef0de0306",
-      "marketplaceSha256": "7aa113875a4643a3796321407b86de321e81cebf9705eb37a923da3835c89e0c",
-      "originPath": "plugins/components/skills/accordion/web/accessibility.md",
-      "originBlobSha": "28ed0f0b8a04dafa52bff9145c14b4eef0de0306",
-      "originSha256": "7aa113875a4643a3796321407b86de321e81cebf9705eb37a923da3835c89e0c",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:interaction",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/accordion/web/interaction.md",
-      "marketplaceBlobSha": "a587e8d12cdf037f63a8f0f38556c8df928e536a",
-      "marketplaceSha256": "84b518e67a94c048d834765a8a834ab030dcc2c2cf539056d1c50e172871f2d9",
-      "originPath": "plugins/components/skills/accordion/web/interaction.md",
-      "originBlobSha": "a587e8d12cdf037f63a8f0f38556c8df928e536a",
-      "originSha256": "84b518e67a94c048d834765a8a834ab030dcc2c2cf539056d1c50e172871f2d9",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:tokens",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/accordion/web/tokens.yaml",
-      "marketplaceBlobSha": "d7d162ea334a50f0498d14c7b79880979e90a66d",
-      "marketplaceSha256": "af44425f9ddac74743e9b91c803865f0ce331aff65175a074744bed73eab2d1f",
-      "originPath": "plugins/components/skills/accordion/web/tokens.yaml",
-      "originBlobSha": "d7d162ea334a50f0498d14c7b79880979e90a66d",
-      "originSha256": "af44425f9ddac74743e9b91c803865f0ce331aff65175a074744bed73eab2d1f",
-      "contentDiffers": false
+      "id": "flex-component",
+      "kind": "flex-skill",
+      "authority": "normative",
+      "skill": "flex-components:accordion",
+      "sourceLock": "flex-1.5.0-206c4996",
+      "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
+      "availableSurfaces": ["shared", "web"],
+      "surfacesConsulted": ["shared", "web"],
+      "sourceFiles": [
+        {
+          "role": "skill",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/accordion/SKILL.md",
+          "marketplaceBlobSha": "2b18787639ff817789e36ba1e318c86f65e59929",
+          "marketplaceSha256": "c1ea94d075eaf931903f7df8d4767aefc4c741227ca4318f34cdb64436aa1320",
+          "originPath": "plugins/components/skills/accordion/SKILL.md",
+          "originBlobSha": "2b18787639ff817789e36ba1e318c86f65e59929",
+          "originSha256": "c1ea94d075eaf931903f7df8d4767aefc4c741227ca4318f34cdb64436aa1320",
+          "contentDiffers": false
+        },
+        {
+          "role": "usage",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/accordion/usage.md",
+          "marketplaceBlobSha": "cd263e7897b28545a6f61c7e1a8162b95ce4687d",
+          "marketplaceSha256": "ee8cb81565a6ebc612231a57440301605dac65155f068cd3afa6b974ea668e75",
+          "originPath": "plugins/components/skills/accordion/usage.md",
+          "originBlobSha": "cd263e7897b28545a6f61c7e1a8162b95ce4687d",
+          "originSha256": "ee8cb81565a6ebc612231a57440301605dac65155f068cd3afa6b974ea668e75",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:accessibility",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/accordion/web/accessibility.md",
+          "marketplaceBlobSha": "28ed0f0b8a04dafa52bff9145c14b4eef0de0306",
+          "marketplaceSha256": "7aa113875a4643a3796321407b86de321e81cebf9705eb37a923da3835c89e0c",
+          "originPath": "plugins/components/skills/accordion/web/accessibility.md",
+          "originBlobSha": "28ed0f0b8a04dafa52bff9145c14b4eef0de0306",
+          "originSha256": "7aa113875a4643a3796321407b86de321e81cebf9705eb37a923da3835c89e0c",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:interaction",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/accordion/web/interaction.md",
+          "marketplaceBlobSha": "a587e8d12cdf037f63a8f0f38556c8df928e536a",
+          "marketplaceSha256": "84b518e67a94c048d834765a8a834ab030dcc2c2cf539056d1c50e172871f2d9",
+          "originPath": "plugins/components/skills/accordion/web/interaction.md",
+          "originBlobSha": "a587e8d12cdf037f63a8f0f38556c8df928e536a",
+          "originSha256": "84b518e67a94c048d834765a8a834ab030dcc2c2cf539056d1c50e172871f2d9",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:tokens",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/accordion/web/tokens.yaml",
+          "marketplaceBlobSha": "d7d162ea334a50f0498d14c7b79880979e90a66d",
+          "marketplaceSha256": "af44425f9ddac74743e9b91c803865f0ce331aff65175a074744bed73eab2d1f",
+          "originPath": "plugins/components/skills/accordion/web/tokens.yaml",
+          "originBlobSha": "d7d162ea334a50f0498d14c7b79880979e90a66d",
+          "originSha256": "af44425f9ddac74743e9b91c803865f0ce331aff65175a074744bed73eab2d1f",
+          "contentDiffers": false
+        }
+      ],
+      "releaseDifferences": []
     }
   ],
-  "releaseDifferences": [],
   "divergences": [
     {
       "id": "accordion-chevron-end-rotation",

--- a/packages/agentic/components/src/components/accordion/useAccordion.ts
+++ b/packages/agentic/components/src/components/accordion/useAccordion.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Pressable, Text, View } from 'react-native';
+import { Pressable, View } from 'react-native';
 
 import { useThemeState } from '@fluentui-react-native/design';
 import {
@@ -12,6 +12,7 @@ import {
 
 import { Icon } from '../../primitives/icon/icon';
 import { semanticIconSources } from '../../common/iconSources';
+import { Text } from '../text/text';
 import type { AccordionProps, AccordionState } from './accordion.types';
 
 const defaultTitle = 'Section title';

--- a/packages/agentic/components/src/components/avatar/avatar.types.ts
+++ b/packages/agentic/components/src/components/avatar/avatar.types.ts
@@ -1,4 +1,4 @@
-import type { Image, StyleProp, Text, View, ViewStyle } from 'react-native';
+import type { Image, StyleProp, View, ViewStyle } from 'react-native';
 import type {
   ComponentProps,
   ComponentState,
@@ -10,6 +10,7 @@ import type {
 import type { ThemeState } from '@fluentui-react-native/design';
 
 import type { Icon } from '../../primitives/icon/icon';
+import type { Text } from '../text/text';
 
 export type AvatarSize = 16 | 20 | 24 | 28 | 32 | 40 | 56 | 120;
 export type AvatarContentMode = 'image' | 'icon' | 'initials';

--- a/packages/agentic/components/src/components/avatar/spec/source.json
+++ b/packages/agentic/components/src/components/avatar/spec/source.json
@@ -1,67 +1,74 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "component": "avatar",
-  "skill": "flex-components:avatar",
-  "sourceLock": "flex-1.5.0-206c4996",
-  "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
   "lifecycle": "implemented",
   "conformance": "reviewed",
   "reviewedAt": "2026-08-28",
-  "availableSurfaces": ["shared", "web"],
-  "surfacesConsulted": ["shared", "web"],
-  "sourceFiles": [
+  "sources": [
     {
-      "role": "skill",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/avatar/SKILL.md",
-      "marketplaceBlobSha": "2fe0b969fc2358d716e2a2d1e7b48e74dd5f6200",
-      "marketplaceSha256": "cbfeee595a3fddf0e02399bc25c4de3bbc4a6ed8ab439c48be3fd88d4882af93",
-      "originPath": "plugins/components/skills/avatar/SKILL.md",
-      "originBlobSha": "2fe0b969fc2358d716e2a2d1e7b48e74dd5f6200",
-      "originSha256": "cbfeee595a3fddf0e02399bc25c4de3bbc4a6ed8ab439c48be3fd88d4882af93",
-      "contentDiffers": false
-    },
-    {
-      "role": "usage",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/avatar/usage.md",
-      "marketplaceBlobSha": "3ff5d8c3aa3d36e72f598a6956966345c1234359",
-      "marketplaceSha256": "d2dc6baf4249e40b508b41d9b1665dc992863f81b177f3859340a21e735cc8a4",
-      "originPath": "plugins/components/skills/avatar/usage.md",
-      "originBlobSha": "3ff5d8c3aa3d36e72f598a6956966345c1234359",
-      "originSha256": "d2dc6baf4249e40b508b41d9b1665dc992863f81b177f3859340a21e735cc8a4",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:accessibility",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/avatar/web/accessibility.md",
-      "marketplaceBlobSha": "1e4c4955a80a74ea321d00d985993077ae63fc0c",
-      "marketplaceSha256": "7a499cf97a53458cee2c396311fcf2f22552e7e66afb40ddfb01bdb65284508d",
-      "originPath": "plugins/components/skills/avatar/web/accessibility.md",
-      "originBlobSha": "1e4c4955a80a74ea321d00d985993077ae63fc0c",
-      "originSha256": "7a499cf97a53458cee2c396311fcf2f22552e7e66afb40ddfb01bdb65284508d",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:interaction",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/avatar/web/interaction.md",
-      "marketplaceBlobSha": "15067f0130fc17bac54d1a7e5594c8079aacf1b6",
-      "marketplaceSha256": "4fa014add135165f4e736387838e669358b5293cd3eb3bea956bf0195b0bf939",
-      "originPath": "plugins/components/skills/avatar/web/interaction.md",
-      "originBlobSha": "15067f0130fc17bac54d1a7e5594c8079aacf1b6",
-      "originSha256": "4fa014add135165f4e736387838e669358b5293cd3eb3bea956bf0195b0bf939",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:tokens",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/avatar/web/tokens.yaml",
-      "marketplaceBlobSha": "b2b13ebc81fda59a1e9cd31f5d39ac8331d950ae",
-      "marketplaceSha256": "d28b1fef9f1888889727611504daeb6257dad78330e4c011354c640d93e8251a",
-      "originPath": "plugins/components/skills/avatar/web/tokens.yaml",
-      "originBlobSha": "b2b13ebc81fda59a1e9cd31f5d39ac8331d950ae",
-      "originSha256": "d28b1fef9f1888889727611504daeb6257dad78330e4c011354c640d93e8251a",
-      "contentDiffers": false
+      "id": "flex-component",
+      "kind": "flex-skill",
+      "authority": "normative",
+      "skill": "flex-components:avatar",
+      "sourceLock": "flex-1.5.0-206c4996",
+      "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
+      "availableSurfaces": ["shared", "web"],
+      "surfacesConsulted": ["shared", "web"],
+      "sourceFiles": [
+        {
+          "role": "skill",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/avatar/SKILL.md",
+          "marketplaceBlobSha": "2fe0b969fc2358d716e2a2d1e7b48e74dd5f6200",
+          "marketplaceSha256": "cbfeee595a3fddf0e02399bc25c4de3bbc4a6ed8ab439c48be3fd88d4882af93",
+          "originPath": "plugins/components/skills/avatar/SKILL.md",
+          "originBlobSha": "2fe0b969fc2358d716e2a2d1e7b48e74dd5f6200",
+          "originSha256": "cbfeee595a3fddf0e02399bc25c4de3bbc4a6ed8ab439c48be3fd88d4882af93",
+          "contentDiffers": false
+        },
+        {
+          "role": "usage",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/avatar/usage.md",
+          "marketplaceBlobSha": "3ff5d8c3aa3d36e72f598a6956966345c1234359",
+          "marketplaceSha256": "d2dc6baf4249e40b508b41d9b1665dc992863f81b177f3859340a21e735cc8a4",
+          "originPath": "plugins/components/skills/avatar/usage.md",
+          "originBlobSha": "3ff5d8c3aa3d36e72f598a6956966345c1234359",
+          "originSha256": "d2dc6baf4249e40b508b41d9b1665dc992863f81b177f3859340a21e735cc8a4",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:accessibility",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/avatar/web/accessibility.md",
+          "marketplaceBlobSha": "1e4c4955a80a74ea321d00d985993077ae63fc0c",
+          "marketplaceSha256": "7a499cf97a53458cee2c396311fcf2f22552e7e66afb40ddfb01bdb65284508d",
+          "originPath": "plugins/components/skills/avatar/web/accessibility.md",
+          "originBlobSha": "1e4c4955a80a74ea321d00d985993077ae63fc0c",
+          "originSha256": "7a499cf97a53458cee2c396311fcf2f22552e7e66afb40ddfb01bdb65284508d",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:interaction",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/avatar/web/interaction.md",
+          "marketplaceBlobSha": "15067f0130fc17bac54d1a7e5594c8079aacf1b6",
+          "marketplaceSha256": "4fa014add135165f4e736387838e669358b5293cd3eb3bea956bf0195b0bf939",
+          "originPath": "plugins/components/skills/avatar/web/interaction.md",
+          "originBlobSha": "15067f0130fc17bac54d1a7e5594c8079aacf1b6",
+          "originSha256": "4fa014add135165f4e736387838e669358b5293cd3eb3bea956bf0195b0bf939",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:tokens",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/avatar/web/tokens.yaml",
+          "marketplaceBlobSha": "b2b13ebc81fda59a1e9cd31f5d39ac8331d950ae",
+          "marketplaceSha256": "d28b1fef9f1888889727611504daeb6257dad78330e4c011354c640d93e8251a",
+          "originPath": "plugins/components/skills/avatar/web/tokens.yaml",
+          "originBlobSha": "b2b13ebc81fda59a1e9cd31f5d39ac8331d950ae",
+          "originSha256": "d28b1fef9f1888889727611504daeb6257dad78330e4c011354c640d93e8251a",
+          "contentDiffers": false
+        }
+      ],
+      "releaseDifferences": []
     }
   ],
-  "releaseDifferences": [],
   "divergences": [
     {
       "id": "avatar-content-precedence",

--- a/packages/agentic/components/src/components/avatar/useAvatar.ts
+++ b/packages/agentic/components/src/components/avatar/useAvatar.ts
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import { Image, Text, View } from 'react-native';
+import { Image, View } from 'react-native';
 
 import { useThemeState } from '@fluentui-react-native/design';
 import { useOptionalSlot, useSlot } from '@fluentui-react-native/framework-base';
 
 import { semanticIconSources } from '../../common/iconSources';
 import { Icon } from '../../primitives/icon/icon';
+import { Text } from '../text/text';
 import type { AvatarProps, AvatarState } from './avatar.types';
 
 const defaultAvatarIcon = {

--- a/packages/agentic/components/src/components/badge/badge.types.ts
+++ b/packages/agentic/components/src/components/badge/badge.types.ts
@@ -1,4 +1,4 @@
-import type { StyleProp, Text, View, ViewStyle } from 'react-native';
+import type { StyleProp, View, ViewStyle } from 'react-native';
 import type {
   ComponentProps,
   ComponentState,
@@ -11,6 +11,7 @@ import type {
 import type { ThemeState } from '@fluentui-react-native/design';
 
 import type { Icon } from '../../primitives/icon/icon';
+import type { Text } from '../text/text';
 
 export type BadgeAppearance = 'tint' | 'outline';
 export type BadgeColor = 'brand' | 'danger' | 'success' | 'warning' | 'informative';

--- a/packages/agentic/components/src/components/badge/spec/source.json
+++ b/packages/agentic/components/src/components/badge/spec/source.json
@@ -1,67 +1,74 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "component": "badge",
-  "skill": "flex-components:badge",
-  "sourceLock": "flex-1.5.0-206c4996",
-  "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
   "lifecycle": "implemented",
   "conformance": "reviewed",
   "reviewedAt": "2026-08-28",
-  "availableSurfaces": ["shared", "web"],
-  "surfacesConsulted": ["shared", "web"],
-  "sourceFiles": [
+  "sources": [
     {
-      "role": "skill",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/badge/SKILL.md",
-      "marketplaceBlobSha": "7b2763cc1ce45c2137bbfef062d8da7d8a1831f3",
-      "marketplaceSha256": "434587faff6340d55102f629e707507361c9fa629dc5d0168050689e6b9d38d2",
-      "originPath": "plugins/components/skills/badge/SKILL.md",
-      "originBlobSha": "7b2763cc1ce45c2137bbfef062d8da7d8a1831f3",
-      "originSha256": "434587faff6340d55102f629e707507361c9fa629dc5d0168050689e6b9d38d2",
-      "contentDiffers": false
-    },
-    {
-      "role": "usage",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/badge/usage.md",
-      "marketplaceBlobSha": "b6455629337e6fec26ca9b5aecc544e502382fe1",
-      "marketplaceSha256": "664a2650189a226d570f0d4873b84047836a474c34e0510fef4b4bb470ea821c",
-      "originPath": "plugins/components/skills/badge/usage.md",
-      "originBlobSha": "b6455629337e6fec26ca9b5aecc544e502382fe1",
-      "originSha256": "664a2650189a226d570f0d4873b84047836a474c34e0510fef4b4bb470ea821c",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:accessibility",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/badge/web/accessibility.md",
-      "marketplaceBlobSha": "76fbfdf6f4b4255041fa0656fe15796fc804f730",
-      "marketplaceSha256": "c6cbbf48eddd9282b639acbfb746d598cd5d54bb22f49db72b4b1c44e8f503f1",
-      "originPath": "plugins/components/skills/badge/web/accessibility.md",
-      "originBlobSha": "76fbfdf6f4b4255041fa0656fe15796fc804f730",
-      "originSha256": "c6cbbf48eddd9282b639acbfb746d598cd5d54bb22f49db72b4b1c44e8f503f1",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:interaction",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/badge/web/interaction.md",
-      "marketplaceBlobSha": "1d64ca4979021fc9852c2146a386030178ee3e27",
-      "marketplaceSha256": "2a5ba92094373f30087795c50c29a9cc0c055502f90395bb847b3d1d689b28f4",
-      "originPath": "plugins/components/skills/badge/web/interaction.md",
-      "originBlobSha": "1d64ca4979021fc9852c2146a386030178ee3e27",
-      "originSha256": "2a5ba92094373f30087795c50c29a9cc0c055502f90395bb847b3d1d689b28f4",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:tokens",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/badge/web/tokens.yaml",
-      "marketplaceBlobSha": "a1306fd6e614969346ed121c71a0018e88317aab",
-      "marketplaceSha256": "7b61e772400973567b02ead046700783854b0da13b2b5959b8a960114441be2c",
-      "originPath": "plugins/components/skills/badge/web/tokens.yaml",
-      "originBlobSha": "a1306fd6e614969346ed121c71a0018e88317aab",
-      "originSha256": "7b61e772400973567b02ead046700783854b0da13b2b5959b8a960114441be2c",
-      "contentDiffers": false
+      "id": "flex-component",
+      "kind": "flex-skill",
+      "authority": "normative",
+      "skill": "flex-components:badge",
+      "sourceLock": "flex-1.5.0-206c4996",
+      "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
+      "availableSurfaces": ["shared", "web"],
+      "surfacesConsulted": ["shared", "web"],
+      "sourceFiles": [
+        {
+          "role": "skill",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/badge/SKILL.md",
+          "marketplaceBlobSha": "7b2763cc1ce45c2137bbfef062d8da7d8a1831f3",
+          "marketplaceSha256": "434587faff6340d55102f629e707507361c9fa629dc5d0168050689e6b9d38d2",
+          "originPath": "plugins/components/skills/badge/SKILL.md",
+          "originBlobSha": "7b2763cc1ce45c2137bbfef062d8da7d8a1831f3",
+          "originSha256": "434587faff6340d55102f629e707507361c9fa629dc5d0168050689e6b9d38d2",
+          "contentDiffers": false
+        },
+        {
+          "role": "usage",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/badge/usage.md",
+          "marketplaceBlobSha": "b6455629337e6fec26ca9b5aecc544e502382fe1",
+          "marketplaceSha256": "664a2650189a226d570f0d4873b84047836a474c34e0510fef4b4bb470ea821c",
+          "originPath": "plugins/components/skills/badge/usage.md",
+          "originBlobSha": "b6455629337e6fec26ca9b5aecc544e502382fe1",
+          "originSha256": "664a2650189a226d570f0d4873b84047836a474c34e0510fef4b4bb470ea821c",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:accessibility",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/badge/web/accessibility.md",
+          "marketplaceBlobSha": "76fbfdf6f4b4255041fa0656fe15796fc804f730",
+          "marketplaceSha256": "c6cbbf48eddd9282b639acbfb746d598cd5d54bb22f49db72b4b1c44e8f503f1",
+          "originPath": "plugins/components/skills/badge/web/accessibility.md",
+          "originBlobSha": "76fbfdf6f4b4255041fa0656fe15796fc804f730",
+          "originSha256": "c6cbbf48eddd9282b639acbfb746d598cd5d54bb22f49db72b4b1c44e8f503f1",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:interaction",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/badge/web/interaction.md",
+          "marketplaceBlobSha": "1d64ca4979021fc9852c2146a386030178ee3e27",
+          "marketplaceSha256": "2a5ba92094373f30087795c50c29a9cc0c055502f90395bb847b3d1d689b28f4",
+          "originPath": "plugins/components/skills/badge/web/interaction.md",
+          "originBlobSha": "1d64ca4979021fc9852c2146a386030178ee3e27",
+          "originSha256": "2a5ba92094373f30087795c50c29a9cc0c055502f90395bb847b3d1d689b28f4",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:tokens",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/badge/web/tokens.yaml",
+          "marketplaceBlobSha": "a1306fd6e614969346ed121c71a0018e88317aab",
+          "marketplaceSha256": "7b61e772400973567b02ead046700783854b0da13b2b5959b8a960114441be2c",
+          "originPath": "plugins/components/skills/badge/web/tokens.yaml",
+          "originBlobSha": "a1306fd6e614969346ed121c71a0018e88317aab",
+          "originSha256": "7b61e772400973567b02ead046700783854b0da13b2b5959b8a960114441be2c",
+          "contentDiffers": false
+        }
+      ],
+      "releaseDifferences": []
     }
   ],
-  "releaseDifferences": [],
   "divergences": [],
   "requirements": [
     {

--- a/packages/agentic/components/src/components/badge/useBadge.ts
+++ b/packages/agentic/components/src/components/badge/useBadge.ts
@@ -1,10 +1,11 @@
-import { Text, View } from 'react-native';
+import { View } from 'react-native';
 
 import { useThemeState } from '@fluentui-react-native/design';
 import { useAccessibilityLabelWarning, useOptionalSlot, useSlot } from '@fluentui-react-native/framework-base';
 
 import { semanticIconSources } from '../../common/iconSources';
 import { Icon } from '../../primitives/icon/icon';
+import { Text } from '../text/text';
 import type { BadgeProps, BadgeState } from './badge.types';
 
 const defaultBadgeIcon = {

--- a/packages/agentic/components/src/components/button/button.types.ts
+++ b/packages/agentic/components/src/components/button/button.types.ts
@@ -1,4 +1,4 @@
-import type { Pressable, StyleProp, Text, ViewStyle } from 'react-native';
+import type { Pressable, StyleProp, ViewStyle } from 'react-native';
 import type {
   Slot,
   OptionalSlot,
@@ -11,6 +11,7 @@ import type {
 import type { ThemeState } from '@fluentui-react-native/design';
 import type { Icon } from '../../primitives/icon/icon';
 import type { FocusVisualProps } from '../../primitives/focus-visual/focus-visual.types';
+import type { Text } from '../text/text';
 
 export type ButtonSlots = {
   /**

--- a/packages/agentic/components/src/components/button/spec/source.json
+++ b/packages/agentic/components/src/components/button/spec/source.json
@@ -1,127 +1,134 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "component": "button",
-  "skill": "flex-components:button",
-  "sourceLock": "flex-1.5.0-206c4996",
-  "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
   "lifecycle": "implemented",
   "conformance": "reviewed",
   "reviewedAt": "2026-08-28",
-  "availableSurfaces": ["mobile", "shared", "web"],
-  "surfacesConsulted": ["mobile", "shared", "web"],
-  "sourceFiles": [
+  "sources": [
     {
-      "role": "mobile:android:accessibility",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/button/mobile/android/accessibility.md",
-      "marketplaceBlobSha": "38bf4f879fb5ae613f771aa7ddd55f9213c0ed45",
-      "marketplaceSha256": "7bab570bb29b37106a1d03014acf5095257009a93a9662705c1e84e32f305979",
-      "originPath": "plugins/components/skills/button/mobile/android/accessibility.md",
-      "originBlobSha": "38bf4f879fb5ae613f771aa7ddd55f9213c0ed45",
-      "originSha256": "7bab570bb29b37106a1d03014acf5095257009a93a9662705c1e84e32f305979",
-      "contentDiffers": false
-    },
-    {
-      "role": "mobile:android:interaction",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/button/mobile/android/interaction.md",
-      "marketplaceBlobSha": "568985182dea2c626607f93fd13c108a64354232",
-      "marketplaceSha256": "6205da5affc9be922b1a0b6b6ba8c677344c6558b653a0816b6a76ddbf03ded0",
-      "originPath": "plugins/components/skills/button/mobile/android/interaction.md",
-      "originBlobSha": "568985182dea2c626607f93fd13c108a64354232",
-      "originSha256": "6205da5affc9be922b1a0b6b6ba8c677344c6558b653a0816b6a76ddbf03ded0",
-      "contentDiffers": false
-    },
-    {
-      "role": "mobile:ios:accessibility",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/button/mobile/ios/accessibility.md",
-      "marketplaceBlobSha": "676a218a691722ec1c8c38108eba6664d59adc12",
-      "marketplaceSha256": "ff76131951caec077fb0ac141c4b2d94f36ce9d81b82987b9e1009f467bee4a6",
-      "originPath": "plugins/components/skills/button/mobile/ios/accessibility.md",
-      "originBlobSha": "676a218a691722ec1c8c38108eba6664d59adc12",
-      "originSha256": "ff76131951caec077fb0ac141c4b2d94f36ce9d81b82987b9e1009f467bee4a6",
-      "contentDiffers": false
-    },
-    {
-      "role": "mobile:ios:interaction",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/button/mobile/ios/interaction.md",
-      "marketplaceBlobSha": "37a6814f67f9f6762dae5dcc2777052042e91d84",
-      "marketplaceSha256": "0823d6e7e01f41ce191a1d983bdf4b0917279d9a09d460311cc168b275f202e4",
-      "originPath": "plugins/components/skills/button/mobile/ios/interaction.md",
-      "originBlobSha": "37a6814f67f9f6762dae5dcc2777052042e91d84",
-      "originSha256": "0823d6e7e01f41ce191a1d983bdf4b0917279d9a09d460311cc168b275f202e4",
-      "contentDiffers": false
-    },
-    {
-      "role": "mobile:overview",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/button/mobile/overview.md",
-      "marketplaceBlobSha": "2668a2fba548663ea7cc0753aad6cb5f3f53ab3b",
-      "marketplaceSha256": "881a47dec1535e572c1e5bfc0d454f031c514e7402a129b7d3109abcc88a4c87",
-      "originPath": "plugins/components/skills/button/mobile/overview.md",
-      "originBlobSha": "2668a2fba548663ea7cc0753aad6cb5f3f53ab3b",
-      "originSha256": "881a47dec1535e572c1e5bfc0d454f031c514e7402a129b7d3109abcc88a4c87",
-      "contentDiffers": false
-    },
-    {
-      "role": "mobile:tokens",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/button/mobile/tokens.yaml",
-      "marketplaceBlobSha": "a7f0686f41bf5502d310c727cad02f6dee7ec650",
-      "marketplaceSha256": "27b5bad579bd882b014ac8e0131960da4bcfd11ff249328b8ddd43f3435a5169",
-      "originPath": "plugins/components/skills/button/mobile/tokens.yaml",
-      "originBlobSha": "a7f0686f41bf5502d310c727cad02f6dee7ec650",
-      "originSha256": "27b5bad579bd882b014ac8e0131960da4bcfd11ff249328b8ddd43f3435a5169",
-      "contentDiffers": false
-    },
-    {
-      "role": "skill",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/button/SKILL.md",
-      "marketplaceBlobSha": "c4bf5eeb245b2e59efa3885e2a008d93dfb820fe",
-      "marketplaceSha256": "b8ea0b2de61164bbcf1b496cd8b5236a0b424653470c07fc78d151239e80d36f",
-      "originPath": "plugins/components/skills/button/SKILL.md",
-      "originBlobSha": "c4bf5eeb245b2e59efa3885e2a008d93dfb820fe",
-      "originSha256": "b8ea0b2de61164bbcf1b496cd8b5236a0b424653470c07fc78d151239e80d36f",
-      "contentDiffers": false
-    },
-    {
-      "role": "usage",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/button/usage.md",
-      "marketplaceBlobSha": "aa86bbbba0efbaa8c254aef2cfaccecd9ed736df",
-      "marketplaceSha256": "727bfe3a3f7402a539b8d58dcc7760df6d383d10699be7597f82addef7ca725c",
-      "originPath": "plugins/components/skills/button/usage.md",
-      "originBlobSha": "aa86bbbba0efbaa8c254aef2cfaccecd9ed736df",
-      "originSha256": "727bfe3a3f7402a539b8d58dcc7760df6d383d10699be7597f82addef7ca725c",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:accessibility",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/button/web/accessibility.md",
-      "marketplaceBlobSha": "f13b8cf376aa43d054edb7a85ed5b9e5ba9453bc",
-      "marketplaceSha256": "ad8a3ab790333655adf039ead2438da0c982fafedb2923afab9c404baf4df477",
-      "originPath": "plugins/components/skills/button/web/accessibility.md",
-      "originBlobSha": "f13b8cf376aa43d054edb7a85ed5b9e5ba9453bc",
-      "originSha256": "ad8a3ab790333655adf039ead2438da0c982fafedb2923afab9c404baf4df477",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:interaction",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/button/web/interaction.md",
-      "marketplaceBlobSha": "ade44d3e4499e7943926d351a8b44bf08cb8e39e",
-      "marketplaceSha256": "c269ba511e1d0de1f49ff01438df6a171de638a8b03a3d49d248fda4ce8b626c",
-      "originPath": "plugins/components/skills/button/web/interaction.md",
-      "originBlobSha": "ade44d3e4499e7943926d351a8b44bf08cb8e39e",
-      "originSha256": "c269ba511e1d0de1f49ff01438df6a171de638a8b03a3d49d248fda4ce8b626c",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:tokens",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/button/web/tokens.yaml",
-      "marketplaceBlobSha": "5f7d568af69fb9f9cc8548f4290ea5d7a1476422",
-      "marketplaceSha256": "3dcdf1d787d2a028f3e279d6b82b32adbfbc8b81532656332642433fcd870f8e",
-      "originPath": "plugins/components/skills/button/web/tokens.yaml",
-      "originBlobSha": "5f7d568af69fb9f9cc8548f4290ea5d7a1476422",
-      "originSha256": "3dcdf1d787d2a028f3e279d6b82b32adbfbc8b81532656332642433fcd870f8e",
-      "contentDiffers": false
+      "id": "flex-component",
+      "kind": "flex-skill",
+      "authority": "normative",
+      "skill": "flex-components:button",
+      "sourceLock": "flex-1.5.0-206c4996",
+      "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
+      "availableSurfaces": ["mobile", "shared", "web"],
+      "surfacesConsulted": ["mobile", "shared", "web"],
+      "sourceFiles": [
+        {
+          "role": "mobile:android:accessibility",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/button/mobile/android/accessibility.md",
+          "marketplaceBlobSha": "38bf4f879fb5ae613f771aa7ddd55f9213c0ed45",
+          "marketplaceSha256": "7bab570bb29b37106a1d03014acf5095257009a93a9662705c1e84e32f305979",
+          "originPath": "plugins/components/skills/button/mobile/android/accessibility.md",
+          "originBlobSha": "38bf4f879fb5ae613f771aa7ddd55f9213c0ed45",
+          "originSha256": "7bab570bb29b37106a1d03014acf5095257009a93a9662705c1e84e32f305979",
+          "contentDiffers": false
+        },
+        {
+          "role": "mobile:android:interaction",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/button/mobile/android/interaction.md",
+          "marketplaceBlobSha": "568985182dea2c626607f93fd13c108a64354232",
+          "marketplaceSha256": "6205da5affc9be922b1a0b6b6ba8c677344c6558b653a0816b6a76ddbf03ded0",
+          "originPath": "plugins/components/skills/button/mobile/android/interaction.md",
+          "originBlobSha": "568985182dea2c626607f93fd13c108a64354232",
+          "originSha256": "6205da5affc9be922b1a0b6b6ba8c677344c6558b653a0816b6a76ddbf03ded0",
+          "contentDiffers": false
+        },
+        {
+          "role": "mobile:ios:accessibility",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/button/mobile/ios/accessibility.md",
+          "marketplaceBlobSha": "676a218a691722ec1c8c38108eba6664d59adc12",
+          "marketplaceSha256": "ff76131951caec077fb0ac141c4b2d94f36ce9d81b82987b9e1009f467bee4a6",
+          "originPath": "plugins/components/skills/button/mobile/ios/accessibility.md",
+          "originBlobSha": "676a218a691722ec1c8c38108eba6664d59adc12",
+          "originSha256": "ff76131951caec077fb0ac141c4b2d94f36ce9d81b82987b9e1009f467bee4a6",
+          "contentDiffers": false
+        },
+        {
+          "role": "mobile:ios:interaction",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/button/mobile/ios/interaction.md",
+          "marketplaceBlobSha": "37a6814f67f9f6762dae5dcc2777052042e91d84",
+          "marketplaceSha256": "0823d6e7e01f41ce191a1d983bdf4b0917279d9a09d460311cc168b275f202e4",
+          "originPath": "plugins/components/skills/button/mobile/ios/interaction.md",
+          "originBlobSha": "37a6814f67f9f6762dae5dcc2777052042e91d84",
+          "originSha256": "0823d6e7e01f41ce191a1d983bdf4b0917279d9a09d460311cc168b275f202e4",
+          "contentDiffers": false
+        },
+        {
+          "role": "mobile:overview",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/button/mobile/overview.md",
+          "marketplaceBlobSha": "2668a2fba548663ea7cc0753aad6cb5f3f53ab3b",
+          "marketplaceSha256": "881a47dec1535e572c1e5bfc0d454f031c514e7402a129b7d3109abcc88a4c87",
+          "originPath": "plugins/components/skills/button/mobile/overview.md",
+          "originBlobSha": "2668a2fba548663ea7cc0753aad6cb5f3f53ab3b",
+          "originSha256": "881a47dec1535e572c1e5bfc0d454f031c514e7402a129b7d3109abcc88a4c87",
+          "contentDiffers": false
+        },
+        {
+          "role": "mobile:tokens",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/button/mobile/tokens.yaml",
+          "marketplaceBlobSha": "a7f0686f41bf5502d310c727cad02f6dee7ec650",
+          "marketplaceSha256": "27b5bad579bd882b014ac8e0131960da4bcfd11ff249328b8ddd43f3435a5169",
+          "originPath": "plugins/components/skills/button/mobile/tokens.yaml",
+          "originBlobSha": "a7f0686f41bf5502d310c727cad02f6dee7ec650",
+          "originSha256": "27b5bad579bd882b014ac8e0131960da4bcfd11ff249328b8ddd43f3435a5169",
+          "contentDiffers": false
+        },
+        {
+          "role": "skill",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/button/SKILL.md",
+          "marketplaceBlobSha": "c4bf5eeb245b2e59efa3885e2a008d93dfb820fe",
+          "marketplaceSha256": "b8ea0b2de61164bbcf1b496cd8b5236a0b424653470c07fc78d151239e80d36f",
+          "originPath": "plugins/components/skills/button/SKILL.md",
+          "originBlobSha": "c4bf5eeb245b2e59efa3885e2a008d93dfb820fe",
+          "originSha256": "b8ea0b2de61164bbcf1b496cd8b5236a0b424653470c07fc78d151239e80d36f",
+          "contentDiffers": false
+        },
+        {
+          "role": "usage",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/button/usage.md",
+          "marketplaceBlobSha": "aa86bbbba0efbaa8c254aef2cfaccecd9ed736df",
+          "marketplaceSha256": "727bfe3a3f7402a539b8d58dcc7760df6d383d10699be7597f82addef7ca725c",
+          "originPath": "plugins/components/skills/button/usage.md",
+          "originBlobSha": "aa86bbbba0efbaa8c254aef2cfaccecd9ed736df",
+          "originSha256": "727bfe3a3f7402a539b8d58dcc7760df6d383d10699be7597f82addef7ca725c",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:accessibility",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/button/web/accessibility.md",
+          "marketplaceBlobSha": "f13b8cf376aa43d054edb7a85ed5b9e5ba9453bc",
+          "marketplaceSha256": "ad8a3ab790333655adf039ead2438da0c982fafedb2923afab9c404baf4df477",
+          "originPath": "plugins/components/skills/button/web/accessibility.md",
+          "originBlobSha": "f13b8cf376aa43d054edb7a85ed5b9e5ba9453bc",
+          "originSha256": "ad8a3ab790333655adf039ead2438da0c982fafedb2923afab9c404baf4df477",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:interaction",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/button/web/interaction.md",
+          "marketplaceBlobSha": "ade44d3e4499e7943926d351a8b44bf08cb8e39e",
+          "marketplaceSha256": "c269ba511e1d0de1f49ff01438df6a171de638a8b03a3d49d248fda4ce8b626c",
+          "originPath": "plugins/components/skills/button/web/interaction.md",
+          "originBlobSha": "ade44d3e4499e7943926d351a8b44bf08cb8e39e",
+          "originSha256": "c269ba511e1d0de1f49ff01438df6a171de638a8b03a3d49d248fda4ce8b626c",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:tokens",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/button/web/tokens.yaml",
+          "marketplaceBlobSha": "5f7d568af69fb9f9cc8548f4290ea5d7a1476422",
+          "marketplaceSha256": "3dcdf1d787d2a028f3e279d6b82b32adbfbc8b81532656332642433fcd870f8e",
+          "originPath": "plugins/components/skills/button/web/tokens.yaml",
+          "originBlobSha": "5f7d568af69fb9f9cc8548f4290ea5d7a1476422",
+          "originSha256": "3dcdf1d787d2a028f3e279d6b82b32adbfbc8b81532656332642433fcd870f8e",
+          "contentDiffers": false
+        }
+      ],
+      "releaseDifferences": []
     }
   ],
-  "releaseDifferences": [],
   "divergences": [
     {
       "id": "button-selection-axis",

--- a/packages/agentic/components/src/components/button/useButton.ts
+++ b/packages/agentic/components/src/components/button/useButton.ts
@@ -1,9 +1,10 @@
 import type { ButtonProps, ButtonState } from './button.types';
 import { useAccessibilityLabelWarning, usePressableState, useSlot, useOptionalSlot } from '@fluentui-react-native/framework-base';
 import { useThemeState } from '@fluentui-react-native/design';
-import { Pressable, Text } from 'react-native';
+import { Pressable } from 'react-native';
 import type { PressableProps } from 'react-native';
 import { Icon } from '../../primitives/icon/icon';
+import { Text } from '../text/text';
 
 type NativeFocusPressableProps = PressableProps & {
   enableFocusRing: boolean;

--- a/packages/agentic/components/src/components/card/spec/source.json
+++ b/packages/agentic/components/src/components/card/spec/source.json
@@ -1,77 +1,84 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "component": "card",
-  "skill": "flex-components:card",
-  "sourceLock": "flex-1.5.0-206c4996",
-  "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
   "lifecycle": "implemented",
   "conformance": "reviewed",
   "reviewedAt": "2026-08-28",
-  "availableSurfaces": ["mobile", "shared", "web"],
-  "surfacesConsulted": ["mobile", "shared", "web"],
-  "sourceFiles": [
+  "sources": [
     {
-      "role": "mobile:overview",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/card/mobile/overview.md",
-      "marketplaceBlobSha": "a36db6e53fb5b18a61a835737f70a0fe8409234d",
-      "marketplaceSha256": "7c7506797bf95944ca9c61681bd6243c647e3d0516a9446fa85680668e0c706f",
-      "originPath": "plugins/components/skills/card/mobile/overview.md",
-      "originBlobSha": "a36db6e53fb5b18a61a835737f70a0fe8409234d",
-      "originSha256": "7c7506797bf95944ca9c61681bd6243c647e3d0516a9446fa85680668e0c706f",
-      "contentDiffers": false
-    },
-    {
-      "role": "skill",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/card/SKILL.md",
-      "marketplaceBlobSha": "0ae2be0c99fd081258e9734e06811bf844a6d6eb",
-      "marketplaceSha256": "e65fda0accc6f672b21e19a1978662d1315138db29da072ec958b35f3aca3ffc",
-      "originPath": "plugins/components/skills/card/SKILL.md",
-      "originBlobSha": "0ae2be0c99fd081258e9734e06811bf844a6d6eb",
-      "originSha256": "e65fda0accc6f672b21e19a1978662d1315138db29da072ec958b35f3aca3ffc",
-      "contentDiffers": false
-    },
-    {
-      "role": "usage",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/card/usage.md",
-      "marketplaceBlobSha": "8e896eef4df658dec4b0af9555912aa307f34e1f",
-      "marketplaceSha256": "01f4698d3c93d42d4d9c6e44bd0539f1764079808eb9a25afb3049a2ef73cf9c",
-      "originPath": "plugins/components/skills/card/usage.md",
-      "originBlobSha": "8e896eef4df658dec4b0af9555912aa307f34e1f",
-      "originSha256": "01f4698d3c93d42d4d9c6e44bd0539f1764079808eb9a25afb3049a2ef73cf9c",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:accessibility",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/card/web/accessibility.md",
-      "marketplaceBlobSha": "41dd3f0f62ca6ff81c7663c67be82b8aea8342a9",
-      "marketplaceSha256": "8fb85024bf2c3b01b4afeff402d01c765d77e24eae6d7d5d437d7ae0fff5dea5",
-      "originPath": "plugins/components/skills/card/web/accessibility.md",
-      "originBlobSha": "41dd3f0f62ca6ff81c7663c67be82b8aea8342a9",
-      "originSha256": "8fb85024bf2c3b01b4afeff402d01c765d77e24eae6d7d5d437d7ae0fff5dea5",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:interaction",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/card/web/interaction.md",
-      "marketplaceBlobSha": "39c1fdcff6b11e56784ae14026ce5df1314f68f0",
-      "marketplaceSha256": "defb1eac5f33da7c2ccabeb756550b53c2cc11b7845a6e6ba9a716568bc9152e",
-      "originPath": "plugins/components/skills/card/web/interaction.md",
-      "originBlobSha": "39c1fdcff6b11e56784ae14026ce5df1314f68f0",
-      "originSha256": "defb1eac5f33da7c2ccabeb756550b53c2cc11b7845a6e6ba9a716568bc9152e",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:tokens",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/card/web/tokens.yaml",
-      "marketplaceBlobSha": "6dc51b581a7bd38b5fe4da2ad4b68039a08c0dfc",
-      "marketplaceSha256": "2abcf45e1f87f04217c22a602efdcfdfd6cd306a173b917f87b99ee7eff56d95",
-      "originPath": "plugins/components/skills/card/web/tokens.yaml",
-      "originBlobSha": "6dc51b581a7bd38b5fe4da2ad4b68039a08c0dfc",
-      "originSha256": "2abcf45e1f87f04217c22a602efdcfdfd6cd306a173b917f87b99ee7eff56d95",
-      "contentDiffers": false
+      "id": "flex-component",
+      "kind": "flex-skill",
+      "authority": "normative",
+      "skill": "flex-components:card",
+      "sourceLock": "flex-1.5.0-206c4996",
+      "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
+      "availableSurfaces": ["mobile", "shared", "web"],
+      "surfacesConsulted": ["mobile", "shared", "web"],
+      "sourceFiles": [
+        {
+          "role": "mobile:overview",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/card/mobile/overview.md",
+          "marketplaceBlobSha": "a36db6e53fb5b18a61a835737f70a0fe8409234d",
+          "marketplaceSha256": "7c7506797bf95944ca9c61681bd6243c647e3d0516a9446fa85680668e0c706f",
+          "originPath": "plugins/components/skills/card/mobile/overview.md",
+          "originBlobSha": "a36db6e53fb5b18a61a835737f70a0fe8409234d",
+          "originSha256": "7c7506797bf95944ca9c61681bd6243c647e3d0516a9446fa85680668e0c706f",
+          "contentDiffers": false
+        },
+        {
+          "role": "skill",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/card/SKILL.md",
+          "marketplaceBlobSha": "0ae2be0c99fd081258e9734e06811bf844a6d6eb",
+          "marketplaceSha256": "e65fda0accc6f672b21e19a1978662d1315138db29da072ec958b35f3aca3ffc",
+          "originPath": "plugins/components/skills/card/SKILL.md",
+          "originBlobSha": "0ae2be0c99fd081258e9734e06811bf844a6d6eb",
+          "originSha256": "e65fda0accc6f672b21e19a1978662d1315138db29da072ec958b35f3aca3ffc",
+          "contentDiffers": false
+        },
+        {
+          "role": "usage",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/card/usage.md",
+          "marketplaceBlobSha": "8e896eef4df658dec4b0af9555912aa307f34e1f",
+          "marketplaceSha256": "01f4698d3c93d42d4d9c6e44bd0539f1764079808eb9a25afb3049a2ef73cf9c",
+          "originPath": "plugins/components/skills/card/usage.md",
+          "originBlobSha": "8e896eef4df658dec4b0af9555912aa307f34e1f",
+          "originSha256": "01f4698d3c93d42d4d9c6e44bd0539f1764079808eb9a25afb3049a2ef73cf9c",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:accessibility",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/card/web/accessibility.md",
+          "marketplaceBlobSha": "41dd3f0f62ca6ff81c7663c67be82b8aea8342a9",
+          "marketplaceSha256": "8fb85024bf2c3b01b4afeff402d01c765d77e24eae6d7d5d437d7ae0fff5dea5",
+          "originPath": "plugins/components/skills/card/web/accessibility.md",
+          "originBlobSha": "41dd3f0f62ca6ff81c7663c67be82b8aea8342a9",
+          "originSha256": "8fb85024bf2c3b01b4afeff402d01c765d77e24eae6d7d5d437d7ae0fff5dea5",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:interaction",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/card/web/interaction.md",
+          "marketplaceBlobSha": "39c1fdcff6b11e56784ae14026ce5df1314f68f0",
+          "marketplaceSha256": "defb1eac5f33da7c2ccabeb756550b53c2cc11b7845a6e6ba9a716568bc9152e",
+          "originPath": "plugins/components/skills/card/web/interaction.md",
+          "originBlobSha": "39c1fdcff6b11e56784ae14026ce5df1314f68f0",
+          "originSha256": "defb1eac5f33da7c2ccabeb756550b53c2cc11b7845a6e6ba9a716568bc9152e",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:tokens",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/card/web/tokens.yaml",
+          "marketplaceBlobSha": "6dc51b581a7bd38b5fe4da2ad4b68039a08c0dfc",
+          "marketplaceSha256": "2abcf45e1f87f04217c22a602efdcfdfd6cd306a173b917f87b99ee7eff56d95",
+          "originPath": "plugins/components/skills/card/web/tokens.yaml",
+          "originBlobSha": "6dc51b581a7bd38b5fe4da2ad4b68039a08c0dfc",
+          "originSha256": "2abcf45e1f87f04217c22a602efdcfdfd6cd306a173b917f87b99ee7eff56d95",
+          "contentDiffers": false
+        }
+      ],
+      "releaseDifferences": []
     }
   ],
-  "releaseDifferences": [],
   "divergences": [
     {
       "id": "card-button-only-activation",

--- a/packages/agentic/components/src/components/checkbox/checkbox.types.ts
+++ b/packages/agentic/components/src/components/checkbox/checkbox.types.ts
@@ -1,4 +1,4 @@
-import type { ColorValue, Pressable, StyleProp, Text, ViewStyle } from 'react-native';
+import type { ColorValue, Pressable, StyleProp, ViewStyle } from 'react-native';
 import type {
   ComponentProps,
   ComponentState,
@@ -10,6 +10,7 @@ import type {
 } from '@fluentui-react-native/framework-base';
 import type { ThemeState } from '@fluentui-react-native/design';
 import type { FocusVisualProps } from '../../primitives/focus-visual/focus-visual.types';
+import type { Text } from '../text/text';
 
 export type CheckboxVariant = 'standard' | 'circular';
 export type CheckboxStatus = 'unchecked' | 'checked' | 'indeterminate';

--- a/packages/agentic/components/src/components/checkbox/spec/source.json
+++ b/packages/agentic/components/src/components/checkbox/spec/source.json
@@ -1,67 +1,74 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "component": "checkbox",
-  "skill": "flex-components:checkbox",
-  "sourceLock": "flex-1.5.0-206c4996",
-  "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
   "lifecycle": "implemented",
   "conformance": "reviewed",
   "reviewedAt": "2026-08-28",
-  "availableSurfaces": ["shared", "web"],
-  "surfacesConsulted": ["shared", "web"],
-  "sourceFiles": [
+  "sources": [
     {
-      "role": "skill",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/checkbox/SKILL.md",
-      "marketplaceBlobSha": "e96989b46ef40bd81431b338e57c588953b37f0e",
-      "marketplaceSha256": "59c18766842da8533e8ce210ccf3fa1631ca1976e2dadede405619d4d5e94160",
-      "originPath": "plugins/components/skills/checkbox/SKILL.md",
-      "originBlobSha": "e96989b46ef40bd81431b338e57c588953b37f0e",
-      "originSha256": "59c18766842da8533e8ce210ccf3fa1631ca1976e2dadede405619d4d5e94160",
-      "contentDiffers": false
-    },
-    {
-      "role": "usage",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/checkbox/usage.md",
-      "marketplaceBlobSha": "c77c7f010abd0fac1d1b4592ae9565d3992137aa",
-      "marketplaceSha256": "c509d947ead1537929fe0fccd889972a2d77150fe737450f115da7c97d884a22",
-      "originPath": "plugins/components/skills/checkbox/usage.md",
-      "originBlobSha": "c77c7f010abd0fac1d1b4592ae9565d3992137aa",
-      "originSha256": "c509d947ead1537929fe0fccd889972a2d77150fe737450f115da7c97d884a22",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:accessibility",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/checkbox/web/accessibility.md",
-      "marketplaceBlobSha": "fa11412a3a1b036dd2be18de360eb11ea9bd615f",
-      "marketplaceSha256": "c591162d0f3f1f43cbf8498c8202aaec9a7f25bf9a6d6d9091d93cb344629dd7",
-      "originPath": "plugins/components/skills/checkbox/web/accessibility.md",
-      "originBlobSha": "fa11412a3a1b036dd2be18de360eb11ea9bd615f",
-      "originSha256": "c591162d0f3f1f43cbf8498c8202aaec9a7f25bf9a6d6d9091d93cb344629dd7",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:interaction",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/checkbox/web/interaction.md",
-      "marketplaceBlobSha": "613f6cfe8b652afb9ec6bd369b5d993d3f3b7961",
-      "marketplaceSha256": "856d2dc8082b99d97826f94b3a6bc802fa86e7cdd69a29c8e53704c57e56fa46",
-      "originPath": "plugins/components/skills/checkbox/web/interaction.md",
-      "originBlobSha": "613f6cfe8b652afb9ec6bd369b5d993d3f3b7961",
-      "originSha256": "856d2dc8082b99d97826f94b3a6bc802fa86e7cdd69a29c8e53704c57e56fa46",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:tokens",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/checkbox/web/tokens.yaml",
-      "marketplaceBlobSha": "222ab7de9e085109232a0abd50a5655794e6103e",
-      "marketplaceSha256": "5a8706211772a4d42b5051431c995698591c1522d1931dd3d66734add2be2d7b",
-      "originPath": "plugins/components/skills/checkbox/web/tokens.yaml",
-      "originBlobSha": "222ab7de9e085109232a0abd50a5655794e6103e",
-      "originSha256": "5a8706211772a4d42b5051431c995698591c1522d1931dd3d66734add2be2d7b",
-      "contentDiffers": false
+      "id": "flex-component",
+      "kind": "flex-skill",
+      "authority": "normative",
+      "skill": "flex-components:checkbox",
+      "sourceLock": "flex-1.5.0-206c4996",
+      "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
+      "availableSurfaces": ["shared", "web"],
+      "surfacesConsulted": ["shared", "web"],
+      "sourceFiles": [
+        {
+          "role": "skill",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/checkbox/SKILL.md",
+          "marketplaceBlobSha": "e96989b46ef40bd81431b338e57c588953b37f0e",
+          "marketplaceSha256": "59c18766842da8533e8ce210ccf3fa1631ca1976e2dadede405619d4d5e94160",
+          "originPath": "plugins/components/skills/checkbox/SKILL.md",
+          "originBlobSha": "e96989b46ef40bd81431b338e57c588953b37f0e",
+          "originSha256": "59c18766842da8533e8ce210ccf3fa1631ca1976e2dadede405619d4d5e94160",
+          "contentDiffers": false
+        },
+        {
+          "role": "usage",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/checkbox/usage.md",
+          "marketplaceBlobSha": "c77c7f010abd0fac1d1b4592ae9565d3992137aa",
+          "marketplaceSha256": "c509d947ead1537929fe0fccd889972a2d77150fe737450f115da7c97d884a22",
+          "originPath": "plugins/components/skills/checkbox/usage.md",
+          "originBlobSha": "c77c7f010abd0fac1d1b4592ae9565d3992137aa",
+          "originSha256": "c509d947ead1537929fe0fccd889972a2d77150fe737450f115da7c97d884a22",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:accessibility",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/checkbox/web/accessibility.md",
+          "marketplaceBlobSha": "fa11412a3a1b036dd2be18de360eb11ea9bd615f",
+          "marketplaceSha256": "c591162d0f3f1f43cbf8498c8202aaec9a7f25bf9a6d6d9091d93cb344629dd7",
+          "originPath": "plugins/components/skills/checkbox/web/accessibility.md",
+          "originBlobSha": "fa11412a3a1b036dd2be18de360eb11ea9bd615f",
+          "originSha256": "c591162d0f3f1f43cbf8498c8202aaec9a7f25bf9a6d6d9091d93cb344629dd7",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:interaction",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/checkbox/web/interaction.md",
+          "marketplaceBlobSha": "613f6cfe8b652afb9ec6bd369b5d993d3f3b7961",
+          "marketplaceSha256": "856d2dc8082b99d97826f94b3a6bc802fa86e7cdd69a29c8e53704c57e56fa46",
+          "originPath": "plugins/components/skills/checkbox/web/interaction.md",
+          "originBlobSha": "613f6cfe8b652afb9ec6bd369b5d993d3f3b7961",
+          "originSha256": "856d2dc8082b99d97826f94b3a6bc802fa86e7cdd69a29c8e53704c57e56fa46",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:tokens",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/checkbox/web/tokens.yaml",
+          "marketplaceBlobSha": "222ab7de9e085109232a0abd50a5655794e6103e",
+          "marketplaceSha256": "5a8706211772a4d42b5051431c995698591c1522d1931dd3d66734add2be2d7b",
+          "originPath": "plugins/components/skills/checkbox/web/tokens.yaml",
+          "originBlobSha": "222ab7de9e085109232a0abd50a5655794e6103e",
+          "originSha256": "5a8706211772a4d42b5051431c995698591c1522d1931dd3d66734add2be2d7b",
+          "contentDiffers": false
+        }
+      ],
+      "releaseDifferences": []
     }
   ],
-  "releaseDifferences": [],
   "divergences": [
     {
       "id": "checkbox-secondary-text-description",

--- a/packages/agentic/components/src/components/checkbox/useCheckbox.ts
+++ b/packages/agentic/components/src/components/checkbox/useCheckbox.ts
@@ -1,10 +1,11 @@
 import * as React from 'react';
-import { Pressable, Text } from 'react-native';
+import { Pressable } from 'react-native';
 import type { StyleProp, ViewStyle } from 'react-native';
 
 import { useControllableValue, useFocusVisible, usePressableState, useOptionalSlot, useSlot } from '@fluentui-react-native/framework-base';
 import { useThemeState } from '@fluentui-react-native/design';
 
+import { Text } from '../text/text';
 import type { CheckboxProps, CheckboxState, CheckboxStatus } from './checkbox.types';
 
 type NativeFocusPressableProps = React.ComponentProps<typeof Pressable> & {

--- a/packages/agentic/components/src/components/divider/divider.types.ts
+++ b/packages/agentic/components/src/components/divider/divider.types.ts
@@ -1,4 +1,4 @@
-import type { StyleProp, ViewStyle, Text, View } from 'react-native';
+import type { StyleProp, ViewStyle, View } from 'react-native';
 
 import type {
   ComponentProps,
@@ -11,6 +11,7 @@ import type {
 import type { ThemeState } from '@fluentui-react-native/design';
 
 import type { Icon } from '../../primitives/icon/icon';
+import type { Text } from '../text/text';
 
 export type DividerLayout = 'center' | 'start' | 'end';
 

--- a/packages/agentic/components/src/components/divider/spec/source.json
+++ b/packages/agentic/components/src/components/divider/spec/source.json
@@ -1,127 +1,134 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "component": "divider",
-  "skill": "flex-components:divider",
-  "sourceLock": "flex-1.5.0-206c4996",
-  "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
   "lifecycle": "implemented",
   "conformance": "reviewed",
   "reviewedAt": "2026-08-28",
-  "availableSurfaces": ["mobile", "shared", "web"],
-  "surfacesConsulted": ["mobile", "shared", "web"],
-  "sourceFiles": [
+  "sources": [
     {
-      "role": "mobile:android:accessibility",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/divider/mobile/android/accessibility.md",
-      "marketplaceBlobSha": "cbea182f84019869dafa9e168aeffe71da4e929f",
-      "marketplaceSha256": "dab045dd655a6a91f15328051163dc231a5ab74574a642073b7c553b144b2432",
-      "originPath": "plugins/components/skills/divider/mobile/android/accessibility.md",
-      "originBlobSha": "cbea182f84019869dafa9e168aeffe71da4e929f",
-      "originSha256": "dab045dd655a6a91f15328051163dc231a5ab74574a642073b7c553b144b2432",
-      "contentDiffers": false
-    },
-    {
-      "role": "mobile:android:interaction",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/divider/mobile/android/interaction.md",
-      "marketplaceBlobSha": "6618e0138e7436460b3c74cfca26f54853809fd9",
-      "marketplaceSha256": "c2002ce79a212494d146c7bdd2a453aa70836c1ce76f95954f7a895f92ed6150",
-      "originPath": "plugins/components/skills/divider/mobile/android/interaction.md",
-      "originBlobSha": "6618e0138e7436460b3c74cfca26f54853809fd9",
-      "originSha256": "c2002ce79a212494d146c7bdd2a453aa70836c1ce76f95954f7a895f92ed6150",
-      "contentDiffers": false
-    },
-    {
-      "role": "mobile:ios:accessibility",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/divider/mobile/ios/accessibility.md",
-      "marketplaceBlobSha": "1ea356216c765cc37c3535e06238e1493a0025d2",
-      "marketplaceSha256": "b638f26bba9a1191a1e9924543a11d2dfceac202b1831c2ac71d4f420f7fa422",
-      "originPath": "plugins/components/skills/divider/mobile/ios/accessibility.md",
-      "originBlobSha": "1ea356216c765cc37c3535e06238e1493a0025d2",
-      "originSha256": "b638f26bba9a1191a1e9924543a11d2dfceac202b1831c2ac71d4f420f7fa422",
-      "contentDiffers": false
-    },
-    {
-      "role": "mobile:ios:interaction",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/divider/mobile/ios/interaction.md",
-      "marketplaceBlobSha": "38bac6c8622ee9356737ab41d051b9a3dddd9dab",
-      "marketplaceSha256": "9a521c6ade731489de823f2084b9c6015e1b431f3013c4c0909974cd7afaa075",
-      "originPath": "plugins/components/skills/divider/mobile/ios/interaction.md",
-      "originBlobSha": "38bac6c8622ee9356737ab41d051b9a3dddd9dab",
-      "originSha256": "9a521c6ade731489de823f2084b9c6015e1b431f3013c4c0909974cd7afaa075",
-      "contentDiffers": false
-    },
-    {
-      "role": "mobile:overview",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/divider/mobile/overview.md",
-      "marketplaceBlobSha": "08146bbaeb4da718b0b54e3a7ef9335ab8ed6b19",
-      "marketplaceSha256": "54e76f300810cf13c2e1513eb641904b799e63563e9f520f169214834ef3c1c3",
-      "originPath": "plugins/components/skills/divider/mobile/overview.md",
-      "originBlobSha": "08146bbaeb4da718b0b54e3a7ef9335ab8ed6b19",
-      "originSha256": "54e76f300810cf13c2e1513eb641904b799e63563e9f520f169214834ef3c1c3",
-      "contentDiffers": false
-    },
-    {
-      "role": "mobile:tokens",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/divider/mobile/tokens.yaml",
-      "marketplaceBlobSha": "8c67cc0f100cb318d3c357b793100cccbce4380f",
-      "marketplaceSha256": "1cb450dcce7fab62ea5a2d9696170cacaa04f5225683967b3374c261924b3012",
-      "originPath": "plugins/components/skills/divider/mobile/tokens.yaml",
-      "originBlobSha": "8c67cc0f100cb318d3c357b793100cccbce4380f",
-      "originSha256": "1cb450dcce7fab62ea5a2d9696170cacaa04f5225683967b3374c261924b3012",
-      "contentDiffers": false
-    },
-    {
-      "role": "skill",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/divider/SKILL.md",
-      "marketplaceBlobSha": "3a65c57a1475d856fc1d18cc79c6bc4088642f22",
-      "marketplaceSha256": "99726fc8a7b705d573518f7543068a26e32dd5d8e8146d822b5703cfb14db35a",
-      "originPath": "plugins/components/skills/divider/SKILL.md",
-      "originBlobSha": "3a65c57a1475d856fc1d18cc79c6bc4088642f22",
-      "originSha256": "99726fc8a7b705d573518f7543068a26e32dd5d8e8146d822b5703cfb14db35a",
-      "contentDiffers": false
-    },
-    {
-      "role": "usage",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/divider/usage.md",
-      "marketplaceBlobSha": "e4a70da2e5be98ad599f7f7202b1e338a5961ed1",
-      "marketplaceSha256": "64c0e3aebb63a168a3aa42b9b973e1a7448f0924517ba601f5e5859eace16c03",
-      "originPath": "plugins/components/skills/divider/usage.md",
-      "originBlobSha": "e4a70da2e5be98ad599f7f7202b1e338a5961ed1",
-      "originSha256": "64c0e3aebb63a168a3aa42b9b973e1a7448f0924517ba601f5e5859eace16c03",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:accessibility",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/divider/web/accessibility.md",
-      "marketplaceBlobSha": "c3729e1052b638a139b7d7f21ae7c4a6aaa93aec",
-      "marketplaceSha256": "ab0a112250b7504289561883b08f65fea6dbb383cabf068f7b3c685071cb393f",
-      "originPath": "plugins/components/skills/divider/web/accessibility.md",
-      "originBlobSha": "c3729e1052b638a139b7d7f21ae7c4a6aaa93aec",
-      "originSha256": "ab0a112250b7504289561883b08f65fea6dbb383cabf068f7b3c685071cb393f",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:interaction",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/divider/web/interaction.md",
-      "marketplaceBlobSha": "95d14240a4c75ab339c79eb98a57e761bdfa7045",
-      "marketplaceSha256": "a8691712b20b54687daaa779e26770f97858fbcc3e7b5287d770ea79c4349372",
-      "originPath": "plugins/components/skills/divider/web/interaction.md",
-      "originBlobSha": "95d14240a4c75ab339c79eb98a57e761bdfa7045",
-      "originSha256": "a8691712b20b54687daaa779e26770f97858fbcc3e7b5287d770ea79c4349372",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:tokens",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/divider/web/tokens.yaml",
-      "marketplaceBlobSha": "2812100818ec69401013dff5975356b7df0b29db",
-      "marketplaceSha256": "5c184e11660aa2a4a08469270b4f4d576b2dd86d889fa91bd338f3a7f2c044f6",
-      "originPath": "plugins/components/skills/divider/web/tokens.yaml",
-      "originBlobSha": "2812100818ec69401013dff5975356b7df0b29db",
-      "originSha256": "5c184e11660aa2a4a08469270b4f4d576b2dd86d889fa91bd338f3a7f2c044f6",
-      "contentDiffers": false
+      "id": "flex-component",
+      "kind": "flex-skill",
+      "authority": "normative",
+      "skill": "flex-components:divider",
+      "sourceLock": "flex-1.5.0-206c4996",
+      "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
+      "availableSurfaces": ["mobile", "shared", "web"],
+      "surfacesConsulted": ["mobile", "shared", "web"],
+      "sourceFiles": [
+        {
+          "role": "mobile:android:accessibility",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/divider/mobile/android/accessibility.md",
+          "marketplaceBlobSha": "cbea182f84019869dafa9e168aeffe71da4e929f",
+          "marketplaceSha256": "dab045dd655a6a91f15328051163dc231a5ab74574a642073b7c553b144b2432",
+          "originPath": "plugins/components/skills/divider/mobile/android/accessibility.md",
+          "originBlobSha": "cbea182f84019869dafa9e168aeffe71da4e929f",
+          "originSha256": "dab045dd655a6a91f15328051163dc231a5ab74574a642073b7c553b144b2432",
+          "contentDiffers": false
+        },
+        {
+          "role": "mobile:android:interaction",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/divider/mobile/android/interaction.md",
+          "marketplaceBlobSha": "6618e0138e7436460b3c74cfca26f54853809fd9",
+          "marketplaceSha256": "c2002ce79a212494d146c7bdd2a453aa70836c1ce76f95954f7a895f92ed6150",
+          "originPath": "plugins/components/skills/divider/mobile/android/interaction.md",
+          "originBlobSha": "6618e0138e7436460b3c74cfca26f54853809fd9",
+          "originSha256": "c2002ce79a212494d146c7bdd2a453aa70836c1ce76f95954f7a895f92ed6150",
+          "contentDiffers": false
+        },
+        {
+          "role": "mobile:ios:accessibility",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/divider/mobile/ios/accessibility.md",
+          "marketplaceBlobSha": "1ea356216c765cc37c3535e06238e1493a0025d2",
+          "marketplaceSha256": "b638f26bba9a1191a1e9924543a11d2dfceac202b1831c2ac71d4f420f7fa422",
+          "originPath": "plugins/components/skills/divider/mobile/ios/accessibility.md",
+          "originBlobSha": "1ea356216c765cc37c3535e06238e1493a0025d2",
+          "originSha256": "b638f26bba9a1191a1e9924543a11d2dfceac202b1831c2ac71d4f420f7fa422",
+          "contentDiffers": false
+        },
+        {
+          "role": "mobile:ios:interaction",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/divider/mobile/ios/interaction.md",
+          "marketplaceBlobSha": "38bac6c8622ee9356737ab41d051b9a3dddd9dab",
+          "marketplaceSha256": "9a521c6ade731489de823f2084b9c6015e1b431f3013c4c0909974cd7afaa075",
+          "originPath": "plugins/components/skills/divider/mobile/ios/interaction.md",
+          "originBlobSha": "38bac6c8622ee9356737ab41d051b9a3dddd9dab",
+          "originSha256": "9a521c6ade731489de823f2084b9c6015e1b431f3013c4c0909974cd7afaa075",
+          "contentDiffers": false
+        },
+        {
+          "role": "mobile:overview",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/divider/mobile/overview.md",
+          "marketplaceBlobSha": "08146bbaeb4da718b0b54e3a7ef9335ab8ed6b19",
+          "marketplaceSha256": "54e76f300810cf13c2e1513eb641904b799e63563e9f520f169214834ef3c1c3",
+          "originPath": "plugins/components/skills/divider/mobile/overview.md",
+          "originBlobSha": "08146bbaeb4da718b0b54e3a7ef9335ab8ed6b19",
+          "originSha256": "54e76f300810cf13c2e1513eb641904b799e63563e9f520f169214834ef3c1c3",
+          "contentDiffers": false
+        },
+        {
+          "role": "mobile:tokens",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/divider/mobile/tokens.yaml",
+          "marketplaceBlobSha": "8c67cc0f100cb318d3c357b793100cccbce4380f",
+          "marketplaceSha256": "1cb450dcce7fab62ea5a2d9696170cacaa04f5225683967b3374c261924b3012",
+          "originPath": "plugins/components/skills/divider/mobile/tokens.yaml",
+          "originBlobSha": "8c67cc0f100cb318d3c357b793100cccbce4380f",
+          "originSha256": "1cb450dcce7fab62ea5a2d9696170cacaa04f5225683967b3374c261924b3012",
+          "contentDiffers": false
+        },
+        {
+          "role": "skill",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/divider/SKILL.md",
+          "marketplaceBlobSha": "3a65c57a1475d856fc1d18cc79c6bc4088642f22",
+          "marketplaceSha256": "99726fc8a7b705d573518f7543068a26e32dd5d8e8146d822b5703cfb14db35a",
+          "originPath": "plugins/components/skills/divider/SKILL.md",
+          "originBlobSha": "3a65c57a1475d856fc1d18cc79c6bc4088642f22",
+          "originSha256": "99726fc8a7b705d573518f7543068a26e32dd5d8e8146d822b5703cfb14db35a",
+          "contentDiffers": false
+        },
+        {
+          "role": "usage",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/divider/usage.md",
+          "marketplaceBlobSha": "e4a70da2e5be98ad599f7f7202b1e338a5961ed1",
+          "marketplaceSha256": "64c0e3aebb63a168a3aa42b9b973e1a7448f0924517ba601f5e5859eace16c03",
+          "originPath": "plugins/components/skills/divider/usage.md",
+          "originBlobSha": "e4a70da2e5be98ad599f7f7202b1e338a5961ed1",
+          "originSha256": "64c0e3aebb63a168a3aa42b9b973e1a7448f0924517ba601f5e5859eace16c03",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:accessibility",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/divider/web/accessibility.md",
+          "marketplaceBlobSha": "c3729e1052b638a139b7d7f21ae7c4a6aaa93aec",
+          "marketplaceSha256": "ab0a112250b7504289561883b08f65fea6dbb383cabf068f7b3c685071cb393f",
+          "originPath": "plugins/components/skills/divider/web/accessibility.md",
+          "originBlobSha": "c3729e1052b638a139b7d7f21ae7c4a6aaa93aec",
+          "originSha256": "ab0a112250b7504289561883b08f65fea6dbb383cabf068f7b3c685071cb393f",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:interaction",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/divider/web/interaction.md",
+          "marketplaceBlobSha": "95d14240a4c75ab339c79eb98a57e761bdfa7045",
+          "marketplaceSha256": "a8691712b20b54687daaa779e26770f97858fbcc3e7b5287d770ea79c4349372",
+          "originPath": "plugins/components/skills/divider/web/interaction.md",
+          "originBlobSha": "95d14240a4c75ab339c79eb98a57e761bdfa7045",
+          "originSha256": "a8691712b20b54687daaa779e26770f97858fbcc3e7b5287d770ea79c4349372",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:tokens",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/divider/web/tokens.yaml",
+          "marketplaceBlobSha": "2812100818ec69401013dff5975356b7df0b29db",
+          "marketplaceSha256": "5c184e11660aa2a4a08469270b4f4d576b2dd86d889fa91bd338f3a7f2c044f6",
+          "originPath": "plugins/components/skills/divider/web/tokens.yaml",
+          "originBlobSha": "2812100818ec69401013dff5975356b7df0b29db",
+          "originSha256": "5c184e11660aa2a4a08469270b4f4d576b2dd86d889fa91bd338f3a7f2c044f6",
+          "contentDiffers": false
+        }
+      ],
+      "releaseDifferences": []
     }
   ],
-  "releaseDifferences": [],
   "divergences": [
     {
       "id": "divider-orientation-semantics",

--- a/packages/agentic/components/src/components/divider/useDivider.ts
+++ b/packages/agentic/components/src/components/divider/useDivider.ts
@@ -1,9 +1,10 @@
-import { Text, View } from 'react-native';
+import { View } from 'react-native';
 
 import { useThemeState } from '@fluentui-react-native/design';
 import { useOptionalSlot, useSlot } from '@fluentui-react-native/framework-base';
 
 import { Icon } from '../../primitives/icon/icon';
+import { Text } from '../text/text';
 import type { DividerProps, DividerState } from './divider.types';
 
 function getTextFromSlotProp(slot: DividerProps['label']): string | undefined {

--- a/packages/agentic/components/src/components/input/spec/source.json
+++ b/packages/agentic/components/src/components/input/spec/source.json
@@ -1,72 +1,79 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "component": "input",
-  "skill": "flex-components:input",
-  "sourceLock": "flex-1.5.0-206c4996",
-  "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
   "lifecycle": "implemented",
   "conformance": "reviewed",
   "reviewedAt": "2026-08-28",
-  "availableSurfaces": ["shared", "web"],
-  "surfacesConsulted": ["shared", "web"],
-  "sourceFiles": [
+  "sources": [
     {
-      "role": "skill",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/input/SKILL.md",
-      "marketplaceBlobSha": "b45afe659bd156e4f8dd4c1a40dfcbd03f49fdca",
-      "marketplaceSha256": "e89ce5d97de6999df25b4fcfc30d4f5319b5d60689699ad088acbccc34e56b4c",
-      "originPath": "plugins/components/skills/input/SKILL.md",
-      "originBlobSha": "b45afe659bd156e4f8dd4c1a40dfcbd03f49fdca",
-      "originSha256": "e89ce5d97de6999df25b4fcfc30d4f5319b5d60689699ad088acbccc34e56b4c",
-      "contentDiffers": false
-    },
-    {
-      "role": "usage",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/input/usage.md",
-      "marketplaceBlobSha": "0feb5189a798b2d414376e28b680efb468c2a346",
-      "marketplaceSha256": "a7d3b87a3608195c6146a56bfe46895af7a0a92c36dff701ba34e8f2433d2bf6",
-      "originPath": "plugins/components/skills/input/usage.md",
-      "originBlobSha": "0feb5189a798b2d414376e28b680efb468c2a346",
-      "originSha256": "a7d3b87a3608195c6146a56bfe46895af7a0a92c36dff701ba34e8f2433d2bf6",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:accessibility",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/input/web/accessibility.md",
-      "marketplaceBlobSha": "a64c91fe49081bcecf3bfa6cd3aa7a9369e00b97",
-      "marketplaceSha256": "0ec138a7a079f1231364cd73c2b6f1dc65b5b7e04cc684f5804815e218221f0f",
-      "originPath": "plugins/components/skills/input/web/accessibility.md",
-      "originBlobSha": "a64c91fe49081bcecf3bfa6cd3aa7a9369e00b97",
-      "originSha256": "0ec138a7a079f1231364cd73c2b6f1dc65b5b7e04cc684f5804815e218221f0f",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:interaction",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/input/web/interaction.md",
-      "marketplaceBlobSha": "03ede936e51eaa069994fa9626dfeff690bf1044",
-      "marketplaceSha256": "7faac6e33f10a723c3c5be137c202e63225e289a222c209f36c447068da371cc",
-      "originPath": "plugins/components/skills/input/web/interaction.md",
-      "originBlobSha": "dd57747c495974741305460b73a9d034103bdc75",
-      "originSha256": "540ad4fbf93ef29dae48b89be8bb5bf49706504f389ccb87bfd8c59c259c02bf",
-      "contentDiffers": true
-    },
-    {
-      "role": "web:tokens",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/input/web/tokens.yaml",
-      "marketplaceBlobSha": "8eac23f893ffba81664ee633b32d552efe483723",
-      "marketplaceSha256": "c3cd8e3b92f17d1c87983681cdee70e2260b262d37457a6cc24abe92f1504d64",
-      "originPath": "plugins/components/skills/input/web/tokens.yaml",
-      "originBlobSha": "8eac23f893ffba81664ee633b32d552efe483723",
-      "originSha256": "c3cd8e3b92f17d1c87983681cdee70e2260b262d37457a6cc24abe92f1504d64",
-      "contentDiffers": false
-    }
-  ],
-  "releaseDifferences": [
-    {
-      "role": "web:interaction",
-      "status": "reviewed",
-      "resolution": "marketplace-authoring-input",
-      "note": "The pinned Marketplace payload is the exact Agency session input; the differing x3 blob remains recorded as release lineage."
+      "id": "flex-component",
+      "kind": "flex-skill",
+      "authority": "normative",
+      "skill": "flex-components:input",
+      "sourceLock": "flex-1.5.0-206c4996",
+      "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
+      "availableSurfaces": ["shared", "web"],
+      "surfacesConsulted": ["shared", "web"],
+      "sourceFiles": [
+        {
+          "role": "skill",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/input/SKILL.md",
+          "marketplaceBlobSha": "b45afe659bd156e4f8dd4c1a40dfcbd03f49fdca",
+          "marketplaceSha256": "e89ce5d97de6999df25b4fcfc30d4f5319b5d60689699ad088acbccc34e56b4c",
+          "originPath": "plugins/components/skills/input/SKILL.md",
+          "originBlobSha": "b45afe659bd156e4f8dd4c1a40dfcbd03f49fdca",
+          "originSha256": "e89ce5d97de6999df25b4fcfc30d4f5319b5d60689699ad088acbccc34e56b4c",
+          "contentDiffers": false
+        },
+        {
+          "role": "usage",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/input/usage.md",
+          "marketplaceBlobSha": "0feb5189a798b2d414376e28b680efb468c2a346",
+          "marketplaceSha256": "a7d3b87a3608195c6146a56bfe46895af7a0a92c36dff701ba34e8f2433d2bf6",
+          "originPath": "plugins/components/skills/input/usage.md",
+          "originBlobSha": "0feb5189a798b2d414376e28b680efb468c2a346",
+          "originSha256": "a7d3b87a3608195c6146a56bfe46895af7a0a92c36dff701ba34e8f2433d2bf6",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:accessibility",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/input/web/accessibility.md",
+          "marketplaceBlobSha": "a64c91fe49081bcecf3bfa6cd3aa7a9369e00b97",
+          "marketplaceSha256": "0ec138a7a079f1231364cd73c2b6f1dc65b5b7e04cc684f5804815e218221f0f",
+          "originPath": "plugins/components/skills/input/web/accessibility.md",
+          "originBlobSha": "a64c91fe49081bcecf3bfa6cd3aa7a9369e00b97",
+          "originSha256": "0ec138a7a079f1231364cd73c2b6f1dc65b5b7e04cc684f5804815e218221f0f",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:interaction",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/input/web/interaction.md",
+          "marketplaceBlobSha": "03ede936e51eaa069994fa9626dfeff690bf1044",
+          "marketplaceSha256": "7faac6e33f10a723c3c5be137c202e63225e289a222c209f36c447068da371cc",
+          "originPath": "plugins/components/skills/input/web/interaction.md",
+          "originBlobSha": "dd57747c495974741305460b73a9d034103bdc75",
+          "originSha256": "540ad4fbf93ef29dae48b89be8bb5bf49706504f389ccb87bfd8c59c259c02bf",
+          "contentDiffers": true
+        },
+        {
+          "role": "web:tokens",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/input/web/tokens.yaml",
+          "marketplaceBlobSha": "8eac23f893ffba81664ee633b32d552efe483723",
+          "marketplaceSha256": "c3cd8e3b92f17d1c87983681cdee70e2260b262d37457a6cc24abe92f1504d64",
+          "originPath": "plugins/components/skills/input/web/tokens.yaml",
+          "originBlobSha": "8eac23f893ffba81664ee633b32d552efe483723",
+          "originSha256": "c3cd8e3b92f17d1c87983681cdee70e2260b262d37457a6cc24abe92f1504d64",
+          "contentDiffers": false
+        }
+      ],
+      "releaseDifferences": [
+        {
+          "role": "web:interaction",
+          "status": "reviewed",
+          "resolution": "marketplace-authoring-input",
+          "note": "The pinned Marketplace payload is the exact Agency session input; the differing x3 blob remains recorded as release lineage."
+        }
+      ]
     }
   ],
   "divergences": [

--- a/packages/agentic/components/src/components/list-item/list-item.types.ts
+++ b/packages/agentic/components/src/components/list-item/list-item.types.ts
@@ -1,4 +1,4 @@
-import type { Pressable, StyleProp, Text, View, ViewStyle } from 'react-native';
+import type { Pressable, StyleProp, Text as NativeText, View, ViewStyle } from 'react-native';
 
 import type { ThemeState } from '@fluentui-react-native/design';
 import type {
@@ -14,6 +14,7 @@ import type {
 import type { Icon } from '../../primitives/icon/icon';
 import type { FocusVisualProps } from '../../primitives/focus-visual/focus-visual.types';
 import type { ItemSecondaryContentPosition } from '../../common/item.types';
+import type { Text } from '../text/text';
 
 export type ListItemSize = 'small' | 'medium' | 'large';
 export type ListItemSelectionMode = 'none' | 'single' | 'multiple';
@@ -21,7 +22,7 @@ export type ListItemSecondaryContentPosition = ItemSecondaryContentPosition;
 
 export type ListItemSlots = {
   root: Slot<typeof Pressable>;
-  content: Slot<typeof Text>;
+  content: Slot<typeof NativeText>;
   secondaryContent: OptionalSlot<typeof Text>;
   icon: OptionalSlot<typeof Icon>;
   selectedIcon: OptionalSlot<typeof Icon>;
@@ -30,8 +31,8 @@ export type ListItemSlots = {
 };
 
 export type ListItemStateSlots = ListItemSlots & {
-  selectionIndicator: OptionalSlot<typeof Text>;
-  contentHidden: Slot<typeof Text>;
+  selectionIndicator: OptionalSlot<typeof NativeText>;
+  contentHidden: Slot<typeof NativeText>;
 };
 
 export type ListItemStateProps = {

--- a/packages/agentic/components/src/components/list-item/spec/source.json
+++ b/packages/agentic/components/src/components/list-item/spec/source.json
@@ -1,67 +1,74 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "component": "list-item",
-  "skill": "flex-components:list-item",
-  "sourceLock": "flex-1.5.0-206c4996",
-  "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
   "lifecycle": "implemented",
   "conformance": "reviewed",
   "reviewedAt": "2026-08-28",
-  "availableSurfaces": ["shared", "web"],
-  "surfacesConsulted": ["shared", "web"],
-  "sourceFiles": [
+  "sources": [
     {
-      "role": "skill",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/list-item/SKILL.md",
-      "marketplaceBlobSha": "2847a936612c6864061461ebb9fc85108c5a7abf",
-      "marketplaceSha256": "038271b4000fdc07834a526bbaf687520e3bbc7d40d2ef68ee78373fcb45d91e",
-      "originPath": "plugins/components/skills/list-item/SKILL.md",
-      "originBlobSha": "2847a936612c6864061461ebb9fc85108c5a7abf",
-      "originSha256": "038271b4000fdc07834a526bbaf687520e3bbc7d40d2ef68ee78373fcb45d91e",
-      "contentDiffers": false
-    },
-    {
-      "role": "usage",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/list-item/usage.md",
-      "marketplaceBlobSha": "eeba12db175de73668f457c4440f26213c85620a",
-      "marketplaceSha256": "935e3723b8192bcec31a825337c52c8aa3eda786102c765e8f92355195005c98",
-      "originPath": "plugins/components/skills/list-item/usage.md",
-      "originBlobSha": "eeba12db175de73668f457c4440f26213c85620a",
-      "originSha256": "935e3723b8192bcec31a825337c52c8aa3eda786102c765e8f92355195005c98",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:accessibility",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/list-item/web/accessibility.md",
-      "marketplaceBlobSha": "7518007cec46b09daef813a01f73ef1bea680444",
-      "marketplaceSha256": "f1d77e547b1b23c04cc175d815c8ca31b96dc16c66790d409c3bffdd3bbbd7c4",
-      "originPath": "plugins/components/skills/list-item/web/accessibility.md",
-      "originBlobSha": "7518007cec46b09daef813a01f73ef1bea680444",
-      "originSha256": "f1d77e547b1b23c04cc175d815c8ca31b96dc16c66790d409c3bffdd3bbbd7c4",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:interaction",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/list-item/web/interaction.md",
-      "marketplaceBlobSha": "1ab0233491f014b96b661a8865c5f88ee19ac5c0",
-      "marketplaceSha256": "2d55c9d6a07afa3268cb03acf0c4430584d9f4c7d009cf75d22e907e832d965b",
-      "originPath": "plugins/components/skills/list-item/web/interaction.md",
-      "originBlobSha": "1ab0233491f014b96b661a8865c5f88ee19ac5c0",
-      "originSha256": "2d55c9d6a07afa3268cb03acf0c4430584d9f4c7d009cf75d22e907e832d965b",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:tokens",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/list-item/web/tokens.yaml",
-      "marketplaceBlobSha": "cdd550012283398483b6588a9521b2468880a278",
-      "marketplaceSha256": "6a22dd9afbec673016cc5e6bfd5fab82e103da901982a2b17a3b6341ffd4f299",
-      "originPath": "plugins/components/skills/list-item/web/tokens.yaml",
-      "originBlobSha": "cdd550012283398483b6588a9521b2468880a278",
-      "originSha256": "6a22dd9afbec673016cc5e6bfd5fab82e103da901982a2b17a3b6341ffd4f299",
-      "contentDiffers": false
+      "id": "flex-component",
+      "kind": "flex-skill",
+      "authority": "normative",
+      "skill": "flex-components:list-item",
+      "sourceLock": "flex-1.5.0-206c4996",
+      "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
+      "availableSurfaces": ["shared", "web"],
+      "surfacesConsulted": ["shared", "web"],
+      "sourceFiles": [
+        {
+          "role": "skill",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/list-item/SKILL.md",
+          "marketplaceBlobSha": "2847a936612c6864061461ebb9fc85108c5a7abf",
+          "marketplaceSha256": "038271b4000fdc07834a526bbaf687520e3bbc7d40d2ef68ee78373fcb45d91e",
+          "originPath": "plugins/components/skills/list-item/SKILL.md",
+          "originBlobSha": "2847a936612c6864061461ebb9fc85108c5a7abf",
+          "originSha256": "038271b4000fdc07834a526bbaf687520e3bbc7d40d2ef68ee78373fcb45d91e",
+          "contentDiffers": false
+        },
+        {
+          "role": "usage",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/list-item/usage.md",
+          "marketplaceBlobSha": "eeba12db175de73668f457c4440f26213c85620a",
+          "marketplaceSha256": "935e3723b8192bcec31a825337c52c8aa3eda786102c765e8f92355195005c98",
+          "originPath": "plugins/components/skills/list-item/usage.md",
+          "originBlobSha": "eeba12db175de73668f457c4440f26213c85620a",
+          "originSha256": "935e3723b8192bcec31a825337c52c8aa3eda786102c765e8f92355195005c98",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:accessibility",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/list-item/web/accessibility.md",
+          "marketplaceBlobSha": "7518007cec46b09daef813a01f73ef1bea680444",
+          "marketplaceSha256": "f1d77e547b1b23c04cc175d815c8ca31b96dc16c66790d409c3bffdd3bbbd7c4",
+          "originPath": "plugins/components/skills/list-item/web/accessibility.md",
+          "originBlobSha": "7518007cec46b09daef813a01f73ef1bea680444",
+          "originSha256": "f1d77e547b1b23c04cc175d815c8ca31b96dc16c66790d409c3bffdd3bbbd7c4",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:interaction",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/list-item/web/interaction.md",
+          "marketplaceBlobSha": "1ab0233491f014b96b661a8865c5f88ee19ac5c0",
+          "marketplaceSha256": "2d55c9d6a07afa3268cb03acf0c4430584d9f4c7d009cf75d22e907e832d965b",
+          "originPath": "plugins/components/skills/list-item/web/interaction.md",
+          "originBlobSha": "1ab0233491f014b96b661a8865c5f88ee19ac5c0",
+          "originSha256": "2d55c9d6a07afa3268cb03acf0c4430584d9f4c7d009cf75d22e907e832d965b",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:tokens",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/list-item/web/tokens.yaml",
+          "marketplaceBlobSha": "cdd550012283398483b6588a9521b2468880a278",
+          "marketplaceSha256": "6a22dd9afbec673016cc5e6bfd5fab82e103da901982a2b17a3b6341ffd4f299",
+          "originPath": "plugins/components/skills/list-item/web/tokens.yaml",
+          "originBlobSha": "cdd550012283398483b6588a9521b2468880a278",
+          "originSha256": "6a22dd9afbec673016cc5e6bfd5fab82e103da901982a2b17a3b6341ffd4f299",
+          "contentDiffers": false
+        }
+      ],
+      "releaseDifferences": []
     }
   ],
-  "releaseDifferences": [],
   "divergences": [
     {
       "id": "list-item-native-selection-indicators",

--- a/packages/agentic/components/src/components/list-item/useListItem.ts
+++ b/packages/agentic/components/src/components/list-item/useListItem.ts
@@ -1,10 +1,11 @@
-import { Pressable, Text, View } from 'react-native';
+import { Pressable, Text as NativeText, View } from 'react-native';
 
 import { useThemeState } from '@fluentui-react-native/design';
 import { useOptionalSlot, usePressableState, useSlot } from '@fluentui-react-native/framework-base';
 
 import { Icon } from '../../primitives/icon/icon';
 import { hideSlotProps } from '../../common/accessibility';
+import { Text } from '../text/text';
 
 import { getListItemAvatarSize, getListItemIconSize, getListItemSelectionIndicatorGlyph } from './list-item.styles';
 import type { ListItemMetrics, ListItemProps, ListItemState } from './list-item.types';
@@ -96,14 +97,14 @@ export function useListItem_unstable(props: ListItemProps): ListItemState {
   });
 
   const root = useSlot(Pressable, { ...pressableProps, ref: rootRef });
-  const content = useSlot(Text, contentProp);
-  const contentHidden = useSlot(Text, contentProp);
+  const content = useSlot(NativeText, contentProp);
+  const contentHidden = useSlot(NativeText, contentProp);
   const secondaryContent = useOptionalSlot(Text, secondaryContentProp);
   const icon = useOptionalSlot(Icon, iconProp);
   const selectedIcon = useOptionalSlot(Icon, selectedIconProp);
   const avatar = useOptionalSlot(View, avatarProp);
   const trailing = useOptionalSlot(View, trailingProp);
-  const selectionIndicator = useOptionalSlot(Text, selectionGlyph, { transform: hideSlotProps });
+  const selectionIndicator = useOptionalSlot(NativeText, selectionGlyph, { transform: hideSlotProps });
 
   return {
     root,

--- a/packages/agentic/components/src/components/listbox-item/listbox-item.types.ts
+++ b/packages/agentic/components/src/components/listbox-item/listbox-item.types.ts
@@ -1,4 +1,4 @@
-import type { Pressable, Text, View, ViewStyle } from 'react-native';
+import type { Pressable, Text as NativeText, View, ViewStyle } from 'react-native';
 import type { StyleProp } from 'react-native';
 
 import type {
@@ -16,13 +16,14 @@ import type { Icon } from '../../primitives/icon/icon';
 import type { CheckboxIndicator } from '../../primitives/checkbox-indicator/checkbox-indicator';
 import type { FocusVisualProps } from '../../primitives/focus-visual/focus-visual.types';
 import type { ItemSecondaryContentPosition } from '../../common/item.types';
+import type { Text } from '../text/text';
 
 export type ListboxItemSecondaryContentPosition = ItemSecondaryContentPosition;
 export type ListboxItemVariant = 'listItem' | 'sectionHeader';
 
 export type ListboxItemSlots = {
   root: Slot<typeof Pressable>;
-  content: Slot<typeof Text>;
+  content: Slot<typeof NativeText>;
   secondaryContent: OptionalSlot<typeof Text>;
   icon: OptionalSlot<typeof Icon>;
   selectedIcon: OptionalSlot<typeof Icon>;

--- a/packages/agentic/components/src/components/listbox-item/spec/source.json
+++ b/packages/agentic/components/src/components/listbox-item/spec/source.json
@@ -1,67 +1,74 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "component": "listbox-item",
-  "skill": "flex-components:listbox-item",
-  "sourceLock": "flex-1.5.0-206c4996",
-  "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
   "lifecycle": "implemented",
   "conformance": "reviewed",
   "reviewedAt": "2026-08-28",
-  "availableSurfaces": ["shared", "web"],
-  "surfacesConsulted": ["shared", "web"],
-  "sourceFiles": [
+  "sources": [
     {
-      "role": "skill",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/listbox-item/SKILL.md",
-      "marketplaceBlobSha": "4a65208a1abb27302dc8eba7882df711f1704147",
-      "marketplaceSha256": "dda66a00388fc912a5e576b3fab51a4db20055e226b0af9117c2f8551f3fb9a7",
-      "originPath": "plugins/components/skills/listbox-item/SKILL.md",
-      "originBlobSha": "4a65208a1abb27302dc8eba7882df711f1704147",
-      "originSha256": "dda66a00388fc912a5e576b3fab51a4db20055e226b0af9117c2f8551f3fb9a7",
-      "contentDiffers": false
-    },
-    {
-      "role": "usage",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/listbox-item/usage.md",
-      "marketplaceBlobSha": "ff11150b9050539cad1eaeec67ccf44240e93207",
-      "marketplaceSha256": "ecc3bf4742445f4a7211e7d29140791e367cf371c3e190b7fe26e4b190fe7d22",
-      "originPath": "plugins/components/skills/listbox-item/usage.md",
-      "originBlobSha": "ff11150b9050539cad1eaeec67ccf44240e93207",
-      "originSha256": "ecc3bf4742445f4a7211e7d29140791e367cf371c3e190b7fe26e4b190fe7d22",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:accessibility",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/listbox-item/web/accessibility.md",
-      "marketplaceBlobSha": "b6dba99deb73da8ae697e1f546765c47e78c9b00",
-      "marketplaceSha256": "93e23d8c5838b834790ec65016bcd948747df76f7b056add87f6dd0d42d2a5ff",
-      "originPath": "plugins/components/skills/listbox-item/web/accessibility.md",
-      "originBlobSha": "b6dba99deb73da8ae697e1f546765c47e78c9b00",
-      "originSha256": "93e23d8c5838b834790ec65016bcd948747df76f7b056add87f6dd0d42d2a5ff",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:interaction",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/listbox-item/web/interaction.md",
-      "marketplaceBlobSha": "10880c6a7a44223bf1a275d9182913617153c7c4",
-      "marketplaceSha256": "fbf6c6f159ad3d0321988bc6909cf3a0793432987a5234b9d72f01ef81e13659",
-      "originPath": "plugins/components/skills/listbox-item/web/interaction.md",
-      "originBlobSha": "10880c6a7a44223bf1a275d9182913617153c7c4",
-      "originSha256": "fbf6c6f159ad3d0321988bc6909cf3a0793432987a5234b9d72f01ef81e13659",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:tokens",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/listbox-item/web/tokens.yaml",
-      "marketplaceBlobSha": "674693aee2649be974bb4e6e468908695c7c581c",
-      "marketplaceSha256": "e825460747611b4a209369c5d646d9d5df5d88c344ecb0111edce153853824d5",
-      "originPath": "plugins/components/skills/listbox-item/web/tokens.yaml",
-      "originBlobSha": "674693aee2649be974bb4e6e468908695c7c581c",
-      "originSha256": "e825460747611b4a209369c5d646d9d5df5d88c344ecb0111edce153853824d5",
-      "contentDiffers": false
+      "id": "flex-component",
+      "kind": "flex-skill",
+      "authority": "normative",
+      "skill": "flex-components:listbox-item",
+      "sourceLock": "flex-1.5.0-206c4996",
+      "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
+      "availableSurfaces": ["shared", "web"],
+      "surfacesConsulted": ["shared", "web"],
+      "sourceFiles": [
+        {
+          "role": "skill",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/listbox-item/SKILL.md",
+          "marketplaceBlobSha": "4a65208a1abb27302dc8eba7882df711f1704147",
+          "marketplaceSha256": "dda66a00388fc912a5e576b3fab51a4db20055e226b0af9117c2f8551f3fb9a7",
+          "originPath": "plugins/components/skills/listbox-item/SKILL.md",
+          "originBlobSha": "4a65208a1abb27302dc8eba7882df711f1704147",
+          "originSha256": "dda66a00388fc912a5e576b3fab51a4db20055e226b0af9117c2f8551f3fb9a7",
+          "contentDiffers": false
+        },
+        {
+          "role": "usage",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/listbox-item/usage.md",
+          "marketplaceBlobSha": "ff11150b9050539cad1eaeec67ccf44240e93207",
+          "marketplaceSha256": "ecc3bf4742445f4a7211e7d29140791e367cf371c3e190b7fe26e4b190fe7d22",
+          "originPath": "plugins/components/skills/listbox-item/usage.md",
+          "originBlobSha": "ff11150b9050539cad1eaeec67ccf44240e93207",
+          "originSha256": "ecc3bf4742445f4a7211e7d29140791e367cf371c3e190b7fe26e4b190fe7d22",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:accessibility",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/listbox-item/web/accessibility.md",
+          "marketplaceBlobSha": "b6dba99deb73da8ae697e1f546765c47e78c9b00",
+          "marketplaceSha256": "93e23d8c5838b834790ec65016bcd948747df76f7b056add87f6dd0d42d2a5ff",
+          "originPath": "plugins/components/skills/listbox-item/web/accessibility.md",
+          "originBlobSha": "b6dba99deb73da8ae697e1f546765c47e78c9b00",
+          "originSha256": "93e23d8c5838b834790ec65016bcd948747df76f7b056add87f6dd0d42d2a5ff",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:interaction",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/listbox-item/web/interaction.md",
+          "marketplaceBlobSha": "10880c6a7a44223bf1a275d9182913617153c7c4",
+          "marketplaceSha256": "fbf6c6f159ad3d0321988bc6909cf3a0793432987a5234b9d72f01ef81e13659",
+          "originPath": "plugins/components/skills/listbox-item/web/interaction.md",
+          "originBlobSha": "10880c6a7a44223bf1a275d9182913617153c7c4",
+          "originSha256": "fbf6c6f159ad3d0321988bc6909cf3a0793432987a5234b9d72f01ef81e13659",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:tokens",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/listbox-item/web/tokens.yaml",
+          "marketplaceBlobSha": "674693aee2649be974bb4e6e468908695c7c581c",
+          "marketplaceSha256": "e825460747611b4a209369c5d646d9d5df5d88c344ecb0111edce153853824d5",
+          "originPath": "plugins/components/skills/listbox-item/web/tokens.yaml",
+          "originBlobSha": "674693aee2649be974bb4e6e468908695c7c581c",
+          "originSha256": "e825460747611b4a209369c5d646d9d5df5d88c344ecb0111edce153853824d5",
+          "contentDiffers": false
+        }
+      ],
+      "releaseDifferences": []
     }
   ],
-  "releaseDifferences": [],
   "divergences": [
     {
       "id": "listbox-item-native-pressed-state",

--- a/packages/agentic/components/src/components/listbox-item/useListboxItem.ts
+++ b/packages/agentic/components/src/components/listbox-item/useListboxItem.ts
@@ -1,4 +1,4 @@
-import { Pressable, Text, View } from 'react-native';
+import { Pressable, Text as NativeText, View } from 'react-native';
 import type { ViewProps } from 'react-native';
 
 import { usePressableState, useOptionalSlot, useSlot } from '@fluentui-react-native/framework-base';
@@ -7,6 +7,7 @@ import { useThemeState } from '@fluentui-react-native/design';
 import { semanticIconSources } from '../../common/iconSources';
 import { CheckboxIndicator } from '../../primitives/checkbox-indicator/checkbox-indicator';
 import { Icon } from '../../primitives/icon/icon';
+import { Text } from '../text/text';
 import type { ListboxItemProps, ListboxItemState } from './listbox-item.types';
 
 const defaultRegularIcon = { fontSource: semanticIconSources.unselectedCircle, testID: 'listbox-item-default-icon' } as const;
@@ -36,7 +37,7 @@ export function useListboxItem_unstable(props: ListboxItemProps): ListboxItemSta
   const isListItem = variant === 'listItem';
 
   const themeState = useThemeState();
-  const content = useSlot(Text, contentProp);
+  const content = useSlot(NativeText, contentProp);
   const contentHidden = useOptionalSlot(Text, isListItem && !multiselect ? contentProp : null);
   const iconSlotProp = iconProp === null ? null : iconProp;
   const selectedIconSlotProp = selectedIconProp === null ? null : selectedIconProp;

--- a/packages/agentic/components/src/components/menu-item/renderMenuItem.tsx
+++ b/packages/agentic/components/src/components/menu-item/renderMenuItem.tsx
@@ -1,10 +1,10 @@
 /** @jsxImportSource @fluentui-react-native/framework-base */
-import { Text } from 'react-native';
 
 import { CompoundItemLayout } from '../../primitives/compound-item-layout/compound-item-layout';
 import { FocusVisual } from '../../primitives/focus-visual/focus-visual';
 import { LayoutStableText } from '../../primitives/layout-stable-text/layout-stable-text';
 import { Skeleton } from '../skeleton/skeleton';
+import { Text } from '../text/text';
 import { getMenuItemContentLayoutStyle, getMenuItemLeadingStyle, getMenuItemTrailingStyle, menuItemStyles } from './menu-item.styles';
 import type { MenuItemState } from './menu-item.types';
 

--- a/packages/agentic/components/src/components/menu-item/spec/source.json
+++ b/packages/agentic/components/src/components/menu-item/spec/source.json
@@ -1,67 +1,74 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "component": "menu-item",
-  "skill": "flex-components:menu-item",
-  "sourceLock": "flex-1.5.0-206c4996",
-  "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
   "lifecycle": "implemented",
   "conformance": "reviewed",
   "reviewedAt": "2026-08-28",
-  "availableSurfaces": ["shared", "web"],
-  "surfacesConsulted": ["shared", "web"],
-  "sourceFiles": [
+  "sources": [
     {
-      "role": "skill",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/menu-item/SKILL.md",
-      "marketplaceBlobSha": "b83c2be00a4935894631edf0458c5d1625fb93b0",
-      "marketplaceSha256": "7376258a1288a5a1dc2c40a4f3888b023cb0378632638be79fc2eed9db645b08",
-      "originPath": "plugins/components/skills/menu-item/SKILL.md",
-      "originBlobSha": "b83c2be00a4935894631edf0458c5d1625fb93b0",
-      "originSha256": "7376258a1288a5a1dc2c40a4f3888b023cb0378632638be79fc2eed9db645b08",
-      "contentDiffers": false
-    },
-    {
-      "role": "usage",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/menu-item/usage.md",
-      "marketplaceBlobSha": "75e4c44aed0be5ca9855fe754db19cb279a28c43",
-      "marketplaceSha256": "c5eca76d1fab6440a40b49e6e9a624124f7010e9532b19e05b846458587eae7d",
-      "originPath": "plugins/components/skills/menu-item/usage.md",
-      "originBlobSha": "75e4c44aed0be5ca9855fe754db19cb279a28c43",
-      "originSha256": "c5eca76d1fab6440a40b49e6e9a624124f7010e9532b19e05b846458587eae7d",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:accessibility",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/menu-item/web/accessibility.md",
-      "marketplaceBlobSha": "7d8c6db9b7c30ad79998e6b12458a620e4d84d88",
-      "marketplaceSha256": "bb7e3005ea3e6ecc5b795ce9fe8dc1ac191b11885eb41a956974ffa5473c723d",
-      "originPath": "plugins/components/skills/menu-item/web/accessibility.md",
-      "originBlobSha": "7d8c6db9b7c30ad79998e6b12458a620e4d84d88",
-      "originSha256": "bb7e3005ea3e6ecc5b795ce9fe8dc1ac191b11885eb41a956974ffa5473c723d",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:interaction",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/menu-item/web/interaction.md",
-      "marketplaceBlobSha": "a5bf707904379a1b10c92064a75b5c9a1e587d50",
-      "marketplaceSha256": "cf6155f944f29e322011b1f228ed934d49032cd4b4701a40c51f536899155d58",
-      "originPath": "plugins/components/skills/menu-item/web/interaction.md",
-      "originBlobSha": "a5bf707904379a1b10c92064a75b5c9a1e587d50",
-      "originSha256": "cf6155f944f29e322011b1f228ed934d49032cd4b4701a40c51f536899155d58",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:tokens",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/menu-item/web/tokens.yaml",
-      "marketplaceBlobSha": "a22f331f21072ae9129093fb95027fbd120b87d2",
-      "marketplaceSha256": "b2cfff32737cc9997e34621fa8d8ba6f422d130994bc95413b276f5f5e4ab59b",
-      "originPath": "plugins/components/skills/menu-item/web/tokens.yaml",
-      "originBlobSha": "a22f331f21072ae9129093fb95027fbd120b87d2",
-      "originSha256": "b2cfff32737cc9997e34621fa8d8ba6f422d130994bc95413b276f5f5e4ab59b",
-      "contentDiffers": false
+      "id": "flex-component",
+      "kind": "flex-skill",
+      "authority": "normative",
+      "skill": "flex-components:menu-item",
+      "sourceLock": "flex-1.5.0-206c4996",
+      "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
+      "availableSurfaces": ["shared", "web"],
+      "surfacesConsulted": ["shared", "web"],
+      "sourceFiles": [
+        {
+          "role": "skill",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/menu-item/SKILL.md",
+          "marketplaceBlobSha": "b83c2be00a4935894631edf0458c5d1625fb93b0",
+          "marketplaceSha256": "7376258a1288a5a1dc2c40a4f3888b023cb0378632638be79fc2eed9db645b08",
+          "originPath": "plugins/components/skills/menu-item/SKILL.md",
+          "originBlobSha": "b83c2be00a4935894631edf0458c5d1625fb93b0",
+          "originSha256": "7376258a1288a5a1dc2c40a4f3888b023cb0378632638be79fc2eed9db645b08",
+          "contentDiffers": false
+        },
+        {
+          "role": "usage",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/menu-item/usage.md",
+          "marketplaceBlobSha": "75e4c44aed0be5ca9855fe754db19cb279a28c43",
+          "marketplaceSha256": "c5eca76d1fab6440a40b49e6e9a624124f7010e9532b19e05b846458587eae7d",
+          "originPath": "plugins/components/skills/menu-item/usage.md",
+          "originBlobSha": "75e4c44aed0be5ca9855fe754db19cb279a28c43",
+          "originSha256": "c5eca76d1fab6440a40b49e6e9a624124f7010e9532b19e05b846458587eae7d",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:accessibility",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/menu-item/web/accessibility.md",
+          "marketplaceBlobSha": "7d8c6db9b7c30ad79998e6b12458a620e4d84d88",
+          "marketplaceSha256": "bb7e3005ea3e6ecc5b795ce9fe8dc1ac191b11885eb41a956974ffa5473c723d",
+          "originPath": "plugins/components/skills/menu-item/web/accessibility.md",
+          "originBlobSha": "7d8c6db9b7c30ad79998e6b12458a620e4d84d88",
+          "originSha256": "bb7e3005ea3e6ecc5b795ce9fe8dc1ac191b11885eb41a956974ffa5473c723d",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:interaction",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/menu-item/web/interaction.md",
+          "marketplaceBlobSha": "a5bf707904379a1b10c92064a75b5c9a1e587d50",
+          "marketplaceSha256": "cf6155f944f29e322011b1f228ed934d49032cd4b4701a40c51f536899155d58",
+          "originPath": "plugins/components/skills/menu-item/web/interaction.md",
+          "originBlobSha": "a5bf707904379a1b10c92064a75b5c9a1e587d50",
+          "originSha256": "cf6155f944f29e322011b1f228ed934d49032cd4b4701a40c51f536899155d58",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:tokens",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/menu-item/web/tokens.yaml",
+          "marketplaceBlobSha": "a22f331f21072ae9129093fb95027fbd120b87d2",
+          "marketplaceSha256": "b2cfff32737cc9997e34621fa8d8ba6f422d130994bc95413b276f5f5e4ab59b",
+          "originPath": "plugins/components/skills/menu-item/web/tokens.yaml",
+          "originBlobSha": "a22f331f21072ae9129093fb95027fbd120b87d2",
+          "originSha256": "b2cfff32737cc9997e34621fa8d8ba6f422d130994bc95413b276f5f5e4ab59b",
+          "contentDiffers": false
+        }
+      ],
+      "releaseDifferences": []
     }
   ],
-  "releaseDifferences": [],
   "divergences": [
     {
       "id": "menu-item-native-header-root",

--- a/packages/agentic/components/src/components/progress-bar/renderProgressBar.tsx
+++ b/packages/agentic/components/src/components/progress-bar/renderProgressBar.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @fluentui-react-native/framework-base */
-import { Text, View } from 'react-native';
+import { View } from 'react-native';
 
+import { Text } from '../text/text';
 import type { ProgressBarState } from './progress-bar.types';
 
 export function renderProgressBar_unstable(state: ProgressBarState) {

--- a/packages/agentic/components/src/components/progress-bar/spec/source.json
+++ b/packages/agentic/components/src/components/progress-bar/spec/source.json
@@ -1,67 +1,74 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "component": "progress-bar",
-  "skill": "flex-components:progress-bar",
-  "sourceLock": "flex-1.5.0-206c4996",
-  "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
   "lifecycle": "implemented",
   "conformance": "reviewed",
   "reviewedAt": "2026-08-28",
-  "availableSurfaces": ["shared", "web"],
-  "surfacesConsulted": ["shared", "web"],
-  "sourceFiles": [
+  "sources": [
     {
-      "role": "skill",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/progress-bar/SKILL.md",
-      "marketplaceBlobSha": "fff90659253e9b1480208a32396999fcfd44bcd5",
-      "marketplaceSha256": "0c91374fd4a0daaa512b49af07e2b7203d15150b01316bf06cc1b177c68d0f86",
-      "originPath": "plugins/components/skills/progress-bar/SKILL.md",
-      "originBlobSha": "fff90659253e9b1480208a32396999fcfd44bcd5",
-      "originSha256": "0c91374fd4a0daaa512b49af07e2b7203d15150b01316bf06cc1b177c68d0f86",
-      "contentDiffers": false
-    },
-    {
-      "role": "usage",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/progress-bar/usage.md",
-      "marketplaceBlobSha": "ad9272776b8db8908a1df567015e54f5d9bfe19a",
-      "marketplaceSha256": "475b1e1b9b54f60576ac634ffe2c88e82bf77cfbb84dd9bd3b320680eba8ce90",
-      "originPath": "plugins/components/skills/progress-bar/usage.md",
-      "originBlobSha": "ad9272776b8db8908a1df567015e54f5d9bfe19a",
-      "originSha256": "475b1e1b9b54f60576ac634ffe2c88e82bf77cfbb84dd9bd3b320680eba8ce90",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:accessibility",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/progress-bar/web/accessibility.md",
-      "marketplaceBlobSha": "76f9ba800b55ab858d3e418796900b7fea54c97d",
-      "marketplaceSha256": "8009c1a22dfa14e7eb4bf2a762a6d2e7c201506295b5a5644918d36da9ae5f2c",
-      "originPath": "plugins/components/skills/progress-bar/web/accessibility.md",
-      "originBlobSha": "76f9ba800b55ab858d3e418796900b7fea54c97d",
-      "originSha256": "8009c1a22dfa14e7eb4bf2a762a6d2e7c201506295b5a5644918d36da9ae5f2c",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:interaction",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/progress-bar/web/interaction.md",
-      "marketplaceBlobSha": "13860529f02ca7299b75c1ab596c392582828174",
-      "marketplaceSha256": "bbf495b921cba77e0584555dc8812103404ab7af1ad64d531a7d3cdaa824e917",
-      "originPath": "plugins/components/skills/progress-bar/web/interaction.md",
-      "originBlobSha": "13860529f02ca7299b75c1ab596c392582828174",
-      "originSha256": "bbf495b921cba77e0584555dc8812103404ab7af1ad64d531a7d3cdaa824e917",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:tokens",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/progress-bar/web/tokens.yaml",
-      "marketplaceBlobSha": "84df4df9c5a795147e8d62ad34eb82d17f0b86d8",
-      "marketplaceSha256": "0c93ee9d7ace8b4e601f6e4d434317d1202f9b5e43acf393bf309f15ff3f5768",
-      "originPath": "plugins/components/skills/progress-bar/web/tokens.yaml",
-      "originBlobSha": "84df4df9c5a795147e8d62ad34eb82d17f0b86d8",
-      "originSha256": "0c93ee9d7ace8b4e601f6e4d434317d1202f9b5e43acf393bf309f15ff3f5768",
-      "contentDiffers": false
+      "id": "flex-component",
+      "kind": "flex-skill",
+      "authority": "normative",
+      "skill": "flex-components:progress-bar",
+      "sourceLock": "flex-1.5.0-206c4996",
+      "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
+      "availableSurfaces": ["shared", "web"],
+      "surfacesConsulted": ["shared", "web"],
+      "sourceFiles": [
+        {
+          "role": "skill",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/progress-bar/SKILL.md",
+          "marketplaceBlobSha": "fff90659253e9b1480208a32396999fcfd44bcd5",
+          "marketplaceSha256": "0c91374fd4a0daaa512b49af07e2b7203d15150b01316bf06cc1b177c68d0f86",
+          "originPath": "plugins/components/skills/progress-bar/SKILL.md",
+          "originBlobSha": "fff90659253e9b1480208a32396999fcfd44bcd5",
+          "originSha256": "0c91374fd4a0daaa512b49af07e2b7203d15150b01316bf06cc1b177c68d0f86",
+          "contentDiffers": false
+        },
+        {
+          "role": "usage",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/progress-bar/usage.md",
+          "marketplaceBlobSha": "ad9272776b8db8908a1df567015e54f5d9bfe19a",
+          "marketplaceSha256": "475b1e1b9b54f60576ac634ffe2c88e82bf77cfbb84dd9bd3b320680eba8ce90",
+          "originPath": "plugins/components/skills/progress-bar/usage.md",
+          "originBlobSha": "ad9272776b8db8908a1df567015e54f5d9bfe19a",
+          "originSha256": "475b1e1b9b54f60576ac634ffe2c88e82bf77cfbb84dd9bd3b320680eba8ce90",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:accessibility",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/progress-bar/web/accessibility.md",
+          "marketplaceBlobSha": "76f9ba800b55ab858d3e418796900b7fea54c97d",
+          "marketplaceSha256": "8009c1a22dfa14e7eb4bf2a762a6d2e7c201506295b5a5644918d36da9ae5f2c",
+          "originPath": "plugins/components/skills/progress-bar/web/accessibility.md",
+          "originBlobSha": "76f9ba800b55ab858d3e418796900b7fea54c97d",
+          "originSha256": "8009c1a22dfa14e7eb4bf2a762a6d2e7c201506295b5a5644918d36da9ae5f2c",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:interaction",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/progress-bar/web/interaction.md",
+          "marketplaceBlobSha": "13860529f02ca7299b75c1ab596c392582828174",
+          "marketplaceSha256": "bbf495b921cba77e0584555dc8812103404ab7af1ad64d531a7d3cdaa824e917",
+          "originPath": "plugins/components/skills/progress-bar/web/interaction.md",
+          "originBlobSha": "13860529f02ca7299b75c1ab596c392582828174",
+          "originSha256": "bbf495b921cba77e0584555dc8812103404ab7af1ad64d531a7d3cdaa824e917",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:tokens",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/progress-bar/web/tokens.yaml",
+          "marketplaceBlobSha": "84df4df9c5a795147e8d62ad34eb82d17f0b86d8",
+          "marketplaceSha256": "0c93ee9d7ace8b4e601f6e4d434317d1202f9b5e43acf393bf309f15ff3f5768",
+          "originPath": "plugins/components/skills/progress-bar/web/tokens.yaml",
+          "originBlobSha": "84df4df9c5a795147e8d62ad34eb82d17f0b86d8",
+          "originSha256": "0c93ee9d7ace8b4e601f6e4d434317d1202f9b5e43acf393bf309f15ff3f5768",
+          "contentDiffers": false
+        }
+      ],
+      "releaseDifferences": []
     }
   ],
-  "releaseDifferences": [],
   "divergences": [
     {
       "id": "progress-bar-value-transition",

--- a/packages/agentic/components/src/components/radio/renderRadio.tsx
+++ b/packages/agentic/components/src/components/radio/renderRadio.tsx
@@ -1,8 +1,9 @@
 /** @jsxImportSource @fluentui-react-native/framework-base */
-import { Text, View } from 'react-native';
+import { View } from 'react-native';
 
 import { FocusVisual } from '../../primitives/focus-visual/focus-visual';
 import { hiddenFromAccessibilityProps } from '../../common/accessibility';
+import { Text } from '../text/text';
 import type { RadioState } from './radio.types';
 
 /**

--- a/packages/agentic/components/src/components/radio/spec/source.json
+++ b/packages/agentic/components/src/components/radio/spec/source.json
@@ -1,67 +1,74 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "component": "radio",
-  "skill": "flex-components:radio",
-  "sourceLock": "flex-1.5.0-206c4996",
-  "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
   "lifecycle": "implemented",
   "conformance": "reviewed",
   "reviewedAt": "2026-08-28",
-  "availableSurfaces": ["shared", "web"],
-  "surfacesConsulted": ["shared", "web"],
-  "sourceFiles": [
+  "sources": [
     {
-      "role": "skill",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/radio/SKILL.md",
-      "marketplaceBlobSha": "1939ba38f7fad44ab0b7f0d7c21ff62081d6cefd",
-      "marketplaceSha256": "16a475dfd2e9a05ca87aaa9f6bdeb467d1617c7f393d45f80dff210dfc47fb54",
-      "originPath": "plugins/components/skills/radio/SKILL.md",
-      "originBlobSha": "1939ba38f7fad44ab0b7f0d7c21ff62081d6cefd",
-      "originSha256": "16a475dfd2e9a05ca87aaa9f6bdeb467d1617c7f393d45f80dff210dfc47fb54",
-      "contentDiffers": false
-    },
-    {
-      "role": "usage",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/radio/usage.md",
-      "marketplaceBlobSha": "527bf9421ee7c7b8b944c6519cd014caabdf1dbf",
-      "marketplaceSha256": "2f1cbf0d01b196378a37a2df87aa0f633acb8e8c23c2766c500df66b59231e7e",
-      "originPath": "plugins/components/skills/radio/usage.md",
-      "originBlobSha": "527bf9421ee7c7b8b944c6519cd014caabdf1dbf",
-      "originSha256": "2f1cbf0d01b196378a37a2df87aa0f633acb8e8c23c2766c500df66b59231e7e",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:accessibility",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/radio/web/accessibility.md",
-      "marketplaceBlobSha": "a9244cfc433bc51e8efb6ba60a6ead3c04634cc5",
-      "marketplaceSha256": "6ea9925d168bab8d9950946e9206e95a1eab43ad055fdf760cdd80629b61523d",
-      "originPath": "plugins/components/skills/radio/web/accessibility.md",
-      "originBlobSha": "a9244cfc433bc51e8efb6ba60a6ead3c04634cc5",
-      "originSha256": "6ea9925d168bab8d9950946e9206e95a1eab43ad055fdf760cdd80629b61523d",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:interaction",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/radio/web/interaction.md",
-      "marketplaceBlobSha": "4a474107c539828eb6c415ca1ed0fc4d7230b2a8",
-      "marketplaceSha256": "dfc15569c688384e967b8384ba35b86320b0edfcce4a959ae2a5d79bc1fbc4e4",
-      "originPath": "plugins/components/skills/radio/web/interaction.md",
-      "originBlobSha": "4a474107c539828eb6c415ca1ed0fc4d7230b2a8",
-      "originSha256": "dfc15569c688384e967b8384ba35b86320b0edfcce4a959ae2a5d79bc1fbc4e4",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:tokens",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/radio/web/tokens.yaml",
-      "marketplaceBlobSha": "7aa265ca7d6ddadf3129e73902112d33dc5bb6c0",
-      "marketplaceSha256": "18de8e57b18b2de77c686d95696dafcdcb775a13afef1062d5e66732cfc971a2",
-      "originPath": "plugins/components/skills/radio/web/tokens.yaml",
-      "originBlobSha": "7aa265ca7d6ddadf3129e73902112d33dc5bb6c0",
-      "originSha256": "18de8e57b18b2de77c686d95696dafcdcb775a13afef1062d5e66732cfc971a2",
-      "contentDiffers": false
+      "id": "flex-component",
+      "kind": "flex-skill",
+      "authority": "normative",
+      "skill": "flex-components:radio",
+      "sourceLock": "flex-1.5.0-206c4996",
+      "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
+      "availableSurfaces": ["shared", "web"],
+      "surfacesConsulted": ["shared", "web"],
+      "sourceFiles": [
+        {
+          "role": "skill",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/radio/SKILL.md",
+          "marketplaceBlobSha": "1939ba38f7fad44ab0b7f0d7c21ff62081d6cefd",
+          "marketplaceSha256": "16a475dfd2e9a05ca87aaa9f6bdeb467d1617c7f393d45f80dff210dfc47fb54",
+          "originPath": "plugins/components/skills/radio/SKILL.md",
+          "originBlobSha": "1939ba38f7fad44ab0b7f0d7c21ff62081d6cefd",
+          "originSha256": "16a475dfd2e9a05ca87aaa9f6bdeb467d1617c7f393d45f80dff210dfc47fb54",
+          "contentDiffers": false
+        },
+        {
+          "role": "usage",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/radio/usage.md",
+          "marketplaceBlobSha": "527bf9421ee7c7b8b944c6519cd014caabdf1dbf",
+          "marketplaceSha256": "2f1cbf0d01b196378a37a2df87aa0f633acb8e8c23c2766c500df66b59231e7e",
+          "originPath": "plugins/components/skills/radio/usage.md",
+          "originBlobSha": "527bf9421ee7c7b8b944c6519cd014caabdf1dbf",
+          "originSha256": "2f1cbf0d01b196378a37a2df87aa0f633acb8e8c23c2766c500df66b59231e7e",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:accessibility",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/radio/web/accessibility.md",
+          "marketplaceBlobSha": "a9244cfc433bc51e8efb6ba60a6ead3c04634cc5",
+          "marketplaceSha256": "6ea9925d168bab8d9950946e9206e95a1eab43ad055fdf760cdd80629b61523d",
+          "originPath": "plugins/components/skills/radio/web/accessibility.md",
+          "originBlobSha": "a9244cfc433bc51e8efb6ba60a6ead3c04634cc5",
+          "originSha256": "6ea9925d168bab8d9950946e9206e95a1eab43ad055fdf760cdd80629b61523d",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:interaction",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/radio/web/interaction.md",
+          "marketplaceBlobSha": "4a474107c539828eb6c415ca1ed0fc4d7230b2a8",
+          "marketplaceSha256": "dfc15569c688384e967b8384ba35b86320b0edfcce4a959ae2a5d79bc1fbc4e4",
+          "originPath": "plugins/components/skills/radio/web/interaction.md",
+          "originBlobSha": "4a474107c539828eb6c415ca1ed0fc4d7230b2a8",
+          "originSha256": "dfc15569c688384e967b8384ba35b86320b0edfcce4a959ae2a5d79bc1fbc4e4",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:tokens",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/radio/web/tokens.yaml",
+          "marketplaceBlobSha": "7aa265ca7d6ddadf3129e73902112d33dc5bb6c0",
+          "marketplaceSha256": "18de8e57b18b2de77c686d95696dafcdcb775a13afef1062d5e66732cfc971a2",
+          "originPath": "plugins/components/skills/radio/web/tokens.yaml",
+          "originBlobSha": "7aa265ca7d6ddadf3129e73902112d33dc5bb6c0",
+          "originSha256": "18de8e57b18b2de77c686d95696dafcdcb775a13afef1062d5e66732cfc971a2",
+          "contentDiffers": false
+        }
+      ],
+      "releaseDifferences": []
     }
   ],
-  "releaseDifferences": [],
   "divergences": [
     {
       "id": "radio-native-composition",

--- a/packages/agentic/components/src/components/skeleton/spec/source.json
+++ b/packages/agentic/components/src/components/skeleton/spec/source.json
@@ -1,67 +1,74 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "component": "skeleton",
-  "skill": "flex-components:skeleton",
-  "sourceLock": "flex-1.5.0-206c4996",
-  "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
   "lifecycle": "implemented",
   "conformance": "reviewed",
   "reviewedAt": "2026-08-28",
-  "availableSurfaces": ["shared", "web"],
-  "surfacesConsulted": ["shared", "web"],
-  "sourceFiles": [
+  "sources": [
     {
-      "role": "skill",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/skeleton/SKILL.md",
-      "marketplaceBlobSha": "7aa1d11e5d9ee718dd69b4acc481394e503d5cae",
-      "marketplaceSha256": "4a013aa7e03dc3fb8ced640b116331460aa7791aee0bb691629fe34351f8bad8",
-      "originPath": "plugins/components/skills/skeleton/SKILL.md",
-      "originBlobSha": "7aa1d11e5d9ee718dd69b4acc481394e503d5cae",
-      "originSha256": "4a013aa7e03dc3fb8ced640b116331460aa7791aee0bb691629fe34351f8bad8",
-      "contentDiffers": false
-    },
-    {
-      "role": "usage",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/skeleton/usage.md",
-      "marketplaceBlobSha": "e360112ff3ddd3ada7026906300907513a998efa",
-      "marketplaceSha256": "642a57670df13a1297c8f71a0b2d5fa077f1b4cb84ac062661ba43174cbc8418",
-      "originPath": "plugins/components/skills/skeleton/usage.md",
-      "originBlobSha": "e360112ff3ddd3ada7026906300907513a998efa",
-      "originSha256": "642a57670df13a1297c8f71a0b2d5fa077f1b4cb84ac062661ba43174cbc8418",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:accessibility",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/skeleton/web/accessibility.md",
-      "marketplaceBlobSha": "b112c488532fd00d2f560379fd2a3879e1500e87",
-      "marketplaceSha256": "c101c80e80ea265f378b9f6d4eacb817cfbf71274a0f110f71b2ed5494374b74",
-      "originPath": "plugins/components/skills/skeleton/web/accessibility.md",
-      "originBlobSha": "b112c488532fd00d2f560379fd2a3879e1500e87",
-      "originSha256": "c101c80e80ea265f378b9f6d4eacb817cfbf71274a0f110f71b2ed5494374b74",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:interaction",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/skeleton/web/interaction.md",
-      "marketplaceBlobSha": "2a7ed4cd2ababdc994a45e1dab7bc53af2134102",
-      "marketplaceSha256": "0763a33452890d37374baf0828ca5f62fad8b04dab88efa412d021f8bd033b38",
-      "originPath": "plugins/components/skills/skeleton/web/interaction.md",
-      "originBlobSha": "2a7ed4cd2ababdc994a45e1dab7bc53af2134102",
-      "originSha256": "0763a33452890d37374baf0828ca5f62fad8b04dab88efa412d021f8bd033b38",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:tokens",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/skeleton/web/tokens.yaml",
-      "marketplaceBlobSha": "9482b54087b8c8e00486e02a5d6543e4e20d2387",
-      "marketplaceSha256": "eaad9de35412d679134b8caaabdbf7334decb76620585b4abcc17f7598375f74",
-      "originPath": "plugins/components/skills/skeleton/web/tokens.yaml",
-      "originBlobSha": "9482b54087b8c8e00486e02a5d6543e4e20d2387",
-      "originSha256": "eaad9de35412d679134b8caaabdbf7334decb76620585b4abcc17f7598375f74",
-      "contentDiffers": false
+      "id": "flex-component",
+      "kind": "flex-skill",
+      "authority": "normative",
+      "skill": "flex-components:skeleton",
+      "sourceLock": "flex-1.5.0-206c4996",
+      "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
+      "availableSurfaces": ["shared", "web"],
+      "surfacesConsulted": ["shared", "web"],
+      "sourceFiles": [
+        {
+          "role": "skill",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/skeleton/SKILL.md",
+          "marketplaceBlobSha": "7aa1d11e5d9ee718dd69b4acc481394e503d5cae",
+          "marketplaceSha256": "4a013aa7e03dc3fb8ced640b116331460aa7791aee0bb691629fe34351f8bad8",
+          "originPath": "plugins/components/skills/skeleton/SKILL.md",
+          "originBlobSha": "7aa1d11e5d9ee718dd69b4acc481394e503d5cae",
+          "originSha256": "4a013aa7e03dc3fb8ced640b116331460aa7791aee0bb691629fe34351f8bad8",
+          "contentDiffers": false
+        },
+        {
+          "role": "usage",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/skeleton/usage.md",
+          "marketplaceBlobSha": "e360112ff3ddd3ada7026906300907513a998efa",
+          "marketplaceSha256": "642a57670df13a1297c8f71a0b2d5fa077f1b4cb84ac062661ba43174cbc8418",
+          "originPath": "plugins/components/skills/skeleton/usage.md",
+          "originBlobSha": "e360112ff3ddd3ada7026906300907513a998efa",
+          "originSha256": "642a57670df13a1297c8f71a0b2d5fa077f1b4cb84ac062661ba43174cbc8418",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:accessibility",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/skeleton/web/accessibility.md",
+          "marketplaceBlobSha": "b112c488532fd00d2f560379fd2a3879e1500e87",
+          "marketplaceSha256": "c101c80e80ea265f378b9f6d4eacb817cfbf71274a0f110f71b2ed5494374b74",
+          "originPath": "plugins/components/skills/skeleton/web/accessibility.md",
+          "originBlobSha": "b112c488532fd00d2f560379fd2a3879e1500e87",
+          "originSha256": "c101c80e80ea265f378b9f6d4eacb817cfbf71274a0f110f71b2ed5494374b74",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:interaction",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/skeleton/web/interaction.md",
+          "marketplaceBlobSha": "2a7ed4cd2ababdc994a45e1dab7bc53af2134102",
+          "marketplaceSha256": "0763a33452890d37374baf0828ca5f62fad8b04dab88efa412d021f8bd033b38",
+          "originPath": "plugins/components/skills/skeleton/web/interaction.md",
+          "originBlobSha": "2a7ed4cd2ababdc994a45e1dab7bc53af2134102",
+          "originSha256": "0763a33452890d37374baf0828ca5f62fad8b04dab88efa412d021f8bd033b38",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:tokens",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/skeleton/web/tokens.yaml",
+          "marketplaceBlobSha": "9482b54087b8c8e00486e02a5d6543e4e20d2387",
+          "marketplaceSha256": "eaad9de35412d679134b8caaabdbf7334decb76620585b4abcc17f7598375f74",
+          "originPath": "plugins/components/skills/skeleton/web/tokens.yaml",
+          "originBlobSha": "9482b54087b8c8e00486e02a5d6543e4e20d2387",
+          "originSha256": "eaad9de35412d679134b8caaabdbf7334decb76620585b4abcc17f7598375f74",
+          "contentDiffers": false
+        }
+      ],
+      "releaseDifferences": []
     }
   ],
-  "releaseDifferences": [],
   "divergences": [
     {
       "id": "skeleton-highlight-band-fill",

--- a/packages/agentic/components/src/components/spinner/spec/source.json
+++ b/packages/agentic/components/src/components/spinner/spec/source.json
@@ -1,67 +1,74 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "component": "spinner",
-  "skill": "flex-components:spinner",
-  "sourceLock": "flex-1.5.0-206c4996",
-  "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
   "lifecycle": "implemented",
   "conformance": "reviewed",
   "reviewedAt": "2026-08-28",
-  "availableSurfaces": ["shared", "web"],
-  "surfacesConsulted": ["shared", "web"],
-  "sourceFiles": [
+  "sources": [
     {
-      "role": "skill",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/spinner/SKILL.md",
-      "marketplaceBlobSha": "3c61677e18f349cd4551fee124c94ea181ae4a0c",
-      "marketplaceSha256": "259c4715f9c97a130c587a5373778203c3d1a25a58f442094cce90cc0fdc589f",
-      "originPath": "plugins/components/skills/spinner/SKILL.md",
-      "originBlobSha": "3c61677e18f349cd4551fee124c94ea181ae4a0c",
-      "originSha256": "259c4715f9c97a130c587a5373778203c3d1a25a58f442094cce90cc0fdc589f",
-      "contentDiffers": false
-    },
-    {
-      "role": "usage",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/spinner/usage.md",
-      "marketplaceBlobSha": "2290c2c8dda7dbe0abb87b49b4b9e1c87ca9d2ed",
-      "marketplaceSha256": "bf4ed82e8aeeb2586c0616d091a3dfb00e1e1e02f9e38edbe5bfb71a1f0dde15",
-      "originPath": "plugins/components/skills/spinner/usage.md",
-      "originBlobSha": "2290c2c8dda7dbe0abb87b49b4b9e1c87ca9d2ed",
-      "originSha256": "bf4ed82e8aeeb2586c0616d091a3dfb00e1e1e02f9e38edbe5bfb71a1f0dde15",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:accessibility",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/spinner/web/accessibility.md",
-      "marketplaceBlobSha": "f50e79bcb4b9d7f1bfd5cc4aa9db8e7f3439337a",
-      "marketplaceSha256": "ef14fa15dac54c6175d59c5693ab9a7d01d6ea24652dcbc5f50eccb85c02a379",
-      "originPath": "plugins/components/skills/spinner/web/accessibility.md",
-      "originBlobSha": "f50e79bcb4b9d7f1bfd5cc4aa9db8e7f3439337a",
-      "originSha256": "ef14fa15dac54c6175d59c5693ab9a7d01d6ea24652dcbc5f50eccb85c02a379",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:interaction",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/spinner/web/interaction.md",
-      "marketplaceBlobSha": "3ce896c9a2a80ae85a975f5ba0af314a88fac3cf",
-      "marketplaceSha256": "588d6f7a1214c0b2c2cfa9d86c60aca01e717b612df768406f9ca9e9219b62fb",
-      "originPath": "plugins/components/skills/spinner/web/interaction.md",
-      "originBlobSha": "3ce896c9a2a80ae85a975f5ba0af314a88fac3cf",
-      "originSha256": "588d6f7a1214c0b2c2cfa9d86c60aca01e717b612df768406f9ca9e9219b62fb",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:tokens",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/spinner/web/tokens.yaml",
-      "marketplaceBlobSha": "9288191474c19aaa10878fb8a3f48d76e8e47996",
-      "marketplaceSha256": "ad5ba5130124464515bc9fb9fda36bd8ee4278fc0a40917533d67d6d1b66bfd7",
-      "originPath": "plugins/components/skills/spinner/web/tokens.yaml",
-      "originBlobSha": "9288191474c19aaa10878fb8a3f48d76e8e47996",
-      "originSha256": "ad5ba5130124464515bc9fb9fda36bd8ee4278fc0a40917533d67d6d1b66bfd7",
-      "contentDiffers": false
+      "id": "flex-component",
+      "kind": "flex-skill",
+      "authority": "normative",
+      "skill": "flex-components:spinner",
+      "sourceLock": "flex-1.5.0-206c4996",
+      "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
+      "availableSurfaces": ["shared", "web"],
+      "surfacesConsulted": ["shared", "web"],
+      "sourceFiles": [
+        {
+          "role": "skill",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/spinner/SKILL.md",
+          "marketplaceBlobSha": "3c61677e18f349cd4551fee124c94ea181ae4a0c",
+          "marketplaceSha256": "259c4715f9c97a130c587a5373778203c3d1a25a58f442094cce90cc0fdc589f",
+          "originPath": "plugins/components/skills/spinner/SKILL.md",
+          "originBlobSha": "3c61677e18f349cd4551fee124c94ea181ae4a0c",
+          "originSha256": "259c4715f9c97a130c587a5373778203c3d1a25a58f442094cce90cc0fdc589f",
+          "contentDiffers": false
+        },
+        {
+          "role": "usage",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/spinner/usage.md",
+          "marketplaceBlobSha": "2290c2c8dda7dbe0abb87b49b4b9e1c87ca9d2ed",
+          "marketplaceSha256": "bf4ed82e8aeeb2586c0616d091a3dfb00e1e1e02f9e38edbe5bfb71a1f0dde15",
+          "originPath": "plugins/components/skills/spinner/usage.md",
+          "originBlobSha": "2290c2c8dda7dbe0abb87b49b4b9e1c87ca9d2ed",
+          "originSha256": "bf4ed82e8aeeb2586c0616d091a3dfb00e1e1e02f9e38edbe5bfb71a1f0dde15",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:accessibility",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/spinner/web/accessibility.md",
+          "marketplaceBlobSha": "f50e79bcb4b9d7f1bfd5cc4aa9db8e7f3439337a",
+          "marketplaceSha256": "ef14fa15dac54c6175d59c5693ab9a7d01d6ea24652dcbc5f50eccb85c02a379",
+          "originPath": "plugins/components/skills/spinner/web/accessibility.md",
+          "originBlobSha": "f50e79bcb4b9d7f1bfd5cc4aa9db8e7f3439337a",
+          "originSha256": "ef14fa15dac54c6175d59c5693ab9a7d01d6ea24652dcbc5f50eccb85c02a379",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:interaction",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/spinner/web/interaction.md",
+          "marketplaceBlobSha": "3ce896c9a2a80ae85a975f5ba0af314a88fac3cf",
+          "marketplaceSha256": "588d6f7a1214c0b2c2cfa9d86c60aca01e717b612df768406f9ca9e9219b62fb",
+          "originPath": "plugins/components/skills/spinner/web/interaction.md",
+          "originBlobSha": "3ce896c9a2a80ae85a975f5ba0af314a88fac3cf",
+          "originSha256": "588d6f7a1214c0b2c2cfa9d86c60aca01e717b612df768406f9ca9e9219b62fb",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:tokens",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/spinner/web/tokens.yaml",
+          "marketplaceBlobSha": "9288191474c19aaa10878fb8a3f48d76e8e47996",
+          "marketplaceSha256": "ad5ba5130124464515bc9fb9fda36bd8ee4278fc0a40917533d67d6d1b66bfd7",
+          "originPath": "plugins/components/skills/spinner/web/tokens.yaml",
+          "originBlobSha": "9288191474c19aaa10878fb8a3f48d76e8e47996",
+          "originSha256": "ad5ba5130124464515bc9fb9fda36bd8ee4278fc0a40917533d67d6d1b66bfd7",
+          "contentDiffers": false
+        }
+      ],
+      "releaseDifferences": []
     }
   ],
-  "releaseDifferences": [],
   "divergences": [
     {
       "id": "spinner-busy-state-on-root",

--- a/packages/agentic/components/src/components/switch/spec/source.json
+++ b/packages/agentic/components/src/components/switch/spec/source.json
@@ -1,67 +1,74 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "component": "switch",
-  "skill": "flex-components:switch",
-  "sourceLock": "flex-1.5.0-206c4996",
-  "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
   "lifecycle": "implemented",
   "conformance": "reviewed",
   "reviewedAt": "2026-08-28",
-  "availableSurfaces": ["shared", "web"],
-  "surfacesConsulted": ["shared", "web"],
-  "sourceFiles": [
+  "sources": [
     {
-      "role": "skill",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/switch/SKILL.md",
-      "marketplaceBlobSha": "309957ff5997e0e659f67a47bf52abf75a17c6dd",
-      "marketplaceSha256": "d3f35b73afe0a76e07189fe8e5a82d134fddad6c3f8fec3fa75844d7e7c83040",
-      "originPath": "plugins/components/skills/switch/SKILL.md",
-      "originBlobSha": "309957ff5997e0e659f67a47bf52abf75a17c6dd",
-      "originSha256": "d3f35b73afe0a76e07189fe8e5a82d134fddad6c3f8fec3fa75844d7e7c83040",
-      "contentDiffers": false
-    },
-    {
-      "role": "usage",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/switch/usage.md",
-      "marketplaceBlobSha": "ba92c061f7027802befa271e538243acf0381698",
-      "marketplaceSha256": "966fd0a311abc3666c7851e0503738c7325dc3862fd909be05627296e572b6ad",
-      "originPath": "plugins/components/skills/switch/usage.md",
-      "originBlobSha": "ba92c061f7027802befa271e538243acf0381698",
-      "originSha256": "966fd0a311abc3666c7851e0503738c7325dc3862fd909be05627296e572b6ad",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:accessibility",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/switch/web/accessibility.md",
-      "marketplaceBlobSha": "7e10e09d1f0bd674e79e7ce065a0f906b6b58beb",
-      "marketplaceSha256": "04c07022d7b464059196dd3a3e2dcc05088975424cc1c908c652fd7965791dc7",
-      "originPath": "plugins/components/skills/switch/web/accessibility.md",
-      "originBlobSha": "7e10e09d1f0bd674e79e7ce065a0f906b6b58beb",
-      "originSha256": "04c07022d7b464059196dd3a3e2dcc05088975424cc1c908c652fd7965791dc7",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:interaction",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/switch/web/interaction.md",
-      "marketplaceBlobSha": "61cf6c42ca454ca481f38111c08daf8e4176794c",
-      "marketplaceSha256": "053aedc2d42fc355dbab0603986d0abd1e04958c197c5f8d312f05a3f645c799",
-      "originPath": "plugins/components/skills/switch/web/interaction.md",
-      "originBlobSha": "61cf6c42ca454ca481f38111c08daf8e4176794c",
-      "originSha256": "053aedc2d42fc355dbab0603986d0abd1e04958c197c5f8d312f05a3f645c799",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:tokens",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/switch/web/tokens.yaml",
-      "marketplaceBlobSha": "26c4305c1c928834324d5aa0c2b47898f380cc36",
-      "marketplaceSha256": "d965f2469095e36034214719999b2b847d41101ef2cac3562d02602965e374d8",
-      "originPath": "plugins/components/skills/switch/web/tokens.yaml",
-      "originBlobSha": "26c4305c1c928834324d5aa0c2b47898f380cc36",
-      "originSha256": "d965f2469095e36034214719999b2b847d41101ef2cac3562d02602965e374d8",
-      "contentDiffers": false
+      "id": "flex-component",
+      "kind": "flex-skill",
+      "authority": "normative",
+      "skill": "flex-components:switch",
+      "sourceLock": "flex-1.5.0-206c4996",
+      "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
+      "availableSurfaces": ["shared", "web"],
+      "surfacesConsulted": ["shared", "web"],
+      "sourceFiles": [
+        {
+          "role": "skill",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/switch/SKILL.md",
+          "marketplaceBlobSha": "309957ff5997e0e659f67a47bf52abf75a17c6dd",
+          "marketplaceSha256": "d3f35b73afe0a76e07189fe8e5a82d134fddad6c3f8fec3fa75844d7e7c83040",
+          "originPath": "plugins/components/skills/switch/SKILL.md",
+          "originBlobSha": "309957ff5997e0e659f67a47bf52abf75a17c6dd",
+          "originSha256": "d3f35b73afe0a76e07189fe8e5a82d134fddad6c3f8fec3fa75844d7e7c83040",
+          "contentDiffers": false
+        },
+        {
+          "role": "usage",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/switch/usage.md",
+          "marketplaceBlobSha": "ba92c061f7027802befa271e538243acf0381698",
+          "marketplaceSha256": "966fd0a311abc3666c7851e0503738c7325dc3862fd909be05627296e572b6ad",
+          "originPath": "plugins/components/skills/switch/usage.md",
+          "originBlobSha": "ba92c061f7027802befa271e538243acf0381698",
+          "originSha256": "966fd0a311abc3666c7851e0503738c7325dc3862fd909be05627296e572b6ad",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:accessibility",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/switch/web/accessibility.md",
+          "marketplaceBlobSha": "7e10e09d1f0bd674e79e7ce065a0f906b6b58beb",
+          "marketplaceSha256": "04c07022d7b464059196dd3a3e2dcc05088975424cc1c908c652fd7965791dc7",
+          "originPath": "plugins/components/skills/switch/web/accessibility.md",
+          "originBlobSha": "7e10e09d1f0bd674e79e7ce065a0f906b6b58beb",
+          "originSha256": "04c07022d7b464059196dd3a3e2dcc05088975424cc1c908c652fd7965791dc7",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:interaction",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/switch/web/interaction.md",
+          "marketplaceBlobSha": "61cf6c42ca454ca481f38111c08daf8e4176794c",
+          "marketplaceSha256": "053aedc2d42fc355dbab0603986d0abd1e04958c197c5f8d312f05a3f645c799",
+          "originPath": "plugins/components/skills/switch/web/interaction.md",
+          "originBlobSha": "61cf6c42ca454ca481f38111c08daf8e4176794c",
+          "originSha256": "053aedc2d42fc355dbab0603986d0abd1e04958c197c5f8d312f05a3f645c799",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:tokens",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/switch/web/tokens.yaml",
+          "marketplaceBlobSha": "26c4305c1c928834324d5aa0c2b47898f380cc36",
+          "marketplaceSha256": "d965f2469095e36034214719999b2b847d41101ef2cac3562d02602965e374d8",
+          "originPath": "plugins/components/skills/switch/web/tokens.yaml",
+          "originBlobSha": "26c4305c1c928834324d5aa0c2b47898f380cc36",
+          "originSha256": "d965f2469095e36034214719999b2b847d41101ef2cac3562d02602965e374d8",
+          "contentDiffers": false
+        }
+      ],
+      "releaseDifferences": []
     }
   ],
-  "releaseDifferences": [],
   "divergences": [
     {
       "id": "switch-label-association-ids",

--- a/packages/agentic/components/src/components/switch/switch.types.ts
+++ b/packages/agentic/components/src/components/switch/switch.types.ts
@@ -1,4 +1,4 @@
-import type { Pressable, StyleProp, Text, View, ViewStyle } from 'react-native';
+import type { Pressable, StyleProp, View, ViewStyle } from 'react-native';
 
 import type {
   ComponentProps,
@@ -11,6 +11,7 @@ import type {
 } from '@fluentui-react-native/framework-base';
 import type { ThemeState } from '@fluentui-react-native/design';
 import type { FocusVisualProps } from '../../primitives/focus-visual/focus-visual.types';
+import type { Text } from '../text/text';
 
 type AnimatedViewComponent = typeof import('react-native').Animated.View;
 

--- a/packages/agentic/components/src/components/switch/useSwitch.ts
+++ b/packages/agentic/components/src/components/switch/useSwitch.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Animated, Easing, Pressable, Text, View } from 'react-native';
+import { Animated, Easing, Pressable, View } from 'react-native';
 
 import {
   useAccessibilityLabelWarning,
@@ -11,6 +11,7 @@ import {
 } from '@fluentui-react-native/framework-base';
 import { useThemeState } from '@fluentui-react-native/design';
 
+import { Text } from '../text/text';
 import type { SwitchProps, SwitchState } from './switch.types';
 
 const TOGGLE_KEYS = new Set(['Enter', ' ', 'Spacebar', 'Space']);

--- a/packages/agentic/components/src/components/tab/spec/source.json
+++ b/packages/agentic/components/src/components/tab/spec/source.json
@@ -1,127 +1,134 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "component": "tab",
-  "skill": "flex-components:tab",
-  "sourceLock": "flex-1.5.0-206c4996",
-  "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
   "lifecycle": "implemented",
   "conformance": "reviewed",
   "reviewedAt": "2026-08-28",
-  "availableSurfaces": ["mobile", "shared", "web"],
-  "surfacesConsulted": ["mobile", "shared", "web"],
-  "sourceFiles": [
+  "sources": [
     {
-      "role": "mobile:android:accessibility",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/tab/mobile/android/accessibility.md",
-      "marketplaceBlobSha": "23bfcbe4e8b94120703edfe800122dfd1ae1be08",
-      "marketplaceSha256": "b225d84dcbc7d868f9a8fe130a1d41d973af0c8a2725776079bae4995118419e",
-      "originPath": "plugins/components/skills/tab/mobile/android/accessibility.md",
-      "originBlobSha": "23bfcbe4e8b94120703edfe800122dfd1ae1be08",
-      "originSha256": "b225d84dcbc7d868f9a8fe130a1d41d973af0c8a2725776079bae4995118419e",
-      "contentDiffers": false
-    },
-    {
-      "role": "mobile:android:interaction",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/tab/mobile/android/interaction.md",
-      "marketplaceBlobSha": "e58a8cf754f5744b48f89d9ed2fc15af21dfc5d6",
-      "marketplaceSha256": "f2c4863267e233466374355d90c550ffea8a8ddb900dde68db1fd5e1e253a4f4",
-      "originPath": "plugins/components/skills/tab/mobile/android/interaction.md",
-      "originBlobSha": "e58a8cf754f5744b48f89d9ed2fc15af21dfc5d6",
-      "originSha256": "f2c4863267e233466374355d90c550ffea8a8ddb900dde68db1fd5e1e253a4f4",
-      "contentDiffers": false
-    },
-    {
-      "role": "mobile:ios:accessibility",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/tab/mobile/ios/accessibility.md",
-      "marketplaceBlobSha": "9e81ddec6815f29c0f18b3ded91c1f9db2319f7e",
-      "marketplaceSha256": "342408d6bc82521a7d1c9911d5ab2ee606a9c97d8be5e07b77634092908ce7b0",
-      "originPath": "plugins/components/skills/tab/mobile/ios/accessibility.md",
-      "originBlobSha": "9e81ddec6815f29c0f18b3ded91c1f9db2319f7e",
-      "originSha256": "342408d6bc82521a7d1c9911d5ab2ee606a9c97d8be5e07b77634092908ce7b0",
-      "contentDiffers": false
-    },
-    {
-      "role": "mobile:ios:interaction",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/tab/mobile/ios/interaction.md",
-      "marketplaceBlobSha": "635cc58fd8a836c6f5bc011ec2ecc3cc6350eca7",
-      "marketplaceSha256": "2ead92732972480a38f88dad999ab3e78e1bdadb6d02cd015409f47f49cf2615",
-      "originPath": "plugins/components/skills/tab/mobile/ios/interaction.md",
-      "originBlobSha": "635cc58fd8a836c6f5bc011ec2ecc3cc6350eca7",
-      "originSha256": "2ead92732972480a38f88dad999ab3e78e1bdadb6d02cd015409f47f49cf2615",
-      "contentDiffers": false
-    },
-    {
-      "role": "mobile:overview",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/tab/mobile/overview.md",
-      "marketplaceBlobSha": "e9b0895479aa9cec1ec8f77fdcad8f7d7833910c",
-      "marketplaceSha256": "3bad9b17282b5b3621b0fe0d58bd27c48cadf46ccde5dcb7b391fc0973cb1b85",
-      "originPath": "plugins/components/skills/tab/mobile/overview.md",
-      "originBlobSha": "e9b0895479aa9cec1ec8f77fdcad8f7d7833910c",
-      "originSha256": "3bad9b17282b5b3621b0fe0d58bd27c48cadf46ccde5dcb7b391fc0973cb1b85",
-      "contentDiffers": false
-    },
-    {
-      "role": "mobile:tokens",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/tab/mobile/tokens.yaml",
-      "marketplaceBlobSha": "5cbbf7822209d7c642ff3c98f06ddda796218b27",
-      "marketplaceSha256": "08eeba2057dcc7d25a8a76f84632072f08ff46739fd06928fd27b48e93ce637c",
-      "originPath": "plugins/components/skills/tab/mobile/tokens.yaml",
-      "originBlobSha": "5cbbf7822209d7c642ff3c98f06ddda796218b27",
-      "originSha256": "08eeba2057dcc7d25a8a76f84632072f08ff46739fd06928fd27b48e93ce637c",
-      "contentDiffers": false
-    },
-    {
-      "role": "skill",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/tab/SKILL.md",
-      "marketplaceBlobSha": "d9c6339f56c7a60ae4dcc7d43800a62567fc8b4b",
-      "marketplaceSha256": "a210ed816679b42ce145fc228e59579f3f7d0b55e0bd5c1b53f38ee40b19e929",
-      "originPath": "plugins/components/skills/tab/SKILL.md",
-      "originBlobSha": "d9c6339f56c7a60ae4dcc7d43800a62567fc8b4b",
-      "originSha256": "a210ed816679b42ce145fc228e59579f3f7d0b55e0bd5c1b53f38ee40b19e929",
-      "contentDiffers": false
-    },
-    {
-      "role": "usage",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/tab/usage.md",
-      "marketplaceBlobSha": "cf8d5dfb94501072c96157558337075d8615beff",
-      "marketplaceSha256": "cb271035008849905727d957cdcd8e2c9906f8ed3231e0a9e41d91c9f330dd06",
-      "originPath": "plugins/components/skills/tab/usage.md",
-      "originBlobSha": "cf8d5dfb94501072c96157558337075d8615beff",
-      "originSha256": "cb271035008849905727d957cdcd8e2c9906f8ed3231e0a9e41d91c9f330dd06",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:accessibility",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/tab/web/accessibility.md",
-      "marketplaceBlobSha": "384458f063122114ef87dc93c1634fc5960c1ccb",
-      "marketplaceSha256": "55aa79cf66cd7ee51222559cb584eae4988abe432468cc00905e9f89dc4c2da8",
-      "originPath": "plugins/components/skills/tab/web/accessibility.md",
-      "originBlobSha": "384458f063122114ef87dc93c1634fc5960c1ccb",
-      "originSha256": "55aa79cf66cd7ee51222559cb584eae4988abe432468cc00905e9f89dc4c2da8",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:interaction",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/tab/web/interaction.md",
-      "marketplaceBlobSha": "3f17a3e691fe28778742627c7b7c631c072bfb1e",
-      "marketplaceSha256": "eeb5bff63162601331564c695da7cba5d9e0f0a19315085b8b2983103d3a15d6",
-      "originPath": "plugins/components/skills/tab/web/interaction.md",
-      "originBlobSha": "3f17a3e691fe28778742627c7b7c631c072bfb1e",
-      "originSha256": "eeb5bff63162601331564c695da7cba5d9e0f0a19315085b8b2983103d3a15d6",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:tokens",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/tab/web/tokens.yaml",
-      "marketplaceBlobSha": "8ad68c3d99c3fad696c223585cd3940669f79013",
-      "marketplaceSha256": "795f9d757c6c85d74fa692d54d7242666306c4e12221b301a22a4d1e4e73b5f5",
-      "originPath": "plugins/components/skills/tab/web/tokens.yaml",
-      "originBlobSha": "8ad68c3d99c3fad696c223585cd3940669f79013",
-      "originSha256": "795f9d757c6c85d74fa692d54d7242666306c4e12221b301a22a4d1e4e73b5f5",
-      "contentDiffers": false
+      "id": "flex-component",
+      "kind": "flex-skill",
+      "authority": "normative",
+      "skill": "flex-components:tab",
+      "sourceLock": "flex-1.5.0-206c4996",
+      "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
+      "availableSurfaces": ["mobile", "shared", "web"],
+      "surfacesConsulted": ["mobile", "shared", "web"],
+      "sourceFiles": [
+        {
+          "role": "mobile:android:accessibility",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/tab/mobile/android/accessibility.md",
+          "marketplaceBlobSha": "23bfcbe4e8b94120703edfe800122dfd1ae1be08",
+          "marketplaceSha256": "b225d84dcbc7d868f9a8fe130a1d41d973af0c8a2725776079bae4995118419e",
+          "originPath": "plugins/components/skills/tab/mobile/android/accessibility.md",
+          "originBlobSha": "23bfcbe4e8b94120703edfe800122dfd1ae1be08",
+          "originSha256": "b225d84dcbc7d868f9a8fe130a1d41d973af0c8a2725776079bae4995118419e",
+          "contentDiffers": false
+        },
+        {
+          "role": "mobile:android:interaction",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/tab/mobile/android/interaction.md",
+          "marketplaceBlobSha": "e58a8cf754f5744b48f89d9ed2fc15af21dfc5d6",
+          "marketplaceSha256": "f2c4863267e233466374355d90c550ffea8a8ddb900dde68db1fd5e1e253a4f4",
+          "originPath": "plugins/components/skills/tab/mobile/android/interaction.md",
+          "originBlobSha": "e58a8cf754f5744b48f89d9ed2fc15af21dfc5d6",
+          "originSha256": "f2c4863267e233466374355d90c550ffea8a8ddb900dde68db1fd5e1e253a4f4",
+          "contentDiffers": false
+        },
+        {
+          "role": "mobile:ios:accessibility",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/tab/mobile/ios/accessibility.md",
+          "marketplaceBlobSha": "9e81ddec6815f29c0f18b3ded91c1f9db2319f7e",
+          "marketplaceSha256": "342408d6bc82521a7d1c9911d5ab2ee606a9c97d8be5e07b77634092908ce7b0",
+          "originPath": "plugins/components/skills/tab/mobile/ios/accessibility.md",
+          "originBlobSha": "9e81ddec6815f29c0f18b3ded91c1f9db2319f7e",
+          "originSha256": "342408d6bc82521a7d1c9911d5ab2ee606a9c97d8be5e07b77634092908ce7b0",
+          "contentDiffers": false
+        },
+        {
+          "role": "mobile:ios:interaction",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/tab/mobile/ios/interaction.md",
+          "marketplaceBlobSha": "635cc58fd8a836c6f5bc011ec2ecc3cc6350eca7",
+          "marketplaceSha256": "2ead92732972480a38f88dad999ab3e78e1bdadb6d02cd015409f47f49cf2615",
+          "originPath": "plugins/components/skills/tab/mobile/ios/interaction.md",
+          "originBlobSha": "635cc58fd8a836c6f5bc011ec2ecc3cc6350eca7",
+          "originSha256": "2ead92732972480a38f88dad999ab3e78e1bdadb6d02cd015409f47f49cf2615",
+          "contentDiffers": false
+        },
+        {
+          "role": "mobile:overview",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/tab/mobile/overview.md",
+          "marketplaceBlobSha": "e9b0895479aa9cec1ec8f77fdcad8f7d7833910c",
+          "marketplaceSha256": "3bad9b17282b5b3621b0fe0d58bd27c48cadf46ccde5dcb7b391fc0973cb1b85",
+          "originPath": "plugins/components/skills/tab/mobile/overview.md",
+          "originBlobSha": "e9b0895479aa9cec1ec8f77fdcad8f7d7833910c",
+          "originSha256": "3bad9b17282b5b3621b0fe0d58bd27c48cadf46ccde5dcb7b391fc0973cb1b85",
+          "contentDiffers": false
+        },
+        {
+          "role": "mobile:tokens",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/tab/mobile/tokens.yaml",
+          "marketplaceBlobSha": "5cbbf7822209d7c642ff3c98f06ddda796218b27",
+          "marketplaceSha256": "08eeba2057dcc7d25a8a76f84632072f08ff46739fd06928fd27b48e93ce637c",
+          "originPath": "plugins/components/skills/tab/mobile/tokens.yaml",
+          "originBlobSha": "5cbbf7822209d7c642ff3c98f06ddda796218b27",
+          "originSha256": "08eeba2057dcc7d25a8a76f84632072f08ff46739fd06928fd27b48e93ce637c",
+          "contentDiffers": false
+        },
+        {
+          "role": "skill",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/tab/SKILL.md",
+          "marketplaceBlobSha": "d9c6339f56c7a60ae4dcc7d43800a62567fc8b4b",
+          "marketplaceSha256": "a210ed816679b42ce145fc228e59579f3f7d0b55e0bd5c1b53f38ee40b19e929",
+          "originPath": "plugins/components/skills/tab/SKILL.md",
+          "originBlobSha": "d9c6339f56c7a60ae4dcc7d43800a62567fc8b4b",
+          "originSha256": "a210ed816679b42ce145fc228e59579f3f7d0b55e0bd5c1b53f38ee40b19e929",
+          "contentDiffers": false
+        },
+        {
+          "role": "usage",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/tab/usage.md",
+          "marketplaceBlobSha": "cf8d5dfb94501072c96157558337075d8615beff",
+          "marketplaceSha256": "cb271035008849905727d957cdcd8e2c9906f8ed3231e0a9e41d91c9f330dd06",
+          "originPath": "plugins/components/skills/tab/usage.md",
+          "originBlobSha": "cf8d5dfb94501072c96157558337075d8615beff",
+          "originSha256": "cb271035008849905727d957cdcd8e2c9906f8ed3231e0a9e41d91c9f330dd06",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:accessibility",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/tab/web/accessibility.md",
+          "marketplaceBlobSha": "384458f063122114ef87dc93c1634fc5960c1ccb",
+          "marketplaceSha256": "55aa79cf66cd7ee51222559cb584eae4988abe432468cc00905e9f89dc4c2da8",
+          "originPath": "plugins/components/skills/tab/web/accessibility.md",
+          "originBlobSha": "384458f063122114ef87dc93c1634fc5960c1ccb",
+          "originSha256": "55aa79cf66cd7ee51222559cb584eae4988abe432468cc00905e9f89dc4c2da8",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:interaction",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/tab/web/interaction.md",
+          "marketplaceBlobSha": "3f17a3e691fe28778742627c7b7c631c072bfb1e",
+          "marketplaceSha256": "eeb5bff63162601331564c695da7cba5d9e0f0a19315085b8b2983103d3a15d6",
+          "originPath": "plugins/components/skills/tab/web/interaction.md",
+          "originBlobSha": "3f17a3e691fe28778742627c7b7c631c072bfb1e",
+          "originSha256": "eeb5bff63162601331564c695da7cba5d9e0f0a19315085b8b2983103d3a15d6",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:tokens",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/tab/web/tokens.yaml",
+          "marketplaceBlobSha": "8ad68c3d99c3fad696c223585cd3940669f79013",
+          "marketplaceSha256": "795f9d757c6c85d74fa692d54d7242666306c4e12221b301a22a4d1e4e73b5f5",
+          "originPath": "plugins/components/skills/tab/web/tokens.yaml",
+          "originBlobSha": "8ad68c3d99c3fad696c223585cd3940669f79013",
+          "originSha256": "795f9d757c6c85d74fa692d54d7242666306c4e12221b301a22a4d1e4e73b5f5",
+          "contentDiffers": false
+        }
+      ],
+      "releaseDifferences": []
     }
   ],
-  "releaseDifferences": [],
   "divergences": [
     {
       "id": "tab-disabled-focusability",

--- a/packages/agentic/components/src/components/tab/tab.types.ts
+++ b/packages/agentic/components/src/components/tab/tab.types.ts
@@ -1,5 +1,5 @@
 import type * as React from 'react';
-import type { Pressable, StyleProp, Text, ViewStyle } from 'react-native';
+import type { Pressable, StyleProp, ViewStyle } from 'react-native';
 
 import type {
   ComponentProps,
@@ -15,6 +15,7 @@ import type { ThemeState } from '@fluentui-react-native/design';
 
 import type { FocusVisualProps } from '../../primitives/focus-visual/focus-visual.types';
 import type { Icon } from '../../primitives/icon/icon';
+import type { Text } from '../text/text';
 import type { TabKeyEvent } from '../tablist/tablist.types';
 
 export type TabLayout = 'iconAndText' | 'iconOnly';

--- a/packages/agentic/components/src/components/tab/useTab.ts
+++ b/packages/agentic/components/src/components/tab/useTab.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Pressable, Text } from 'react-native';
+import { Pressable } from 'react-native';
 
 import {
   type PropsWithRefOf,
@@ -13,6 +13,7 @@ import { useThemeState } from '@fluentui-react-native/design';
 import type { TabProps, TabState } from './tab.types';
 import { Icon } from '../../primitives/icon/icon';
 import { TabListContext } from '../tablist/TabListContext';
+import { Text } from '../text/text';
 
 /**
  * Hook to create the state for a Tab component.

--- a/packages/agentic/components/src/components/tablist/spec/source.json
+++ b/packages/agentic/components/src/components/tablist/spec/source.json
@@ -1,127 +1,134 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "component": "tablist",
-  "skill": "flex-components:tablist",
-  "sourceLock": "flex-1.5.0-206c4996",
-  "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
   "lifecycle": "implemented",
   "conformance": "reviewed",
   "reviewedAt": "2026-08-30",
-  "availableSurfaces": ["mobile", "shared", "web"],
-  "surfacesConsulted": ["mobile", "shared", "web"],
-  "sourceFiles": [
+  "sources": [
     {
-      "role": "mobile:android:accessibility",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/tablist/mobile/android/accessibility.md",
-      "marketplaceBlobSha": "f84a4e9fa6a8cc0f8b8233de4b8322b6f050f974",
-      "marketplaceSha256": "52f9238ee1732868564112686ea6b2d78274706c0ae9b6fb922339869e73718c",
-      "originPath": "plugins/components/skills/tablist/mobile/android/accessibility.md",
-      "originBlobSha": "f84a4e9fa6a8cc0f8b8233de4b8322b6f050f974",
-      "originSha256": "52f9238ee1732868564112686ea6b2d78274706c0ae9b6fb922339869e73718c",
-      "contentDiffers": false
-    },
-    {
-      "role": "mobile:android:interaction",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/tablist/mobile/android/interaction.md",
-      "marketplaceBlobSha": "863dd8b683757cf7a5f71392de51332cf50da666",
-      "marketplaceSha256": "7eebac898c0d5b051e07624006b107ccf7e87d2e3b520128da7da11a9573ca22",
-      "originPath": "plugins/components/skills/tablist/mobile/android/interaction.md",
-      "originBlobSha": "863dd8b683757cf7a5f71392de51332cf50da666",
-      "originSha256": "7eebac898c0d5b051e07624006b107ccf7e87d2e3b520128da7da11a9573ca22",
-      "contentDiffers": false
-    },
-    {
-      "role": "mobile:ios:accessibility",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/tablist/mobile/ios/accessibility.md",
-      "marketplaceBlobSha": "89ba23c710e99a4bf9371d661951ab803b862015",
-      "marketplaceSha256": "c7fafbd60b747d7500112cf6816b84f22641c9da27bbe773c46804a2820e58eb",
-      "originPath": "plugins/components/skills/tablist/mobile/ios/accessibility.md",
-      "originBlobSha": "89ba23c710e99a4bf9371d661951ab803b862015",
-      "originSha256": "c7fafbd60b747d7500112cf6816b84f22641c9da27bbe773c46804a2820e58eb",
-      "contentDiffers": false
-    },
-    {
-      "role": "mobile:ios:interaction",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/tablist/mobile/ios/interaction.md",
-      "marketplaceBlobSha": "0ce59f92c4b03ddc87bbc44291c08c936ffca022",
-      "marketplaceSha256": "a750f1dcab6682cd0da51bce0f21e073576f6e636d7fee179674da7690e18c2a",
-      "originPath": "plugins/components/skills/tablist/mobile/ios/interaction.md",
-      "originBlobSha": "0ce59f92c4b03ddc87bbc44291c08c936ffca022",
-      "originSha256": "a750f1dcab6682cd0da51bce0f21e073576f6e636d7fee179674da7690e18c2a",
-      "contentDiffers": false
-    },
-    {
-      "role": "mobile:overview",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/tablist/mobile/overview.md",
-      "marketplaceBlobSha": "e939603e35cc33c55d16693c76ce9e7e0dfaf6a2",
-      "marketplaceSha256": "1f200e0e077a92fd86136f4652d76e96db2800ade9943b69aea6707aad44e052",
-      "originPath": "plugins/components/skills/tablist/mobile/overview.md",
-      "originBlobSha": "e939603e35cc33c55d16693c76ce9e7e0dfaf6a2",
-      "originSha256": "1f200e0e077a92fd86136f4652d76e96db2800ade9943b69aea6707aad44e052",
-      "contentDiffers": false
-    },
-    {
-      "role": "mobile:tokens",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/tablist/mobile/tokens.yaml",
-      "marketplaceBlobSha": "8637fac272b22f0fcd9ebe19197ea3187a06d299",
-      "marketplaceSha256": "89d1d6098f44af6abc561baa70f17d986d69e5a6ad66c4de4d3d9aedc74b096c",
-      "originPath": "plugins/components/skills/tablist/mobile/tokens.yaml",
-      "originBlobSha": "8637fac272b22f0fcd9ebe19197ea3187a06d299",
-      "originSha256": "89d1d6098f44af6abc561baa70f17d986d69e5a6ad66c4de4d3d9aedc74b096c",
-      "contentDiffers": false
-    },
-    {
-      "role": "skill",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/tablist/SKILL.md",
-      "marketplaceBlobSha": "e4e19702982280fcb057fcd452c1125952d52887",
-      "marketplaceSha256": "636361908921af105a98e00b0c3c6ef12d19057e4ddab9ef9d3451dbd454d029",
-      "originPath": "plugins/components/skills/tablist/SKILL.md",
-      "originBlobSha": "e4e19702982280fcb057fcd452c1125952d52887",
-      "originSha256": "636361908921af105a98e00b0c3c6ef12d19057e4ddab9ef9d3451dbd454d029",
-      "contentDiffers": false
-    },
-    {
-      "role": "usage",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/tablist/usage.md",
-      "marketplaceBlobSha": "2c1e9af165e23e486f249402f749568712a1f0c5",
-      "marketplaceSha256": "8a206fa3d301d7dfc1a0a0af8352f2ccbd68bf48c84c338117540730c113e984",
-      "originPath": "plugins/components/skills/tablist/usage.md",
-      "originBlobSha": "2c1e9af165e23e486f249402f749568712a1f0c5",
-      "originSha256": "8a206fa3d301d7dfc1a0a0af8352f2ccbd68bf48c84c338117540730c113e984",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:accessibility",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/tablist/web/accessibility.md",
-      "marketplaceBlobSha": "19c89074081286996cf5a828f503a731ea77d3a3",
-      "marketplaceSha256": "15c9e27338eb47b08607f92e16923f8952209ddc94fd996d193e5e0e34a566cd",
-      "originPath": "plugins/components/skills/tablist/web/accessibility.md",
-      "originBlobSha": "19c89074081286996cf5a828f503a731ea77d3a3",
-      "originSha256": "15c9e27338eb47b08607f92e16923f8952209ddc94fd996d193e5e0e34a566cd",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:interaction",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/tablist/web/interaction.md",
-      "marketplaceBlobSha": "1bc5eb645bfe152505c022cd5b23bd0fbb50e8f5",
-      "marketplaceSha256": "3abbb40b527fe98f5c008840f1866895e246f3767288b6359128670e692c600d",
-      "originPath": "plugins/components/skills/tablist/web/interaction.md",
-      "originBlobSha": "1bc5eb645bfe152505c022cd5b23bd0fbb50e8f5",
-      "originSha256": "3abbb40b527fe98f5c008840f1866895e246f3767288b6359128670e692c600d",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:tokens",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/tablist/web/tokens.yaml",
-      "marketplaceBlobSha": "013a024ce5c7449877eadf9f9d0a65af583c00f2",
-      "marketplaceSha256": "f72934fb768f0569ffe5f43d36ed54b92c6b555550dcf1e23a8002ddefcbab40",
-      "originPath": "plugins/components/skills/tablist/web/tokens.yaml",
-      "originBlobSha": "013a024ce5c7449877eadf9f9d0a65af583c00f2",
-      "originSha256": "f72934fb768f0569ffe5f43d36ed54b92c6b555550dcf1e23a8002ddefcbab40",
-      "contentDiffers": false
+      "id": "flex-component",
+      "kind": "flex-skill",
+      "authority": "normative",
+      "skill": "flex-components:tablist",
+      "sourceLock": "flex-1.5.0-206c4996",
+      "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
+      "availableSurfaces": ["mobile", "shared", "web"],
+      "surfacesConsulted": ["mobile", "shared", "web"],
+      "sourceFiles": [
+        {
+          "role": "mobile:android:accessibility",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/tablist/mobile/android/accessibility.md",
+          "marketplaceBlobSha": "f84a4e9fa6a8cc0f8b8233de4b8322b6f050f974",
+          "marketplaceSha256": "52f9238ee1732868564112686ea6b2d78274706c0ae9b6fb922339869e73718c",
+          "originPath": "plugins/components/skills/tablist/mobile/android/accessibility.md",
+          "originBlobSha": "f84a4e9fa6a8cc0f8b8233de4b8322b6f050f974",
+          "originSha256": "52f9238ee1732868564112686ea6b2d78274706c0ae9b6fb922339869e73718c",
+          "contentDiffers": false
+        },
+        {
+          "role": "mobile:android:interaction",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/tablist/mobile/android/interaction.md",
+          "marketplaceBlobSha": "863dd8b683757cf7a5f71392de51332cf50da666",
+          "marketplaceSha256": "7eebac898c0d5b051e07624006b107ccf7e87d2e3b520128da7da11a9573ca22",
+          "originPath": "plugins/components/skills/tablist/mobile/android/interaction.md",
+          "originBlobSha": "863dd8b683757cf7a5f71392de51332cf50da666",
+          "originSha256": "7eebac898c0d5b051e07624006b107ccf7e87d2e3b520128da7da11a9573ca22",
+          "contentDiffers": false
+        },
+        {
+          "role": "mobile:ios:accessibility",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/tablist/mobile/ios/accessibility.md",
+          "marketplaceBlobSha": "89ba23c710e99a4bf9371d661951ab803b862015",
+          "marketplaceSha256": "c7fafbd60b747d7500112cf6816b84f22641c9da27bbe773c46804a2820e58eb",
+          "originPath": "plugins/components/skills/tablist/mobile/ios/accessibility.md",
+          "originBlobSha": "89ba23c710e99a4bf9371d661951ab803b862015",
+          "originSha256": "c7fafbd60b747d7500112cf6816b84f22641c9da27bbe773c46804a2820e58eb",
+          "contentDiffers": false
+        },
+        {
+          "role": "mobile:ios:interaction",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/tablist/mobile/ios/interaction.md",
+          "marketplaceBlobSha": "0ce59f92c4b03ddc87bbc44291c08c936ffca022",
+          "marketplaceSha256": "a750f1dcab6682cd0da51bce0f21e073576f6e636d7fee179674da7690e18c2a",
+          "originPath": "plugins/components/skills/tablist/mobile/ios/interaction.md",
+          "originBlobSha": "0ce59f92c4b03ddc87bbc44291c08c936ffca022",
+          "originSha256": "a750f1dcab6682cd0da51bce0f21e073576f6e636d7fee179674da7690e18c2a",
+          "contentDiffers": false
+        },
+        {
+          "role": "mobile:overview",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/tablist/mobile/overview.md",
+          "marketplaceBlobSha": "e939603e35cc33c55d16693c76ce9e7e0dfaf6a2",
+          "marketplaceSha256": "1f200e0e077a92fd86136f4652d76e96db2800ade9943b69aea6707aad44e052",
+          "originPath": "plugins/components/skills/tablist/mobile/overview.md",
+          "originBlobSha": "e939603e35cc33c55d16693c76ce9e7e0dfaf6a2",
+          "originSha256": "1f200e0e077a92fd86136f4652d76e96db2800ade9943b69aea6707aad44e052",
+          "contentDiffers": false
+        },
+        {
+          "role": "mobile:tokens",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/tablist/mobile/tokens.yaml",
+          "marketplaceBlobSha": "8637fac272b22f0fcd9ebe19197ea3187a06d299",
+          "marketplaceSha256": "89d1d6098f44af6abc561baa70f17d986d69e5a6ad66c4de4d3d9aedc74b096c",
+          "originPath": "plugins/components/skills/tablist/mobile/tokens.yaml",
+          "originBlobSha": "8637fac272b22f0fcd9ebe19197ea3187a06d299",
+          "originSha256": "89d1d6098f44af6abc561baa70f17d986d69e5a6ad66c4de4d3d9aedc74b096c",
+          "contentDiffers": false
+        },
+        {
+          "role": "skill",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/tablist/SKILL.md",
+          "marketplaceBlobSha": "e4e19702982280fcb057fcd452c1125952d52887",
+          "marketplaceSha256": "636361908921af105a98e00b0c3c6ef12d19057e4ddab9ef9d3451dbd454d029",
+          "originPath": "plugins/components/skills/tablist/SKILL.md",
+          "originBlobSha": "e4e19702982280fcb057fcd452c1125952d52887",
+          "originSha256": "636361908921af105a98e00b0c3c6ef12d19057e4ddab9ef9d3451dbd454d029",
+          "contentDiffers": false
+        },
+        {
+          "role": "usage",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/tablist/usage.md",
+          "marketplaceBlobSha": "2c1e9af165e23e486f249402f749568712a1f0c5",
+          "marketplaceSha256": "8a206fa3d301d7dfc1a0a0af8352f2ccbd68bf48c84c338117540730c113e984",
+          "originPath": "plugins/components/skills/tablist/usage.md",
+          "originBlobSha": "2c1e9af165e23e486f249402f749568712a1f0c5",
+          "originSha256": "8a206fa3d301d7dfc1a0a0af8352f2ccbd68bf48c84c338117540730c113e984",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:accessibility",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/tablist/web/accessibility.md",
+          "marketplaceBlobSha": "19c89074081286996cf5a828f503a731ea77d3a3",
+          "marketplaceSha256": "15c9e27338eb47b08607f92e16923f8952209ddc94fd996d193e5e0e34a566cd",
+          "originPath": "plugins/components/skills/tablist/web/accessibility.md",
+          "originBlobSha": "19c89074081286996cf5a828f503a731ea77d3a3",
+          "originSha256": "15c9e27338eb47b08607f92e16923f8952209ddc94fd996d193e5e0e34a566cd",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:interaction",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/tablist/web/interaction.md",
+          "marketplaceBlobSha": "1bc5eb645bfe152505c022cd5b23bd0fbb50e8f5",
+          "marketplaceSha256": "3abbb40b527fe98f5c008840f1866895e246f3767288b6359128670e692c600d",
+          "originPath": "plugins/components/skills/tablist/web/interaction.md",
+          "originBlobSha": "1bc5eb645bfe152505c022cd5b23bd0fbb50e8f5",
+          "originSha256": "3abbb40b527fe98f5c008840f1866895e246f3767288b6359128670e692c600d",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:tokens",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/tablist/web/tokens.yaml",
+          "marketplaceBlobSha": "013a024ce5c7449877eadf9f9d0a65af583c00f2",
+          "marketplaceSha256": "f72934fb768f0569ffe5f43d36ed54b92c6b555550dcf1e23a8002ddefcbab40",
+          "originPath": "plugins/components/skills/tablist/web/tokens.yaml",
+          "originBlobSha": "013a024ce5c7449877eadf9f9d0a65af583c00f2",
+          "originSha256": "f72934fb768f0569ffe5f43d36ed54b92c6b555550dcf1e23a8002ddefcbab40",
+          "contentDiffers": false
+        }
+      ],
+      "releaseDifferences": []
     }
   ],
-  "releaseDifferences": [],
   "divergences": [
     {
       "id": "tablist-controls-value-fallback",

--- a/packages/agentic/components/src/components/tag/spec/source.json
+++ b/packages/agentic/components/src/components/tag/spec/source.json
@@ -1,127 +1,134 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "component": "tag",
-  "skill": "flex-components:tag",
-  "sourceLock": "flex-1.5.0-206c4996",
-  "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
   "lifecycle": "implemented",
   "conformance": "reviewed",
   "reviewedAt": "2026-08-28",
-  "availableSurfaces": ["mobile", "shared", "web"],
-  "surfacesConsulted": ["mobile", "shared", "web"],
-  "sourceFiles": [
+  "sources": [
     {
-      "role": "mobile:android:accessibility",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/tag/mobile/android/accessibility.md",
-      "marketplaceBlobSha": "baa0a9436659e2c551c601b63c3025f6a885bcb4",
-      "marketplaceSha256": "08e477f375e2e1835f82e0b1cd3f9fcd65d28dbcc37be8541287f07df44614c3",
-      "originPath": "plugins/components/skills/tag/mobile/android/accessibility.md",
-      "originBlobSha": "baa0a9436659e2c551c601b63c3025f6a885bcb4",
-      "originSha256": "08e477f375e2e1835f82e0b1cd3f9fcd65d28dbcc37be8541287f07df44614c3",
-      "contentDiffers": false
-    },
-    {
-      "role": "mobile:android:interaction",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/tag/mobile/android/interaction.md",
-      "marketplaceBlobSha": "b6a0c7fb97b5292a7c0bf93ed0398ce4452321dd",
-      "marketplaceSha256": "d0522f36a2ca4e96b9eb970d3cc7795da2ec8385d9fab18d9116f95fdd3387f1",
-      "originPath": "plugins/components/skills/tag/mobile/android/interaction.md",
-      "originBlobSha": "b6a0c7fb97b5292a7c0bf93ed0398ce4452321dd",
-      "originSha256": "d0522f36a2ca4e96b9eb970d3cc7795da2ec8385d9fab18d9116f95fdd3387f1",
-      "contentDiffers": false
-    },
-    {
-      "role": "mobile:ios:accessibility",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/tag/mobile/ios/accessibility.md",
-      "marketplaceBlobSha": "aa7f37eaf7b9826d2e8fb570e74f669eac2b29e9",
-      "marketplaceSha256": "986ee0c3782b397af42ec1fb46d780fbcd42386f3374f6fb970a9f9e1d447d5d",
-      "originPath": "plugins/components/skills/tag/mobile/ios/accessibility.md",
-      "originBlobSha": "aa7f37eaf7b9826d2e8fb570e74f669eac2b29e9",
-      "originSha256": "986ee0c3782b397af42ec1fb46d780fbcd42386f3374f6fb970a9f9e1d447d5d",
-      "contentDiffers": false
-    },
-    {
-      "role": "mobile:ios:interaction",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/tag/mobile/ios/interaction.md",
-      "marketplaceBlobSha": "9a7b4cb4fea448327d6b2b3b975bb23427bf4150",
-      "marketplaceSha256": "6d01fbd4ad06f1ece31e0cf22626bb605406f62d973603ae37eec0e177f23398",
-      "originPath": "plugins/components/skills/tag/mobile/ios/interaction.md",
-      "originBlobSha": "9a7b4cb4fea448327d6b2b3b975bb23427bf4150",
-      "originSha256": "6d01fbd4ad06f1ece31e0cf22626bb605406f62d973603ae37eec0e177f23398",
-      "contentDiffers": false
-    },
-    {
-      "role": "mobile:overview",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/tag/mobile/overview.md",
-      "marketplaceBlobSha": "4cb287bd21953924c1be2f628b8b3f6dd230f868",
-      "marketplaceSha256": "a26f23f036e031083774eb3d6946cbd710f8ab4f40f9ce65f3e073ba766c1985",
-      "originPath": "plugins/components/skills/tag/mobile/overview.md",
-      "originBlobSha": "4cb287bd21953924c1be2f628b8b3f6dd230f868",
-      "originSha256": "a26f23f036e031083774eb3d6946cbd710f8ab4f40f9ce65f3e073ba766c1985",
-      "contentDiffers": false
-    },
-    {
-      "role": "mobile:tokens",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/tag/mobile/tokens.yaml",
-      "marketplaceBlobSha": "f6c1f1a06225c39c0f0f4953bbdac274cd26dece",
-      "marketplaceSha256": "d1e66ccfcf41fa49a82fa81f53e5e7e9d250aa54936e6fd39899561decd9671f",
-      "originPath": "plugins/components/skills/tag/mobile/tokens.yaml",
-      "originBlobSha": "f6c1f1a06225c39c0f0f4953bbdac274cd26dece",
-      "originSha256": "d1e66ccfcf41fa49a82fa81f53e5e7e9d250aa54936e6fd39899561decd9671f",
-      "contentDiffers": false
-    },
-    {
-      "role": "skill",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/tag/SKILL.md",
-      "marketplaceBlobSha": "5fd9c996d99c93187c9e54efa6843f8a4de0acd0",
-      "marketplaceSha256": "676f24699b6081ee4d96a05cc6b897256fbd52503da3d3c3ea82666448dd00bb",
-      "originPath": "plugins/components/skills/tag/SKILL.md",
-      "originBlobSha": "5fd9c996d99c93187c9e54efa6843f8a4de0acd0",
-      "originSha256": "676f24699b6081ee4d96a05cc6b897256fbd52503da3d3c3ea82666448dd00bb",
-      "contentDiffers": false
-    },
-    {
-      "role": "usage",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/tag/usage.md",
-      "marketplaceBlobSha": "e127d740e81bad4f05dfd0a0c9c28f8a9f2da830",
-      "marketplaceSha256": "bee0e5bd197789f0373411252c8c70358987e9d3e51a18452ea705617ada0edb",
-      "originPath": "plugins/components/skills/tag/usage.md",
-      "originBlobSha": "e127d740e81bad4f05dfd0a0c9c28f8a9f2da830",
-      "originSha256": "bee0e5bd197789f0373411252c8c70358987e9d3e51a18452ea705617ada0edb",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:accessibility",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/tag/web/accessibility.md",
-      "marketplaceBlobSha": "f9652b4fea6706188df7c03ebe38620b231fba9d",
-      "marketplaceSha256": "77c8c53b4af7180ead85b48ecec484bdafa326641ec3564322b70c7a1210b62f",
-      "originPath": "plugins/components/skills/tag/web/accessibility.md",
-      "originBlobSha": "f9652b4fea6706188df7c03ebe38620b231fba9d",
-      "originSha256": "77c8c53b4af7180ead85b48ecec484bdafa326641ec3564322b70c7a1210b62f",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:interaction",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/tag/web/interaction.md",
-      "marketplaceBlobSha": "36f2523e7adc4df91cde26df1ca56957fb3374fe",
-      "marketplaceSha256": "72dd23d7ed5b850b20b89c717a9836ca5566de7ccde24eff448238c4cf5950c5",
-      "originPath": "plugins/components/skills/tag/web/interaction.md",
-      "originBlobSha": "36f2523e7adc4df91cde26df1ca56957fb3374fe",
-      "originSha256": "72dd23d7ed5b850b20b89c717a9836ca5566de7ccde24eff448238c4cf5950c5",
-      "contentDiffers": false
-    },
-    {
-      "role": "web:tokens",
-      "marketplacePath": "catalogs/flex/plugins/components/skills/tag/web/tokens.yaml",
-      "marketplaceBlobSha": "83cf06760bcc8d77702bfd2cabf9e4604022beaf",
-      "marketplaceSha256": "1e35992c80f95459969cee47df0e7fa121f43a8e13f00be0d7ac276f7ff177bb",
-      "originPath": "plugins/components/skills/tag/web/tokens.yaml",
-      "originBlobSha": "83cf06760bcc8d77702bfd2cabf9e4604022beaf",
-      "originSha256": "1e35992c80f95459969cee47df0e7fa121f43a8e13f00be0d7ac276f7ff177bb",
-      "contentDiffers": false
+      "id": "flex-component",
+      "kind": "flex-skill",
+      "authority": "normative",
+      "skill": "flex-components:tag",
+      "sourceLock": "flex-1.5.0-206c4996",
+      "sourceLockFingerprint": "a69997212ec1b89510c94176801bf5a146ed7e7d8c80cc7db40ac8f60cf9f119",
+      "availableSurfaces": ["mobile", "shared", "web"],
+      "surfacesConsulted": ["mobile", "shared", "web"],
+      "sourceFiles": [
+        {
+          "role": "mobile:android:accessibility",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/tag/mobile/android/accessibility.md",
+          "marketplaceBlobSha": "baa0a9436659e2c551c601b63c3025f6a885bcb4",
+          "marketplaceSha256": "08e477f375e2e1835f82e0b1cd3f9fcd65d28dbcc37be8541287f07df44614c3",
+          "originPath": "plugins/components/skills/tag/mobile/android/accessibility.md",
+          "originBlobSha": "baa0a9436659e2c551c601b63c3025f6a885bcb4",
+          "originSha256": "08e477f375e2e1835f82e0b1cd3f9fcd65d28dbcc37be8541287f07df44614c3",
+          "contentDiffers": false
+        },
+        {
+          "role": "mobile:android:interaction",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/tag/mobile/android/interaction.md",
+          "marketplaceBlobSha": "b6a0c7fb97b5292a7c0bf93ed0398ce4452321dd",
+          "marketplaceSha256": "d0522f36a2ca4e96b9eb970d3cc7795da2ec8385d9fab18d9116f95fdd3387f1",
+          "originPath": "plugins/components/skills/tag/mobile/android/interaction.md",
+          "originBlobSha": "b6a0c7fb97b5292a7c0bf93ed0398ce4452321dd",
+          "originSha256": "d0522f36a2ca4e96b9eb970d3cc7795da2ec8385d9fab18d9116f95fdd3387f1",
+          "contentDiffers": false
+        },
+        {
+          "role": "mobile:ios:accessibility",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/tag/mobile/ios/accessibility.md",
+          "marketplaceBlobSha": "aa7f37eaf7b9826d2e8fb570e74f669eac2b29e9",
+          "marketplaceSha256": "986ee0c3782b397af42ec1fb46d780fbcd42386f3374f6fb970a9f9e1d447d5d",
+          "originPath": "plugins/components/skills/tag/mobile/ios/accessibility.md",
+          "originBlobSha": "aa7f37eaf7b9826d2e8fb570e74f669eac2b29e9",
+          "originSha256": "986ee0c3782b397af42ec1fb46d780fbcd42386f3374f6fb970a9f9e1d447d5d",
+          "contentDiffers": false
+        },
+        {
+          "role": "mobile:ios:interaction",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/tag/mobile/ios/interaction.md",
+          "marketplaceBlobSha": "9a7b4cb4fea448327d6b2b3b975bb23427bf4150",
+          "marketplaceSha256": "6d01fbd4ad06f1ece31e0cf22626bb605406f62d973603ae37eec0e177f23398",
+          "originPath": "plugins/components/skills/tag/mobile/ios/interaction.md",
+          "originBlobSha": "9a7b4cb4fea448327d6b2b3b975bb23427bf4150",
+          "originSha256": "6d01fbd4ad06f1ece31e0cf22626bb605406f62d973603ae37eec0e177f23398",
+          "contentDiffers": false
+        },
+        {
+          "role": "mobile:overview",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/tag/mobile/overview.md",
+          "marketplaceBlobSha": "4cb287bd21953924c1be2f628b8b3f6dd230f868",
+          "marketplaceSha256": "a26f23f036e031083774eb3d6946cbd710f8ab4f40f9ce65f3e073ba766c1985",
+          "originPath": "plugins/components/skills/tag/mobile/overview.md",
+          "originBlobSha": "4cb287bd21953924c1be2f628b8b3f6dd230f868",
+          "originSha256": "a26f23f036e031083774eb3d6946cbd710f8ab4f40f9ce65f3e073ba766c1985",
+          "contentDiffers": false
+        },
+        {
+          "role": "mobile:tokens",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/tag/mobile/tokens.yaml",
+          "marketplaceBlobSha": "f6c1f1a06225c39c0f0f4953bbdac274cd26dece",
+          "marketplaceSha256": "d1e66ccfcf41fa49a82fa81f53e5e7e9d250aa54936e6fd39899561decd9671f",
+          "originPath": "plugins/components/skills/tag/mobile/tokens.yaml",
+          "originBlobSha": "f6c1f1a06225c39c0f0f4953bbdac274cd26dece",
+          "originSha256": "d1e66ccfcf41fa49a82fa81f53e5e7e9d250aa54936e6fd39899561decd9671f",
+          "contentDiffers": false
+        },
+        {
+          "role": "skill",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/tag/SKILL.md",
+          "marketplaceBlobSha": "5fd9c996d99c93187c9e54efa6843f8a4de0acd0",
+          "marketplaceSha256": "676f24699b6081ee4d96a05cc6b897256fbd52503da3d3c3ea82666448dd00bb",
+          "originPath": "plugins/components/skills/tag/SKILL.md",
+          "originBlobSha": "5fd9c996d99c93187c9e54efa6843f8a4de0acd0",
+          "originSha256": "676f24699b6081ee4d96a05cc6b897256fbd52503da3d3c3ea82666448dd00bb",
+          "contentDiffers": false
+        },
+        {
+          "role": "usage",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/tag/usage.md",
+          "marketplaceBlobSha": "e127d740e81bad4f05dfd0a0c9c28f8a9f2da830",
+          "marketplaceSha256": "bee0e5bd197789f0373411252c8c70358987e9d3e51a18452ea705617ada0edb",
+          "originPath": "plugins/components/skills/tag/usage.md",
+          "originBlobSha": "e127d740e81bad4f05dfd0a0c9c28f8a9f2da830",
+          "originSha256": "bee0e5bd197789f0373411252c8c70358987e9d3e51a18452ea705617ada0edb",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:accessibility",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/tag/web/accessibility.md",
+          "marketplaceBlobSha": "f9652b4fea6706188df7c03ebe38620b231fba9d",
+          "marketplaceSha256": "77c8c53b4af7180ead85b48ecec484bdafa326641ec3564322b70c7a1210b62f",
+          "originPath": "plugins/components/skills/tag/web/accessibility.md",
+          "originBlobSha": "f9652b4fea6706188df7c03ebe38620b231fba9d",
+          "originSha256": "77c8c53b4af7180ead85b48ecec484bdafa326641ec3564322b70c7a1210b62f",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:interaction",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/tag/web/interaction.md",
+          "marketplaceBlobSha": "36f2523e7adc4df91cde26df1ca56957fb3374fe",
+          "marketplaceSha256": "72dd23d7ed5b850b20b89c717a9836ca5566de7ccde24eff448238c4cf5950c5",
+          "originPath": "plugins/components/skills/tag/web/interaction.md",
+          "originBlobSha": "36f2523e7adc4df91cde26df1ca56957fb3374fe",
+          "originSha256": "72dd23d7ed5b850b20b89c717a9836ca5566de7ccde24eff448238c4cf5950c5",
+          "contentDiffers": false
+        },
+        {
+          "role": "web:tokens",
+          "marketplacePath": "catalogs/flex/plugins/components/skills/tag/web/tokens.yaml",
+          "marketplaceBlobSha": "83cf06760bcc8d77702bfd2cabf9e4604022beaf",
+          "marketplaceSha256": "1e35992c80f95459969cee47df0e7fa121f43a8e13f00be0d7ac276f7ff177bb",
+          "originPath": "plugins/components/skills/tag/web/tokens.yaml",
+          "originBlobSha": "83cf06760bcc8d77702bfd2cabf9e4604022beaf",
+          "originSha256": "1e35992c80f95459969cee47df0e7fa121f43a8e13f00be0d7ac276f7ff177bb",
+          "contentDiffers": false
+        }
+      ],
+      "releaseDifferences": []
     }
   ],
-  "releaseDifferences": [],
   "divergences": [
     {
       "id": "tag-small-circular-padding",

--- a/packages/agentic/components/src/components/tag/tag.types.ts
+++ b/packages/agentic/components/src/components/tag/tag.types.ts
@@ -1,4 +1,4 @@
-import type { Pressable, StyleProp, Text, ViewStyle } from 'react-native';
+import type { Pressable, StyleProp, ViewStyle } from 'react-native';
 import type {
   ComponentProps,
   ComponentState,
@@ -12,6 +12,7 @@ import type { ThemeState } from '@fluentui-react-native/design';
 
 import type { FocusVisualProps } from '../../primitives/focus-visual/focus-visual.types';
 import type { Icon } from '../../primitives/icon/icon';
+import type { Text } from '../text/text';
 
 export type TagSlots = {
   root: Slot<typeof Pressable>;

--- a/packages/agentic/components/src/components/tag/useTag.ts
+++ b/packages/agentic/components/src/components/tag/useTag.ts
@@ -1,10 +1,11 @@
 import * as React from 'react';
-import { Pressable, Text } from 'react-native';
+import { Pressable } from 'react-native';
 import { useThemeState } from '@fluentui-react-native/design';
 import { useAccessibilityLabelWarning, useOptionalSlot, usePressableState, useSlot } from '@fluentui-react-native/framework-base';
 
 import { semanticIconSources } from '../../common/iconSources';
 import { Icon } from '../../primitives/icon/icon';
+import { Text } from '../text/text';
 import type { TagProps, TagState } from './tag.types';
 
 const defaultDismissIcon = {

--- a/packages/agentic/components/src/components/text/SPEC.md
+++ b/packages/agentic/components/src/components/text/SPEC.md
@@ -1,0 +1,82 @@
+---
+name: text
+platform: react-native (Windows, macOS)
+status: implemented
+source: ./spec/source.json
+tokens: ./spec/tokens.yaml
+accessibility: ./spec/accessibility.md
+interaction: ./spec/interaction.md
+usage: ./spec/usage.md
+---
+
+# Text
+
+## Scope
+
+Text is the theme-aware primitive for displaying textual content in the agentic
+component library. Web-authored component contracts rely on inherited CSS
+typography, while React Native only inherits text styles within a native text
+subtree. Text establishes the library's functional body typography and primary
+foreground color at that boundary.
+
+Text deliberately preserves the React Native Text prop surface. It does not add
+variants, aliases, truncation policy, press handling, or Dynamic Type
+calculations that would compete with native behavior or component-owned
+typography.
+
+## Public contract
+
+### Theme defaults
+
+**TXT-001:** Text MUST resolve its default font family, size, line height,
+weight, and foreground color from the nearest Flex theme.
+
+**TXT-002:** Caller-provided style MUST follow the theme defaults so every
+native text style remains directly overridable.
+
+### Native behavior and composition
+
+**TXT-003:** Text MUST delegate React Native Text props, accessibility,
+interaction, text layout, and nested native-text behavior without normalization.
+
+**TXT-004:** Text MUST use phased rendering and return its stable native root
+slot as the continuation so required component slots can flatten it without a
+wrapper or per-render continuation allocation. Required and optional slots MUST
+preserve shorthand and default children.
+
+**TXT-005:** Text MUST accept its native root ref as an ordinary React 19 prop
+and forward that ref to the native Text instance without `forwardRef`.
+
+### Styling ownership
+
+Component-owned text slots MAY apply typography and state styles after Text's
+defaults. Nested Agentic Text instances establish a new default boundary;
+strings and raw React Native Text descendants inherit from the nearest native
+text ancestor.
+
+## Platform behavior
+
+The same token bindings and native prop contract apply on Windows and macOS.
+The active React Native platform implementation remains responsible for text
+measurement, font fallback, scaling, selection, truncation, press events, and
+accessibility exposure.
+
+## Divergences from Flex
+
+- `text-local-foundation-source` (`accepted`) - Flex web component skills do not
+  define a styled Text component because CSS inheritance supplies this
+  behavior. The React Native component is therefore governed by the local
+  foundation contract and cited platform evidence rather than a fabricated
+  Flex component source.
+- `text-native-only-api` (`accepted`) - Text exposes native Text props and
+  theme defaults, not the expanded variants and convenience props of Fluent UI
+  React Native Text V1.
+- `text-nested-default-boundary` (`accepted`) - Each Agentic Text instance
+  reapplies theme defaults because React Native's private text-ancestor context
+  is not a supported public API.
+
+## Conformance
+
+The contract is implemented and reviewed against React Native 0.81 Text
+behavior, the repository Text V1 precedent, the Flex token map, unit and type
+tests, and the component stories.

--- a/packages/agentic/components/src/components/text/renderText.ts
+++ b/packages/agentic/components/src/components/text/renderText.ts
@@ -1,0 +1,5 @@
+import type { TextState } from './text.types';
+
+export function renderText_unstable(state: TextState): TextState['root'] {
+  return state.root;
+}

--- a/packages/agentic/components/src/components/text/spec/accessibility.md
+++ b/packages/agentic/components/src/components/text/spec/accessibility.md
@@ -1,0 +1,10 @@
+# Text accessibility
+
+- Text preserves the active React Native Text implementation's accessibility
+  behavior.
+- Native accessibility props, labels, roles, states, language, scaling, and
+  selection settings pass through unchanged.
+- Text does not assign an accessibility role or synthesize an accessibility
+  label by default.
+- Pressable text relies on the native `onPress` and `onLongPress` semantics and
+  the accessibility props supplied by the caller.

--- a/packages/agentic/components/src/components/text/spec/interaction.md
+++ b/packages/agentic/components/src/components/text/spec/interaction.md
@@ -1,0 +1,9 @@
+# Text interaction
+
+Text adds no interaction state machine. It forwards native press callbacks,
+selection behavior, responder props, disabled state, and event ordering to the
+React Native Text implementation.
+
+Theme defaults do not change across interaction states. Components that use
+Text as a content slot own their hover, press, focus, selection, and disabled
+foreground styles.

--- a/packages/agentic/components/src/components/text/spec/source.json
+++ b/packages/agentic/components/src/components/text/spec/source.json
@@ -1,25 +1,34 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "component": "text",
-  "sourceKind": "local-foundation",
   "lifecycle": "implemented",
   "conformance": "reviewed",
   "reviewedAt": "2026-09-01",
-  "references": [
+  "sources": [
     {
-      "id": "flex-text-token-map",
-      "type": "repository",
-      "location": "packages/agentic/design/src/tokens/mappings/flex-token-map.yaml"
-    },
-    {
-      "id": "furn-text-v1",
-      "type": "repository",
-      "location": "packages/components/Text/src/Text.tsx"
-    },
-    {
-      "id": "react-native-text-081",
-      "type": "external",
-      "location": "https://reactnative.dev/docs/0.81/text"
+      "id": "local-foundation",
+      "kind": "local-foundation",
+      "authority": "normative",
+      "references": [
+        {
+          "id": "flex-text-token-map",
+          "type": "repository",
+          "authority": "token-reference",
+          "location": "packages/agentic/design/src/tokens/mappings/flex-token-map.yaml"
+        },
+        {
+          "id": "furn-text-v1",
+          "type": "repository",
+          "authority": "compatibility-reference",
+          "location": "packages/components/Text/src/Text.tsx"
+        },
+        {
+          "id": "react-native-text-081",
+          "type": "external",
+          "authority": "platform-contract",
+          "location": "https://reactnative.dev/docs/0.81/text"
+        }
+      ]
     }
   ],
   "divergences": [

--- a/packages/agentic/components/src/components/text/spec/source.json
+++ b/packages/agentic/components/src/components/text/spec/source.json
@@ -1,0 +1,61 @@
+{
+  "schemaVersion": 1,
+  "component": "text",
+  "sourceKind": "local-foundation",
+  "lifecycle": "implemented",
+  "conformance": "reviewed",
+  "reviewedAt": "2026-09-01",
+  "references": [
+    {
+      "id": "flex-text-token-map",
+      "type": "repository",
+      "location": "packages/agentic/design/src/tokens/mappings/flex-token-map.yaml"
+    },
+    {
+      "id": "furn-text-v1",
+      "type": "repository",
+      "location": "packages/components/Text/src/Text.tsx"
+    },
+    {
+      "id": "react-native-text-081",
+      "type": "external",
+      "location": "https://reactnative.dev/docs/0.81/text"
+    }
+  ],
+  "divergences": [
+    {
+      "id": "text-local-foundation-source",
+      "status": "accepted"
+    },
+    {
+      "id": "text-native-only-api",
+      "status": "accepted"
+    },
+    {
+      "id": "text-nested-default-boundary",
+      "status": "accepted"
+    }
+  ],
+  "requirements": [
+    {
+      "id": "TXT-001",
+      "evidence": ["text.styles.ts", "text.test.tsx"]
+    },
+    {
+      "id": "TXT-002",
+      "evidence": ["useTextStyles.ts", "text.test.tsx"]
+    },
+    {
+      "id": "TXT-003",
+      "evidence": ["text.test.tsx", "text.types.test.tsx", "text.types.ts"]
+    },
+    {
+      "id": "TXT-004",
+      "evidence": ["renderText.ts", "text.test.tsx", "text.ts"]
+    },
+    {
+      "id": "TXT-005",
+      "evidence": ["text.test.tsx", "text.types.test.tsx", "useText.ts"]
+    }
+  ]
+}

--- a/packages/agentic/components/src/components/text/spec/tokens.yaml
+++ b/packages/agentic/components/src/components/text/spec/tokens.yaml
@@ -1,0 +1,12 @@
+schemaVersion: 1
+component: text
+implementation: text.styles.ts
+statePrecedence: []
+bindings:
+  root:
+    fontFamily: fontFamily.functional
+    fontSize: fontSize.functionalBodyMedium
+    lineHeight: lineHeight.functionalBodyMedium
+    fontWeight: fontWeight.functionalRegular
+    color: color.foregroundNeutralPrimary
+tokenGaps: []

--- a/packages/agentic/components/src/components/text/spec/usage.md
+++ b/packages/agentic/components/src/components/text/spec/usage.md
@@ -1,0 +1,23 @@
+# Text usage
+
+Use Text for standalone textual content and as the base component for text
+slots in agentic components.
+
+```tsx
+import { Text } from '@fluentui-react-native/agentic-components';
+
+<Text selectable>Theme-aware body text</Text>;
+<Text style={{ fontSize: 20 }}>Caller style wins</Text>;
+```
+
+Text accepts the React Native Text ref directly as an ordinary React 19 prop.
+It does not require `forwardRef`.
+
+Raw string children and raw React Native Text descendants inherit native text
+styles. A nested Agentic Text instance starts a new theme-default boundary, and
+its own style can override those defaults.
+
+Keep component-specific typography in the owning component. Text supplies
+fallback body typography and primary foreground color; it is not a replacement
+for a component's display, label, caption, or interaction-state token
+bindings.

--- a/packages/agentic/components/src/components/text/text.stories.tsx
+++ b/packages/agentic/components/src/components/text/text.stories.tsx
@@ -1,0 +1,87 @@
+/** @jsxImportSource @fluentui-react-native/framework-base */
+import { StyleSheet, View } from 'react-native';
+
+import type { Meta, StoryObj } from '@storybook/react-native';
+
+import { Text } from './text';
+
+const styles = StyleSheet.create({
+  stack: {
+    gap: 12,
+  },
+  override: {
+    color: '#b10e1c',
+    fontSize: 20,
+  },
+  constrained: {
+    maxWidth: 240,
+  },
+});
+
+const meta = {
+  title: 'Components/Text',
+  component: Text,
+  args: {
+    children: 'Theme-aware functional body text',
+    testID: 'text-default',
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: 'A React Native Text primitive with theme-aware functional body typography and native prop behavior.',
+      },
+    },
+  },
+} satisfies Meta<typeof Text>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Text reads body typography and the primary foreground color from the nearest theme.',
+      },
+    },
+  },
+};
+
+export const Overview: Story = {
+  render: () => (
+    <View style={styles.stack}>
+      <Text>Default functional body text</Text>
+      <Text style={styles.override}>Caller styles override theme defaults</Text>
+      <Text>
+        Raw strings inherit from their nearest native text parent.{' '}
+        <Text style={{ fontWeight: '700' }}>Nested Text reapplies defaults.</Text>
+      </Text>
+    </View>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Caller styles follow theme defaults, while each nested Agentic Text starts a new default boundary.',
+      },
+    },
+  },
+};
+
+export const NativeBehavior: Story = {
+  render: () => (
+    <View style={styles.stack}>
+      <Text selectable>Selectable text delegates to the React Native Text implementation.</Text>
+      <Text numberOfLines={1} style={styles.constrained}>
+        Number-of-lines behavior also remains native and truncates this deliberately long sentence.
+      </Text>
+    </View>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Selection and truncation are delegated to the platform Text implementation.',
+      },
+    },
+  },
+};

--- a/packages/agentic/components/src/components/text/text.styles.ts
+++ b/packages/agentic/components/src/components/text/text.styles.ts
@@ -1,0 +1,15 @@
+import { StyleSheet } from 'react-native';
+
+import { themedStyleSheetFactory } from '@fluentui-react-native/design';
+
+export const getTextStyles = themedStyleSheetFactory('Text.styles', ({ tokens }) =>
+  StyleSheet.create({
+    root: {
+      color: tokens.color.foregroundNeutralPrimary,
+      fontFamily: tokens.fontFamily.functional,
+      fontSize: tokens.fontSize.functionalBodyMedium,
+      fontWeight: tokens.fontWeight.functionalRegular,
+      lineHeight: tokens.lineHeight.functionalBodyMedium,
+    },
+  }),
+);

--- a/packages/agentic/components/src/components/text/text.test.tsx
+++ b/packages/agentic/components/src/components/text/text.test.tsx
@@ -1,0 +1,133 @@
+/** @jsxImportSource @fluentui-react-native/framework-base */
+import * as React from 'react';
+import { StyleSheet } from 'react-native';
+
+import { fireEvent, render } from '@testing-library/react-native';
+import { FlexThemeReference, ThemeProvider } from '@fluentui-react-native/design';
+import { useOptionalSlot, useSlot } from '@fluentui-react-native/framework-base';
+import type { SlotProp } from '@fluentui-react-native/framework-base';
+
+import { Text } from './text';
+import type { TextState } from './text.types';
+import { useText_unstable } from './useText';
+
+type SlotHostProps = {
+  content: SlotProp<typeof Text>;
+  optionalContent?: SlotProp<typeof Text>;
+};
+
+function SlotHost({ content, optionalContent }: SlotHostProps) {
+  const Content = useSlot(Text, content);
+  const OptionalContent = useOptionalSlot(Text, optionalContent);
+  const DefaultContent = useSlot(Text, undefined, { defaultProps: { children: 'Default child' } });
+  const OptionalDefaultContent = useOptionalSlot(Text, undefined, {
+    defaultProps: { children: 'Optional default child' },
+    renderByDefault: true,
+  });
+
+  return (
+    <>
+      <Content testID="required-text" />
+      {OptionalContent && <OptionalContent testID="optional-text" />}
+      <DefaultContent testID="default-text" />
+      {OptionalDefaultContent && <OptionalDefaultContent testID="optional-default-text" />}
+    </>
+  );
+}
+
+function TextStateProbe({ seen, children }: { seen: TextState['root'][]; children: React.ReactNode }) {
+  const state = useText_unstable({ children });
+  seen.push(state.root);
+
+  const Root = state.root;
+  return <Root>{children}</Root>;
+}
+
+describe('Text', () => {
+  it('applies theme typography and foreground defaults', async () => {
+    const theme = new FlexThemeReference({
+      base: {
+        color: { foregroundNeutralPrimary: '#123456' },
+        fontFamily: { functional: 'Test Family' },
+        fontSize: { functionalBodyMedium: 17 },
+        fontWeight: { functionalRegular: '600' },
+        lineHeight: { functionalBodyMedium: 23 },
+      },
+    });
+    const { getByTestId } = await render(
+      <ThemeProvider theme={theme}>
+        <Text testID="text">Theme text</Text>
+      </ThemeProvider>,
+    );
+
+    expect(StyleSheet.flatten(getByTestId('text').props.style)).toMatchObject({
+      color: '#123456',
+      fontFamily: 'Test Family',
+      fontSize: 17,
+      fontWeight: '600',
+      lineHeight: 23,
+    });
+  });
+
+  it('applies user styles after theme defaults', async () => {
+    const { getByTestId } = await render(
+      <Text testID="text" style={{ color: '#abcdef', fontSize: 21 }}>
+        Styled text
+      </Text>,
+    );
+
+    expect(StyleSheet.flatten(getByTestId('text').props.style)).toMatchObject({
+      color: '#abcdef',
+      fontSize: 21,
+    });
+  });
+
+  it('delegates native Text behavior and forwards the native ref prop', async () => {
+    const onPress = jest.fn();
+    const ref = React.createRef<React.ComponentRef<typeof Text>>();
+    const { getByTestId } = await render(
+      <Text ref={ref} testID="text" selectable onPress={onPress}>
+        Pressable text
+      </Text>,
+    );
+
+    await fireEvent.press(getByTestId('text'));
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+    expect(getByTestId('text').props.selectable).toBe(true);
+    expect(ref.current).not.toBeNull();
+  });
+
+  it('resolves as both a required and optional slot without losing shorthand children', async () => {
+    const { getByTestId } = await render(<SlotHost content="Required child" optionalContent="Optional child" />);
+
+    expect(getByTestId('required-text')).toHaveTextContent('Required child');
+    expect(getByTestId('optional-text')).toHaveTextContent('Optional child');
+    expect(getByTestId('default-text')).toHaveTextContent('Default child');
+    expect(getByTestId('optional-default-text')).toHaveTextContent('Optional default child');
+  });
+
+  it('reapplies theme defaults at nested Agentic Text boundaries', async () => {
+    const theme = new FlexThemeReference({ base: { fontSize: { functionalBodyMedium: 17 } } });
+    const { getByTestId } = await render(
+      <ThemeProvider theme={theme}>
+        <Text style={{ fontSize: 30 }}>
+          Parent
+          <Text testID="nested-text">Nested</Text>
+        </Text>
+      </ThemeProvider>,
+    );
+
+    expect(StyleSheet.flatten(getByTestId('nested-text').props.style)).toMatchObject({ fontSize: 17 });
+  });
+
+  it('keeps the returned root slot identity stable across renders', async () => {
+    const seen: TextState['root'][] = [];
+    const { rerender } = await render(<TextStateProbe seen={seen}>First</TextStateProbe>);
+
+    await rerender(<TextStateProbe seen={seen}>Second</TextStateProbe>);
+
+    expect(seen).toHaveLength(2);
+    expect(seen[1]).toBe(seen[0]);
+  });
+});

--- a/packages/agentic/components/src/components/text/text.ts
+++ b/packages/agentic/components/src/components/text/text.ts
@@ -1,0 +1,19 @@
+/** @jsxImportSource @fluentui-react-native/framework-base */
+import { phasedComponent } from '@fluentui-react-native/framework-base';
+
+import { renderText_unstable } from './renderText';
+import type { TextProps } from './text.types';
+import { useText_unstable } from './useText';
+import { useTextStyles_unstable } from './useTextStyles';
+
+export const Text = phasedComponent<TextProps>((props) => {
+  const state = useText_unstable(props);
+
+  useTextStyles_unstable(state);
+
+  return renderText_unstable(state);
+});
+
+Text.displayName = 'Text';
+
+export default Text;

--- a/packages/agentic/components/src/components/text/text.types.test.tsx
+++ b/packages/agentic/components/src/components/text/text.types.test.tsx
@@ -1,0 +1,30 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import * as React from 'react';
+import type { Text as NativeText } from 'react-native';
+
+import type { SlotProp } from '@fluentui-react-native/framework-base';
+
+import { Text } from './text';
+import type { TextProps } from './text.types';
+
+const nativeRef = React.createRef<React.ComponentRef<typeof NativeText>>();
+const textProps: TextProps = {
+  children: 'Native props',
+  ref: nativeRef,
+  selectable: true,
+  style: { fontSize: 18 },
+};
+const textSlot: SlotProp<typeof Text> = {
+  children: 'Slot props',
+  ref: nativeRef,
+};
+
+<Text {...textProps} />;
+<Text {...textSlot} />;
+
+describe('Text type coverage', () => {
+  it('accepts native props, refs, and slot props', () => {
+    expect(textProps).toBeDefined();
+    expect(textSlot).toBeDefined();
+  });
+});

--- a/packages/agentic/components/src/components/text/text.types.ts
+++ b/packages/agentic/components/src/components/text/text.types.ts
@@ -1,0 +1,15 @@
+import type { Text as NativeText, StyleProp, TextStyle } from 'react-native';
+
+import type { ThemeState } from '@fluentui-react-native/design';
+import type { ComponentState, PropsWithRefOf, Slot } from '@fluentui-react-native/framework-base';
+
+export type TextSlots = {
+  root: Slot<typeof NativeText>;
+};
+
+export type TextProps = PropsWithRefOf<typeof NativeText>;
+
+export type TextState = ComponentState<TextSlots> &
+  ThemeState & {
+    userStyle: StyleProp<TextStyle>;
+  };

--- a/packages/agentic/components/src/components/text/useText.ts
+++ b/packages/agentic/components/src/components/text/useText.ts
@@ -1,0 +1,17 @@
+import { Text as NativeText } from 'react-native';
+
+import { useThemeState } from '@fluentui-react-native/design';
+import { useSlot } from '@fluentui-react-native/framework-base';
+
+import type { TextProps, TextState } from './text.types';
+
+export function useText_unstable(props: TextProps): TextState {
+  const { ref, style: userStyle, ...nativeProps } = props;
+  const root = useSlot(NativeText, { ...nativeProps, ref });
+
+  return {
+    root,
+    userStyle,
+    ...useThemeState(),
+  };
+}

--- a/packages/agentic/components/src/components/text/useTextStyles.ts
+++ b/packages/agentic/components/src/components/text/useTextStyles.ts
@@ -1,0 +1,12 @@
+import { attachSlotProps } from '@fluentui-react-native/framework-base';
+
+import { getTextStyles } from './text.styles';
+import type { TextState } from './text.types';
+
+export function useTextStyles_unstable(state: TextState): void {
+  const styles = getTextStyles(state);
+
+  attachSlotProps(state.root, {
+    style: [styles.root, state.userStyle],
+  });
+}

--- a/packages/agentic/components/src/index.test.ts
+++ b/packages/agentic/components/src/index.test.ts
@@ -23,6 +23,7 @@ describe('component exports', () => {
         'Tab',
         'TabList',
         'Tag',
+        'Text',
         'renderAccordion_unstable',
         'renderAvatar_unstable',
         'renderBadge_unstable',
@@ -42,6 +43,7 @@ describe('component exports', () => {
         'renderTab_unstable',
         'renderTabList_unstable',
         'renderTag_unstable',
+        'renderText_unstable',
         'useAccordionStyles_unstable',
         'useAccordion_unstable',
         'useAvatarStyles_unstable',
@@ -80,6 +82,8 @@ describe('component exports', () => {
         'useTab_unstable',
         'useTagStyles_unstable',
         'useTag_unstable',
+        'useTextStyles_unstable',
+        'useText_unstable',
       ].sort(),
     );
   });

--- a/packages/agentic/components/src/index.ts
+++ b/packages/agentic/components/src/index.ts
@@ -167,3 +167,9 @@ export type { TagAppearance, TagLayout, TagProps, TagShape, TagSize, TagSlots, T
 export { renderTag_unstable } from './components/tag/renderTag';
 export { useTagStyles_unstable } from './components/tag/useTagStyles';
 export { useTag_unstable } from './components/tag/useTag';
+
+export { Text } from './components/text/text';
+export { renderText_unstable } from './components/text/renderText';
+export type { TextProps, TextSlots, TextState } from './components/text/text.types';
+export { useText_unstable } from './components/text/useText';
+export { useTextStyles_unstable } from './components/text/useTextStyles';

--- a/packages/agentic/components/src/refs.types.test.tsx
+++ b/packages/agentic/components/src/refs.types.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import * as React from 'react';
-import type { Image, Pressable, View } from 'react-native';
-import { Text } from 'react-native';
+import type { Image, Pressable, Text as NativeText, View } from 'react-native';
+import { Text as ReactNativeText } from 'react-native';
 
 import {
   Accordion,
@@ -23,6 +23,7 @@ import {
   Tab,
   TabList,
   Tag,
+  Text,
 } from './index';
 import { CheckboxIndicator, CompoundItemLayout, FocusVisual, LayoutStableText } from './primitives/index';
 import type { IconProps } from './primitives/index';
@@ -30,6 +31,7 @@ import type { IconProps } from './primitives/index';
 const pressableRef = React.createRef<React.ElementRef<typeof Pressable>>();
 const viewRef = React.createRef<React.ElementRef<typeof View>>();
 const imageRef = React.createRef<React.ElementRef<typeof Image>>();
+const textRef = React.createRef<React.ElementRef<typeof NativeText>>();
 
 function ComponentsWithNativeRootRefs() {
   return (
@@ -55,6 +57,7 @@ function ComponentsWithNativeRootRefs() {
         <Tab controls="panel" />
       </TabList>
       <Tag ref={pressableRef} />
+      <Text ref={textRef} />
     </>
   );
 }
@@ -65,7 +68,7 @@ function PrimitivesWithStableNativeRootRefs() {
       <CheckboxIndicator ref={viewRef} />
       <CompoundItemLayout primary={null} ref={viewRef} />
       <FocusVisual ref={viewRef} />
-      <LayoutStableText ref={viewRef} reserve={<Text />} visible={<Text />} />
+      <LayoutStableText ref={viewRef} reserve={<ReactNativeText />} visible={<ReactNativeText />} />
     </>
   );
 }


### PR DESCRIPTION
### Platforms Impacted

- [ ] iOS
- [x] macOS
- [x] win32 (Office)
- [x] windows
- [ ] android

### Description of changes

This adds a `Text` component to the components package which uses several reference points to generate its spec. As part of this the spec building process has been made more general to allow specs from different sources and creating a framework for fanning out source specific instructions.
